### PR TITLE
If a part has no bom items, the 'can_build' function now returns zero

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -284,7 +284,7 @@ class Part(models.Model):
 
         # If this part does NOT have a BOM, result is simply the currently available stock
         if not self.has_bom:
-            return self.available_stock
+            return 0
 
         total = None
 


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/274