### PR TITLE
Fuzzy search

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -106,7 +106,7 @@ def str2bool(text, test=True):
     if test:
         return str(text).lower() in ['1', 'y', 'yes', 't', 'true', 'ok', 'on', ]
     else:
-        return str(text).lower() in ['0', 'n', 'no', 'none', 'f', 'false', 'off',]
+        return str(text).lower() in ['0', 'n', 'no', 'none', 'f', 'false', 'off', ]
 
 
 def WrapWithQuotes(text, quote='"'):

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -104,9 +104,9 @@ def str2bool(text, test=True):
         True if the text looks like the selected boolean value
     """
     if test:
-        return str(text).lower() in ['1', 'y', 'yes', 't', 'true', 'ok', ]
+        return str(text).lower() in ['1', 'y', 'yes', 't', 'true', 'ok', 'on', ]
     else:
-        return str(text).lower() in ['0', 'n', 'no', 'none', 'f', 'false', ]
+        return str(text).lower() in ['0', 'n', 'no', 'none', 'f', 'false', 'off',]
 
 
 def WrapWithQuotes(text, quote='"'):

--- a/InvenTree/part/admin.py
+++ b/InvenTree/part/admin.py
@@ -9,7 +9,7 @@ from .models import BomItem
 
 class PartAdmin(ImportExportModelAdmin):
 
-    list_display = ('name', 'IPN', 'description', 'total_stock', 'category')
+    list_display = ('long_name', 'IPN', 'description', 'total_stock', 'category')
 
 
 class PartCategoryAdmin(ImportExportModelAdmin):

--- a/InvenTree/part/forms.py
+++ b/InvenTree/part/forms.py
@@ -60,9 +60,12 @@ class EditPartAttachmentForm(HelperForm):
 class EditPartForm(HelperForm):
     """ Form for editing a Part object """
 
+    confirm_creation = forms.BooleanField(required=False, initial=False, help_text='Confirm part creation', widget=forms.HiddenInput())
+
     class Meta:
         model = Part
         fields = [
+            'confirm_creation',
             'category',
             'name',
             'variant',

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -146,7 +146,7 @@ def match_part_names(match, threshold=80, reverse=True, compare_length=False):
         if len(compare) == 0:
             continue
 
-        ratio = fuzz.partial_ratio(compare, match)
+        ratio = fuzz.partial_token_sort_ratio(compare, match)
 
         if compare_length:
             # Also employ primitive length comparison

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -24,6 +24,8 @@ from django.contrib.auth.models import User
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
+from fuzzywuzzy import fuzz
+
 from InvenTree import helpers
 from InvenTree import validators
 from InvenTree.models import InvenTreeTree
@@ -88,8 +90,6 @@ def before_delete_part_category(sender, instance, using, **kwargs):
         child.save()
 
 
-# Function to automatically rename a part image on upload
-# Format: part_pk.<img>
 def rename_part_image(instance, filename):
     """ Function for renaming a part image file
 
@@ -114,6 +114,43 @@ def rename_part_image(instance, filename):
         fn += '.' + ext
 
     return os.path.join(base, fn)
+
+
+def match_part_names(match, include_description=False, threshold=65, reverse=True):
+    """ Return a list of parts whose name matches the search term using fuzzy search.
+
+    Args:
+        match: Term to match against
+        include_description: Also search the part description (default = False)
+        threshold: Match percentage that must be exceeded (default = 65)
+        reverse: Ordering for search results (default = True - highest match is first)
+
+    Returns:
+        A sorted dict where each element contains the following key:value pairs:
+            - 'part' : The matched part
+            - 'ratio' : The matched ratio
+    """
+
+    parts = Part.objects.all()
+
+    matches = []
+
+    for part in parts:
+        compare = part.name
+        if include_description:
+            compare += part.description
+
+        ratio = fuzz.partial_ratio(match, compare)
+
+        if ratio >= threshold:
+            matches.append({
+                'part': part,
+                'ratio': ratio
+            })
+
+    matches = sorted(matches, key=lambda item: item['ratio'], reverse=reverse)
+
+    return matches
 
 
 class Part(models.Model):

--- a/InvenTree/part/templates/part/create_part.html
+++ b/InvenTree/part/templates/part/create_part.html
@@ -1,0 +1,18 @@
+{% extends "modal_form.html" %}
+
+{% block pre_form_content %}
+
+{{ block.super }}
+
+{% if matches %}
+<b>Matching Parts</b>
+<ul class='list-group'>
+{% for match in matches %}
+<li class='list-group-item list-group-item-condensed'>
+    {{ match.part.name }} - <i>{{ match.part.description }}</i> ({{ match.ratio }}%)
+</li>
+{% endfor %}
+</ul>
+{% endif %}
+
+{% endblock %}

--- a/InvenTree/part/templates/part/create_part.html
+++ b/InvenTree/part/templates/part/create_part.html
@@ -5,7 +5,8 @@
 {{ block.super }}
 
 {% if matches %}
-<b>Matching Parts</b>
+<b>Possible Matching Parts</b>
+<p>The new part may be a duplicate of these existing parts:</p>
 <ul class='list-group'>
 {% for match in matches %}
 <li class='list-group-item list-group-item-condensed'>

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -17,14 +17,7 @@ from .models import PartCategory, Part, PartAttachment
 from .models import BomItem
 from .models import SupplierPart
 
-from .forms import PartImageForm
-from .forms import EditPartForm
-from .forms import EditPartAttachmentForm
-from .forms import EditCategoryForm
-from .forms import EditBomItemForm
-from .forms import BomExportForm
-
-from .forms import EditSupplierPartForm
+from . import forms as part_forms
 
 from InvenTree.views import AjaxView, AjaxCreateView, AjaxUpdateView, AjaxDeleteView
 from InvenTree.views import QRCodeView
@@ -60,7 +53,7 @@ class PartAttachmentCreate(AjaxCreateView):
     - The view only makes sense if a Part object is passed to it
     """
     model = PartAttachment
-    form_class = EditPartAttachmentForm
+    form_class = part_forms.EditPartAttachmentForm
     ajax_form_title = "Add part attachment"
     ajax_template_name = "modal_form.html"
 
@@ -99,7 +92,7 @@ class PartAttachmentCreate(AjaxCreateView):
 class PartAttachmentEdit(AjaxUpdateView):
     """ View for editing a PartAttachment object """
     model = PartAttachment
-    form_class = EditPartAttachmentForm
+    form_class = part_forms.EditPartAttachmentForm
     ajax_template_name = 'modal_form.html'
     ajax_form_title = 'Edit attachment'
     
@@ -139,7 +132,7 @@ class PartCreate(AjaxCreateView):
     - Copy an existing Part
     """
     model = Part
-    form_class = EditPartForm
+    form_class = part_forms.EditPartForm
 
     ajax_form_title = 'Create new part'
     ajax_template_name = 'modal_form.html'
@@ -260,7 +253,7 @@ class PartImage(AjaxUpdateView):
     model = Part
     ajax_template_name = 'modal_form.html'
     ajax_form_title = 'Upload Part Image'
-    form_class = PartImageForm
+    form_class = part_forms.PartImageForm
 
     def get_data(self):
         return {
@@ -272,7 +265,7 @@ class PartEdit(AjaxUpdateView):
     """ View for editing Part object """
 
     model = Part
-    form_class = EditPartForm
+    form_class = part_forms.EditPartForm
     ajax_template_name = 'modal_form.html'
     ajax_form_title = 'Edit Part Properties'
     context_object_name = 'part'
@@ -298,7 +291,7 @@ class BomExport(AjaxView):
     ajax_form_title = 'Export BOM'
     ajax_template_name = 'part/bom_export.html'
     context_object_name = 'part'
-    form_class = BomExportForm
+    form_class = part_forms.BomExportForm
 
     def get_object(self):
         return get_object_or_404(Part, pk=self.kwargs['pk'])
@@ -396,7 +389,7 @@ class CategoryDetail(DetailView):
 class CategoryEdit(AjaxUpdateView):
     """ Update view to edit a PartCategory """
     model = PartCategory
-    form_class = EditCategoryForm
+    form_class = part_forms.EditCategoryForm
     ajax_template_name = 'modal_form.html'
     ajax_form_title = 'Edit Part Category'
 
@@ -449,7 +442,7 @@ class CategoryCreate(AjaxCreateView):
     ajax_form_action = reverse_lazy('category-create')
     ajax_form_title = 'Create new part category'
     ajax_template_name = 'modal_form.html'
-    form_class = EditCategoryForm
+    form_class = part_forms.EditCategoryForm
 
     def get_context_data(self, **kwargs):
         """ Add extra context data to template.
@@ -496,7 +489,7 @@ class BomItemDetail(DetailView):
 class BomItemCreate(AjaxCreateView):
     """ Create view for making a new BomItem object """
     model = BomItem
-    form_class = EditBomItemForm
+    form_class = part_forms.EditBomItemForm
     ajax_template_name = 'modal_form.html'
     ajax_form_title = 'Create BOM item'
 
@@ -554,7 +547,7 @@ class BomItemEdit(AjaxUpdateView):
     """ Update view for editing BomItem """
 
     model = BomItem
-    form_class = EditBomItemForm
+    form_class = part_forms.EditBomItemForm
     ajax_template_name = 'modal_form.html'
     ajax_form_title = 'Edit BOM item'
 
@@ -580,7 +573,7 @@ class SupplierPartEdit(AjaxUpdateView):
 
     model = SupplierPart
     context_object_name = 'part'
-    form_class = EditSupplierPartForm
+    form_class = part_forms.EditSupplierPartForm
     ajax_template_name = 'modal_form.html'
     ajax_form_title = 'Edit Supplier Part'
 
@@ -589,7 +582,7 @@ class SupplierPartCreate(AjaxCreateView):
     """ Create view for making new SupplierPart """
 
     model = SupplierPart
-    form_class = EditSupplierPartForm
+    form_class = part_forms.EditSupplierPartForm
     ajax_template_name = 'modal_form.html'
     ajax_form_title = 'Create new Supplier Part'
     context_object_name = 'part'

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -179,7 +179,6 @@ class PartCreate(AjaxCreateView):
 
         form = self.get_form()
 
-
         context = {}
 
         valid = form.is_valid()

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -16,6 +16,7 @@ from company.models import Company
 from .models import PartCategory, Part, PartAttachment
 from .models import BomItem
 from .models import SupplierPart
+from .models import match_part_names
 
 from . import forms as part_forms
 
@@ -135,7 +136,7 @@ class PartCreate(AjaxCreateView):
     form_class = part_forms.EditPartForm
 
     ajax_form_title = 'Create new part'
-    ajax_template_name = 'modal_form.html'
+    ajax_template_name = 'part/create_part.html'
 
     def get_data(self):
         return {
@@ -173,6 +174,28 @@ class PartCreate(AjaxCreateView):
         form.fields['default_supplier'].widget = HiddenInput()
 
         return form
+
+    def post(self, request, *args, **kwargs):
+
+        form = self.get_form()
+
+        name = request.POST.get('name', None)
+
+        context = {}
+        
+        if name:
+            matches = match_part_names(name)
+
+            if len(matches) > 0:
+                context['matches'] = matches
+            
+                form.non_field_errors = 'Check matches'
+
+        data = {
+            'form_valid': False
+        }
+
+        return self.renderJsonResponse(request, form, data, context=context)
 
     def get_initial(self):
         """ Get initial data for the new Part object:

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -191,13 +191,16 @@ class PartCreate(AjaxCreateView):
             if len(matches) > 0:
                 context['matches'] = matches
             
+                # Enforce display of the checkbox
+                form.fields['confirm_creation'].widget = CheckboxInput()
+                
                 # Check if the user has checked the 'confirm_creation' input
                 confirmed = str2bool(request.POST.get('confirm_creation', False))
 
                 if not confirmed:
-                    form.fields['confirm_creation'].widget = CheckboxInput()
                     form.errors['confirm_creation'] = ['Possible matches exist - confirm creation of new part']
-                    form.non_field_errors = 'Possible matches exist - confirm creation of new part'
+                    
+                    form.pre_form_warning = 'Possible matches exist - confirm creation of new part'
                     valid = False
 
         data = {

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -192,7 +192,7 @@ class PartCreate(AjaxCreateView):
                 context['matches'] = matches
             
                 # Check if the user has checked the 'confirm_creation' input
-                confirmed = request.POST.get('confirm_creation', False)
+                confirmed = str2bool(request.POST.get('confirm_creation', False))
 
                 if not confirmed:
                     form.fields['confirm_creation'].widget = CheckboxInput()

--- a/InvenTree/static/css/inventree.css
+++ b/InvenTree/static/css/inventree.css
@@ -27,6 +27,10 @@
     padding: 6px 12px;
 }
 
+.list-group-item-condensed {
+    padding: 5px 10px;
+}
+
 /* Force select2 elements in modal forms to be full width */
 .select-full-width {
     width: 100%;

--- a/InvenTree/templates/modal_form.html
+++ b/InvenTree/templates/modal_form.html
@@ -1,13 +1,14 @@
-{% block pre_form_content %}
-{% endblock %}
-
+{% block non_field_error %}
 {% if form.non_field_errors %}
 <div class='alert alert-danger' role='alert' style='display: block;'>
   <b>Error Submitting Form:</b>
   {{ form.non_field_errors }}
 </div>
 {% endif %}
+{% endblock %}
 
+{% block pre_form_content %}
+{% endblock %}
 <form method="post" action='' class='js-modal-form' enctype="multipart/form-data">
   {% csrf_token %}
   {% load crispy_forms_tags %}

--- a/InvenTree/templates/modal_form.html
+++ b/InvenTree/templates/modal_form.html
@@ -1,3 +1,14 @@
+<div>
+{% if form.pre_form_info %}
+<div class='alert alert-info' role='alert' style='display: block;'>
+{{ form.pre_form_info }}
+</div>
+{% endif %}
+{% if form.pre_form_warning %}
+<div class='alert alert-warning' role='alert' style='display: block;'>
+{{ form.pre_form_warning }}
+</div>
+{% endif %}
 {% block non_field_error %}
 {% if form.non_field_errors %}
 <div class='alert alert-danger' role='alert' style='display: block;'>
@@ -6,6 +17,7 @@
 </div>
 {% endif %}
 {% endblock %}
+</div>
 
 {% block pre_form_content %}
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ django-qr-code==1.0.0           # Generate QR codes
 flake8==3.3.0                   # PEP checking
 coverage>=4.5.3                 # Unit test coverage
 python-coveralls==2.9.1         # Coveralls linking (for Travis)
+fuzzywuzzy>=0.17.0              # Fuzzy string matching


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/88

Fuzzy-search lookup on part names when creating a new part. If there are any parts with a significantly close match, they are displayed and part creation is prevented unless the user selects a confirmation checkbox.

Note: The search algorithm isn't *fantastic* yet, could certainly do with some work.