### PR TITLE
Rest simplify

### DIFF
--- a/InvenTree/company/api.py
+++ b/InvenTree/company/api.py
@@ -11,6 +11,8 @@ from rest_framework import generics, permissions
 
 from django.conf.urls import url, include
 
+from InvenTree.helpers import str2bool
+
 from .models import Company
 from .models import SupplierPart, SupplierPriceBreak
 
@@ -83,6 +85,16 @@ class SupplierPartList(generics.ListCreateAPIView):
         'part__builds',
         'supplier',
         'pricebreaks')
+
+    def get_serializer(self, *args, **kwargs):
+
+        # Do we wish to include extra detail?
+        part_detail = str2bool(self.request.GET.get('part_detail', None))
+
+        kwargs['part_detail'] = part_detail
+        kwargs['context'] = self.get_serializer_context()
+
+        return self.serializer_class(*args, **kwargs)
 
     serializer_class = SupplierPartSerializer
 

--- a/InvenTree/company/serializers.py
+++ b/InvenTree/company/serializers.py
@@ -64,6 +64,15 @@ class SupplierPartSerializer(serializers.ModelSerializer):
 
     pricing = serializers.CharField(source='unit_pricing', read_only=True)
 
+    def __init__(self, *args, **kwargs):
+
+        part_detail = kwargs.pop('part_detail', False)
+
+        super(SupplierPartSerializer, self).__init__(*args, **kwargs)
+
+        if part_detail is not True:
+            self.fields.pop('part_detail')
+
     class Meta:
         model = SupplierPart
         fields = [

--- a/InvenTree/company/templates/company/detail_part.html
+++ b/InvenTree/company/templates/company/detail_part.html
@@ -47,10 +47,13 @@
     $("#part-table").bootstrapTable({
         sortable: true,
         search: true,
+        pagination: true,
+        pageSize: 50,
         formatNoMatches: function() { return "No supplier parts found for {{ company.name }}"; },
         queryParams: function(p) {
             return {
-                supplier: {{ company.id }}
+                supplier: {{ company.id }},
+                part_detail: true,
             }
         },
         columns: [

--- a/InvenTree/company/templates/company/detail_stock.html
+++ b/InvenTree/company/templates/company/detail_stock.html
@@ -17,6 +17,8 @@
         url: "{% url 'api-stock-list' %}",
         params: {
             supplier: {{ company.id }},
+            part_detail: true,
+            location_detail: true,
         },
         buttons: [
             '#stock-options',

--- a/InvenTree/company/templates/company/index.html
+++ b/InvenTree/company/templates/company/index.html
@@ -45,6 +45,7 @@ InvenTree | Supplier List
         sortable: true,
         search: true,
         pagination: true,
+        pageSize: 50,
         formatNoMatches: function() { return "No company information found"; },
         columns: [
             {

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -22,6 +22,7 @@ from .serializers import CategorySerializer
 from .serializers import PartStarSerializer
 
 from InvenTree.views import TreeSerializer
+from InvenTree.helpers import str2bool
 
 
 class PartCategoryTree(TreeSerializer):
@@ -203,8 +204,20 @@ class BomList(generics.ListCreateAPIView):
     - GET: Return list of BomItem objects
     - POST: Create a new BomItem object
     """
-    
+
     serializer_class = BomItemSerializer
+    
+    def get_serializer(self, *args, **kwargs):
+
+        # Do we wish to include extra detail?
+        part_detail = str2bool(self.request.GET.get('part_detail', None))
+        sub_part_detail = str2bool(self.request.GET.get('sub_part_detail', None))
+
+        kwargs['part_detail'] = part_detail
+        kwargs['sub_part_detail'] = sub_part_detail
+
+        kwargs['context'] = self.get_serializer_context()
+        return self.serializer_class(*args, **kwargs)
 
     def get_queryset(self):
         queryset = BomItem.objects.all()

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -125,7 +125,7 @@ class BomItemSerializer(InvenTreeModelSerializer):
     price_range = serializers.CharField(read_only=True)
 
     def __init__(self, *args, **kwargs):
-        # part_detail and sub_part_detail serializers are only included if requested. 
+        # part_detail and sub_part_detail serializers are only included if requested.
         # This saves a bunch of database requests
 
         part_detail = kwargs.pop('part_detail', False)

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -124,6 +124,21 @@ class BomItemSerializer(InvenTreeModelSerializer):
     sub_part_detail = PartBriefSerializer(source='sub_part', many=False, read_only=True)
     price_range = serializers.CharField(read_only=True)
 
+    def __init__(self, *args, **kwargs):
+        # part_detail and sub_part_detail serializers are only included if requested. 
+        # This saves a bunch of database requests
+
+        part_detail = kwargs.pop('part_detail', False)
+        sub_part_detail = kwargs.pop('sub_part_detail', False)
+
+        super(BomItemSerializer, self).__init__(*args, **kwargs)
+
+        if part_detail is not True:
+            self.fields.pop('part_detail')
+
+        if sub_part_detail is not True:
+            self.fields.pop('sub_part_detail')
+
     @staticmethod
     def setup_eager_loading(queryset):
         queryset = queryset.prefetch_related('part')

--- a/InvenTree/part/templates/part/bom.html
+++ b/InvenTree/part/templates/part/bom.html
@@ -72,7 +72,8 @@
         editable: {{ editing_enabled }},
         bom_url: "{% url 'api-bom-list' %}",
         part_url: "{% url 'api-part-list' %}",
-        parent_id: {{ part.id }} 
+        parent_id: {{ part.id }} ,
+        sub_part_detail: true,
     });
 
     {% if editing_enabled %}

--- a/InvenTree/part/templates/part/build.html
+++ b/InvenTree/part/templates/part/build.html
@@ -35,6 +35,7 @@
         sortable: true,
         search: true,
         pagination: true,
+        pageSize: 50,
         queryParams: function(p) {
             return {
                 part: {{ part.id }},

--- a/InvenTree/part/templates/part/stock.html
+++ b/InvenTree/part/templates/part/stock.html
@@ -37,6 +37,8 @@
     loadStockTable($("#stock-table"), {
         params: {
             part: {{ part.id }},
+            location_detail: true,
+            part_detail: true,
         },
         buttons: [
             '#stock-options',

--- a/InvenTree/part/templates/part/used_in.html
+++ b/InvenTree/part/templates/part/used_in.html
@@ -30,7 +30,8 @@
         formatNoMatches: function() { return "{{ part.full_name }} is not used to make any other parts"; },
         queryParams: function(p) {
             return {
-                sub_part: {{ part.id }}
+                sub_part: {{ part.id }},
+                part_detail: true,
             }
         },
         columns: [

--- a/InvenTree/static/script/inventree/bom.js
+++ b/InvenTree/static/script/inventree/bom.js
@@ -189,6 +189,19 @@ function loadBomTable(table, options) {
     }
 
     // Configure the table (bootstrap-table)
+
+    var params = {
+        part: options.parent_id,
+        ordering: 'name',
+    }
+
+    if (options.part_detail) {
+        params.part_detail = true;
+    }
+
+    if (options.sub_part_detail) {
+        params.sub_part_detail = true;
+    }
     
     table.bootstrapTable({
         sortable: true,
@@ -196,14 +209,11 @@ function loadBomTable(table, options) {
         formatNoMatches: function() { return "No BOM items found"; },
         clickToSelect: true,
         queryParams: function(p) {
-            return {
-                part: options.parent_id,
-                ordering: 'name',
-        }
-    },
-    columns: cols,
-    url: options.bom_url
-});
+            return params;
+        },
+        columns: cols,
+        url: options.bom_url
+    });
 
     // In editing mode, attached editables to the appropriate table elements
     if (options.editable) {

--- a/InvenTree/static/script/inventree/stock.js
+++ b/InvenTree/static/script/inventree/stock.js
@@ -377,7 +377,7 @@ function loadStockTable(table, options) {
         search: true,
         method: 'get',
         pagination: true,
-        pageSize: 25,
+        pageSize: 50,
         rememberOrder: true,
         queryParams: options.params,
         columns: [
@@ -558,6 +558,7 @@ function loadStockTrackingTable(table, options) {
         queryParams: options.params,
         columns: cols,
         pagination: true,
+        pageSize: 50,
         url: options.url,
     });
 

--- a/InvenTree/static/script/inventree/stock.js
+++ b/InvenTree/static/script/inventree/stock.js
@@ -392,25 +392,25 @@ function loadStockTable(table, options) {
                 visible: false,
             },
             {
-                field: 'part.full_name',
+                field: 'part_detail',
                 title: 'Part',
                 sortable: true,
                 formatter: function(value, row, index, field) {
-                    return imageHoverIcon(row.part.image_url) + renderLink(value, row.part.url + 'stock/');
+                    return imageHoverIcon(value.image_url) + renderLink(value.full_name, value.url + 'stock/');
                 }
             },
             {
-                field: 'part.description',
+                field: 'part_detail.description',
                 title: 'Description',
                 sortable: true,
             },
             {
-                field: 'location',
+                field: 'location_detail',
                 title: 'Location',
                 sortable: true,
                 formatter: function(value, row, index, field) {
-                    if (row.location) {
-                        return renderLink(row.location.pathstring, row.location.url);
+                    if (value) {
+                        return renderLink(value.pathstring, value.url);
                     }
                     else {
                         return '<i>No stock location set</i>';

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -18,6 +18,7 @@ from .serializers import LocationSerializer
 from .serializers import StockTrackingSerializer
 
 from InvenTree.views import TreeSerializer
+from InvenTree.helpers import str2bool
 
 from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
@@ -244,6 +245,17 @@ class StockList(generics.ListCreateAPIView):
         - category: Filter by parts belonging to a certain category
         - supplier: Filter by supplier
     """
+
+    def get_serializer(self, *args, **kwargs):
+
+        part_detail = str2bool(self.request.GET.get('part_detail', None))
+        location_detail = str2bool(self.request.GET.get('location_detail', None))
+
+        kwargs['part_detail'] = part_detail
+        kwargs['location_detail'] = location_detail
+        
+        kwargs['context'] = self.get_serializer_context()
+        return self.serializer_class(*args, **kwargs)
 
     def get_queryset(self):
         """

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -55,11 +55,11 @@ class StockItemSerializer(serializers.ModelSerializer):
     """
 
     url = serializers.CharField(source='get_absolute_url', read_only=True)
-
-    part = PartBriefSerializer(many=False, read_only=True)
-    location = LocationBriefSerializer(many=False, read_only=True)
     status_text = serializers.CharField(source='get_status_display', read_only=True)
 
+    part_detail = PartBriefSerializer(source='part', many=False, read_only=True)
+    location_detail = LocationBriefSerializer(source='location', many=False, read_only=True)
+    
     @staticmethod
     def setup_eager_loading(queryset):
         queryset = queryset.prefetch_related('part')
@@ -69,14 +69,29 @@ class StockItemSerializer(serializers.ModelSerializer):
 
         return queryset
 
+    def __init__(self, *args, **kwargs):
+
+        part_detail = kwargs.pop('part_detail', False)
+        location_detail = kwargs.pop('location_detail', False)
+
+        super(StockItemSerializer, self).__init__(*args, **kwargs)
+
+        if part_detail is not True:
+            self.fields.pop('part_detail')
+
+        if location_detail is not True:
+            self.fields.pop('location_detail')
+
     class Meta:
         model = StockItem
         fields = [
             'pk',
             'url',
             'part',
+            'part_detail',
             'supplier_part',
             'location',
+            'location_detail',
             'in_stock',
             'quantity',
             'serial',

--- a/InvenTree/stock/templates/stock/location.html
+++ b/InvenTree/stock/templates/stock/location.html
@@ -141,6 +141,8 @@
             {% if location %}
             location: {{ location.id }},
             {% endif %}
+            part_detail: true,
+            location_detail: true,
         },
         url: "{% url 'api-stock-list' %}",
     });


### PR DESCRIPTION
Only include linked field details in API if requested

- Cuts down on database queries drastically
- Especially in case of much duplicated data e.g. BomItem request

Fixes https://github.com/inventree/InvenTree/issues/360