### PR TITLE
Catch case in which a request.GET is not available

### DIFF
--- a/InvenTree/company/api.py
+++ b/InvenTree/company/api.py
@@ -89,7 +89,10 @@ class SupplierPartList(generics.ListCreateAPIView):
     def get_serializer(self, *args, **kwargs):
 
         # Do we wish to include extra detail?
-        part_detail = str2bool(self.request.GET.get('part_detail', None))
+        try:
+            part_detail = str2bool(self.request.GET.get('part_detail', None))
+        except AttributeError:
+            part_detail = None
 
         kwargs['part_detail'] = part_detail
         kwargs['context'] = self.get_serializer_context()

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -273,8 +273,12 @@ class BomList(generics.ListCreateAPIView):
     def get_serializer(self, *args, **kwargs):
 
         # Do we wish to include extra detail?
-        part_detail = str2bool(self.request.GET.get('part_detail', None))
-        sub_part_detail = str2bool(self.request.GET.get('sub_part_detail', None))
+        try:
+            part_detail = str2bool(self.request.GET.get('part_detail', None))
+            sub_part_detail = str2bool(self.request.GET.get('sub_part_detail', None))
+        except AttributeError:
+            part_detail = None
+            sub_part_detail = None
 
         kwargs['part_detail'] = part_detail
         kwargs['sub_part_detail'] = sub_part_detail

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -261,8 +261,12 @@ class StockList(generics.ListCreateAPIView):
 
     def get_serializer(self, *args, **kwargs):
 
-        part_detail = str2bool(self.request.GET.get('part_detail', None))
-        location_detail = str2bool(self.request.GET.get('location_detail', None))
+        try:
+            part_detail = str2bool(self.request.GET.get('part_detail', None))
+            location_detail = str2bool(self.request.GET.get('location_detail', None))
+        except AttributeError:
+            part_detail = None
+            location_detail = None
 
         kwargs['part_detail'] = part_detail
         kwargs['location_detail'] = location_detail


### PR DESCRIPTION
The /apidoc/ endpoint seems to request the API views differently, and request.GET is not available.

Fixes https://github.com/inventree/InvenTree/issues/419