### PR TITLE
Makefile: add .PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,5 @@ documentation:
 backup:
 	python3 InvenTree/manage.py dbbackup
 	python3 InvenTree/manage.py mediabackup
+
+.PHONY: clean migrate requirements secret superuser install style test coverage documentation backup


### PR DESCRIPTION
Given all the targets are actions instead of files to be generated,
.PHONY should be used, mainly to avoid a conflict with a file of the same name.

See https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html