### PR TITLE
Fixes for migrate target in makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 before_install:
     - make install
     - make migrate
+    - cd InvenTree && python3 manage.py createsuper --username InvenTreeAdmin --email admin@inventree.com --noinput
 
 script:
     - git ls-files --exclude-standard --others

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 before_install:
     - make install
     - make migrate
-    - cd InvenTree && python3 manage.py createsuper --username InvenTreeAdmin --email admin@inventree.com --noinput
+    - cd InvenTree && python3 manage.py createsuperuser --username InvenTreeAdmin --email admin@inventree.com --noinput
 
 script:
     - git ls-files --exclude-standard --others

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 before_install:
     - make install
     - make migrate
-    - cd InvenTree && python3 manage.py createsuperuser --username InvenTreeAdmin --email admin@inventree.com --noinput
+    - cd InvenTree && python3 manage.py createsuperuser --username InvenTreeAdmin --email admin@inventree.com --noinput && cd ..
 
 script:
     - git ls-files --exclude-standard --others

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -5,7 +5,7 @@
 database:
   # Example configuration - sqlite (default)
   ENGINE: django.db.backends.sqlite3
-  NAME: inventree_db.sqlite3 
+  NAME: '../inventree_default_db.sqlite3' 
   
   # For more complex database installations, further parameters are required
   # Refer to the django documentation for full list of options
@@ -41,11 +41,11 @@ cors:
 # MEDIA_ROOT is the local filesystem location for storing uploaded files
 # By default, it is stored in a directory named 'media' local to the InvenTree directory
 # This should be changed for a production installation
-media_root: './media'
+media_root: '../inventree_media'
 
 # STATIC_ROOT is the local filesystem location for storing static files
 # By default it is stored in a directory named 'static' local to the InvenTree directory
-static_root: './static'
+static_root: '../inventree_static'
 
 # Logging options
 log_queries: False

--- a/Makefile
+++ b/Makefile
@@ -11,26 +11,20 @@ update: backup install migrate
 
 # Perform database migrations (after schema changes are made)
 migrate:
-	python3 InvenTree/manage.py makemigrations common
-	python3 InvenTree/manage.py makemigrations company
-	python3 InvenTree/manage.py makemigrations part
-	python3 InvenTree/manage.py makemigrations stock
-	python3 InvenTree/manage.py makemigrations build
-	python3 InvenTree/manage.py makemigrations order
-	python3 InvenTree/manage.py makemigrations
+	cd InvenTree && python3 manage.py makemigrations
 	cd InvenTree && python3 manage.py migrate
 	cd InvenTree && python3 manage.py migrate --run-syncdb
-	python3 InvenTree/manage.py check
+	cd InvenTree && python3 manage.py check
 	cd InvenTree && python3 manage.py collectstatic
 
 # Install all required packages
 install:
 	pip3 install -U -r requirements.txt
-	python3 InvenTree/setup.py
+	cd InvenTree && python3 setup.py
 
 # Create a superuser account
 superuser:
-	python3 InvenTree/manage.py createsuperuser
+	cd InvenTree && python3 manage.py createsuperuser
 
 # Install pre-requisites for mysql setup
 mysql:
@@ -48,8 +42,8 @@ style:
 
 # Run unit tests
 test:
-	python3 InvenTree/manage.py check
-	python3 InvenTree/manage.py test build common company order part stock 
+	cd InvenTree && python3 manage.py check
+	cd InvenTree && python3 manage.py test build common company order part stock 
 
 # Run code coverage
 coverage:
@@ -67,7 +61,7 @@ docs:
 
 # Make database backup
 backup:
-	python3 InvenTree/manage.py dbbackup
-	python3 InvenTree/manage.py mediabackup
+	cd InvenTree && python3 manage.py dbbackup
+	cd InvenTree && python3 manage.py mediabackup
 
 .PHONY: clean migrate superuser install mysql postgresql style test coverage docreqs docs backup update

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test:
 
 # Run code coverage
 coverage:
-	python3 InvenTree/manage.py check
+	cd InvenTree && python3 manage.py check
 	coverage run InvenTree/manage.py test build common company order part stock InvenTree
 	coverage html
 


### PR DESCRIPTION
Fixes for `make migrate` target

- Some commands in the target were not being called in the correct directory
- For a local db (e.g. SQLite) this meant that two separate databases were being constructed
- Different parts of the install were applied to each database
- NO THIS IS BAD