### PR TITLE
Bug fix for order-parts form

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -202,8 +202,8 @@ class PurchaseOrder(Order):
             raise ValidationError({'supplier': _("Part supplier must match PO supplier")})
 
         if group:
-            # Check if there is already a matching line item
-            matches = PurchaseOrderLineItem.objects.filter(part=supplier_part)
+            # Check if there is already a matching line item (for this PO)
+            matches = self.lines.filter(part=supplier_part)
 
             if matches.count() > 0:
                 line = matches.first()

--- a/InvenTree/order/views.py
+++ b/InvenTree/order/views.py
@@ -5,6 +5,7 @@ Django views for interacting with Order app
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _
 from django.views.generic import DetailView, ListView
@@ -557,6 +558,7 @@ class OrderParts(AjaxView):
 
         return self.renderJsonResponse(self.request, data=data)
 
+    @transaction.atomic
     def order_items(self):
         """ Add the selected items to the purchase orders. """
 


### PR DESCRIPTION
- Check for parts already existing in PO must filter by the purchase order ID in addition to the part ID