### PR TITLE
Fixes problem with 'New Purchase Order' button from Suppliers page.

### DIFF
--- a/InvenTree/company/templates/company/detail_purchase_orders.html
+++ b/InvenTree/company/templates/company/detail_purchase_orders.html
@@ -9,7 +9,7 @@
 
 <div id='button-bar'>
     <div class='btn-group'>
-        <button class='btn btn-primary' type='button' id='company-order-2' title='Create new purchase order'>New Purchase Order</button>
+        <button class='btn btn-primary' type='button' id='company-order2' title='Create new purchase order'>New Purchase Order</button>
     </div>
 </div>
 
@@ -38,7 +38,7 @@
         newOrder();
     });
 
-    $("#company-order-2").click(function() {
+    $("#company-order2").click(function() {
         newOrder();
     });
 


### PR DESCRIPTION
This fixes an issue where the 'New Purchase Order' button doesn't work from the 'Purchase Order' tab of a Supplier page.

It seems to be an issue with the id of the button and the second hyphen as renaming the button id from 'company-order-2' to 'company-order2' resolves the issue.

The issue has been confirmed on Mac OSX 10.14.6 with Brave Version 0.67.125 Chromium: 76.0.3809.100 and Safari Version 12.1.2 (14607.3.9)