### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/InvenTree/part/bom.py
+++ b/InvenTree/part/bom.py
@@ -3,7 +3,7 @@ Functionality for Bill of Material (BOM) management.
 Primarily BOM upload tools.
 """
 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import tablib
 import os
 

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -29,7 +29,7 @@ from mptt.models import TreeForeignKey
 
 from decimal import Decimal
 from datetime import datetime
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import hashlib
 
 from InvenTree import helpers

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -18,7 +18,7 @@ from django.conf import settings
 
 import os
 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from decimal import Decimal
 
 from .models import PartCategory, Part, PartAttachment

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,4 @@ django-qr-code==1.1.0           # Generate QR codes
 flake8==3.3.0                   # PEP checking
 coverage==4.0.3                 # Unit test coverage
 python-coveralls==2.9.1         # Coveralls linking (for Travis)
-fuzzywuzzy==0.17.0              # Fuzzy string matching
-python-Levenshtein==0.12.0      # Required for fuzzywuzzy
+rapidfuzz==0.2.1                # Fuzzy string matching


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.