### PR TITLE
Add "On Order" badge

### DIFF
--- a/InvenTree/InvenTree/static/script/inventree/part.js
+++ b/InvenTree/InvenTree/static/script/inventree/part.js
@@ -182,17 +182,27 @@ function loadPartTable(table, url, options={}) {
         searchable: false,
         sortable: true,
         formatter: function(value, row, index, field) {
+            console.log("On order:", row.on_order);
+            
+            var html = "";
+            var link = "stock";
+
             if (value) {
 
                 if (row.units) {
                     value += ' <i><small>' + row.units + '</small></i>';
                 }
 
-                return renderLink(value, '/part/' + row.pk + '/stock/');
+                html = value;
+
+            } else if (row.on_order) {
+                value = "<span class='label label-primary'>On Order : " + row.on_order + "</span>";
+                link = "orders";
+            } else {
+                value ="<span class='label label-warning'>No Stock</span>";
             }
-            else {
-                return "<span class='label label-warning'>No Stock</span>";
-            }
+            
+            return renderLink(value, '/part/' + row.pk + "/" + link + "/");
         }
     });
 

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -172,6 +172,7 @@ class PartList(generics.ListCreateAPIView):
             'active',
         ).annotate(
             in_stock=Sum('stock_items__quantity'),
+            on_order=Sum('supplier_parts__purchase_order_line_items__quantity'),
         )
 
         # TODO - Annotate total being built


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/674

![image](https://user-images.githubusercontent.com/10080325/77608208-adbbae80-6f70-11ea-9905-9bd1f7b2cb49.png)

If a part has no stock, but is on order, display a special "on order" badge