### PR TITLE
Improve logic of "quantity_to_order" function

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -594,7 +594,16 @@ class Part(MPTTModel):
     def quantity_to_order(self):
         """ Return the quantity needing to be ordered for this part. """
 
-        required = -1 * self.net_stock
+        # How many do we need to have "on hand" at any point?
+        required = self.net_stock - self.minimum_stock
+
+        if required < 0:
+            return abs(required)
+
+        # Do not need to order any
+        return 0
+
+        required = self.net_stock
         return max(required, 0)
 
     @property


### PR DESCRIPTION
This PR improves the logic of calculating how many items we need to order of a particular part.

Previously the logic was simple. Sometimes simple is good. But here, it was wrong - it did not take into account the "minimum_quantity" parameter of the Part object.

Fixes https://github.com/inventree/InvenTree/issues/752