### PR TITLE
Allow Part thumbnail update via API

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -190,6 +190,21 @@ class PartThumbs(generics.ListAPIView):
         return Response(data)
 
 
+class PartThumbsUpdate(generics.RetrieveUpdateAPIView):
+    """ API endpoint for updating Part thumbnails"""
+
+    queryset = Part.objects.all()
+    serializer_class = part_serializers.PartThumbSerializerUpdate
+
+    permission_classes = [
+        permissions.IsAuthenticated,
+    ]
+
+    filter_backends = [
+        DjangoFilterBackend
+    ]
+
+
 class PartDetail(generics.RetrieveUpdateDestroyAPIView):
     """ API endpoint for detail view of a single Part object """
 
@@ -716,7 +731,10 @@ part_api_urls = [
         url(r'^.*$', PartParameterList.as_view(), name='api-part-param-list'),
     ])),
 
-    url(r'^thumbs/', PartThumbs.as_view(), name='api-part-thumbs'),
+    url(r'^thumbs/', include([
+        url(r'^$', PartThumbs.as_view(), name='api-part-thumbs'),
+        url(r'^(?P<pk>\d+)/?', PartThumbsUpdate.as_view(), name='api-part-thumbs-update'),
+    ])),
 
     url(r'^(?P<pk>\d+)/?', PartDetail.as_view(), name='api-part-detail'),
 

--- a/InvenTree/part/bom.py
+++ b/InvenTree/part/bom.py
@@ -30,8 +30,8 @@ def MakeBomTemplate(fmt):
     if not IsValidBOMFormat(fmt):
         fmt = 'csv'
 
-    query = BomItem.objects.filter(pk=None)
-    dataset = BomItemResource().export(queryset=query)
+    # query = BomItem.objects.filter(pk=None)
+    dataset = BomItemResource().export()
 
     data = dataset.export(fmt)
 

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1355,7 +1355,7 @@ class PartParameter(models.Model):
 class BomItem(models.Model):
     """ A BomItem links a part to its component items.
     A part can have a BOM (bill of materials) which defines
-    which parts are required (and in what quatity) to make it.
+    which parts are required (and in what quantity) to make it.
 
     Attributes:
         part: Link to the parent part (the part that will be produced)

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -92,6 +92,18 @@ class PartThumbSerializer(serializers.Serializer):
     count = serializers.IntegerField(read_only=True)
 
 
+class PartThumbSerializerUpdate(InvenTreeModelSerializer):
+    """ Serializer for updating Part thumbnail """
+
+    image = InvenTreeAttachmentSerializerField(required=True)
+
+    class Meta:
+        model = Part
+        fields = [
+            'image',
+        ]
+
+
 class PartBriefSerializer(InvenTreeModelSerializer):
     """ Serializer for Part (brief detail) """
 


### PR DESCRIPTION
Added `PartThumbsUpdate` API view to allow Parts thumbnails to be updated directly from the API