### PR TITLE
Allowing Part thumbnail (image) update via API

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -190,6 +190,21 @@ class PartThumbs(generics.ListAPIView):
         return Response(data)
 
 
+class PartThumbsUpdate(generics.RetrieveUpdateAPIView):
+    """ API endpoint for updating Part thumbnails"""
+
+    queryset = Part.objects.all()
+    serializer_class = part_serializers.PartThumbSerializerUpdate
+
+    permission_classes = [
+        permissions.IsAuthenticated,
+    ]
+
+    filter_backends = [
+        DjangoFilterBackend
+    ]
+
+
 class PartDetail(generics.RetrieveUpdateDestroyAPIView):
     """ API endpoint for detail view of a single Part object """
 
@@ -716,7 +731,10 @@ part_api_urls = [
         url(r'^.*$', PartParameterList.as_view(), name='api-part-param-list'),
     ])),
 
-    url(r'^thumbs/', PartThumbs.as_view(), name='api-part-thumbs'),
+    url(r'^thumbs/', include([
+        url(r'^$', PartThumbs.as_view(), name='api-part-thumbs'),
+        url(r'^(?P<pk>\d+)/?', PartThumbsUpdate.as_view(), name='api-part-thumbs-update'),
+    ])),
 
     url(r'^(?P<pk>\d+)/?', PartDetail.as_view(), name='api-part-detail'),
 

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -92,6 +92,18 @@ class PartThumbSerializer(serializers.Serializer):
     count = serializers.IntegerField(read_only=True)
 
 
+class PartThumbSerializerUpdate(InvenTreeModelSerializer):
+    """ Serializer for updating Part thumbnail """
+
+    image = InvenTreeAttachmentSerializerField(required=True)
+
+    class Meta:
+        model = Part
+        fields = [
+            'image',
+        ]
+
+
 class PartBriefSerializer(InvenTreeModelSerializer):
     """ Serializer for Part (brief detail) """
 

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -1,6 +1,7 @@
 """
 JSON serializers for Part app
 """
+import imghdr
 
 from rest_framework import serializers
 
@@ -94,6 +95,15 @@ class PartThumbSerializer(serializers.Serializer):
 
 class PartThumbSerializerUpdate(InvenTreeModelSerializer):
     """ Serializer for updating Part thumbnail """
+
+    def validate_image(self, value):
+        """
+        Check that file is an image.
+        """
+        validate = imghdr.what(value)
+        if not validate:
+            raise serializers.ValidationError("File is not an image")
+        return value
 
     image = InvenTreeAttachmentSerializerField(required=True)
 


### PR DESCRIPTION
Added `PartThumbsUpdate` API view to allow Parts thumbnails to be updated directly from the API