### PR TITLE
Tex response

### DIFF
--- a/InvenTree/report/models.py
+++ b/InvenTree/report/models.py
@@ -8,6 +8,8 @@ from __future__ import unicode_literals
 import os
 import sys
 
+import datetime
+
 from django.db import models
 from django.conf import settings
 
@@ -160,6 +162,8 @@ class ReportTemplateBase(models.Model):
         context = self.get_context_data(request)
 
         context['request'] = request
+        context['user'] = request.user
+        context['datetime'] = datetime.datetime.now()
 
         if self.extension == '.tex':
             # Render LaTeX template to PDF

--- a/InvenTree/report/models.py
+++ b/InvenTree/report/models.py
@@ -40,6 +40,7 @@ if settings.LATEX_ENABLED:
 
 from django.http import HttpResponse
 
+
 class TexResponse(HttpResponse):
     def __init__(self, content, filename=None):
         super().__init__(content_type="application/txt")


### PR DESCRIPTION
Handle a LaTeX template report which results in an error

- Return the failed LaTeX file itself, rather than the output PDF
- This at least allows the user to understand what has gone wrong