### PR TITLE
Fix disabled form item from preventing location moves for serialized stock

### DIFF
--- a/InvenTree/stock/templates/stock/stock_adjust.html
+++ b/InvenTree/stock/templates/stock/stock_adjust.html
@@ -32,7 +32,6 @@
             <input class='numberinput'
               min='0'
               {% if stock_action == 'take' or stock_action == 'move' %} max='{{ item.quantity }}' {% endif %}
-              {% if item.serialized %} disabled='true' title='{% trans "Stock item is serialized and quantity cannot be adjusted" %}' {% endif %}
               value='{% decimal item.new_quantity %}' type='number' name='stock-id-{{ item.id }}' id='stock-id-{{ item.id }}'/>
             {% if item.error %}
             <br><span class='help-inline'>{{ item.error }}</span>


### PR DESCRIPTION
Stock that has serial numbers can't be moved between stock locations as the form in InvenTree/stock/templates/stock/stock_adjust.html marks the quantity control as disabled for a serialized item. The item IDs are supplied using this form component, and setting the disabled flag means those IDs are not supplied, at least by Firefox and Chromium.

To reproduce, move a serialized item between locations, and you'll get a "No items were moved" message. Checking the request details, the item name="stock-id-N" is missing, so no item is found. This works fine for stock that is not serialized.

I've removed the 'disabled' flag entirely - the max value already restricts the value from being increased above 1 and if the count is reduced to 0 then no items are moved as expected.