### PR TITLE
Allow custom authentication/middleware in config.yaml

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -163,7 +163,7 @@ LOGGING = {
     },
 }
 
-MIDDLEWARE = [
+MIDDLEWARE = CONFIG.get('middleware', [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -173,9 +173,12 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
     'InvenTree.middleware.AuthRequiredMiddleware'
-]
+])
+
+AUTHENTICATION_BACKENDS = CONFIG.get('authentication_backends', [
+    'django.contrib.auth.backends.ModelBackend'
+])
 
 # If the debug toolbar is enabled, add the modules
 if DEBUG and CONFIG.get('debug_toolbar', False):

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -87,3 +87,20 @@ latex:
   interpreter: pdflatex 
   # Extra options to pass through to the LaTeX interpreter
   options: ''
+
+# Permit custom authentication backends
+#authentication_backends:
+#  - 'django.contrib.auth.backends.ModelBackend'
+
+#  Custom middleware, sometimes needed alongside an authentication backend change.
+#middleware:
+#  - 'django.middleware.security.SecurityMiddleware'
+#  - 'django.contrib.sessions.middleware.SessionMiddleware'
+#  - 'django.middleware.locale.LocaleMiddleware'
+#  - 'django.middleware.common.CommonMiddleware'
+#  - 'django.middleware.csrf.CsrfViewMiddleware'
+#  - 'corsheaders.middleware.CorsMiddleware'
+#  - 'django.contrib.auth.middleware.AuthenticationMiddleware'
+#  - 'django.contrib.messages.middleware.MessageMiddleware'
+#  - 'django.middleware.clickjacking.XFrameOptionsMiddleware'
+#  - 'InvenTree.middleware.AuthRequiredMiddleware'


### PR DESCRIPTION
It is useful to be able to customise the middleware / authentication_backends without editing settings.py. This PR optionally loads them from config.yaml.

My use case is to be able to add 'django.contrib.auth.middleware.RemoteUserMiddleware' to MIDDLEWARE  and set AUTHENTICATION_BACKENDS to 'django.contrib.auth.backends.RemoteUserBackend' to make inventree use the REMOTE_USER variable alongside client certificate TLS auth. 

I'm happy to maintain this change in a local branch if you're not keen, but I thought it might potentially be a useful option for others.