### PR TITLE
Fix internal server error when serializing stock with no location

### DIFF
--- a/InvenTree/stock/views.py
+++ b/InvenTree/stock/views.py
@@ -1120,7 +1120,8 @@ class StockItemSerialize(AjaxUpdateView):
 
         initials['quantity'] = item.quantity
         initials['serial_numbers'] = item.part.getSerialNumberString(item.quantity)
-        initials['destination'] = item.location.pk
+        if item.location is not None:
+            initials['destination'] = item.location.pk
 
         return initials
 


### PR DESCRIPTION
If you attempt to serialize stock which has no location, the following error occurs:

  File "inventree/InvenTree/stock/views.py", line 1123, in get_initial
    initials['destination'] = item.location.pk
AttributeError: 'NoneType' object has no attribute 'pk'

This is a trivial fix, and the following form offers to set a location, so there's no sense in making that a requirement. 