### PR TITLE
Loading stock item after creation and fixed form validation for 'dynamic' supplier part

### DIFF
--- a/InvenTree/stock/templates/stock/location.html
+++ b/InvenTree/stock/templates/stock/location.html
@@ -205,6 +205,7 @@
 
     $('#item-create').click(function () {
         createNewStockItem({
+            follow: true,
             data: {
                 {% if location %}
                 location: {{ location.id }}

--- a/InvenTree/stock/views.py
+++ b/InvenTree/stock/views.py
@@ -1273,8 +1273,12 @@ class StockItemCreate(AjaxCreateView):
             form.fields['supplier_part'].queryset = SupplierPart.objects.none()
 
         # Otherwise if the user has selected a SupplierPart, we know what Part they meant!
-        if form['supplier_part'].value() is not None:
-            pass
+        supplier_part = form['supplier_part'].value()
+        if supplier_part is not None:
+            # Check if supplier part is default
+            if not supplier_part.isdigit():
+                # Remove field from form (to prevent "dynamic" field validation)
+                form.fields.pop('supplier_part')
             
         return form
 


### PR DESCRIPTION
@SchrodingersGat I am not sure the behavior was intentional but after creating a stock item, there would be no redirect and the Stock index was shown and not updated. Instead I thought it would be better to show the newly created stock item, like it is showing the part details after a part creation.

Second thing, it looks like the new "dynamic" fields (#934) prevent form validation when reloaded and there is no further user interaction. Using the create stock item modal form, I was trying to select a Base part only and it would not validate the "supplier part". After immediately re-submitting, it would validate.
The way I fixed it was to remove the "supplier part" field from the form if user has not selected any item (eg. still at the default value `------`). I am not sure what could be a better way, I tried to overwrite the "supplier part" field in the Form instance with a `ModelChoiceField` and the `required=False` argument but it still wouldn't validate...