### PR TITLE
Fixed borders of navbar barcode button

### DIFF
--- a/InvenTree/InvenTree/static/css/inventree.css
+++ b/InvenTree/InvenTree/static/css/inventree.css
@@ -82,9 +82,10 @@
     float: left;
 }
 
-.navbar-barcode-li {
+#navbar-barcode-li {
     border-left: none;
     border-right: none;
+    padding-right: 5px;
 }
 
 .navbar-nav > li {

--- a/InvenTree/templates/navbar.html
+++ b/InvenTree/templates/navbar.html
@@ -36,7 +36,7 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
           {% include "search_form.html" %}
-          <li class ='navbar-barcode-li nav navbar-nav'>
+          <li id='navbar-barcode-li'>
             <button id='barcode-scan' class='btn btn-default' title='{% trans "Scan Barcode" %}'>
                 <span class='fas fa-qrcode'></span>
             </button>


### PR DESCRIPTION
`border: none` statements were overpowered, increased specificity.