### PR TITLE
Add the concept of "belongs to"/"installed in" to single output trackable builds

### DIFF
--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -405,9 +405,9 @@ class Build(MPTTModel):
                     subitem.belongs_to = build_output
                     subitem.save()
                     # Add a new note detailed the stock item has been installed into a build output
-                    subitem.addTransactionNote("Installed Items",
+                    subitem.addTransactionNote("Installed Item(s)",
                                                user,
-                                               "{} installed in {}".format(subitem, build_output))  # TODO check for serialized subparts
+                                               "{} installed in {}".format(subitem, build_output))
         else:
             # TODO: Installing stock items into multiple build outputs is not yet supported
             pass

--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -491,6 +491,9 @@ class BuildItem(models.Model):
 
         item = self.stock_item
 
+        # link the stock item to this specific build
+        item.belongs_to = self.build
+
         # Split the allocated stock if there are more available than allocated
         if item.quantity > self.quantity:
             item = item.splitStock(self.quantity, None, user)

--- a/InvenTree/build/test_build.py
+++ b/InvenTree/build/test_build.py
@@ -288,7 +288,6 @@ class BuildBelongsToTest(TestCase):
             description="A widget",
             component=True,
             trackable=True,
-
         )
         # Create BOM item links for the parts
         BomItem.objects.create(
@@ -331,7 +330,6 @@ class BuildBelongsToTest(TestCase):
             description="A widget",
             component=True,
             trackable=True,
-
         )
         # Create BOM item links for the parts
         BomItem.objects.create(

--- a/InvenTree/build/test_build.py
+++ b/InvenTree/build/test_build.py
@@ -241,23 +241,22 @@ class BuildBelongsToTest(TestCase):
             trackable=True,
         )
 
+    def test_build_single_output_untrackable_component(self):
         self.sub_part = Part.objects.create(
             name="Widget A",
             description="A widget",
-            component=True
+            component=True,
+            trackable=False
         )
-
         # Create BOM item links for the parts
         BomItem.objects.create(
             part=self.assembly,
             sub_part=self.sub_part,
             quantity=2
         )
-
         # Create some stock items to assign to the build
         self.stock = StockItem.objects.create(part=self.sub_part, quantity=100)
 
-    def test_build_single_output_untrackable_component(self):
         # Create a "Build" object to make 1x assembly
         self.build = Build.objects.create(
             title="This is a build",
@@ -282,3 +281,98 @@ class BuildBelongsToTest(TestCase):
         # Ensure that the component stock now "belongs_to" the build stock item ID
         self.assertEqual(3, self.build.build_outputs.all()[0].pk)  # confirm that the build output pk == 3
         self.assertEqual(allocated_stock.belongs_to_id, 3)  # confirm that the component stock items belong to ID 3
+
+    def test_build_single_output_trackable_component(self):
+        self.sub_part = Part.objects.create(
+            name="Widget A",
+            description="A widget",
+            component=True,
+            trackable=True,
+
+        )
+        # Create BOM item links for the parts
+        BomItem.objects.create(
+            part=self.assembly,
+            sub_part=self.sub_part,
+            quantity=1
+        )
+        # Create some stock items to assign to the build
+        self.stock = StockItem.objects.create(part=self.sub_part, quantity=1, serial="101")
+
+        # Create a "Build" object to make 1x assembly
+        self.build = Build.objects.create(
+            title="This is a build",
+            part=self.assembly,
+            quantity=1
+        )
+        # Create a new allocation
+        build_item = BuildItem(
+            build=self.build,
+            stock_item=self.stock,
+            quantity=1)
+        build_item.save()
+
+        self.assertTrue(self.build.isFullyAllocated())
+        self.build.completeBuild(None, [5], None)
+
+        # Ensure that we created an output with the expected serial number
+        self.assertEqual("5", StockItem.objects.filter(build=self.build)[0].serial)
+        # Ensure that there is 1 unit of stock allocated to the build
+        allocated_stock = StockItem.objects.filter(build_order=self.build)[0]
+        self.assertEqual(allocated_stock.quantity, Decimal(1))
+        # Ensure that the component stock now "belongs_to" the build stock item ID
+        self.assertEqual(2, self.build.build_outputs.all()[0].pk)  # confirm that the build output pk == 2
+        self.assertEqual(allocated_stock.belongs_to_id, 2)  # confirm that the component stock items belong to ID 2
+        self.assertEqual("101", allocated_stock.serial)
+
+    def test_build_single_output_trackable_two_components(self):
+        self.sub_part = Part.objects.create(
+            name="Widget A",
+            description="A widget",
+            component=True,
+            trackable=True,
+
+        )
+        # Create BOM item links for the parts
+        BomItem.objects.create(
+            part=self.assembly,
+            sub_part=self.sub_part,
+            quantity=2
+        )
+        # Create some stock items to assign to the build
+        self.stock_101 = StockItem.objects.create(part=self.sub_part, quantity=1, serial="101")
+        self.stock_102 = StockItem.objects.create(part=self.sub_part, quantity=1, serial="102")
+
+        # Create a "Build" object to make 1x assembly
+        self.build = Build.objects.create(
+            title="This is a build",
+            part=self.assembly,
+            quantity=1
+        )
+        # Create new allocations
+        build_item_101 = BuildItem(
+            build=self.build,
+            stock_item=self.stock_101,
+            quantity=1)
+        build_item_101.save()
+        build_item_102 = BuildItem(
+            build=self.build,
+            stock_item=self.stock_102,
+            quantity=1)
+        build_item_102.save()
+
+        self.assertTrue(self.build.isFullyAllocated())
+        self.build.completeBuild(None, [5], None)
+
+        # Ensure that we created an output with the expected serial number
+        self.assertEqual("5", StockItem.objects.filter(build=self.build)[0].serial)
+        # Ensure that there are 2 units of stock allocated to the build
+        allocated_stock = StockItem.objects.filter(build_order=self.build)
+        self.assertEqual(2, len(allocated_stock))
+        # Ensure that the component stock now "belongs_to" the build stock item ID
+        self.assertEqual(3, self.build.build_outputs.all()[0].pk)  # confirm that the build output pk == 3
+        serials_found = set()
+        for subpart_stock in allocated_stock:
+            self.assertEqual(subpart_stock.belongs_to_id, 3)  # confirm that the component stock items belong to ID 3
+            serials_found.add(subpart_stock.serial)
+        self.assertEqual({"101", "102"}, serials_found)

--- a/InvenTree/build/test_build.py
+++ b/InvenTree/build/test_build.py
@@ -279,8 +279,7 @@ class BuildBelongsToTest(TestCase):
         allocated_stock = StockItem.objects.filter(build_order=self.build)[0]
         self.assertEqual(allocated_stock.quantity, Decimal(2))
         # Ensure that the component stock now "belongs_to" the build stock item ID
-        self.assertEqual(3, self.build.build_outputs.all()[0].pk)  # confirm that the build output pk == 3
-        self.assertEqual(allocated_stock.belongs_to_id, 3)  # confirm that the component stock items belong to ID 3
+        self.assertEqual(allocated_stock.belongs_to_id, self.build.build_outputs.all()[0].pk)
 
     def test_build_single_output_trackable_component(self):
         self.sub_part = Part.objects.create(
@@ -320,8 +319,7 @@ class BuildBelongsToTest(TestCase):
         allocated_stock = StockItem.objects.filter(build_order=self.build)[0]
         self.assertEqual(allocated_stock.quantity, Decimal(1))
         # Ensure that the component stock now "belongs_to" the build stock item ID
-        self.assertEqual(2, self.build.build_outputs.all()[0].pk)  # confirm that the build output pk == 2
-        self.assertEqual(allocated_stock.belongs_to_id, 2)  # confirm that the component stock items belong to ID 2
+        self.assertEqual(allocated_stock.belongs_to_id, self.build.build_outputs.all()[0].pk)
         self.assertEqual("101", allocated_stock.serial)
 
     def test_build_single_output_trackable_two_components(self):
@@ -368,9 +366,8 @@ class BuildBelongsToTest(TestCase):
         allocated_stock = StockItem.objects.filter(build_order=self.build)
         self.assertEqual(2, len(allocated_stock))
         # Ensure that the component stock now "belongs_to" the build stock item ID
-        self.assertEqual(3, self.build.build_outputs.all()[0].pk)  # confirm that the build output pk == 3
         serials_found = set()
         for subpart_stock in allocated_stock:
-            self.assertEqual(subpart_stock.belongs_to_id, 3)  # confirm that the component stock items belong to ID 3
+            self.assertEqual(subpart_stock.belongs_to_id, self.build.build_outputs.all()[0].pk)
             serials_found.add(subpart_stock.serial)
         self.assertEqual({"101", "102"}, serials_found)

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -338,7 +338,7 @@ class StockItem(MPTTModel):
     )
 
     belongs_to = models.ForeignKey(
-        'self',
+        'build.Build',
         verbose_name=_('Installed In'),
         on_delete=models.DO_NOTHING,
         related_name='owned_parts', blank=True, null=True,

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -338,7 +338,7 @@ class StockItem(MPTTModel):
     )
 
     belongs_to = models.ForeignKey(
-        'build.Build',
+        'self',
         verbose_name=_('Installed In'),
         on_delete=models.DO_NOTHING,
         related_name='owned_parts', blank=True, null=True,


### PR DESCRIPTION
Multiple issues related to this PR but the most recent are #977 and #918 .
This PR only adds the concept of "belongs_to" for builds that meet the following criteria:

1. There is a single build output
2. The build part is trackable

It handles the case where the subparts are trackable as well as non-trackable.
There are follow-on features of "modifying" a build as well as supporting multiple build outputs (this would require a good deal of UI and a specific workflow) can be added later.

This is my first time working with a Django model so any feedback regarding conventions (the right way to query data for instance) is much appreciated! 