### PR TITLE
Fixed Group model permissions redundant saves

### DIFF
--- a/InvenTree/users/admin.py
+++ b/InvenTree/users/admin.py
@@ -97,15 +97,11 @@ class RoleGroupAdmin(admin.ModelAdmin):
     # Save inlines before model
     # https://stackoverflow.com/a/14860703/12794913
     def save_model(self, request, obj, form, change):
-        if obj is not None:
-            # Save model immediately only if in 'Add role' view
-            super().save_model(request, obj, form, change)
-        else:
-            pass  # don't actually save the parent instance
+        pass  # don't actually save the parent instance
 
     def save_formset(self, request, form, formset, change):
         formset.save()  # this will save the children
-        form.instance.save()  # form.instance is the parent
+        form.instance.save(update_fields=['name'])  # form.instance is the parent
 
 
 class InvenTreeUserAdmin(UserAdmin):

--- a/InvenTree/users/admin.py
+++ b/InvenTree/users/admin.py
@@ -101,6 +101,7 @@ class RoleGroupAdmin(admin.ModelAdmin):
 
     def save_formset(self, request, form, formset, change):
         formset.save()  # this will save the children
+        # update_fields is required to trigger permissions update
         form.instance.save(update_fields=['name'])  # form.instance is the parent
 
 

--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -155,8 +155,15 @@ class RuleSet(models.Model):
             model=model
         )
 
-    def __str__(self):
-        return self.name
+    def __str__(self, debug=False):
+        """ Ruleset string representation """
+        if debug:
+            # Makes debugging easier
+            return f'{str(self.group).ljust(15)}: {self.name.title().ljust(15)} | ' \
+                   f'v: {str(self.can_view).ljust(5)} | a: {str(self.can_add).ljust(5)} | ' \
+                   f'c: {str(self.can_change).ljust(5)} | d: {str(self.can_delete).ljust(5)}'
+        else:
+            return self.name
 
     def save(self, *args, **kwargs):
 
@@ -327,5 +334,8 @@ def create_missing_rule_sets(sender, instance, **kwargs):
     then we can now use these RuleSet values to update the
     group permissions.
     """
+    created = kwargs.get('created', False)
+    update_fields = kwargs.get('update_fields', None)
 
-    update_group_roles(instance)
+    if created or update_fields:
+        update_group_roles(instance)

--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -335,6 +335,7 @@ def create_missing_rule_sets(sender, instance, **kwargs):
     group permissions.
     """
     created = kwargs.get('created', False)
+    # To trigger the group permissions update: update_fields should not be None
     update_fields = kwargs.get('update_fields', None)
 
     if created or update_fields:

--- a/InvenTree/users/tests.py
+++ b/InvenTree/users/tests.py
@@ -137,7 +137,8 @@ class RuleSetModelTest(TestCase):
 
             rule.save()
 
-        group.save()
+        # update_fields is required to trigger permissions update
+        group.save(update_fields=['name'])
 
         # There should now be three permissions for each rule set
         self.assertEqual(group.permissions.count(), 3 * len(permission_set))
@@ -151,7 +152,8 @@ class RuleSetModelTest(TestCase):
 
             rule.save()
 
-        group.save()
+        # update_fields is required to trigger permissions update
+        group.save(update_fields=['name'])
 
         # There should now not be any permissions assigned to this group
         self.assertEqual(group.permissions.count(), 0)


### PR DESCRIPTION
Now only updating all permissions on Group creation and after Rulesets are saved.