### PR TITLE
fix error when submitting some non-dict barcodes

### DIFF
--- a/InvenTree/barcode/plugins/inventree_barcode.py
+++ b/InvenTree/barcode/plugins/inventree_barcode.py
@@ -42,6 +42,8 @@ class InvenTreeBarcodePlugin(BarcodePlugin):
         elif type(self.data) is str:
             try:
                 self.data = json.loads(self.data)
+                if type(self.data) is not dict:
+                    return False
             except json.JSONDecodeError:
                 return False
         else:

--- a/InvenTree/barcode/tests.py
+++ b/InvenTree/barcode/tests.py
@@ -56,6 +56,34 @@ class BarcodeAPITest(APITestCase):
         self.assertIn('plugin', data)
         self.assertIsNone(data['plugin'])
 
+    def test_integer_barcode(self):
+
+        response = self.postBarcode(self.scan_url, '123456789')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.data
+        self.assertIn('error', data)
+
+        self.assertIn('barcode_data', data)
+        self.assertIn('hash', data)
+        self.assertIn('plugin', data)
+        self.assertIsNone(data['plugin'])
+
+    def test_array_barcode(self):
+
+        response = self.postBarcode(self.scan_url, "['foo', 'bar']")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.data
+        self.assertIn('error', data)
+
+        self.assertIn('barcode_data', data)
+        self.assertIn('hash', data)
+        self.assertIn('plugin', data)
+        self.assertIsNone(data['plugin'])
+
     def test_barcode_generation(self):
 
         item = StockItem.objects.get(pk=522)


### PR DESCRIPTION
An assumption was made that json.loads() will always return an object with a .keys() function. However this is only true for a dict.

I noticed the issue by trying to search or add a 'barcode' that only contained numbers, which was parsed to int by json.loads(), and this then gave an error in the logs (line 54). All this happened silently for the user, without any indication of why this was not allowed on the UI side.

As I don't see why arbitrary strings like 'foobar' would be correct 'barcodes', while '123456789' or '["foo", "bar"]' wouldn't be, I think just handling all these strings in the same way (hashing them and using them as UID, unless another plugin picks them up) seems sensible.