### PR TITLE
Fix table sorting when groups are used.

### DIFF
--- a/InvenTree/InvenTree/static/script/inventree/tables.js
+++ b/InvenTree/InvenTree/static/script/inventree/tables.js
@@ -181,8 +181,15 @@ function customGroupSorter(sortName, sortOrder, sortData) {
     sortData.sort(function(a, b) {
 
         // Extract default field values
-        var aa = a[sortName];
-        var bb = b[sortName];
+        // Allow multi-level access if required
+        // Ref: https://stackoverflow.com/a/6394168
+
+        function extract(obj, i) {
+            return obj[i];
+        }
+
+        var aa = sortName.split('.').reduce(extract, a);
+        var bb = sortName.split('.').reduce(extract, b);
 
         // Extract parent information
         var aparent = a._data && a._data['parent-index'];

--- a/InvenTree/templates/js/stock.html
+++ b/InvenTree/templates/js/stock.html
@@ -274,16 +274,16 @@ function loadStockTable(table, options) {
 
             var row = data[0];
 
-            if (field == 'part_name') {
+            if (field == 'part_detail.name') {
 
                 var name = row.part_detail.full_name;
 
                 return imageHoverIcon(row.part_detail.thumbnail) + name + ' <i>(' + data.length + ' items)</i>';
             }
-            else if (field == 'IPN') {
+            else if (field == 'part_detail.IPN') {
                 return row.part_detail.IPN;
             }
-            else if (field == 'part_description') {
+            else if (field == 'part_detail.description') {
                 return row.part_detail.description;
             }
             else if (field == 'quantity') {
@@ -417,9 +417,10 @@ function loadStockTable(table, options) {
                 switchable: false,
             },
             {
-                field: 'part_name',
+                field: 'part_detail.name',
                 title: '{% trans "Part" %}',
                 sortable: true,
+                switchable: false,
                 formatter: function(value, row, index, field) {
 
                     var url = `/stock/item/${row.pk}/`;
@@ -432,7 +433,7 @@ function loadStockTable(table, options) {
                 }
             },
             {
-                field: 'IPN',
+                field: 'part_detail.IPN',
                 title: 'IPN',
                 sortable: true,
                 formatter: function(value, row, index, field) {
@@ -440,7 +441,7 @@ function loadStockTable(table, options) {
                 },
             },
             {
-                field: 'part_description',
+                field: 'part_detail.description',
                 title: '{% trans "Description" %}',
                 sortable: true,
                 formatter: function(value, row, index, field) {


### PR DESCRIPTION
This is necessary because the field names of the tables are specified like "part_detail.IPN" and multi-level string-based object access is weird.
Luckily someone has worked out the hard part for me.

Ref: https://stackoverflow.com/questions/6393943/convert-javascript-string-in-dot-notation-into-an-object-reference

Fixes https://github.com/inventree/InvenTree/issues/1057