### PR TITLE
Bug fix: Part thumbnail API list was not working

### DIFF
--- a/InvenTree/company/templates/company/index.html
+++ b/InvenTree/company/templates/company/index.html
@@ -15,7 +15,9 @@ InvenTree | {% trans "Supplier List" %}
 {% if pagetype == 'manufacturers' and roles.purchase_order.add or pagetype == 'suppliers' and roles.purchase_order.add or pagetype == 'customers' and roles.sales_order.add %}
 <div id='button-toolbar'>
     <div class='btn-group'>
-        <button type='button' class="btn btn-success" id='new-company'>{{ button_text }}</button>
+        <button type='button' class="btn btn-success" id='new-company'>
+            <span class='fas fa-plus-circle'></span> {{ button_text }}
+        </button>
     </div>
 </div>
 {% endif %}

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -186,9 +186,21 @@ class PartTestTemplateList(generics.ListCreateAPIView):
 
 
 class PartThumbs(generics.ListAPIView):
-    """ API endpoint for retrieving information on available Part thumbnails """
+    """
+    API endpoint for retrieving information on available Part thumbnails
+    """
 
+    queryset = Part.objects.all()
     serializer_class = part_serializers.PartThumbSerializer
+
+    def get_queryset(self):
+
+        queryset = super().get_queryset()
+
+        # Get all Parts which have an associated image
+        queryset = queryset.exclude(image='')
+        
+        return queryset
 
     def list(self, request, *args, **kwargs):
         """
@@ -196,8 +208,7 @@ class PartThumbs(generics.ListAPIView):
         - Images may be used for multiple parts!
         """
 
-        # Get all Parts which have an associated image
-        queryset = Part.objects.all().exclude(image='')
+        queryset = self.get_queryset()
 
         # TODO - We should return the thumbnails here, not the full image!
 

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -241,6 +241,17 @@ class PartAPITest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_get_thumbs(self):
+        """
+        Return list of part thumbnails
+        """
+
+        url = reverse('api-part-thumbs')
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
 class PartAPIAggregationTest(APITestCase):
     """


### PR DESCRIPTION
- Part images could not be selected from grid

Adds some unit testing that would have caught this problem..