### PR TITLE
Set the specified location of a build output

### DIFF
--- a/InvenTree/build/forms.py
+++ b/InvenTree/build/forms.py
@@ -66,7 +66,7 @@ class BuildOutputCreateForm(HelperForm):
         'serial_numbers': 'fa-hashtag',
     }
 
-    quantity = forms.IntegerField(
+    output_quantity = forms.IntegerField(
         label=_('Quantity'),
         help_text=_('Enter quantity for build output'),
     )
@@ -86,7 +86,7 @@ class BuildOutputCreateForm(HelperForm):
     class Meta:
         model = Build
         fields = [
-            'quantity',
+            'output_quantity',
             'batch',
             'serial_numbers',
             'confirm',

--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -183,6 +183,14 @@ class Build(MPTTModel):
     )
 
     @property
+    def active(self):
+        """
+        Return True if this build is active
+        """
+
+        return self.status in BuildStatus.ACTIVE_CODES
+
+    @property
     def bom_items(self):
         """
         Returns the BOM items for the part referenced by this BuildOrder

--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -594,6 +594,9 @@ class Build(MPTTModel):
         - Mark the output as complete
         """
 
+        # Select the location for the build output
+        location = kwargs.get('location', self.destination)
+
         # List the allocated BuildItem objects for the given output
         allocated_items = output.items_to_install.all()
 
@@ -613,6 +616,7 @@ class Build(MPTTModel):
         # Ensure that the output is updated correctly
         output.build = self
         output.is_building = False
+        output.location = location
 
         output.save()
 

--- a/InvenTree/build/templates/build/allocate.html
+++ b/InvenTree/build/templates/build/allocate.html
@@ -21,6 +21,7 @@ InvenTree | Allocate Parts
 </div>
 {% else %}
 <div class='btn-group' role='group'>
+    {% if build.active %}
     <button class='btn btn-primary' type='button' id='btn-create-output' title='{% trans "Create new build output" %}'>
         <span class='fas fa-plus-circle'></span> {% trans "Create New Output" %}
     </button>
@@ -32,6 +33,7 @@ InvenTree | Allocate Parts
     <button class='btn btn-danger' type='button' id='btn-unallocate' title='{% trans "Unallocate stock" %}'>
         <span class='fas fa-minus-circle'></span> {% trans "Unallocate Stock" %}
     </button>
+    {% endif %}
 </div>
 
 <hr>
@@ -74,7 +76,7 @@ InvenTree | Allocate Parts
     );
     {% endfor %}
 
-    {% if build.status == BuildStatus.PENDING %}
+    {% if build.active %}
     $("#btn-allocate").on('click', function() {
         launchModalForm(
             "{% url 'build-auto-allocate' build.id %}",

--- a/InvenTree/build/views.py
+++ b/InvenTree/build/views.py
@@ -188,7 +188,7 @@ class BuildOutputCreate(AjaxUpdateView):
         Validation for the form:
         """
 
-        quantity = form.cleaned_data.get('quantity', None)
+        quantity = form.cleaned_data.get('output_quantity', None)
         serials = form.cleaned_data.get('serial_numbers', None)
 
         # Check that the serial numbers are valid
@@ -222,7 +222,7 @@ class BuildOutputCreate(AjaxUpdateView):
 
         data = form.cleaned_data
 
-        quantity = data.get('quantity', None)
+        quantity = data.get('output_quantity', None)
         batch = data.get('batch', None)
 
         serials = data.get('serial_numbers', None)


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/1104

- [x] Build Quantity field is set to partial build output after the later is created
- [x] Build Outputs shows 1 tag before any partial build is completed
- [x] Create New Output button (under "Allocated Parts" tab) stops working after partial build output is created
- [x] If Destination Location is not set, partial build output shows "No stock location set" under Location column