### PR TITLE
Fix PostGreSQL migration (permissions handler)

### DIFF
--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -316,7 +316,8 @@ def update_group_roles(group, debug=False):
 
         permission = get_permission_object(perm)
 
-        group.permissions.add(permission)
+        if permission:
+            group.permissions.add(permission)
 
         if debug:
             print(f"Adding permission {perm} to group {group.name}")

--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -331,7 +331,8 @@ def update_group_roles(group, debug=False):
 
         permission = get_permission_object(perm)
 
-        group.permissions.remove(permission)
+        if permission:
+            group.permissions.remove(permission)
 
         if debug:
             print(f"Removing permission {perm} from group {group.name}")


### PR DESCRIPTION
It looks like `Group.permissions.add()` method handles well NoneType with SQLite but not with PostGreSQL.
So if `get_permission_object()` method returns `None` for the permission, you'll get an error during migration on PostGreSQL database, something like:
```
psycopg2.errors.NotNullViolation: null value in column "permission_id" violates not-null constraint
DETAIL:  Failing row contains (258, 1, null).
```
The error track showed:
```
File "/home/elec/InvenTree/inventree-main/InvenTree/users/models.py", line 319, in update_group_roles
    group.permissions.add(permission)
```
to be the culprit. As permission was of NoneType, psycopg2 chocked.