### PR TITLE
Fix for #1111 (missing logic to check for model errors)

### DIFF
--- a/InvenTree/InvenTree/forms.py
+++ b/InvenTree/InvenTree/forms.py
@@ -27,7 +27,11 @@ class HelperForm(forms.ModelForm):
         self.helper = FormHelper()
 
         self.helper.form_tag = False
-        self.helper.form_show_errors = False
+
+        # Check for errors from model validation
+        # If none, disable crispy form errors
+        if not self.errors:
+            self.helper.form_show_errors = False
 
         """
         Create a default 'layout' for this form.


### PR DESCRIPTION
Field errors from model validation were not displayed anymore (reference #1111)