### PR TITLE
Add requirement for django-error-report

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -155,6 +155,8 @@ INSTALLED_APPS = [
     'markdownify',                  # Markdown template rendering
     'django_tex',                   # LaTeX output
     'django_admin_shell',           # Python shell for the admin interface
+    'error_report',                 # Error reporting in the admin interface
+
 ]
 
 LOGGING = {
@@ -180,6 +182,9 @@ MIDDLEWARE = CONFIG.get('middleware', [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'InvenTree.middleware.AuthRequiredMiddleware'
 ])
+
+# Error reporting middleware
+MIDDLEWARE.append('error_report.middleware.ExceptionProcessor')
 
 AUTHENTICATION_BACKENDS = CONFIG.get('authentication_backends', [
     'django.contrib.auth.backends.ModelBackend'

--- a/InvenTree/InvenTree/urls.py
+++ b/InvenTree/InvenTree/urls.py
@@ -126,6 +126,7 @@ urlpatterns = [
     url(r'^edit-user/', EditUserView.as_view(), name='edit-user'),
     url(r'^set-password/', SetPasswordView.as_view(), name='set-password'),
 
+    url(r'^admin/error_log/', include('error_report.urls')),
     url(r'^admin/shell/', include('django_admin_shell.urls')),
     url(r'^admin/', admin.site.urls, name='inventree-admin'),
 

--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -109,6 +109,9 @@ class RuleSet(models.Model):
         'report_reportasset',
         'report_testreport',
         'part_partstar',
+
+        # Third-party tables
+        'error_report_error',
     ]
 
     RULE_OPTIONS = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,6 @@ django-tex==1.1.7               # LaTeX PDF export
 django-weasyprint==1.0.1        # HTML PDF export
 django-debug-toolbar==2.2       # Debug / profiling toolbar
 django-admin-shell==0.1.2       # Python shell for the admin interface
+django-error-report==0.2.0      # Error report viewer for the admin interface
 
 inventree                       # Install the latest version of the InvenTree API python library


### PR DESCRIPTION
- Provides an error log viewer in the admin interface at /admin/error_report/error/
- Allows viewing of error logs even in a remote production environment (i.e. no access to command line)