### PR TITLE
Fixed disabling of form errors messing-up with global settings validation

### DIFF
--- a/InvenTree/InvenTree/forms.py
+++ b/InvenTree/InvenTree/forms.py
@@ -29,11 +29,6 @@ class HelperForm(forms.ModelForm):
 
         self.helper.form_tag = False
 
-        # Check for errors from model validation
-        # If none, disable crispy form errors
-        if not self.errors:
-            self.helper.form_show_errors = False
-
         """
         Create a default 'layout' for this form.
         Ref: https://django-crispy-forms.readthedocs.io/en/latest/layouts.html
@@ -43,6 +38,17 @@ class HelperForm(forms.ModelForm):
         """
 
         self.rebuild_layout()
+
+    def is_valid(self):
+
+        valid = super(HelperForm, self).is_valid()
+
+        # Check for errors from model validation
+        # If none, disable crispy form errors
+        if not self.errors:
+            self.helper.form_show_errors = False
+
+        return valid
 
     def rebuild_layout(self):
 


### PR DESCRIPTION
As it turns out, accessing `form.errors` triggers a form validation:
https://docs.djangoproject.com/en/3.1/ref/forms/api/#django.forms.Form.errors

> You can access errors without having to call is_valid() first. The form’s data will be validated the first time either you call is_valid() or access errors.

And it was a BAD thing to call it inside the `__init__` method, causing early form validation errors and problems toggling the Part global settings.

Now overwriting the `is_valid()` method of `HelperForm` seems to do it. I tested the forms in multiple places and don't have either duplicate error messages or validation errors...