### PR TITLE
Check that category was selected before fetching templates

### DIFF
--- a/InvenTree/part/forms.py
+++ b/InvenTree/part/forms.py
@@ -215,6 +215,7 @@ class EditPartForm(HelperForm):
     class Meta:
         model = Part
         fields = [
+            'confirm_creation',
             'category',
             'selected_category_templates',
             'parent_category_templates',
@@ -224,7 +225,6 @@ class EditPartForm(HelperForm):
             'revision',
             'bom_copy',
             'parameters_copy',
-            'confirm_creation',
             'keywords',
             'variant_of',
             'link',

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -350,7 +350,7 @@ class Part(MPTTModel):
             # Get part category
             category = self.category
 
-            if add_category_templates:
+            if category and add_category_templates:
                 # Store templates added to part
                 template_list = []
 


### PR DESCRIPTION
@SchrodingersGat This also moved back the `confirm_validation` field up on top for the Part creation form, it was buried in the middle of the form.

### Before

![image](https://user-images.githubusercontent.com/4020546/99001142-5ae73500-2508-11eb-8e0a-d546a86d3c2c.png)

### After

![image](https://user-images.githubusercontent.com/4020546/99001206-75b9a980-2508-11eb-8266-8dc0ca11b0c9.png)
