### PR TITLE
Fix for SupplierPart edit form validation

### DIFF
--- a/InvenTree/company/views.py
+++ b/InvenTree/company/views.py
@@ -274,6 +274,12 @@ class SupplierPartEdit(AjaxUpdateView):
     def get_form(self):
         form = super().get_form()
 
+        supplier_part = self.get_object()
+
+        # It appears that hiding a MoneyField fails validation
+        # Therefore the idea to set the value before hiding
+        if form.is_valid():
+             form.cleaned_data['single_pricing'] = supplier_part.unit_pricing
         # Hide the single-pricing field (only for creating a new SupplierPart!)
         form.fields['single_pricing'].widget = HiddenInput()
 

--- a/InvenTree/company/views.py
+++ b/InvenTree/company/views.py
@@ -279,7 +279,7 @@ class SupplierPartEdit(AjaxUpdateView):
         # It appears that hiding a MoneyField fails validation
         # Therefore the idea to set the value before hiding
         if form.is_valid():
-             form.cleaned_data['single_pricing'] = supplier_part.unit_pricing
+            form.cleaned_data['single_pricing'] = supplier_part.unit_pricing
         # Hide the single-pricing field (only for creating a new SupplierPart!)
         form.fields['single_pricing'].widget = HiddenInput()
 


### PR DESCRIPTION
This one was rather strange... if one attempted to edit a SupplierPart item, the form wouldn't validate because the hidden field `single_pricing` (a `MoneyField` instance) made the validation failed, despite being optional.