### PR TITLE
Vastly improved speed of BOM upload

### DIFF
--- a/InvenTree/part/templates/part/bom_upload/select_fields.html
+++ b/InvenTree/part/templates/part/bom_upload/select_fields.html
@@ -59,7 +59,7 @@
                             {% endfor %}
                     </select>
                     {% if col.duplicate %}
-                    <p class='help-inline'>Duplicate column selection</p>
+                    <p class='help-inline'>{% trans "Duplicate column selection" %}</p>
                     {% endif %}
                 </td>
                 {% endfor %}

--- a/InvenTree/part/templates/part/bom_upload/select_parts.html
+++ b/InvenTree/part/templates/part/bom_upload/select_parts.html
@@ -63,7 +63,7 @@
                         <option value=''>--- {% trans "Select Part" %} ---</option>
                         {% for part in row.part_options %}
                         <option value='{{ part.id }}' {% if part.id == row.part.id %} selected='selected' {% elif part.id == row.part_match.id %} selected='selected' {% endif %}>
-                            {{ part }} - {{ part.available_stock }}
+                            {{ part }}
                         </option>
                         {% endfor %}
                     </select>


### PR DESCRIPTION
- Was calculating the stock levels for *every* part, for *every* drop down
- Many many many calls were being made
- Just remove stock count entirely from the drop-down menus