### PR TITLE
Fixed category parameter templates settings view

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -130,7 +130,7 @@ class CategoryParameters(generics.ListAPIView):
         """
 
         try:
-            cat_id = int(self.request.query_params.get('category', None))
+            cat_id = int(self.kwargs.get('pk', None))
         except TypeError:
             cat_id = None
         fetch_parent = str2bool(self.request.query_params.get('fetch_parent', 'true'))
@@ -910,8 +910,8 @@ part_api_urls = [
 
     # Base URL for PartCategory API endpoints
     url(r'^category/', include([
+        url(r'^(?P<pk>\d+)/parameters/?', CategoryParameters.as_view(), name='api-part-category-parameters'),
         url(r'^(?P<pk>\d+)/?', CategoryDetail.as_view(), name='api-part-category-detail'),
-        url(r'^parameters/?', CategoryParameters.as_view(), name='api-part-category-parameters'),
         url(r'^$', CategoryList.as_view(), name='api-part-category-list'),
     ])),
 

--- a/InvenTree/templates/InvenTree/settings/category.html
+++ b/InvenTree/templates/InvenTree/settings/category.html
@@ -45,7 +45,7 @@
 
 {% if category %}
 	$("#param-table").inventreeTable({
-        url: "{% url 'api-part-category-parameters' category.pk %}",
+        url: "{% url 'api-part-category-parameters' pk=category.pk %}",
         queryParams: {
             ordering: 'name',
         },
@@ -58,7 +58,7 @@
                 switchable: false,
             },
             {
-                field: 'parameter_template_detail.name',
+                field: 'parameter_template.name',
                 title: '{% trans "Parameter Template" %}',
                 sortable: 'true',
             },


### PR DESCRIPTION
Previous to this fix, the Category parameter templates settings view resulted in error with URL reverse when a category was selected