### PR TITLE
Keep 'stock actions' button enabled when on children tab

### DIFF
--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -114,7 +114,7 @@ InvenTree | {% trans "Stock Item" %} - {{ item }}
     <!-- Stock adjustment menu -->
     {% if roles.stock.change and not item.is_building %}
     <div class='btn-group'>
-        <button id='stock-options' title='{% trans "Stock adjustment actions" %}' class='btn btn-default dropdown-toggle' type='button' data-toggle='dropdown'><span class='fas fa-boxes'></span> <span class='caret'></span></button>
+        <button id='stock-actions' title='{% trans "Stock adjustment actions" %}' class='btn btn-default dropdown-toggle' type='button' data-toggle='dropdown'><span class='fas fa-boxes'></span> <span class='caret'></span></button>
         <ul class='dropdown-menu' role='menu'>
             {% if item.in_stock %}
             {% if not item.serialized %}


### PR DESCRIPTION
Bug was in the Stock item detail view when the "Children" tab is selected (ex: http://127.0.0.1:8000/stock/item/1/children/).

## Before
![image](https://user-images.githubusercontent.com/4020546/102552438-39d9ad00-408f-11eb-84ee-7c2356992340.png)

## With Fix
![image](https://user-images.githubusercontent.com/4020546/102552385-20d0fc00-408f-11eb-8a70-804414d8ab50.png)

## Root Cause
The `stock_table.html` file already contains a `<button id='stock-options' ...>` button group with the same id (`stock-options`) as the one present on the Stock item detail page (in `item_base.html`). The button group in the `stock_table.html` is referenced in multiple places, whereas the button group on the Stock item detail page is not. Therefore I renamed the ID for the later to `stock-actions`.