### PR TITLE
Fix (?) for "create new stock item" form validation when called from part detail view

### DIFF
--- a/InvenTree/stock/views.py
+++ b/InvenTree/stock/views.py
@@ -1522,7 +1522,10 @@ class StockItemCreate(AjaxCreateView):
             form.rebuild_layout()
 
             if not part.purchaseable:
-                form.fields['purchase_price'].widget = HiddenInput()
+                # Disabling purchase_price field makes validation fail
+                # when form is called from the part detail page (Stock tab)
+                # form.fields['purchase_price'].widget = HiddenInput()
+                form.fields['purchase_price'].disabled = True
 
             # Hide the 'part' field (as a valid part is selected)
             # form.fields['part'].widget = HiddenInput()


### PR DESCRIPTION
I ran into this weird validation issue, to reproduce:
- navigate to part detail view (eg. /part/1)
- make the part **not** purchasable
- click on "Stock" tab
- Click on "New Stock Item" button
- Try to submit the form

Form will return an error (not displayed) and won't let user create a new stock item.

Debugging the error, I found it was related to the `purchase_price` field, here is the form error HTML:
``` html
<ul class="errorlist"><li>purchase_price<ul class="errorlist"><li>Enter a list of values.</li></ul></li></ul>
```

I don't exactly understand why the field failed validation, it looks like crispy form expect a value and the `get_initial` method is not able to feed it through.

My proposed "fix" (more like a band-aid) is to disable that field instead of calling the `HiddenInput()` method, this strangely works fine...

@SchrodingersGat If you have a better idea what's happening and how to solve it, I would be keen to hear it.