### PR TITLE
Fix variable scope issue

### DIFF
--- a/InvenTree/part/forms.py
+++ b/InvenTree/part/forms.py
@@ -319,7 +319,9 @@ class EditBomItemForm(HelperForm):
         ]
 
         # Prevent editing of the part associated with this BomItem
-        widgets = {'part': forms.HiddenInput()}
+        widgets = {
+            'part': forms.HiddenInput()
+        }
 
 
 class PartPriceForm(forms.Form):

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1074,7 +1074,7 @@ class Part(MPTTModel):
 
         self.bom_items.all().delete()
 
-    def getRequiredParts(self, recursive=False, parts=set()):
+    def getRequiredParts(self, recursive=False, parts=None):
         """
         Return a list of parts required to make this part (i.e. BOM items).
 
@@ -1083,7 +1083,10 @@ class Part(MPTTModel):
             parts: Set of parts already found (to prevent recursion issues)
         """
 
-        items = self.bom_items.all().prefetch_related('sub_part')
+        if parts is None:
+            parts = set()
+
+        items = BomItem.objects.filter(part=self.pk)
 
         for bom_item in items:
 

--- a/InvenTree/part/templates/part/bom.html
+++ b/InvenTree/part/templates/part/bom.html
@@ -32,7 +32,7 @@
     <div class="btn-group" role="group" aria-label="...">
         {% if editing_enabled %}
         <button class='btn btn-default' type='button' title='{% trans "Remove selected BOM items" %}' id='bom-item-delete'>
-            <span class='fas fa-trash-alt'></span>
+            <span class='fas fa-trash-alt icon-red'></span>
         </button>
         <button class='btn btn-primary' type='button' title='{% trans "Import BOM data" %}' id='bom-upload'>
             <span class='fas fa-file-upload'></span> {% trans "Import from File" %}


### PR DESCRIPTION
Incorrect variable scope would result in a cached `set` being provided to the getRequiredParts function

Fixes https://github.com/inventree/InvenTree/issues/1160