### PR TITLE
Allow user with part.change permission to delete BOM items, part attachments and parameters

### DIFF
--- a/InvenTree/part/templates/part/params.html
+++ b/InvenTree/part/templates/part/params.html
@@ -37,7 +37,7 @@
                     {% if roles.part.change %}
                     <button title='{% trans "Edit" %}' class='btn btn-default btn-glyph param-edit' url="{% url 'part-param-edit' param.id %}" type='button'><span class='fas fa-edit'/></button>
                     {% endif %}
-                    {% if roles.part.delete %}
+                    {% if roles.part.change %}
                     <button title='{% trans "Delete" %}' class='btn btn-default btn-glyph param-delete' url="{% url 'part-param-delete' param.id %}" type='button'><span class='fas fa-trash-alt icon-red'/></button>
                     {% endif %}
                 </div>

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -2554,7 +2554,7 @@ class BomItemDelete(AjaxDeleteView):
     context_object_name = 'item'
     ajax_form_title = _('Confim BOM item deletion')
 
-    role_required = 'part.delete'
+    role_required = 'part.change'
 
 
 class PartSalePriceBreakCreate(AjaxCreateView):

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -231,7 +231,7 @@ class PartAttachmentDelete(AjaxDeleteView):
     ajax_template_name = "attachment_delete.html"
     context_object_name = "attachment"
 
-    role_required = 'part.delete'
+    role_required = 'part.change'
 
     def get_data(self):
         return {
@@ -2073,7 +2073,7 @@ class PartParameterEdit(AjaxUpdateView):
 class PartParameterDelete(AjaxDeleteView):
     """ View for deleting a PartParameter """
 
-    role_required = 'part.delete'
+    role_required = 'part.change'
 
     model = PartParameter
     ajax_template_name = 'part/param_delete.html'


### PR DESCRIPTION
I think they deserve it :smile: 

And more seriously, it should be allowed IMO.
Any object connected to a Part instance should be able to be deleted if `part.change` permission is granted.
However, user should **NOT** be able to delete the part itself if missing the `part.delete` permision, does it make sense?