### PR TITLE
Add option to show part quantity in various forms

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -160,6 +160,13 @@ class InvenTreeSetting(models.Model):
             'validator': bool,
         },
 
+        'PART_SHOW_QUANTITY_IN_FORMS': {
+            'name': _('Show Quantity in Forms'),
+            'description': _('Display available part quantity in some forms'),
+            'default': True,
+            'validator': bool,
+        },
+
         'STOCK_ENABLE_EXPIRY': {
             'name': _('Stock Expiry'),
             'description': _('Enable stock expiry functionality'),

--- a/InvenTree/part/forms.py
+++ b/InvenTree/part/forms.py
@@ -13,6 +13,8 @@ from mptt.fields import TreeNodeChoiceField
 from django import forms
 from django.utils.translation import ugettext as _
 
+import common.models
+
 from .models import Part, PartCategory, PartAttachment, PartRelated
 from .models import BomItem
 from .models import PartParameterTemplate, PartParameter
@@ -23,8 +25,16 @@ from .models import PartSellPriceBreak
 
 class PartModelChoiceField(forms.ModelChoiceField):
     """ Extending string representation of Part instance with available stock """
+
     def label_from_instance(self, part):
-        return f'{part} - {part.available_stock}'
+
+        label = str(part)
+
+        # Optionally display available part quantity
+        if common.models.InvenTreeSetting.get_setting('PART_SHOW_QUANTITY_IN_FORMS'):
+            label += f" - {part.available_stock}"
+
+        return label
 
 
 class PartImageForm(HelperForm):

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1990,7 +1990,13 @@ class BomItem(models.Model):
         Return the available stock items for the referenced sub_part
         """
 
-        query = self.sub_part.stock_items.filter(StockModels.StockItem.IN_STOCK_FILTER).aggregate(
+        query = self.sub_part.stock_items.all()
+        
+        query = query.prefetch_related([
+            'sub_part__stock_items',
+        ])
+
+        query = query.filter(StockModels.StockItem.IN_STOCK_FILTER).aggregate(
             available=Coalesce(Sum('quantity'), 0)
         )
 

--- a/InvenTree/templates/InvenTree/settings/part.html
+++ b/InvenTree/templates/InvenTree/settings/part.html
@@ -18,6 +18,7 @@
     <tbody>
         {% include "InvenTree/settings/setting.html" with key="PART_IPN_REGEX" %}
         {% include "InvenTree/settings/setting.html" with key="PART_ALLOW_DUPLICATE_IPN" %}
+        {% include "InvenTree/settings/setting.html" with key="PART_SHOW_QUANTITY_IN_FORMS" icon="fa-hashtag" %}
         <tr><td colspan='5  '></td></tr>
         {% include "InvenTree/settings/setting.html" with key="PART_TEMPLATE" icon="fa-clone" %}
         {% include "InvenTree/settings/setting.html" with key="PART_ASSEMBLY" icon="fa-tools" %}


### PR DESCRIPTION
Enabling this option can make BOM item forms *very* slow!

Fixes https://github.com/inventree/InvenTree/issues/979