### PR TITLE
Fix misspelled query filter method name

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -455,7 +455,7 @@ class SalesOrder(Order):
         """
 
         query = SalesOrder.objects.filter(pk=self.pk)
-        query = query.filer(SalesOrder.OVERDUE_FILTER)
+        query = query.filter(SalesOrder.OVERDUE_FILTER)
 
         return query.exists()
 


### PR DESCRIPTION
Opening a sales order will break because query.filter was misspelled.