### PR TITLE
Remove regex search functionality from part api

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -665,9 +665,9 @@ class PartList(generics.ListCreateAPIView):
     ordering = 'name'
 
     search_fields = [
-        '$name',
+        'name',
         'description',
-        '$IPN',
+        'IPN',
         'keywords',
     ]
 


### PR DESCRIPTION
Regex search implementation would error out when special characters were used