### PR TITLE
Fix for SupplierPart API permissions

### DIFF
--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -68,6 +68,7 @@ class RuleSet(models.Model):
             'part_partparameter',
             'part_partrelated',
             'part_partstar',
+            'part_supplierpart',
         ],
         'stock_location': [
             'stock_stocklocation',


### PR DESCRIPTION
Missing `part_supplierpart` table permissions