### PR TITLE
Pagination Bug Fix

### DIFF
--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -412,7 +412,23 @@ class SOLineItemList(generics.ListCreateAPIView):
 
         return queryset
 
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [
+        DjangoFilterBackend,
+        filters.SearchFilter,
+        filters.OrderingFilter
+    ]
+
+    ordering_fields = [
+        'part__name',
+        'quantity',
+        'reference',
+    ]
+
+    search_fields = [
+        'part__name',
+        'quantity',
+        'reference',
+    ]
 
     filter_fields = [
         'order',

--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -200,6 +200,22 @@ class POLineItemList(generics.ListCreateAPIView):
 
     filter_backends = [
         DjangoFilterBackend,
+        filters.SearchFilter,
+        filters.OrderingFilter
+    ]
+
+    ordering_fields = [
+        'part__part__name',
+        'part__MPN',
+        'part__SKU',
+        'reference',
+        'quantity',
+        'received',
+    ]
+
+    search_Fields = [
+        'part__part__name',
+        'part__part__description',
     ]
 
     filter_fields = [

--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -213,9 +213,12 @@ class POLineItemList(generics.ListCreateAPIView):
         'received',
     ]
 
-    search_Fields = [
+    search_fields = [
         'part__part__name',
         'part__part__description',
+        'part__MPN',
+        'part__SKU',
+        'reference',
     ]
 
     filter_fields = [

--- a/InvenTree/order/templates/order/purchase_order_detail.html
+++ b/InvenTree/order/templates/order/purchase_order_detail.html
@@ -135,6 +135,7 @@ function setupCallbacks() {
 $("#po-table").inventreeTable({
     onPostBody: setupCallbacks,
     name: 'purchaseorder',
+    sidePagination: 'server',
     formatNoMatches: function() { return "{% trans 'No line items found' %}"; },
     queryParams: {
         order: {{ order.id }},
@@ -151,6 +152,7 @@ $("#po-table").inventreeTable({
         {
             field: 'part',
             sortable: true,
+            sortName: 'part__part__name',
             title: '{% trans "Part" %}',
             switchable: false,
             formatter: function(value, row, index, field) {
@@ -162,17 +164,23 @@ $("#po-table").inventreeTable({
             },
         },
         {
-            sortable: true,
             field: 'part_detail.description',
             title: '{% trans "Description" %}',
         },
         {
             sortable: true,
+            sortName: 'part__SKU',
             field: 'supplier_part_detail.SKU',
-            title: '{% trans "Order Code" %}',
+            title: '{% trans "SKU" %}',
             formatter: function(value, row, index, field) {
                 return renderLink(value, `/supplier-part/${row.part}/`);
             },
+        },
+        {
+            sortable: true,
+            sortName: 'part__MPN',
+            field: 'supplier_part_detail.MPN',
+            title: '{% trans "MPN" %}',
         },
         {
             sortable: true,

--- a/InvenTree/order/templates/order/sales_order_detail.html
+++ b/InvenTree/order/templates/order/sales_order_detail.html
@@ -173,6 +173,7 @@ $("#so-lines-table").inventreeTable({
         part_detail: true,
         allocations: true,
     },
+    sidePagination: 'server',
     uniqueId: 'pk',
     url: "{% url 'api-so-line-list' %}",
     onPostBody: setupCallbacks,
@@ -201,6 +202,7 @@ $("#so-lines-table").inventreeTable({
         },
         {
             sortable: true,
+            sortName: 'part__name',
             field: 'part',
             title: 'Part',
             formatter: function(value, row, index, field) {
@@ -222,7 +224,6 @@ $("#so-lines-table").inventreeTable({
             title: 'Quantity',
         },
         {
-            sortable: true,
             field: 'allocated',
             {% if order.status == SalesOrderStatus.PENDING %}
             title: '{% trans "Allocated" %}',

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -853,7 +853,9 @@ class StockList(generics.ListCreateAPIView):
         'status',
     ]
 
-    ordering = ['part__name']
+    ordering = [
+        'part__name'
+    ]
 
     search_fields = [
         'serial',

--- a/InvenTree/templates/js/tables.js
+++ b/InvenTree/templates/js/tables.js
@@ -145,10 +145,7 @@ $.fn.inventreeTable = function(options) {
     var filters = options.queryParams || options.filters || {};
 
     options.queryParams = function(params) {
-        for (var key in filters) {
-            params[key] = filters[key];
-        }
-
+        
         // Override the way that we ask the server to sort results
         // It seems bootstrap-table does not offer a "native" way to do this...
         if ('sort' in params) {
@@ -170,6 +167,15 @@ $.fn.inventreeTable = function(options) {
 
         }
 
+        for (var key in filters) {
+            params[key] = filters[key];
+        }
+
+        // Add "order" back in (if it was originally specified by InvenTree)
+        // Annoyingly, "order" shadows some field names in InvenTree...
+        if ('order' in filters) {
+            params['order'] = filters['order'];
+        }
         return params;
     }
 


### PR DESCRIPTION
Recent server-side pagination code has introduced a funny little bug.

By default, bootstrap-table uses `?order=` to specify the ordering of API query results.

However django-rest-framework uses `ordering`.

This was fine, as we renamed the parameter and deleted `order` from the query.

**HOWEVER** - any InvenTree API query which requires the `order` parameter to be set (e.g. POLineItem / SOLineItem) was then breaking because we had deleted `order` parameter...

So.. yeah.