### PR TITLE
Split required and part match headers for BOM import

### DIFF
--- a/InvenTree/part/bom.py
+++ b/InvenTree/part/bom.py
@@ -232,14 +232,18 @@ class BomUploadManager:
 
     # Fields which are absolutely necessary for valid upload
     REQUIRED_HEADERS = [
-        'Part_Name',
         'Quantity'
+    ]
+
+    # Fields which are used for part matching (only one of them is needed)
+    PART_MATCH_HEADERS = [
+        'Part_Name',
+        'Part_IPN',
+        'Part_ID',
     ]
     
     # Fields which would be helpful but are not required
     OPTIONAL_HEADERS = [
-        'Part_IPN',
-        'Part_ID',
         'Reference',
         'Note',
         'Overage',
@@ -251,7 +255,7 @@ class BomUploadManager:
         'Overage'
     ]
 
-    HEADERS = REQUIRED_HEADERS + OPTIONAL_HEADERS
+    HEADERS = REQUIRED_HEADERS + PART_MATCH_HEADERS + OPTIONAL_HEADERS
 
     def __init__(self, bom_file):
         """ Initialize the BomUpload class with a user-uploaded file object """

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1372,7 +1372,7 @@ class Part(MPTTModel):
         """ Check if the BOM is 'valid' - if the calculated checksum matches the stored value
         """
 
-        return self.get_bom_hash() == self.bom_checksum
+        return self.get_bom_hash() == self.bom_checksum or not self.has_bom
 
     @transaction.atomic
     def validate_bom(self, user):

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -1425,8 +1425,21 @@ class BomUpload(InvenTreeRoleMixin, FormView):
         # Are there any missing columns?
         self.missing_columns = []
 
+        # Check that all required fields are present
         for col in BomUploadManager.REQUIRED_HEADERS:
             if col not in self.column_selections.values():
+                self.missing_columns.append(col)
+
+        # Check that at least one of the part match field is present
+        part_match_found = False
+        for col in BomUploadManager.PART_MATCH_HEADERS:
+            if col in self.column_selections.values():
+                part_match_found = True
+                break
+        
+        # If not, notify user
+        if not part_match_found:
+            for col in BomUploadManager.PART_MATCH_HEADERS:
                 self.missing_columns.append(col)
 
     def handleFieldSelection(self):


### PR DESCRIPTION
As mentioned in #1404 only one of the following field should be required for part matching: part ID, part IPN or part name