### PR TITLE
Replace normalize with integer wrapper for quantity field

### DIFF
--- a/InvenTree/part/admin.py
+++ b/InvenTree/part/admin.py
@@ -180,7 +180,7 @@ class BomItemResource(ModelResource):
 
         Ref: https://django-import-export.readthedocs.io/en/latest/getting_started.html#advanced-data-manipulation-on-export
         """
-        return normalize(item.quantity)
+        return int(item.quantity)
 
     def before_export(self, queryset, *args, **kwargs):
 

--- a/InvenTree/part/admin.py
+++ b/InvenTree/part/admin.py
@@ -16,8 +16,6 @@ from .models import PartCategoryParameterTemplate
 from .models import PartTestTemplate
 from .models import PartSellPriceBreak
 
-from InvenTree.helpers import normalize
-
 from stock.models import StockLocation
 from company.models import SupplierPart
 

--- a/InvenTree/part/admin.py
+++ b/InvenTree/part/admin.py
@@ -178,7 +178,7 @@ class BomItemResource(ModelResource):
 
         Ref: https://django-import-export.readthedocs.io/en/latest/getting_started.html#advanced-data-manipulation-on-export
         """
-        return int(item.quantity)
+        return float(item.quantity)
 
     def before_export(self, queryset, *args, **kwargs):
 


### PR DESCRIPTION
In a attempt to fix #1443 

I don't see when can the BOM Item quantity be a decimal number and it was causing the error in the BOM export because the PyYAML library doesn't have a `Decimal` object representation.
