### PR TITLE
Added revision and stock item QR code URL for label creation

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -280,7 +280,7 @@ def MakeBarcode(object_name, object_pk, object_data={}, **kwargs):
         json string of the supplied data plus some other data
     """
 
-    url = kwargs.get('url', True)
+    url = kwargs.get('url', False)
     brief = kwargs.get('brief', True)
 
     data = {}

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -280,11 +280,25 @@ def MakeBarcode(object_name, object_pk, object_data={}, **kwargs):
         json string of the supplied data plus some other data
     """
 
+    url = kwargs.get('url', True)
     brief = kwargs.get('brief', True)
 
     data = {}
 
-    if brief:
+    if url:
+        request = object_data.get('request', None)
+        item_url = object_data.get('item_url', None)
+        absolute_url = None
+
+        if request and item_url:
+            absolute_url = request.build_absolute_uri(item_url)
+            # Return URL (No JSON)
+            return absolute_url
+
+        if item_url:
+            # Return URL (No JSON)
+            return item_url
+    elif brief:
         data[object_name] = object_pk
     else:
         data['tool'] = 'InvenTree'

--- a/InvenTree/label/models.py
+++ b/InvenTree/label/models.py
@@ -253,10 +253,12 @@ class StockItemLabel(LabelTemplate):
             'part': stock_item.part,
             'name': stock_item.part.full_name,
             'ipn': stock_item.part.IPN,
+            'revision': stock_item.part.revision,
             'quantity': normalize(stock_item.quantity),
             'serial': stock_item.serial,
             'uid': stock_item.uid,
             'qr_data': stock_item.format_barcode(brief=True),
+            'qr_url': stock_item.format_barcode(url=True, request=request),
             'tests': stock_item.testResultMap()
         }
 

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -344,6 +344,8 @@ class StockItem(MPTTModel):
             "stockitem",
             self.id,
             {
+                "request": kwargs.get('request', None),
+                "item_url": reverse('stock-item-detail', kwargs={'pk': self.id}),
                 "url": reverse('api-stock-detail', kwargs={'pk': self.id}),
             },
             **kwargs


### PR DESCRIPTION
@SchrodingersGat I wanted to code the stock item absolute URL directly into the QR code, so a phone can open the link directly.

In the label template, this will generate the QR code URL:
``` html
<img class='qr' src='{% qrcode qr_url %}'>
```

I also added the part revision in the context data so I could create some sweet labels like:

![image](https://user-images.githubusercontent.com/4020546/114771913-2556aa00-9d3b-11eb-916d-47ba7030e0be.png)
