### PR TITLE
Show PO for Stock Items on Sales Order Detail and stock

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -826,6 +826,9 @@ class SalesOrderAllocation(models.Model):
         else:
             return ""
 
+    def get_po(self):
+        return self.item.purchase_order
+
     def complete_allocation(self, user):
         """
         Complete this allocation (called when the parent SalesOrder is marked as "shipped"):

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -235,6 +235,7 @@ class SalesOrderAllocationSerializer(InvenTreeModelSerializer):
     location_path = serializers.CharField(source='get_location_path')
     location_id = serializers.IntegerField(source='get_location')
     serial = serializers.CharField(source='get_serial')
+    po = serializers.CharField(source='get_po')
     quantity = serializers.FloatField()
 
     class Meta:
@@ -247,6 +248,7 @@ class SalesOrderAllocationSerializer(InvenTreeModelSerializer):
             'quantity',
             'location_id',
             'location_path',
+            'po',
             'item',
         ]
 

--- a/InvenTree/order/templates/order/sales_order_detail.html
+++ b/InvenTree/order/templates/order/sales_order_detail.html
@@ -88,6 +88,9 @@ function showAllocationSubTable(index, row, element) {
             },
         },
         {
+            field: 'po'
+        },
+        {
             field: 'buttons',
             title: '{% trans "Actions" %}',
             formatter: function(value, row, index, field) {
@@ -159,9 +162,12 @@ function showFulfilledSubTable(index, row, element) {
                         text = `{% trans "Quantity" %}: ${row.quantity}`;
                     }
 
-                    return renderLink(text, `/stock/item/${row.pk}/`);  
+                    return renderLink(text, `/stock/item/${row.pk}/`);
                 },
-            }
+            },
+            {
+                field: 'po'
+            },
         ],
     });
 }
@@ -270,6 +276,25 @@ $("#so-lines-table").inventreeTable({
         {
             field: 'notes',
             title: '{% trans "Notes" %}',
+        },
+        {
+            field: 'po',
+            title: '{% trans "PO" %}',
+            formatter: function(value, row, index, field) {
+                var po_name = "";
+                if (row.allocated) {
+                    row.allocations.forEach(function(allocation) {
+                        if (allocation.po != po_name) {
+                            if (po_name) {
+                                po_name = "-";
+                            } else {
+                                po_name = allocation.po
+                            }
+                        }
+                    })
+                }
+                return `<div>` + po_name + `</div>`;
+            }
         },
         {% if order.status == SalesOrderStatus.PENDING %}
         {

--- a/InvenTree/order/views.py
+++ b/InvenTree/order/views.py
@@ -90,7 +90,7 @@ class SalesOrderDetail(InvenTreeRoleMixin, DetailView):
     """ Detail view for a SalesOrder object """
 
     context_object_name = 'order'
-    queryset = SalesOrder.objects.all().prefetch_related('lines')
+    queryset = SalesOrder.objects.all().prefetch_related('lines__allocations__item__purchase_order')
     template_name = 'order/sales_order_detail.html'
 
 

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -1370,6 +1370,12 @@ class StockItem(MPTTModel):
         if self.location:
             s += ' @ {loc}'.format(loc=self.location.name)
 
+        if self.purchase_order:
+            s += " ({pre}{po})".format(
+                pre=helpers.getSetting("PURCHASEORDER_REFERENCE_PREFIX"),
+                po=self.purchase_order,
+            )
+
         return s
 
     @transaction.atomic


### PR DESCRIPTION
Stock items show the PO number that they were purchased on when being viewed in the sales order allocation modal and when viewing the sales order details.