### PR TITLE
Enabled default email sender setting

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -512,8 +512,8 @@ EXCHANGE_BACKEND = 'InvenTree.exchange.InvenTreeManualExchangeBackend'
 email_config = CONFIG.get('email', {})
 
 EMAIL_BACKEND = get_setting(
-    'django.core.mail.backends.smtp.EmailBackend',
-    email_config.get('backend', '')
+    'INVENTREE_EMAIL_BACKEND',
+    email_config.get('backend', 'django.core.mail.backends.smtp.EmailBackend')
 )
 
 # Email backend settings
@@ -535,6 +535,11 @@ EMAIL_HOST_USER = get_setting(
 EMAIL_HOST_PASSWORD = get_setting(
     'INVENTREE_EMAIL_PASSWORD',
     email_config.get('password', ''),
+)
+
+DEFAULT_FROM_EMAIL = get_setting(
+    'INVENTREE_EMAIL_SENDER',
+    email_config.get('sender', ''),
 )
 
 EMAIL_SUBJECT_PREFIX = '[InvenTree] '

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -85,6 +85,7 @@ email:
   port: 25
   username: ''
   password: ''
+  sender: ''
   tls: False
   ssl: False
 


### PR DESCRIPTION
Was just testing the email reset form and found out that Microsoft requires the sender email address to match the username so I added this setting to the `config_template.yaml` and `settings.py`.

Also in `settings.py`, it looked like the default backend (`django.core.mail.backends.smtp.EmailBackend`) was not loaded if not found in the config, however it is commented in the `config_template.yaml` so I think it was a mistake and corrected it.