### PR TITLE
Multi platform docker image

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:
@@ -24,6 +28,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./docker
+          platforms: linux/amd64,linux/arm64
           push: true
           repository: inventree/inventree
           tags: inventree/inventree:latest

--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: cd
         run: |
           cd docker
@@ -24,3 +28,4 @@ jobs:
           repository: inventree/inventree
           tag_with_ref: true
           dockerfile: ./Dockerfile
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
I use Inventree for my personal use on a raspberry pi and i think many other that want to start small or just want to fiddle around will too. So, I think that an ARM docker version could be a nice addition. 
I tried to change the workflow to create also a ARM64 version. The code is based on the following docs [https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md]().
Unfortunately I have no clue how to test this, if this is really working :disappointed:

Please review it and tell me what you think about it.