### PR TITLE
fixed wrong i18n-code for polish

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -491,7 +491,7 @@ LANGUAGES = [
     ('en', _('English')),
     ('fr', _('French')),
     ('de', _('German')),
-    ('pk', _('Polish')),
+    ('pl', _('Polish')),
     ('tr', _('Turkish')),
 ]
 


### PR DESCRIPTION
The i18n code for Polish should be pl not pk, maybe typo.
Discovered during dev for #1527.