### PR TITLE
Fixes to create build output form

### DIFF
--- a/InvenTree/build/templates/build/complete_output.html
+++ b/InvenTree/build/templates/build/complete_output.html
@@ -40,8 +40,8 @@
     <div class='panel-heading'>
         {% trans "The following items will be created" %}
     </div>
-    <div class='panel-content'>
-        {% include "hover_image.html" with image=build.part.image hover=True %}
+    <div class='panel-content' style='padding-bottom:16px'>
+        {% include "hover_image.html" with image=build.part.image %}
         {% if output.serialized %}
         {{ output.part.full_name }} - {% trans "Serial Number" %} {{ output.serial }}
         {% else %}

--- a/InvenTree/build/views.py
+++ b/InvenTree/build/views.py
@@ -157,6 +157,17 @@ class BuildOutputCreate(AjaxUpdateView):
         quantity = form.cleaned_data.get('output_quantity', None)
         serials = form.cleaned_data.get('serial_numbers', None)
 
+        if quantity:
+            build = self.get_object()
+            
+            # Check that requested output don't exceed build remaining quantity
+            maximum_output = int(build.remaining - build.incomplete_count)
+            if quantity > maximum_output:
+                form.add_error(
+                    'output_quantity',
+                    _('Maximum output quantity is ') + str(maximum_output),
+                )
+
         # Check that the serial numbers are valid
         if serials:
             try:
@@ -212,7 +223,7 @@ class BuildOutputCreate(AjaxUpdateView):
 
         # Calculate the required quantity
         quantity = max(0, build.remaining - build.incomplete_count)
-        initials['output_quantity'] = quantity
+        initials['output_quantity'] = int(quantity)
 
         return initials
 


### PR DESCRIPTION
Added validation on quantity field and removed image tag `hover` argument which was falsely creating the entire form being a single link or something like that.