### PR TITLE
Purchase order fixes

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -342,7 +342,7 @@ class PurchaseOrder(Order):
             if quantity < 0:
                 raise ValidationError({"quantity": _("Quantity must be a positive number")})
             quantity = int(quantity)
-        except ValueError:
+        except (ValueError, TypeError):
             raise ValidationError({"quantity": _("Invalid quantity provided")})
 
         # Create a new stock item

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -337,14 +337,16 @@ class PurchaseOrder(Order):
             raise ValidationError({"status": _("Lines can only be received against an order marked as 'Placed'")})
 
         try:
+            if not (quantity % 1 == 0):
+                raise ValidationError({"quantity": _("Quantity must be an integer")})
+            if quantity < 0:
+                raise ValidationError({"quantity": _("Quantity must be a positive number")})
             quantity = int(quantity)
-            if quantity <= 0:
-                raise ValidationError({"quantity": _("Quantity must be greater than zero")})
         except ValueError:
             raise ValidationError({"quantity": _("Invalid quantity provided")})
 
         # Create a new stock item
-        if line.part:
+        if line.part and quantity > 0:
             stock = stock_models.StockItem(
                 part=line.part.part,
                 supplier_part=line.part,

--- a/InvenTree/order/templates/order/order_base.html
+++ b/InvenTree/order/templates/order/order_base.html
@@ -171,10 +171,34 @@ $("#edit-order").click(function() {
     );
 });
 
+$("#receive-order").click(function() {
+    launchModalForm("{% url 'po-receive' order.id %}", {
+        reload: true,
+        secondary: [
+            {
+                field: 'location',
+                label: '{% trans "New Location" %}',
+                title: '{% trans "Create new stock location" %}',
+                url: "{% url 'stock-location-create' %}",
+            },
+        ]
+    });
+});
+
+$("#complete-order").click(function() {
+    launchModalForm("{% url 'po-complete' order.id %}", {
+        reload: true,
+    });
+});
+
 $("#cancel-order").click(function() {
     launchModalForm("{% url 'po-cancel' order.id %}", {
         reload: true,
     });
+});
+
+$("#export-order").click(function() {
+    location.href = "{% url 'po-export' order.id %}";
 });
 
 

--- a/InvenTree/order/templates/order/order_cancel.html
+++ b/InvenTree/order/templates/order/order_cancel.html
@@ -4,6 +4,8 @@
 
 {% block pre_form_content %}
 
-{% trans "Cancelling this order means that the order will no longer be editable." %}
+<div class='alert alert-danger alert-block'>
+    {% trans "Cancelling this order means that the order and line items will no longer be editable." %}
+</div>
 
 {% endblock %}

--- a/InvenTree/order/templates/order/order_complete.html
+++ b/InvenTree/order/templates/order/order_complete.html
@@ -6,9 +6,9 @@
 
 {% trans 'Mark this order as complete?' %}
 {% if not order.is_complete %}
-<div class='alert alert-warning alert-block'>
-    {% trans 'This order has line items which have not been marked as received.' %}
-    {% trans 'Marking this order as complete will remove these line items.' %}
+<div class='alert alert-warning alert-block' style='margin-top:12px'>
+    {% trans 'This order has line items which have not been marked as received.' %}</br>
+    {% trans 'Completing this order means that the order and line items will no longer be editable.' %}
 </div>
 {% endif %}
 

--- a/InvenTree/order/templates/order/order_issue.html
+++ b/InvenTree/order/templates/order/order_issue.html
@@ -4,6 +4,8 @@
 
 {% block pre_form_content %}
 
-{% trans 'After placing this purchase order, line items will no longer be editable.' %}
+<div class='alert alert-warning alert-block'>
+    {% trans 'After placing this purchase order, line items will no longer be editable.' %}
+</div>
 
 {% endblock %}

--- a/InvenTree/order/templates/order/purchase_order_detail.html
+++ b/InvenTree/order/templates/order/purchase_order_detail.html
@@ -35,31 +35,6 @@
 
 {{ block.super }}
 
-
-$("#receive-order").click(function() {
-    launchModalForm("{% url 'po-receive' order.id %}", {
-        reload: true,
-        secondary: [
-            {
-                field: 'location',
-                label: '{% trans "New Location" %}',
-                title: '{% trans "Create new stock location" %}',
-                url: "{% url 'stock-location-create' %}",
-            },
-        ]
-    });
-});
-
-$("#complete-order").click(function() {
-    launchModalForm("{% url 'po-complete' order.id %}", {
-        reload: true,
-    });
-});
-
-$("#export-order").click(function() {
-    location.href = "{% url 'po-export' order.id %}";
-});
-
 {% if order.status == PurchaseOrderStatus.PENDING %}
 $('#new-po-line').click(function() {
     launchModalForm("{% url 'po-line-item-create' %}",
@@ -260,6 +235,5 @@ $("#po-table").inventreeTable({
         }
     ]
 });
-
 
 {% endblock %}

--- a/InvenTree/templates/stock_table.html
+++ b/InvenTree/templates/stock_table.html
@@ -16,7 +16,7 @@
             </button>
 
             {% if owner_control.value == "True" and user in owners or user.is_superuser or owner_control.value == "False" %}
-            {% if roles.stock.add %}
+            {% if not read_only and roles.stock.add %}
             <button class="btn btn-success" id='item-create' title='{% trans "New Stock Item" %}'>
                 <span class='fas fa-plus-circle'></span>
             </button>
@@ -44,6 +44,7 @@
                     {% endif %}
                 </ul>
             </div>
+            {% if not read_only %}
             {% if roles.stock.change or roles.stock.delete %}
             <div class="btn-group">
                 <button id='stock-options' class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" title='{% trans "Stock Options" %}'>
@@ -63,6 +64,7 @@
                     {% endif %}
                     </ul>
                 </div>
+            {% endif %}
             {% endif %}
             {% endif %}
             <div class='filter-list' id='filter-list-stock'>


### PR DESCRIPTION
* Fixed the purchase orders action buttons only working for "Details" view (moved JS to the right place)
* Allow to receive `0` for a line item, in this case it does not create any stock item for this specific item
* Improved the messaging what "completing" an order means