### PR TITLE
feat(admin): Show the line items on the PO on the Admin Site

### DIFF
--- a/InvenTree/order/admin.py
+++ b/InvenTree/order/admin.py
@@ -13,6 +13,10 @@ from .models import SalesOrder, SalesOrderLineItem
 from .models import SalesOrderAllocation
 
 
+class PurchaseOrderLineItemInlineAdmin(admin.StackedInline):
+    model = PurchaseOrderLineItem
+
+
 class PurchaseOrderAdmin(ImportExportModelAdmin):
 
     list_display = (
@@ -27,6 +31,10 @@ class PurchaseOrderAdmin(ImportExportModelAdmin):
         'reference',
         'supplier__name',
         'description',
+    ]
+
+    inlines = [
+        PurchaseOrderLineItemInlineAdmin
     ]
 
 


### PR DESCRIPTION
Super simple.  Just show the PO Line items of a PO when on the Admin Site.  This makes finding the line items much easier.