### PR TITLE
Fixer currency integration

### DIFF
--- a/InvenTree/InvenTree/apps.py
+++ b/InvenTree/InvenTree/apps.py
@@ -44,3 +44,8 @@ class InvenTreeConfig(AppConfig):
             schedule_type=Schedule.MINUTES,
             minutes=15
         )
+
+        InvenTree.tasks.schedule_task(
+            'InvenTree.tasks.update_exchange_rates',
+            schedule_type=Schedule.DAILY,
+        )

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -513,7 +513,8 @@ CURRENCIES = CONFIG.get(
     ],
 )
 
-# TODO - Allow live web-based backends in the future
+BASE_CURRENCY = CONFIG.get('base_currency', 'USD')
+
 EXCHANGE_BACKEND = 'InvenTree.exchange.InvenTreeManualExchangeBackend'
 
 # Extract email settings from the config file

--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -186,7 +186,7 @@ def update_exchange_rates():
 
     base = settings.BASE_CURRENCY
 
-    result = backend.update_rates(base_currency=base, symbols=currencies)
+    backend.update_rates(base_currency=base, symbols=currencies)
 
 
 def send_email(subject, body, recipients, from_email=None):

--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -161,6 +161,34 @@ def check_for_updates():
     )
 
 
+def update_exchange_rates():
+    """
+    If an API key for fixer.io has been provided, attempt to update currency exchange rates
+    """
+
+    try:
+        import common.models
+        from django.conf import settings
+        from djmoney.contrib.exchange.backends import FixerBackend
+    except AppRegistryNotReady:
+        # Apps not yet loaded!
+        return
+
+    fixer_api_key = common.models.InvenTreeSetting.get_setting('INVENTREE_FIXER_API_KEY', '').strip()
+
+    if not fixer_api_key:
+        # API key not provided
+        return
+
+    backend = FixerBackend(access_key=fixer_api_key)
+
+    currencies = ','.join(settings.CURRENCIES)
+
+    base = settings.BASE_CURRENCY
+
+    result = backend.update_rates(base_currency=base, symbols=currencies)
+
+
 def send_email(subject, body, recipients, from_email=None):
     """
     Send an email with the specified subject and body,

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -87,6 +87,12 @@ class InvenTreeSetting(models.Model):
             'choices': djmoney.settings.CURRENCY_CHOICES,
         },
 
+        'INVENTREE_FIXER_API_KEY': {
+            'name': _('fixer.io API key'),
+            'description': _('API key for fixer.io currency conversion service'),
+            'default': '',
+        },
+
         'INVENTREE_DOWNLOAD_FROM_URL': {
             'name': _('Download from URL'),
             'description': _('Allow download of remote images and files from external URL'),

--- a/InvenTree/templates/InvenTree/settings/global.html
+++ b/InvenTree/templates/InvenTree/settings/global.html
@@ -20,6 +20,7 @@
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_BASE_URL" icon="fa-globe" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_COMPANY_NAME" icon="fa-building" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DEFAULT_CURRENCY" icon="fa-dollar-sign" %}
+        {% include "InvenTree/settings/setting.html" with key="INVENTREE_FIXER_API_KEY" icon="fa-key" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DOWNLOAD_FROM_URL" icon="fa-cloud-download-alt" %}
     </tbody>
 </table>


### PR DESCRIPTION
Adds integration with the fixer.io currency conversion API.

If an API key is provided, currency rates are updates once per day.

The free API allows 1,000 API calls per month

Ref: https://github.com/inventree/InvenTree/pull/1482