### PR TITLE
Bump API version to 3

### DIFF
--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -10,8 +10,15 @@ import common.models
 
 INVENTREE_SW_VERSION = "0.2.2 pre"
 
-# Increment this number whenever there is a significant change to the API that any clients need to know about
-INVENTREE_API_VERSION = 2
+"""
+Increment thi API version number whenever there is a significant change to the API that any clients need to know about
+
+v3 -> 2021-05-22:
+    - The updated StockItem "history tracking" now uses a different interface
+
+"""
+
+INVENTREE_API_VERSION = 3
 
 
 def inventreeInstanceName():

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -120,6 +120,12 @@ def inventree_version(*args, **kwargs):
 
 
 @register.simple_tag()
+def inventree_api_version(*args, **kwargs):
+    """ Return InvenTree API version """
+    return version.inventreeApiVersion()
+
+
+@register.simple_tag()
 def django_version(*args, **kwargs):
     """ Return Django version string """
     return version.inventreeDjangoVersion()

--- a/InvenTree/templates/about.html
+++ b/InvenTree/templates/about.html
@@ -30,6 +30,11 @@
                                 </td>
                             </tr>
                             <tr>
+                                <td><span class='fas fa-code'></span></td>
+                                <td>{% trans "API Version" %}</td>
+                                <td>{% inventree_api_version %}{% include "clip.html" %}</td>
+                            </tr>
+                            <tr>
                                 <td><span class='fas fa-hashtag'></span></td>
                                 <td>{% trans "Django Version" %}</td>
                                 <td><a href="https://www.djangoproject.com/">{% django_version %}</a>{% include "clip.html" %}</td>


### PR DESCRIPTION
- New stock item history tracking is incompatible
- Adds API info to the "about" dialog