### PR TITLE
Fixed price break row actions after sorting

### DIFF
--- a/InvenTree/company/templates/company/supplier_part_pricing.html
+++ b/InvenTree/company/templates/company/supplier_part_pricing.html
@@ -40,7 +40,7 @@ $('#price-break-table').inventreeTable({
         part: {{ part.id }},
     },
     url: "{% url 'api-part-supplier-price' %}",
-    onLoadSuccess: function() {
+    onPostBody: function() {
         var table = $('#price-break-table');
 
         table.find('.button-price-break-delete').click(function() {

--- a/InvenTree/part/templates/part/sale_prices.html
+++ b/InvenTree/part/templates/part/sale_prices.html
@@ -48,7 +48,7 @@ $('#price-break-table').inventreeTable({
         part: {{ part.id }},
     },
     url: "{% url 'api-part-sale-price-list' %}",
-    onLoadSuccess: function() {
+    onPostBody: function() {
         var table = $('#price-break-table');
 
         table.find('.button-price-break-delete').click(function() {


### PR DESCRIPTION
To reproduce the issue:
* Navigate to supplier page view
* Sort the price break table by quantity or price
* Click on "edit" or "delete" button on a row, it wouldn't do anything

Seems like `onPostBody` event handler handles sorting better than `onLoadSuccess` would do.
Reference: https://bootstrap-table.com/docs/api/events/#onpostbody

Note: `onLoadSuccess` is also used in `bom.js`, `build.js` and `stock.js` files for respective bootstrap tables but have not looked those up to see if `onPostBody` would fit better there too.