### PR TITLE
Money format

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -703,7 +703,7 @@ class PriceBreak(models.Model):
     price = MoneyField(
         max_digits=19,
         decimal_places=4,
-        default_currency='USD',
+        default_currency=currency_code_default(),
         null=True,
         verbose_name=_('Price'),
         help_text=_('Unit price at specified quantity'),

--- a/InvenTree/company/forms.py
+++ b/InvenTree/company/forms.py
@@ -15,6 +15,7 @@ import djmoney.settings
 from djmoney.forms.fields import MoneyField
 
 import common.settings
+from common.settings import currency_code_default
 
 from .models import Company
 from .models import ManufacturerPart
@@ -38,7 +39,7 @@ class EditCompanyForm(HelperForm):
         label=_('Currency'),
         help_text=_('Default currency used for this company'),
         choices=[('', '----------')] + djmoney.settings.CURRENCY_CHOICES,
-        initial=common.settings.currency_code_default,
+        initial=currency_code_default,
     )
 
     class Meta:
@@ -116,7 +117,7 @@ class EditSupplierPartForm(HelperForm):
 
     single_pricing = MoneyField(
         label=_('Single Price'),
-        default_currency='USD',
+        default_currency=currency_code_default(),
         help_text=_('Single quantity price'),
         decimal_places=4,
         max_digits=19,

--- a/InvenTree/company/forms.py
+++ b/InvenTree/company/forms.py
@@ -14,7 +14,6 @@ import django.forms
 import djmoney.settings
 from djmoney.forms.fields import MoneyField
 
-import common.settings
 from common.settings import currency_code_default
 
 from .models import Company

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -17,6 +17,8 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
+from common.settings import currency_code_default
+
 from markdownx.models import MarkdownxField
 
 from djmoney.models.fields import MoneyField
@@ -664,7 +666,7 @@ class PurchaseOrderLineItem(OrderLineItem):
     purchase_price = MoneyField(
         max_digits=19,
         decimal_places=4,
-        default_currency='USD',
+        default_currency=currency_code_default(),
         null=True, blank=True,
         verbose_name=_('Purchase Price'),
         help_text=_('Unit purchase price'),
@@ -693,7 +695,7 @@ class SalesOrderLineItem(OrderLineItem):
     sale_price = MoneyField(
         max_digits=19,
         decimal_places=4,
-        default_currency='USD',
+        default_currency=currency_code_default(),
         null=True, blank=True,
         verbose_name=_('Sale Price'),
         help_text=_('Unit sale price'),

--- a/InvenTree/part/templates/part/order_prices.html
+++ b/InvenTree/part/templates/part/order_prices.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block details %}
-{% settings_value "INVENTREE_DEFAULT_CURRENCY" as currency %}
+{% default_currency as currency %}
 
 {% crispy form %}
 
@@ -130,7 +130,7 @@ the part single price shown is the current price for that supplier part"></i></h
 {% block js_ready %}
     {{ block.super }}
 
-    {% settings_value "INVENTREE_DEFAULT_CURRENCY" as currency %}
+    {% default_currency as currency %}
     {% if price_history %}
             var pricedata = {
                     labels: [

--- a/InvenTree/part/templates/part/part_pricing.html
+++ b/InvenTree/part/templates/part/part_pricing.html
@@ -3,7 +3,7 @@
 {% load i18n inventree_extras %}
 
 {% block pre_form_content %}
-{% settings_value "INVENTREE_DEFAULT_CURRENCY" as currency %}
+{% default_currency as currency %}
 <table class='table table-striped table-condensed table-price-two'>
     <tr>
         <td><b>{% trans 'Part' %}</b></td>

--- a/InvenTree/part/templates/part/part_pricing.html
+++ b/InvenTree/part/templates/part/part_pricing.html
@@ -1,8 +1,9 @@
 {% extends "modal_form.html" %}
 
-{% load i18n %}
+{% load i18n inventree_extras %}
 
 {% block pre_form_content %}
+{% settings_value "INVENTREE_DEFAULT_CURRENCY" as currency %}
 <table class='table table-striped table-condensed table-price-two'>
     <tr>
         <td><b>{% trans 'Part' %}</b></td>

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -18,6 +18,7 @@ from InvenTree import version, settings
 import InvenTree.helpers
 
 from common.models import InvenTreeSetting, ColorTheme
+from common.settings import currency_code_default
 
 register = template.Library()
 
@@ -159,6 +160,12 @@ def inventree_docs_url(*args, **kwargs):
 def inventree_credits_url(*args, **kwargs):
     """ Return URL for InvenTree credits site """
     return "https://inventree.readthedocs.io/en/latest/credits/"
+
+
+@register.simple_tag()
+def default_currency(*args, **kwargs):
+    """ Returns the default currency code """
+    return currency_code_default()
 
 
 @register.simple_tag()

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -20,6 +20,8 @@ from django.contrib.auth.models import User
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
+from common.settings import currency_code_default
+
 from markdownx.models import MarkdownxField
 
 from mptt.models import MPTTModel, TreeForeignKey
@@ -534,7 +536,7 @@ class StockItem(MPTTModel):
     purchase_price = MoneyField(
         max_digits=19,
         decimal_places=4,
-        default_currency='USD',
+        default_currency=currency_code_default(),
         blank=True,
         null=True,
         verbose_name=_('Purchase Price'),

--- a/InvenTree/templates/price.html
+++ b/InvenTree/templates/price.html
@@ -1,1 +1,2 @@
-{% if currency %}{{ currency.symbol }}{% endif %}{{ price }}{% if currency %} {{ currency.suffix }}{% endif %}
+{% load djmoney %}
+{% money_localize price currency %}


### PR DESCRIPTION
For some reason the formatting of prices seems to be broken, this PR fixes it by using the dj-money formatting tag.
Also the default currency will be used in all forms now.