### PR TITLE
more modal options

### DIFF
--- a/InvenTree/templates/js/modals.js
+++ b/InvenTree/templates/js/modals.js
@@ -851,6 +851,7 @@ function launchModalForm(url, options = {}) {
      * secondary - List of secondary modals to attach
      * callback - List of callback functions to attach to inputs
      * focus - Select which field to focus on by default
+     * buttons - additional buttons that should be added as array with [name, title]
      */
 
     var modal = options.modal || '#modal-form';

--- a/InvenTree/templates/js/modals.js
+++ b/InvenTree/templates/js/modals.js
@@ -797,6 +797,14 @@ function handleModalForm(url, options) {
                             if (response.title) {
                                 modalSetTitle(modal, response.title);
                             }
+
+                            // Clean custom action buttons
+                            $(modal).find('#modal-footer-buttons').html('');
+
+                            // Add custom action buttons with response
+                            if (response.buttons) {
+                                attachButtons(modal, response.buttons);
+                            }
                         }
                         else {
                             $(modal).modal('hide');
@@ -900,6 +908,11 @@ function launchModalForm(url, options = {}) {
 
                 if (options.buttons) {
                     attachButtons(modal, options.buttons);
+                }
+
+                // Add custom buttons from response
+                if (response.buttons) {
+                    attachButtons(modal, response.buttons);
                 }
 
             } else {

--- a/InvenTree/templates/js/modals.js
+++ b/InvenTree/templates/js/modals.js
@@ -776,7 +776,8 @@ function handleModalForm(url, options) {
                     // Form was returned, invalid!
                     else {
 
-                        if (!options.hideErrorMessage) {
+                        // Disable error message with option or response
+                        if (!options.hideErrorMessage && !response.hideErrorMessage) {
                             var warningDiv = $(modal).find('#form-validation-warning');
                             warningDiv.css('display', 'block');
                         }

--- a/InvenTree/templates/js/modals.js
+++ b/InvenTree/templates/js/modals.js
@@ -792,6 +792,11 @@ function handleModalForm(url, options) {
                             if (options.secondary) {
                                 attachSecondaries(modal, options.secondary);
                             }
+
+                            // Set modal title with response
+                            if (response.title) {
+                                modalSetTitle(modal, response.title);
+                            }
                         }
                         else {
                             $(modal).modal('hide');


### PR DESCRIPTION
This PR adds some more options for manipulation modal appreances in multistep:
- modal title
- hiding an error message (was wished for by @SchrodingersGat  in #1588 and should be applied to the pricing modal too)
- adding more submittion buttons to a modal
 
Also one line of missing doc for a init - option