### PR TITLE
fix for timezone warning on heartbeat

### DIFF
--- a/InvenTree/InvenTree/status.py
+++ b/InvenTree/InvenTree/status.py
@@ -4,9 +4,10 @@ Provides system status functionality checks.
 # -*- coding: utf-8 -*-
 
 from django.utils.translation import ugettext_lazy as _
+from django.utils import timezone
 
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django_q.models import Success
 from django_q.monitor import Stat
@@ -34,7 +35,7 @@ def is_worker_running(**kwargs):
     Check to see if we have a result within the last 20 minutes
     """
 
-    now = datetime.now()
+    now = timezone.now()
     past = now - timedelta(minutes=20)
 
     results = Success.objects.filter(


### PR DESCRIPTION
In the logs of my debugging system I get the below error on every POST / GET operation:

InvenTree/env/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1419: RuntimeWarning: DateTimeField Task.started received a naive datetime (2021-06-20 17:27:07.065021) while time zone support is active. RuntimeWarning)

I think that error is caused by the heartbeat check for the background tasks, this should fix it.