### PR TITLE
Fix supplier part view/edit without a manufacturer

### DIFF
--- a/InvenTree/company/views.py
+++ b/InvenTree/company/views.py
@@ -623,7 +623,8 @@ class SupplierPartEdit(AjaxUpdateView):
         supplier_part = self.get_object()
 
         if supplier_part.manufacturer_part:
-            initials['manufacturer'] = supplier_part.manufacturer_part.manufacturer.id
+            if supplier_part.manufacturer_part.manufacturer:
+                initials['manufacturer'] = supplier_part.manufacturer_part.manufacturer.id
             initials['MPN'] = supplier_part.manufacturer_part.MPN
 
         return initials

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -350,7 +350,12 @@
     <tr>
         <td><span class='fas fa-industry'></span></td>
         <td>{% trans "Manufacturer" %}</td>
-        <td><a href="{% url 'company-detail' item.supplier_part.manufacturer_part.manufacturer.id %}">{{ item.supplier_part.manufacturer_part.manufacturer.name }}</a></td>
+        {% if item.supplier_part.manufacturer_part.manufacturer %}
+            <td><a href="{% url 'company-detail' item.supplier_part.manufacturer_part.manufacturer.id %}">{{ item.supplier_part.manufacturer_part.manufacturer.name }}</a></td>
+        {% else %}
+            <td><i>{% trans "No manufacturer set" %}</i></td>
+        {% endif %}
+
     </tr>
     <tr>
         <td><span class='fas fa-hashtag'></span></td>


### PR DESCRIPTION
Fixes the following issues when a supplier part was created with an MPN but no manufacturer was assigned:
- Viewing a supplier part stock item
- Editing a supplier part stock item

---

<details>
<summary>Translation discussion...</summary>


@SchrodingersGat - I ran `invoke translate` in 402a7da, but this resulted in a massive diff. The only new translatable text was the `'No manufacturer set'` text on the supplier part stock details page. Here's the lines in the en translation: https://github.com/inventree/InvenTree/blob/402a7dabf1a0a44e668aee01722b380240e5fadd/InvenTree/locale/en/LC_MESSAGES/django.po#L5743-L5745

<img width="699" alt="Screen Shot 2021-06-21 at 11 12 54 AM" src="https://user-images.githubusercontent.com/1350214/122788575-7677a280-d284-11eb-8cab-606cb6892b91.png">

Let me know how you would like to proceed with the translations. Maybe I ran the translation script incorrectly?

</details>