### PR TITLE
Fixes for order API interface

### DIFF
--- a/InvenTree/InvenTree/api_tester.py
+++ b/InvenTree/InvenTree/api_tester.py
@@ -73,22 +73,50 @@ class InvenTreeAPITestCase(APITestCase):
                 ruleset.save()
                 break
 
-    def get(self, url, data={}, code=200):
+    def get(self, url, data={}, expected_code=200):
         """
         Issue a GET request
         """
 
         response = self.client.get(url, data, format='json')
 
-        self.assertEqual(response.status_code, code)
+        if expected_code is not None:
+            self.assertEqual(response.status_code, expected_code)
 
         return response
 
-    def post(self, url, data):
+    def post(self, url, data, expected_code=None):
         """
         Issue a POST request
         """
 
         response = self.client.post(url, data=data, format='json')
+
+        if expected_code is not None:
+            self.assertEqual(response.status_code, expected_code)
+
+        return response
+
+    def delete(self, url, expected_code=None):
+        """
+        Issue a DELETE request
+        """
+
+        response = self.client.delete(url)
+
+        if expected_code is not None:
+            self.assertEqual(response.status_code, expected_code)
+
+        return response
+
+    def patch(self, url, data, expected_code=None):
+        """
+        Issue a PATCH request
+        """
+
+        response = self.client.patch(url, data=data, format='json')
+
+        if expected_code is not None:
+            self.assertEqual(response.status_code, expected_code)
 
         return response

--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -382,7 +382,7 @@ class SOList(generics.ListCreateAPIView):
     ordering = '-creation_date'
 
 
-class SODetail(generics.RetrieveUpdateAPIView):
+class SODetail(generics.RetrieveUpdateDestroyAPIView):
     """
     API endpoint for detail view of a SalesOrder object.
     """

--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -157,7 +157,7 @@ class POList(generics.ListCreateAPIView):
     ordering = '-creation_date'
 
 
-class PODetail(generics.RetrieveUpdateAPIView):
+class PODetail(generics.RetrieveUpdateDestroyAPIView):
     """ API endpoint for detail view of a PurchaseOrder object """
 
     queryset = PurchaseOrder.objects.all()

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -112,8 +112,9 @@ class POLineItemSerializer(InvenTreeModelSerializer):
             self.fields.pop('part_detail')
             self.fields.pop('supplier_part_detail')
 
-    quantity = serializers.FloatField()
-    received = serializers.FloatField()
+    # TODO: Once https://github.com/inventree/InvenTree/issues/1687 is fixed, remove default values
+    quantity = serializers.FloatField(default=1)
+    received = serializers.FloatField(default=0)
 
     part_detail = PartBriefSerializer(source='get_base_part', many=False, read_only=True)
     supplier_part_detail = SupplierPartSerializer(source='part', many=False, read_only=True)
@@ -316,7 +317,9 @@ class SOLineItemSerializer(InvenTreeModelSerializer):
     part_detail = PartBriefSerializer(source='part', many=False, read_only=True)
     allocations = SalesOrderAllocationSerializer(many=True, read_only=True)
 
-    quantity = serializers.FloatField()
+    # TODO: Once https://github.com/inventree/InvenTree/issues/1687 is fixed, remove default values
+    quantity = serializers.FloatField(default=1)
+
     allocated = serializers.FloatField(source='allocated_quantity', read_only=True)
     fulfilled = serializers.FloatField(source='fulfilled_quantity', read_only=True)
     sale_price_string = serializers.CharField(source='sale_price', read_only=True)

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -228,8 +228,9 @@ class SalesOrderSerializer(InvenTreeModelSerializer):
         ]
 
         read_only_fields = [
-            'reference',
-            'status'
+            'status',
+            'creation_date',
+            'shipment_date',
         ]
 
 

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -93,8 +93,10 @@ class POSerializer(InvenTreeModelSerializer):
         ]
 
         read_only_fields = [
-            'reference',
             'status'
+            'issue_date',
+            'complete_date',
+            'creation_date',
         ]
 
 

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -258,7 +258,6 @@ class SalesOrderTest(OrderTest):
 
         self.get(url)
 
-
     def test_so_operations(self):
         """
         Test that we can create / edit and delete a SalesOrder via the API


### PR DESCRIPTION
Fixing some recently uncovered bugs in the API:

### Problem

- PurchaseOrder and SalesOrder cannot be deleted via the API
- 'reference' field is read-only (and thus cannot be set via the API!)

### Solution

- Allow DELETE endpoint for PurchaseOrder
- Remove 'read_only' attribute for 'reference' field
- Add extra functionality to API test class
- Add unit testing