### PR TITLE
full Internal price coverage

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1577,9 +1577,10 @@ class Part(MPTTModel):
 
         - Supplier price (if purchased from suppliers)
         - BOM price (if built from other parts)
+        - Internal price (if set for the part)
 
         Returns:
-            Minimum of the supplier price or BOM price. If no pricing available, returns None
+            Minimum of the supplier, BOM or internal price. If no pricing available, returns None
         """
 
         # only get internal price if set and should be used

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1479,16 +1479,17 @@ class Part(MPTTModel):
 
         return True
 
-    def get_price_info(self, quantity=1, buy=True, bom=True):
+    def get_price_info(self, quantity=1, buy=True, bom=True, internal=False):
         """ Return a simplified pricing string for this part
 
         Args:
             quantity: Number of units to calculate price for
             buy: Include supplier pricing (default = True)
             bom: Include BOM pricing (default = True)
+            internal: Include internal pricing (default = False)
         """
 
-        price_range = self.get_price_range(quantity, buy, bom)
+        price_range = self.get_price_range(quantity, buy, bom, internal)
 
         if price_range is None:
             return None
@@ -2499,7 +2500,9 @@ class BomItem(models.Model):
     def price_range(self):
         """ Return the price-range for this BOM item. """
 
-        prange = self.sub_part.get_price_range(self.quantity)
+        # get internal price setting
+        use_internal = common.models.InvenTreeSetting.get_setting('PART_BOM_USE_INTERNAL_PRICE', False)
+        prange = self.sub_part.get_price_range(self.quantity, intenal=use_internal)
 
         if prange is None:
             return prange

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -847,11 +847,13 @@ class PartPricingView(PartDetail):
 
         # BOM Information for Pie-Chart
         if part.has_bom:
+            # get internal price setting
+            use_internal = InvenTreeSetting.get_setting('PART_BOM_USE_INTERNAL_PRICE', False)
             ctx_bom_parts = []
             # iterate over all bom-items
             for item in part.bom_items.all():
                 ctx_item = {'name': str(item.sub_part)}
-                price, qty = item.sub_part.get_price_range(quantity), item.quantity
+                price, qty = item.sub_part.get_price_range(quantity, internal=use_internal), item.quantity
 
                 price_min, price_max = 0, 0
                 if price:  # check if price available


### PR DESCRIPTION
Seems like I missed to use the internal price in all places (thanks @rgilham / #1718  for discovering that) .
This PR adds:
- a flag to `get_price_info` - defaults internal to false because that funtion is used for displaying prices - better to go higher by default
- a bit of doc to `get_price_range`
- usage of internal price in a BOM Items `price_range`
- uses internal price range for BOM price pie-chart

