### PR TITLE
make currency selection options human-readable

### DIFF
--- a/InvenTree/common/settings.py
+++ b/InvenTree/common/settings.py
@@ -28,7 +28,7 @@ def currency_code_mappings():
     """
     Returns the current currency choices
     """
-    return [(a, a) for a in settings.CURRENCIES]
+    return [(a, CURRENCIES[a].name) for a in settings.CURRENCIES]
 
 
 def currency_codes():


### PR DESCRIPTION
Sort of forget that in #1736 👼- makes options for the currency dropdowns human-readable