### PR TITLE
Depleted stock on start page

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -651,7 +651,7 @@ class PartList(generics.ListCreateAPIView):
                 # Filter items which have an 'in_stock' level higher than 'minimum_stock'
                 queryset = queryset.filter(Q(in_stock__gte=F('minimum_stock')))
 
-        # If we are filtering by 'depleted_stock' status
+        # Filer by 'depleted_stock' status -> has no stock and stock items
         depleted_stock = params.get('depleted_stock', None)
 
         if depleted_stock is not None:

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -651,6 +651,15 @@ class PartList(generics.ListCreateAPIView):
                 # Filter items which have an 'in_stock' level higher than 'minimum_stock'
                 queryset = queryset.filter(Q(in_stock__gte=F('minimum_stock')))
 
+        # If we are filtering by 'depleted_stock' status
+        depleted_stock = params.get('depleted_stock', None)
+
+        if depleted_stock is not None:
+            depleted_stock = str2bool(depleted_stock)
+
+            if depleted_stock:
+                queryset = queryset.filter(Q(in_stock=0) & ~Q(stock_item_count=0))
+
         # Filter by "parts which need stock to complete build"
         stock_to_build = params.get('stock_to_build', None)
 

--- a/InvenTree/templates/InvenTree/index.html
+++ b/InvenTree/templates/InvenTree/index.html
@@ -128,6 +128,7 @@ loadSimplePartTable("#table-bom-validation", "{% url 'api-part-list' %}", {
 addHeaderTitle('{% trans "Stock" %}');
 addHeaderAction('recently-updated-stock', '{% trans "Recently Updated" %}', 'fa-clock');
 addHeaderAction('low-stock', '{% trans "Low Stock" %}', 'fa-shopping-cart');
+addHeaderAction('depleted-stock', '{% trans "Depleted Stock" %}', 'fa-times');
 addHeaderAction('stock-to-build', '{% trans "Required for Build Orders" %}', 'fa-bullhorn');
 
 loadStockTable($('#table-recently-updated-stock'), {
@@ -168,6 +169,13 @@ loadSimplePartTable("#table-low-stock", "{% url 'api-part-list' %}", {
         low_stock: true,
     },
     name: "low_stock_parts",
+});
+
+loadSimplePartTable("#table-depleted-stock", "{% url 'api-part-list' %}", {
+    params: {
+        depleted_stock: true,
+    },
+    name: "depleted_stock_parts",
 });
 
 loadSimplePartTable("#table-stock-to-build", "{% url 'api-part-list' %}", {


### PR DESCRIPTION
This PR adds the first item of #1245, a filter for depleted stock on the home-page.

![grafik](https://user-images.githubusercontent.com/66015116/124332957-25748200-db93-11eb-850f-762ef17ef555.png)
