### PR TITLE
changes email-warning to yellow #1732

### DIFF
--- a/InvenTree/templates/stats.html
+++ b/InvenTree/templates/stats.html
@@ -63,7 +63,7 @@
         <td>{% trans "Email Settings" %}</td>
         <td>
             <a href='https://inventree.readthedocs.io/en/latest/admin/email'>
-                <span class='label label-red'>{% trans "Email settings not configured" %}</span>
+                <span class='label label-yellow'>{% trans "Email settings not configured" %}</span>
             </a>
         </td>
     </tr>


### PR DESCRIPTION
Fixes #1732 

@SchrodingersGat I changed the warning color to yellow - would you like to change more colors?
![grafik](https://user-images.githubusercontent.com/66015116/124334426-53f45c00-db97-11eb-8b56-ec32fb5b90df.png)
