### PR TITLE
Fixes for stock modal and notes propagation to tracking items

### DIFF
--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -1211,7 +1211,7 @@ class StockItem(MPTTModel):
             # We need to split the stock!
 
             # Split the existing StockItem in two
-            self.splitStock(quantity, location, user)
+            self.splitStock(quantity, location, user, **{'notes': notes})
 
             return True
 


### PR DESCRIPTION
I noticed that the modal was losing stock item information if not valid in the `POST` request (see missing stock item up top):

![image](https://user-images.githubusercontent.com/4020546/124519607-d0658580-ddb7-11eb-802d-7a64d1f29fe0.png)

This PR fixes it:

![image](https://user-images.githubusercontent.com/4020546/124519662-f5f28f00-ddb7-11eb-9c22-ed7875cccee2.png)

Also the "Notes" field would not be propagated to the stock tracking items during a "move" action, this PR fixes this too