### PR TITLE
Fixed supplier part detail handling in stock table

### DIFF
--- a/InvenTree/company/templates/company/detail_stock.html
+++ b/InvenTree/company/templates/company/detail_stock.html
@@ -23,7 +23,7 @@
         params: {
             company: {{ company.id }},
             part_detail: true,
-            supplier_detail: true,
+            supplier_part_detail: true,
             location_detail: true,
         },
         buttons: [

--- a/InvenTree/order/templates/order/po_received_items.html
+++ b/InvenTree/order/templates/order/po_received_items.html
@@ -25,7 +25,7 @@ loadStockTable($("#stock-table"), {
     params: {
         purchase_order: {{ order.id }},
         part_detail: true,
-        supplier_detail: true,
+        supplier_part_detail: true,
         location_detail: true,
     },
     buttons: [

--- a/InvenTree/stock/templates/stock/location.html
+++ b/InvenTree/stock/templates/stock/location.html
@@ -265,6 +265,7 @@
             {% endif %}
             part_detail: true,
             location_detail: true,
+            supplier_part_detail: true,
         },
         url: "{% url 'api-stock-list' %}",
     });

--- a/InvenTree/templates/js/stock.js
+++ b/InvenTree/templates/js/stock.js
@@ -688,6 +688,8 @@ function loadStockTable(table, options) {
             {
                 field: 'supplier_part',
                 title: '{% trans "Supplier Part" %}',
+                visible: params['supplier_part_detail'] || false,
+                switchable: params['supplier_part_detail'] || false,
                 formatter: function(value, row) {
                     if (!value) {
                         return '-';


### PR DESCRIPTION
This line would throw JS error when "Supplier Part" column was enabled on the stock tables that did **not** specify to the API to return `supplier_part_detail` data:

https://github.com/inventree/InvenTree/blob/c2df1fcd95c461bb7f1929368e96f45b1ad779b5/InvenTree/templates/js/stock.js#L697

Also there were a few stock table calls referencing `supplier_detail: true` instead of `supplier_part_detail: true` (`supplier_detail` is not a valid API filter).

Now should be good!