### PR TITLE
Reintroduces "part" column to part stock

### DIFF
--- a/InvenTree/part/templates/part/stock.html
+++ b/InvenTree/part/templates/part/stock.html
@@ -40,7 +40,7 @@
         params: {
             part: {{ part.id }},
             location_detail: true,
-            part_detail: false,
+            part_detail: true,
             supplier_part_detail: true,
         },
         groupByField: 'location',


### PR DESCRIPTION
If a part is a "template" part then it is useful to be able to see which "sub part" a particular stock item relates to.