### PR TITLE
Initial amount

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -233,6 +233,13 @@ class InvenTreeSetting(models.Model):
             'validator': bool,
         },
 
+        'PART_CREATE_INITIAL': {
+            'name': _('Create initial stock'),
+            'description': _('Create initial stock on part creation'),
+            'default': False,
+            'validator': bool,
+        },
+
         'PART_INTERNAL_PRICE': {
             'name': _('Internal Prices'),
             'description': _('Enable internal prices for parts'),

--- a/InvenTree/part/forms.py
+++ b/InvenTree/part/forms.py
@@ -217,6 +217,11 @@ class EditPartForm(HelperForm):
                                                    label=_('Include parent categories parameter templates'),
                                                    widget=forms.HiddenInput())
 
+    initial_stock = forms.IntegerField(required=False,
+                                       initial=0,
+                                       label=_('Initial stock amount'),
+                                       help_text=_('Create stock for this part'))
+
     class Meta:
         model = Part
         fields = [
@@ -238,6 +243,7 @@ class EditPartForm(HelperForm):
             'default_expiry',
             'units',
             'minimum_stock',
+            'initial_stock',
             'component',
             'assembly',
             'is_template',

--- a/InvenTree/templates/InvenTree/settings/part.html
+++ b/InvenTree/templates/InvenTree/settings/part.html
@@ -23,7 +23,8 @@
         {% include "InvenTree/settings/setting.html" with key="PART_SHOW_PRICE_IN_FORMS" icon="fa-dollar-sign" %}
         {% include "InvenTree/settings/setting.html" with key="PART_SHOW_RELATED" icon="fa-random" %}
         {% include "InvenTree/settings/setting.html" with key="PART_RECENT_COUNT" icon="fa-clock" %}
-        <tr><td colspan='5  '></td></tr>
+        {% include "InvenTree/settings/setting.html" with key="PART_CREATE_INITIAL" icon="fa-plus" %}
+        <tr><td colspan='5'></td></tr>
         {% include "InvenTree/settings/setting.html" with key="PART_TEMPLATE" icon="fa-clone" %}
         {% include "InvenTree/settings/setting.html" with key="PART_ASSEMBLY" icon="fa-tools" %}
         {% include "InvenTree/settings/setting.html" with key="PART_COMPONENT" icon="fa-th"%}

--- a/InvenTree/templates/InvenTree/settings/part.html
+++ b/InvenTree/templates/InvenTree/settings/part.html
@@ -23,7 +23,7 @@
         {% include "InvenTree/settings/setting.html" with key="PART_SHOW_PRICE_IN_FORMS" icon="fa-dollar-sign" %}
         {% include "InvenTree/settings/setting.html" with key="PART_SHOW_RELATED" icon="fa-random" %}
         {% include "InvenTree/settings/setting.html" with key="PART_RECENT_COUNT" icon="fa-clock" %}
-        {% include "InvenTree/settings/setting.html" with key="PART_CREATE_INITIAL" icon="fa-plus" %}
+        {% include "InvenTree/settings/setting.html" with key="PART_CREATE_INITIAL" icon="fa-boxes" %}
         <tr><td colspan='5'></td></tr>
         {% include "InvenTree/settings/setting.html" with key="PART_TEMPLATE" icon="fa-clone" %}
         {% include "InvenTree/settings/setting.html" with key="PART_ASSEMBLY" icon="fa-tools" %}


### PR DESCRIPTION
This PR adds the ability to create initial stock when creating a part. If a default location is set it is used as the location for the part, there is a setting to enable this feature, defaluted to false.
Closes #1796