### PR TITLE
Api speed

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -571,10 +571,6 @@ class PartList(generics.ListCreateAPIView):
 
         params = self.request.query_params
 
-        # Annotate calculated data to the queryset
-        # (This will be used for further filtering)
-        queryset = part_serializers.PartSerializer.annotate_queryset(queryset)
-
         queryset = super().filter_queryset(queryset)
 
         # Filter by "uses" query - Limit to parts which use the provided part

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -361,7 +361,6 @@ class PartDetail(generics.RetrieveUpdateDestroyAPIView):
     def get_queryset(self, *args, **kwargs):
         queryset = super().get_queryset(*args, **kwargs)
 
-        queryset = part_serializers.PartSerializer.prefetch_queryset(queryset)
         queryset = part_serializers.PartSerializer.annotate_queryset(queryset)
 
         return queryset

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -536,14 +536,74 @@ class PartList(generics.ListCreateAPIView):
 
         kwargs['starred_parts'] = self.starred_parts
 
-        try:
-            params = self.request.query_params
-
-            kwargs['category_detail'] = str2bool(params.get('category_detail', False))
-        except AttributeError:
-            pass
-
         return self.serializer_class(*args, **kwargs)
+
+    def list(self, request, *args, **kwargs):
+        """
+        Overide the 'list' method, as the PartCategory objects are
+        very expensive to serialize!
+
+        So we will serialize them first, and keep them in memory,
+        so that they do not have to be serialized multiple times...
+        """
+
+        queryset = self.filter_queryset(self.get_queryset())
+
+        page = self.paginate_queryset(queryset)
+
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+        else:
+            serializer = self.get_serializer(queryset, many=True)
+
+        data = serializer.data
+
+        # Do we wish to include PartCategory detail?
+        if str2bool(request.query_params.get('category_detail', False)):
+
+            # Work out which part categories we need to query
+            category_ids = set()
+
+            for part in data:
+                cat_id = part['category']
+
+                if cat_id is not None:
+                    category_ids.add(cat_id)
+
+            # Fetch only the required PartCategory objects from the database
+            categories = PartCategory.objects.filter(pk__in=category_ids).prefetch_related(
+                'parts',
+                'parent',
+                'children',
+            )
+
+            category_map = {}
+
+            # Serialize each PartCategory object
+            for category in categories:
+                category_map[category.pk] = part_serializers.CategorySerializer(category).data
+
+            for part in data:
+                cat_id = part['category']
+
+                if cat_id is not None and cat_id in category_map.keys():
+                    detail = category_map[cat_id]
+                else:
+                    detail = None
+
+                part['category_detail'] = detail
+
+        """
+        Determine the response type based on the request.
+        a) For HTTP requests (e.g. via the browseable API) return a DRF response
+        b) For AJAX requests, simply return a JSON rendered response.
+        """
+        if page is not None:
+            return self.get_paginated_response(data)
+        elif request.is_ajax():
+            return JsonResponse(data, safe=False)
+        else:
+            return Response(data)
 
     def perform_create(self, serializer):
         """

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -536,74 +536,14 @@ class PartList(generics.ListCreateAPIView):
 
         kwargs['starred_parts'] = self.starred_parts
 
+        try:
+            params = self.request.query_params
+
+            kwargs['category_detail'] = str2bool(params.get('category_detail', False))
+        except AttributeError:
+            pass
+
         return self.serializer_class(*args, **kwargs)
-
-    def list(self, request, *args, **kwargs):
-        """
-        Overide the 'list' method, as the PartCategory objects are
-        very expensive to serialize!
-
-        So we will serialize them first, and keep them in memory,
-        so that they do not have to be serialized multiple times...
-        """
-
-        queryset = self.filter_queryset(self.get_queryset())
-
-        page = self.paginate_queryset(queryset)
-
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-        else:
-            serializer = self.get_serializer(queryset, many=True)
-
-        data = serializer.data
-
-        # Do we wish to include PartCategory detail?
-        if str2bool(request.query_params.get('category_detail', False)):
-
-            # Work out which part categories we need to query
-            category_ids = set()
-
-            for part in data:
-                cat_id = part['category']
-
-                if cat_id is not None:
-                    category_ids.add(cat_id)
-
-            # Fetch only the required PartCategory objects from the database
-            categories = PartCategory.objects.filter(pk__in=category_ids).prefetch_related(
-                'parts',
-                'parent',
-                'children',
-            )
-
-            category_map = {}
-
-            # Serialize each PartCategory object
-            for category in categories:
-                category_map[category.pk] = part_serializers.CategorySerializer(category).data
-
-            for part in data:
-                cat_id = part['category']
-
-                if cat_id is not None and cat_id in category_map.keys():
-                    detail = category_map[cat_id]
-                else:
-                    detail = None
-
-                part['category_detail'] = detail
-
-        """
-        Determine the response type based on the request.
-        a) For HTTP requests (e.g. via the browseable API) return a DRF response
-        b) For AJAX requests, simply return a JSON rendered response.
-        """
-        if page is not None:
-            return self.get_paginated_response(data)
-        elif request.is_ajax():
-            return JsonResponse(data, safe=False)
-        else:
-            return Response(data)
 
     def perform_create(self, serializer):
         """
@@ -619,8 +559,6 @@ class PartList(generics.ListCreateAPIView):
     def get_queryset(self, *args, **kwargs):
 
         queryset = super().get_queryset(*args, **kwargs)
-
-        queryset = part_serializers.PartSerializer.prefetch_queryset(queryset)
         queryset = part_serializers.PartSerializer.annotate_queryset(queryset)
 
         return queryset

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -296,8 +296,9 @@ class PartManager(models.Manager):
 
         return super().get_queryset().prefetch_related(
             'category',
+            'category__parent',
             'stock_items',
-            'builds',    
+            'builds',
         )
 
 

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -27,6 +27,7 @@ from markdownx.models import MarkdownxField
 from django_cleanup import cleanup
 
 from mptt.models import TreeForeignKey, MPTTModel
+from mptt.managers import TreeManager
 
 from stdimage.models import StdImageField
 
@@ -284,7 +285,7 @@ def match_part_names(match, threshold=80, reverse=True, compare_length=False):
     return matches
 
 
-class PartManager(models.Manager):
+class PartManager(TreeManager):
     """
     Defines a custom object manager for the Part model.
 

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -284,6 +284,23 @@ def match_part_names(match, threshold=80, reverse=True, compare_length=False):
     return matches
 
 
+class PartManager(models.Manager):
+    """
+    Defines a custom object manager for the Part model.
+
+    The main purpose of this manager is to reduce the number of database hits,
+    as the Part model has a large number of ForeignKey fields!
+    """
+
+    def get_queryset(self):
+
+        return super().get_queryset().prefetch_related(
+            'category',
+            'stock_items',
+            'builds',    
+        )
+
+
 @cleanup.ignore
 class Part(MPTTModel):
     """ The Part object represents an abstract part, the 'concept' of an actual entity.
@@ -320,6 +337,8 @@ class Part(MPTTModel):
         creation_user: User who added this part to the database
         responsible: User who is responsible for this part (optional)
     """
+
+    objects = PartManager()
 
     class Meta:
         verbose_name = _("Part")

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -216,25 +216,6 @@ class PartSerializer(InvenTreeModelSerializer):
             self.fields.pop('category_detail')
 
     @staticmethod
-    def prefetch_queryset(queryset):
-        """
-        Prefetch related database tables,
-        to reduce database hits.
-        """
-
-        return queryset.prefetch_related(
-            'category',
-            'category__parts',
-            'category__parent',
-            'stock_items',
-            'bom_items',
-            'builds',
-            'supplier_parts',
-            'supplier_parts__purchase_order_line_items',
-            'supplier_parts__purchase_order_line_items__order',
-        )
-
-    @staticmethod
     def annotate_queryset(queryset):
         """
         Add some extra annotations to the queryset,

--- a/InvenTree/part/test_category.py
+++ b/InvenTree/part/test_category.py
@@ -99,7 +99,7 @@ class CategoryTest(TestCase):
         """ Test that the Category parameters are correctly fetched """
 
         # Check number of SQL queries to iterate other parameters
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(7):
             # Prefetch: 3 queries (parts, parameters and parameters_template)
             fasteners = self.fasteners.prefetch_parts_parameters()
             # Iterate through all parts and parameters

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -84,7 +84,6 @@ class StockDetail(generics.RetrieveUpdateDestroyAPIView):
     def get_queryset(self, *args, **kwargs):
 
         queryset = super().get_queryset(*args, **kwargs)
-        queryset = StockItemSerializer.prefetch_queryset(queryset)
         queryset = StockItemSerializer.annotate_queryset(queryset)
 
         return queryset
@@ -637,7 +636,6 @@ class StockList(generics.ListCreateAPIView):
 
         queryset = super().get_queryset(*args, **kwargs)
 
-        queryset = StockItemSerializer.prefetch_queryset(queryset)
         queryset = StockItemSerializer.annotate_queryset(queryset)
 
         return queryset

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -23,6 +23,7 @@ from django.dispatch import receiver
 from markdownx.models import MarkdownxField
 
 from mptt.models import MPTTModel, TreeForeignKey
+from mptt.managers import TreeManager
 
 from decimal import Decimal, InvalidOperation
 from datetime import datetime, timedelta
@@ -128,6 +129,31 @@ def before_delete_stock_location(sender, instance, using, **kwargs):
     for child in instance.children.all():
         child.parent = instance.parent
         child.save()
+
+
+class StockItemManager(TreeManager):
+    """
+    Custom database manager for the StockItem class.
+
+    StockItem querysets will automatically prefetch related fields.
+    """
+
+    def get_queryset(self):
+
+        return super().get_queryset().prefetch_related(
+            'belongs_to',
+            'build',
+            'customer',
+            'purchase_order',
+            'sales_order',
+            'supplier_part',
+            'supplier_part__supplier',
+            'allocations',
+            'sales_order_allocations',
+            'location',
+            'part',
+            'tracking_info'
+        )
 
 
 class StockItem(MPTTModel):

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -71,29 +71,6 @@ class StockItemSerializer(InvenTreeModelSerializer):
     """
 
     @staticmethod
-    def prefetch_queryset(queryset):
-        """
-        Prefetch related database tables,
-        to reduce database hits.
-        """
-
-        return queryset.prefetch_related(
-            'belongs_to',
-            'build',
-            'customer',
-            'purchase_order',
-            'sales_order',
-            'supplier_part',
-            'supplier_part__supplier',
-            'supplier_part__manufacturer_part__manufacturer',
-            'allocations',
-            'sales_order_allocations',
-            'location',
-            'part',
-            'tracking_info',
-        )
-
-    @staticmethod
     def annotate_queryset(queryset):
         """
         Add some extra annotations to the queryset,


### PR DESCRIPTION
Addressing some of the API request speed issues discovered in https://github.com/inventree/InvenTree/pull/1838

Parts in database: 5,000

| Query | Results | Before | After |
| --- | --- | --- | --- |
|  `/api/part/?limit=25&offset=0&format=json&search=ab` | 25 |  356ms  | **80ms** |
| `/api/part/?limit=25&offset=0&format=json&category_detail=true` | 25  |  746ms | **125ms** |
| `/api/part/?limit=500&offset=0&format=json&category_detail=true` | 500 | 1100ms | 1350ms | 
| `/api/part/?format=json&category_detail=false` | 5000 | 2800ms  | 1887ms |
| `/api/part/?format=json&category_detail=true` | 5000 | 3512ms | 3250ms  |

For future people looking back at this PR: The main expense here is `category_detail=true` due to the *recursive* category tree. The MPTT model structure mostly takes care of this, but still have not worked out a good method of annotation the "pathstring" to the queryset in a single database hit.
