### PR TITLE
Part: exclude itself from "Variant Of" choices

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -768,6 +768,10 @@ class PartList(generics.ListCreateAPIView):
             except (ValueError):
                 pass
 
+        # Variant list request (is_template): exclude itself from list
+        if params.get('is_template', False) and params.get('part', None):
+            queryset = queryset.exclude(pk=params.get('part', None))
+
         return queryset
 
     filter_backends = [

--- a/InvenTree/templates/js/part.js
+++ b/InvenTree/templates/js/part.js
@@ -54,7 +54,11 @@ function editPart(pk, options={}) {
         keywords: {
             icon: 'fa-key',
         },
-        variant_of: {},
+        variant_of: {
+            filters: {
+                part: pk,
+            },
+        },
         link: {
             icon: 'fa-link',
         },


### PR DESCRIPTION
This was a more difficult problem than I thought :sweat_smile: 

It appeared that with the new API form, the same part than the one being edited was listed in the "Variant Of" choices.

I dug into in the data flow for this field (this information is mostly for myself to remember next time I have to play with API forms!):
1. "Edit Part" form is requested by user thru UI
2. Javascript kicks in to send the `OPTIONS` request
3. The metadata is retrieved from part serializers and _enhanced_ in `metadata.py` then passed back to JS form
4. Each "related field" gets automatically translated to select2 dropdown with data received from `OPTIONS` request
5. Filters for "related field" are built-in filters from model or hard-coded manually in the main JS form function (in this case `editPart`)
6. Each time a "related field" dropdown is clicked on, the preset filters are passed to a `GET` request to the API (at this point, there is no more customization for the filters)

My proposed implementation is:
* add hard-coded `part` filter into the JS form function (`variant_of` field) referencing the primary key from the part being edited
* in the API, detect if both `is_template` and `part` filter are present, this indicates the request is about variants
* exclude the part being edited from the queryset

I hope this makes sense, let me know @SchrodingersGat if I got that right or if there is a better way to do this!