### PR TITLE
Improved handling of PO items destination

### DIFF
--- a/InvenTree/order/forms.py
+++ b/InvenTree/order/forms.py
@@ -84,9 +84,9 @@ class ReceivePurchaseOrderForm(HelperForm):
 
     location = TreeNodeChoiceField(
         queryset=StockLocation.objects.all(),
-        required=True,
+        required=False,
         label=_("Destination"),
-        help_text=_("Receive parts to this location"),
+        help_text=_("Set all received parts listed above to this location (if left blank, use \"Destination\" column value in above table)"),
     )
 
     class Meta:

--- a/InvenTree/order/templates/order/receive_parts.html
+++ b/InvenTree/order/templates/order/receive_parts.html
@@ -12,7 +12,7 @@
     {% load crispy_forms_tags %}
 
     <label class='control-label'>{% trans "Parts" %}</label>
-    <p class='help-block'>{% trans "Select parts to receive against this order" %}</p>
+    <p class='help-block'>{% trans "Fill out number of parts received, the status and destination" %}</p>
 
     <table class='table table-striped'>
         <tr>
@@ -55,7 +55,14 @@
                 </div>
             </td>
             <td>
-                {{ line.get_destination }}
+                <div class='control-group'>
+                    <select class='select' name='destination-{{ line.id }}'>
+                        <option value="">----------</option>
+                        {% for location in stock_locations %}
+                        <option value="{{ location.pk }}" {% if location == line.get_destination %}selected="selected"{% endif %}>{{ location }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
             </td>
             <td>
                 <button class='btn btn-default btn-remove' onClick="removeOrderRowFromOrderWizard()" id='del_item_{{ line.id }}' title='{% trans "Remove line" %}' type='button'>
@@ -67,6 +74,8 @@
     </table>
 
     {% crispy form %}
+
+    <div id='form-errors'>{{ form_errors }}</div>
 </form>
 
 {% endblock %}

--- a/InvenTree/order/views.py
+++ b/InvenTree/order/views.py
@@ -491,6 +491,7 @@ class PurchaseOrderReceive(AjaxUpdateView):
         ctx = {
             'order': self.order,
             'lines': self.lines,
+            'stock_locations': StockLocation.objects.all(),
         }
 
         return ctx
@@ -543,6 +544,7 @@ class PurchaseOrderReceive(AjaxUpdateView):
 
         self.request = request
         self.order = get_object_or_404(PurchaseOrder, pk=self.kwargs['pk'])
+        errors = False
 
         self.lines = []
         self.destination = None
@@ -556,12 +558,6 @@ class PurchaseOrderReceive(AjaxUpdateView):
                 self.destination = StockLocation.objects.get(id=pk)
             except (StockLocation.DoesNotExist, ValueError):
                 pass
-
-        errors = False
-
-        if self.destination is None:
-            errors = True
-            msg = _("No destination set")
 
         # Extract information on all submitted line items
         for item in request.POST:
@@ -586,6 +582,21 @@ class PurchaseOrderReceive(AjaxUpdateView):
                     line.status_code = status
                 else:
                     line.status_code = StockStatus.OK
+
+                # Check the destination field
+                line.destination = None
+                if self.destination:
+                    # If global destination is set, overwrite line value
+                    line.destination = self.destination
+                else:
+                    destination_key = f'destination-{pk}'
+                    destination = request.POST.get(destination_key, None)
+
+                    if destination:
+                        try:
+                            line.destination = StockLocation.objects.get(pk=destination)
+                        except (StockLocation.DoesNotExist, ValueError):
+                            pass
 
                 # Check that line matches the order
                 if not line.order == self.order:
@@ -645,7 +656,7 @@ class PurchaseOrderReceive(AjaxUpdateView):
 
             self.order.receive_line_item(
                 line,
-                self.destination,
+                line.destination,
                 line.receive_quantity,
                 self.request.user,
                 status=line.status_code,


### PR DESCRIPTION
Fixes #1832

* Adds "Destination" as select field in the receive part form
* Made the global "Destination" an optional field (stock location is optional for stock items)
* If the "destination" value is set for purchase order item then use it
* If the global "destination" field is set, override values of each line in the form

## Screenshots
### Order with items set to different destinations
![image](https://user-images.githubusercontent.com/4020546/126397035-bb8c8599-bc70-4551-b69c-d06bd6b36892.png)

### Receive form
![image](https://user-images.githubusercontent.com/4020546/126397130-02fd93d8-cee2-4564-903c-356212142581.png)
