### PR TITLE
Add instance-specific filters to API OPTIONS data

### DIFF
--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -93,6 +93,17 @@ class InvenTreeTree(MPTTModel):
         parent: The item immediately above this one. An item with a null parent is a top-level item
     """
 
+    def api_instance_filters(self):
+        """
+        Instance filters for InvenTreeTree models
+        """
+
+        return {
+            'parent': {
+                'exclude_tree': self.pk,
+            }
+        }
+
     def save(self, *args, **kwargs):
 
         try:

--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -104,6 +104,21 @@ class BuildList(generics.ListCreateAPIView):
 
         params = self.request.query_params
 
+        # exclude parent tree
+        exclude_tree = params.get('exclude_tree', None)
+
+        if exclude_tree is not None:
+
+            try:
+                build = Build.objects.get(pk=exclude_tree)
+
+                queryset = queryset.exclude(
+                    pk__in=[bld.pk for bld in build.get_descendants(include_self=True)]
+                )
+
+            except (ValueError, Build.DoesNotExist):
+                pass
+
         # Filter by "parent"
         parent = params.get('parent', None)
 

--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -96,6 +96,14 @@ class Build(MPTTModel):
     def get_api_url():
         return reverse('api-build-list')
 
+    def api_instance_filters(self):
+
+        return {
+            'parent': {
+                'exclude_tree': self.pk,
+            }
+        }
+
     def save(self, *args, **kwargs):
 
         try:

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -644,6 +644,20 @@ class PartList(generics.ListCreateAPIView):
             except (ValueError, Part.DoesNotExist):
                 pass
 
+        # Exclude part variant tree?
+        exclude_tree = params.get('exclude_tree', None)
+
+        if exclude_tree is not None:
+            try:
+                top_level_part = Part.objects.get(pk=exclude_tree)
+
+                queryset = queryset.exclude(
+                    pk__in=[prt.pk for prt in top_level_part.get_descendants(include_self=True)]
+                )
+
+            except (ValueError, Part.DoesNotExist):
+                pass
+
         # Filter by 'ancestor'?
         ancestor = params.get('ancestor', None)
 

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -105,6 +105,20 @@ class CategoryList(generics.ListCreateAPIView):
             except (ValueError, PartCategory.DoesNotExist):
                 pass
 
+        # Exclude PartCategory tree
+        exclude_tree = params.get('exclude_tree', None)
+
+        if exclude_tree is not None:
+            try:
+                cat = PartCategory.objects.get(pk=exclude_tree)
+
+                queryset = queryset.exclude(
+                    pk__in=[c.pk for c in cat.get_descendants(include_self=True)]
+                )
+
+            except (ValueError, PartCategory.DoesNotExist):
+                pass
+
         return queryset
 
     filter_backends = [

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -371,7 +371,6 @@ class Part(MPTTModel):
             }
         }
 
-
     def get_context_data(self, request, **kwargs):
         """
         Return some useful context data about this part for template rendering

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -359,6 +359,18 @@ class Part(MPTTModel):
 
         return reverse('api-part-list')
 
+    def api_instance_filters(self):
+        """
+        Return API query filters for limiting field results against this instance
+        """
+
+        return {
+            'variant_of': {
+                'exclude_tree': self.pk,
+            }
+        }
+
+
     def get_context_data(self, request, **kwargs):
         """
         Return some useful context data about this part for template rendering

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -27,6 +27,7 @@ from markdownx.models import MarkdownxField
 from django_cleanup import cleanup
 
 from mptt.models import TreeForeignKey, MPTTModel
+from mptt.exceptions import InvalidMove
 from mptt.managers import TreeManager
 
 from stdimage.models import StdImageField
@@ -426,7 +427,12 @@ class Part(MPTTModel):
 
         self.full_clean()
 
-        super().save(*args, **kwargs)
+        try:
+            super().save(*args, **kwargs)
+        except InvalidMove:
+            raise ValidationError({
+                'variant_of': _('Invalid choice for parent part'),
+            })
 
         if add_category_templates:
             # Get part category

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -343,6 +343,20 @@ class StockLocationList(generics.ListCreateAPIView):
             except (ValueError, StockLocation.DoesNotExist):
                 pass
 
+        # Exclude StockLocation tree
+        exclude_tree = params.get('exclude_tree', None)
+
+        if exclude_tree is not None:
+            try:
+                loc = StockLocation.objects.get(pk=exclude_tree)
+
+                queryset = queryset.exclude(
+                    pk__in=[l.pk for l in loc.get_descendants(include_self=True)]
+                )
+
+            except (ValueError, StockLocation.DoesNotExist):
+                pass
+
         return queryset
 
     filter_backends = [

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -733,6 +733,20 @@ class StockList(generics.ListCreateAPIView):
         if customer:
             queryset = queryset.filter(customer=customer)
 
+        # Exclude stock item tree
+        exclude_tree = params.get('exclude_tree', None)
+
+        if exclude_tree is not None:
+            try:
+                item = StockItem.objects.get(pk=exclude_tree)
+
+                queryset = queryset.exclude(
+                    pk__in=[it.pk for it in item.get_descendants(include_self=True)]
+                )
+
+            except (ValueError, StockItem.DoesNotExist):
+                pass
+
         # Filter by 'allocated' parts?
         allocated = params.get('allocated', None)
 

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -351,7 +351,7 @@ class StockLocationList(generics.ListCreateAPIView):
                 loc = StockLocation.objects.get(pk=exclude_tree)
 
                 queryset = queryset.exclude(
-                    pk__in=[l.pk for l in loc.get_descendants(include_self=True)]
+                    pk__in=[subloc.pk for subloc in loc.get_descendants(include_self=True)]
                 )
 
             except (ValueError, StockLocation.DoesNotExist):

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -191,6 +191,17 @@ class StockItem(MPTTModel):
     def get_api_url():
         return reverse('api-stock-list')
 
+    def api_instance_filters(self):
+        """
+        Custom API instance filters
+        """
+
+        return {
+            'parent': {
+                'exclude_tree': self.pk,
+            }
+        }
+
     # A Query filter which will be re-used in multiple places to determine if a StockItem is actually "in stock"
     IN_STOCK_FILTER = Q(
         quantity__gt=0,

--- a/InvenTree/templates/js/forms.js
+++ b/InvenTree/templates/js/forms.js
@@ -350,6 +350,12 @@ function constructFormBody(fields, options) {
     for(field in fields) {
         fields[field].name = field;
 
+        
+        // If any "instance_filters" are defined for the endpoint, copy them across (overwrite)
+        if (fields[field].instance_filters) {
+            fields[field].filters = Object.assign(fields[field].filters || {}, fields[field].instance_filters);
+        }
+
         var field_options = displayed_fields[field];
 
         // Copy custom options across to the fields object


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/pull/1851

Adds a separate field to the OPTIONS endpoint for ForeignKey fields, called `instance_filters`

If the API endpoint is associated with a particular model instance, then that model has the opportunity to provide custom filters *for that model instance*

- [x] Part
- [x] PartCategory
- [x] StockItem
- [x] StockLocation
- [x] BuildOrder

This does not require hard-coded filters to be added to the client-side code, it all happens on the server. It also allows a future path for other instance-specific filters to add other functionality.
