### PR TITLE
Part parameters in reports

### DIFF
--- a/InvenTree/label/models.py
+++ b/InvenTree/label/models.py
@@ -296,7 +296,9 @@ class StockItemLabel(LabelTemplate):
             'uid': stock_item.uid,
             'qr_data': stock_item.format_barcode(brief=True),
             'qr_url': stock_item.format_barcode(url=True, request=request),
-            'tests': stock_item.testResultMap()
+            'tests': stock_item.testResultMap(),
+            'parameters': stock_item.part.parameters_map(),
+
         }
 
 

--- a/InvenTree/label/models.py
+++ b/InvenTree/label/models.py
@@ -398,4 +398,5 @@ class PartLabel(LabelTemplate):
             'revision': part.revision,
             'qr_data': part.format_barcode(brief=True),
             'qr_url': part.format_barcode(url=True, request=request),
+            'parameters': part.parameters_map(),
         }

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1904,6 +1904,23 @@ class Part(MPTTModel):
 
         return self.parameters.order_by('template__name')
 
+    def parameters_map(self):
+        """
+        Return a map (dict) of parameter values assocaited with this Part instance,
+        of the form:
+        {
+            "name_1": "value_1",
+            "name_2": "value_2",
+        }
+        """
+
+        params = {}
+
+        for parameter in self.parameters.all():
+            params[parameter.template.name] = parameter.data
+
+        return params
+
     @property
     def has_variants(self):
         """ Check if this Part object has variants underneath it. """

--- a/InvenTree/report/models.py
+++ b/InvenTree/report/models.py
@@ -356,6 +356,7 @@ class TestReport(ReportTemplateBase):
             'stock_item': stock_item,
             'serial': stock_item.serial,
             'part': stock_item.part,
+            'parameters': stock_item.part.parameters_map(),
             'results': stock_item.testResultMap(include_installed=self.include_installed),
             'result_list': stock_item.testResultList(include_installed=self.include_installed),
             'installed_items': stock_item.get_installed_items(cascade=True),


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/1762

Exposes part parameters as key:value map to report and label templates

Docs: https://github.com/inventree/inventree-docs/pull/137