### PR TITLE
fix for phantom migration warning

### DIFF
--- a/InvenTree/InvenTree/fields.py
+++ b/InvenTree/InvenTree/fields.py
@@ -55,7 +55,7 @@ class InvenTreeModelMoneyField(ModelMoneyField):
     
     def __init__(self, **kwargs):
         # detect if creating migration
-        if 'makemigrations' in sys.argv:
+        if 'migrate' in sys.argv or 'makemigrations' in sys.argv:
             # remove currency information for a clean migration
             kwargs['default_currency'] = ''
             kwargs['currency_choices'] = []


### PR DESCRIPTION
Closes #1775

@eeintech So turns out the phantom part changes shown are the result of me forgetting to also check if a migration is run, not only if migrations are generated. This PR fixes that.