### PR TITLE
Re-enabled installing stock items into others

### DIFF
--- a/InvenTree/build/templates/build/build_base.html
+++ b/InvenTree/build/templates/build/build_base.html
@@ -111,8 +111,8 @@ src="{% static 'img/blank_image.png' %}"
             <li><a href='#' id='build-cancel'><span class='fas fa-times-circle icon-red'></span> {% trans "Cancel Build" %}</a></li>
             {% endif %}
             {% if build.status == BuildStatus.CANCELLED and roles.build.delete %}
-            <li><a href='#' id='build-delete'><span class='fas fa-trash-alt'></span> {% trans "Delete Build"% }</a>
-                {% endif %}
+            <li><a href='#' id='build-delete'><span class='fas fa-trash-alt'></span> {% trans "Delete Build" %}</a>
+            {% endif %}
         </ul>
     </div>
     {% endif %}

--- a/InvenTree/stock/forms.py
+++ b/InvenTree/stock/forms.py
@@ -241,15 +241,20 @@ class InstallStockForm(HelperForm):
         help_text=_('Stock item to install')
     )
 
-    quantity_to_install = RoundingDecimalFormField(
-        max_digits=10, decimal_places=5,
-        initial=1,
-        label=_('Quantity'),
-        help_text=_('Stock quantity to assign'),
-        validators=[
-            MinValueValidator(0.001)
-        ]
+    to_install = forms.BooleanField(
+        widget=forms.HiddenInput(), 
+        required=False
     )
+
+    # quantity_to_install = RoundingDecimalFormField(
+    #     max_digits=10, decimal_places=5,
+    #     initial=1,
+    #     label=_('Quantity'),
+    #     help_text=_('Stock quantity to assign'),
+    #     validators=[
+    #         MinValueValidator(0.001)
+    #     ]
+    # )
 
     notes = forms.CharField(
         required=False,
@@ -261,7 +266,7 @@ class InstallStockForm(HelperForm):
         fields = [
             'part',
             'stock_item',
-            'quantity_to_install',
+            # 'quantity_to_install',
             'notes',
         ]
 

--- a/InvenTree/stock/forms.py
+++ b/InvenTree/stock/forms.py
@@ -245,16 +245,6 @@ class InstallStockForm(HelperForm):
         required=False,
     )
 
-    # quantity_to_install = RoundingDecimalFormField(
-    #     max_digits=10, decimal_places=5,
-    #     initial=1,
-    #     label=_('Quantity'),
-    #     help_text=_('Stock quantity to assign'),
-    #     validators=[
-    #         MinValueValidator(0.001)
-    #     ]
-    # )
-
     notes = forms.CharField(
         required=False,
         help_text=_('Notes')

--- a/InvenTree/stock/forms.py
+++ b/InvenTree/stock/forms.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 from django import forms
 from django.forms.utils import ErrorDict
 from django.utils.translation import ugettext_lazy as _
-from django.core.validators import MinValueValidator
 from django.core.exceptions import ValidationError
 
 from mptt.fields import TreeNodeChoiceField
@@ -242,8 +241,8 @@ class InstallStockForm(HelperForm):
     )
 
     to_install = forms.BooleanField(
-        widget=forms.HiddenInput(), 
-        required=False
+        widget=forms.HiddenInput(),
+        required=False,
     )
 
     # quantity_to_install = RoundingDecimalFormField(

--- a/InvenTree/stock/templates/stock/item.html
+++ b/InvenTree/stock/templates/stock/item.html
@@ -119,6 +119,11 @@
         <h4>{% trans "Installed Stock Items" %}</h4>
     </div>
     <div class='panel-content'>
+        <div class='btn-group'>
+        <button type='button' class='btn btn-success' id='stock-item-install'>
+            <span class='fas fa-plus-circle'></span> {% trans "Install Stock Item" %}
+        </button>
+        </div>
         <table class='table table-striped table-condensed' id='installed-table'></table>
     </div>
 </div>
@@ -127,6 +132,20 @@
 
 {% block js_ready %}
 {{ block.super }}
+
+    $('#stock-item-install').click(function() {
+
+        launchModalForm(
+            "{% url 'stock-item-install' item.pk %}",
+            {
+                data: {
+                    'part': {{ item.part.pk }},
+                    'install_item': true,
+                },
+                reload: true,
+            }
+        );
+    });
 
     loadInstalledInTable(
         $('#installed-table'),

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -127,9 +127,11 @@
                 <li><a href='#' id='stock-return-from-customer' title='{% trans "Return to stock" %}'><span class='fas fa-undo'></span> {% trans "Return to stock" %}</a></li>
                 {% endif %}
                 {% if item.belongs_to %}
-                <li>
-                    <a href='#' id='stock-uninstall' title='{% trans "Uninstall stock item" %}'><span class='fas fa-unlink'></span> {% trans "Uninstall" %}</a>
-                </li>
+                <li><a href='#' id='stock-uninstall' title='{% trans "Uninstall stock item" %}'><span class='fas fa-unlink'></span> {% trans "Uninstall" %}</a></li>
+                {% else %}
+                {% if item.part.get_used_in %}
+                <li><a href='#' id='stock-install-in' title='{% trans "Install stock item" %}'><span class='fas fa-link'></span> {% trans "Install" %}</a></li>
+                {% endif %}
                 {% endif %}
             </ul>
         </div>
@@ -461,13 +463,27 @@ $("#stock-serialize").click(function() {
     );
 });
 
+$('#stock-install-in').click(function() {
+
+    launchModalForm(
+        "{% url 'stock-item-install' item.pk %}",
+        {
+            data: {
+                'part': {{ item.part.pk }},
+                'install_in': true,
+            },
+            reload: true,
+        }
+    );
+});
+
 $('#stock-uninstall').click(function() {
 
     launchModalForm(
         "{% url 'stock-item-uninstall' %}",
         {
             data: {
-                'items[]': [{{ item.pk}}],
+                'items[]': [{{ item.pk }}],
             },
             reload: true,
         }

--- a/InvenTree/stock/templates/stock/item_install.html
+++ b/InvenTree/stock/templates/stock/item_install.html
@@ -3,15 +3,31 @@
 
 {% block pre_form_content %}
 
+{% if install_item %}
 <p>
-    {% trans "Install another StockItem into this item." %}
+    {% trans "Install another Stock Item into this item." %}
 </p>
 <p>
     {% trans "Stock items can only be installed if they meet the following criteria" %}:
 
     <ul>
-        <li>{% trans "The StockItem links to a Part which is in the BOM for this StockItem" %}</li>
-        <li>{% trans "The StockItem is currently in stock" %}</li>
+        <li>{% trans "The Stock Item links to a Part which is in the BOM for this Stock Item" %}</li>
+        <li>{% trans "The Stock Item is currently in stock" %}</li>
+        <li>{% trans "The Stock Item is serialized and does not belong to another item" %}</li>
     </ul>
 </p>
+{% elif install_in %}
+<p>
+    {% trans "Install this Stock Item in another stock item." %}
+</p>
+<p>
+    {% trans "Stock items can only be installed if they meet the following criteria" %}:
+
+    <ul>
+        <li>{% trans "The part associated to this Stock Item belongs to another part's BOM" %}</li>
+        <li>{% trans "This Stock Item is serialized and does not belong to another item" %}</li>
+    </ul>
+</p>
+{% endif %}
+
 {% endblock %}

--- a/InvenTree/stock/views.py
+++ b/InvenTree/stock/views.py
@@ -595,7 +595,6 @@ class StockItemInstall(AjaxUpdateView):
         if items.count() == 1:
             item = items.first()
             initials['stock_item'] = item.pk
-            # initials['quantity_to_install'] = item.quantity
 
         if self.part:
             initials['part'] = self.part
@@ -629,7 +628,6 @@ class StockItemInstall(AjaxUpdateView):
             data = form.cleaned_data
 
             other_stock_item = data['stock_item']
-            # quantity = data['quantity_to_install']
             # Quantity will always be 1 for serialized item
             quantity = 1
             notes = data['notes']


### PR DESCRIPTION
Intent is to fix #1770 

This implementation manages both:
* installing the current stock item into another stock item (action item "Install)

![image](https://user-images.githubusercontent.com/4020546/127911528-255709fd-ae6b-4fde-a09f-9e3de6d94ab5.png)

* installing other stock items into the current stock item ("Installed Items" tab)

![image](https://user-images.githubusercontent.com/4020546/127911567-32e33ba4-22c5-4c6a-a3f6-397c5cd1b126.png)
