### PR TITLE
Pin weasyprint version to 52.5

### DIFF
--- a/InvenTree/report/templates/report/inventree_build_order_base.html
+++ b/InvenTree/report/templates/report/inventree_build_order_base.html
@@ -79,7 +79,7 @@ content: "v{{report_revision}} - {{ date.isoformat }}";
 
 {% block header_content %}
     <!-- TODO - Make the company logo asset generic -->
-    <img class='logo' src="{% asset 'company_logo.png' %}" alt="hello" width="150">
+    <img class='logo' src="{% asset 'company_logo.png' %}" alt="logo" width="150">
 
     <div class='header-right'>
         <h3>

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,8 @@ coverage==5.3                   # Unit test coverage
 coveralls==2.1.2                # Coveralls linking (for Travis)
 rapidfuzz==0.7.6                # Fuzzy string matching
 django-stdimage==5.1.1          # Advanced ImageField management
-django-weasyprint==1.0.1        # HTML PDF export
+weasyprint==52.5                # PDF generation library (Note: in the future need to update to 53)
+django-weasyprint==1.0.1        # django weasyprint integration
 django-debug-toolbar==2.2       # Debug / profiling toolbar
 django-admin-shell==0.1.2       # Python shell for the admin interface
 py-moneyed==0.8.0               # Specific version requirement for py-moneyed


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/1903

- Weasyprint recently updated to 53
- breaks integration with django-weasyprint
- Ref: https://github.com/fdemmer/django-weasyprint/issues/53