### PR TITLE
Re-added ability to link manufacturer part to supplier part via API

### DIFF
--- a/InvenTree/company/models.py
+++ b/InvenTree/company/models.py
@@ -9,7 +9,9 @@ import os
 
 from django.utils.translation import ugettext_lazy as _
 from django.core.validators import MinValueValidator
+from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.utils import IntegrityError
 from django.db.models import Sum, Q, UniqueConstraint
 
 from django.apps import apps
@@ -472,6 +474,57 @@ class SupplierPart(models.Model):
 
     def get_absolute_url(self):
         return reverse('supplier-part-detail', kwargs={'pk': self.id})
+
+    def save(self, *args, **kwargs):
+        """ Overriding save method to process the linked ManufacturerPart
+        """
+
+        if 'manufacturer' in kwargs:
+            manufacturer_id = kwargs.pop('manufacturer')
+
+            try:
+                manufacturer = Company.objects.get(pk=int(manufacturer_id))
+            except (ValueError, Company.DoesNotExist):
+                manufacturer = None
+        else:
+            manufacturer = None
+        if 'MPN' in kwargs:
+            MPN = kwargs.pop('MPN')
+        else:
+            MPN = None
+
+        if manufacturer or MPN:
+            if not self.manufacturer_part:
+                # Create ManufacturerPart
+                manufacturer_part = ManufacturerPart.create(part=self.part,
+                                                            manufacturer=manufacturer,
+                                                            mpn=MPN,
+                                                            description=self.description)
+                self.manufacturer_part = manufacturer_part
+            else:
+                # Update ManufacturerPart (if ID exists)
+                try:
+                    manufacturer_part_id = self.manufacturer_part.id
+                except AttributeError:
+                    manufacturer_part_id = None
+
+                if manufacturer_part_id:
+                    try:
+                        (manufacturer_part, created) = ManufacturerPart.objects.update_or_create(part=self.part,
+                                                                                                 manufacturer=manufacturer,
+                                                                                                 MPN=MPN)
+                    except IntegrityError:
+                        manufacturer_part = None
+                        raise ValidationError(f'ManufacturerPart linked to {self.part} from manufacturer {manufacturer.name}'
+                                              f'with part number {MPN} already exists!')
+
+                if manufacturer_part:
+                    self.manufacturer_part = manufacturer_part
+
+        self.clean()
+        self.validate_unique()
+
+        super().save(*args, **kwargs)
 
     class Meta:
         unique_together = ('part', 'supplier', 'SKU')

--- a/InvenTree/company/serializers.py
+++ b/InvenTree/company/serializers.py
@@ -231,6 +231,24 @@ class SupplierPartSerializer(InvenTreeModelSerializer):
             'supplier_detail',
         ]
 
+    def create(self, validated_data):
+        """ Extract manufacturer data and process ManufacturerPart """
+
+        # Create SupplierPart
+        supplier_part = super().create(validated_data)
+
+        # Get ManufacturerPart raw data (unvalidated)
+        manufacturer_id = self.initial_data.get('manufacturer', None)
+        MPN = self.initial_data.get('MPN', None)
+
+        if manufacturer_id or MPN:
+            kwargs = {'manufacturer': manufacturer_id,
+                      'MPN': MPN,
+                      }
+            supplier_part.save(**kwargs)
+
+        return supplier_part
+
 
 class SupplierPriceBreakSerializer(InvenTreeModelSerializer):
     """ Serializer for SupplierPriceBreak object """


### PR DESCRIPTION
@SchrodingersGat In #1836, the ability to link a manufacturer part to a supplier part using:
- manufacturer ID
- manufacturer MPN

was removed.

The idea was to create a shortcut in the creation of the supplier part, not having to find out which manufacturer parts are associated to the same part on the client side. In this case the validation of link is done on the server side and, if both information above are correct, the supplier is automatically connected to the corresponding manufacturer part.

Did you intentionally intend to force the client to retrieve the list of manufacturer parts, then get the correct manufacturer part id, then link it directly to the supplier part? Or are you open for shortcuts in this process? (if you have any better idea than the one presented here, let me know!)