### PR TITLE
Label print options

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -344,13 +344,15 @@ def GetExportFormats():
     ]
 
 
-def DownloadFile(data, filename, content_type='application/text'):
-    """ Create a dynamic file for the user to download.
+def DownloadFile(data, filename, content_type='application/text', inline=False):
+    """
+    Create a dynamic file for the user to download.
 
     Args:
         data: Raw file data (string or bytes)
         filename: Filename for the file download
         content_type: Content type for the download
+        inline: Download "inline" or as attachment? (Default = attachment)
 
     Return:
         A StreamingHttpResponse object wrapping the supplied data
@@ -365,7 +367,10 @@ def DownloadFile(data, filename, content_type='application/text'):
 
     response = StreamingHttpResponse(wrapper, content_type=content_type)
     response['Content-Length'] = len(data)
-    response['Content-Disposition'] = 'attachment; filename={f}'.format(f=filename)
+
+    disposition = "inline" if inline else "attachment"
+
+    response['Content-Disposition'] = f'{disposition}; filename={filename}'
 
     return response
 

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -979,7 +979,10 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
 
     @classmethod
     def get_filters(cls, key, **kwargs):
-        return {'key__iexact': key, 'user__id': kwargs['user'].id}
+        return {
+            'key__iexact': key,
+            'user__id': kwargs['user'].id
+        }
 
 
 class PriceBreak(models.Model):

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -926,6 +926,20 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
             'validator': bool,
         },
 
+        "LABEL_INLINE": {
+            'name': _('Inline label display'),
+            'description': _('Display PDF labels in the browser, instead of downloading as a file'),
+            'default': True,
+            'validator': bool,
+        },
+
+        "REPORT_INLINE": {
+            'name': _('Inline report display'),
+            'description': _('Display PDF reports in the browser, instead of downloading as a file'),
+            'default': False,
+            'validator': bool,
+        },
+
         'SEARCH_PREVIEW_RESULTS': {
             'name': _('Search Preview Results'),
             'description': _('Number of results to show in search preview window'),

--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -109,10 +109,12 @@ class LabelPrintMixin:
             else:
                 pdf = outputs[0].get_document().write_pdf()
 
+            inline = common.models.InvenTreeUserSetting.get_setting('LABEL_INLINE', user=request.user)
             return InvenTree.helpers.DownloadFile(
                 pdf,
                 label_name,
-                content_type='application/pdf'
+                content_type='application/pdf',
+                inline=inline
             )
 
 

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -204,6 +204,7 @@ def settings_value(key, *args, **kwargs):
 
     if 'user' in kwargs:
         return InvenTreeUserSetting.get_setting(key, user=kwargs['user'])
+        
     return InvenTreeSetting.get_setting(key)
 
 

--- a/InvenTree/templates/InvenTree/settings/navbar.html
+++ b/InvenTree/templates/InvenTree/settings/navbar.html
@@ -30,6 +30,18 @@
         </a>
     </li>
 
+    <li class='list-group-item' title='{% trans "Labels" %}'>
+        <a href='#' class='nav-toggle' id='select-user-labels'>
+            <span class='fas fa-tag'></span> {% trans "Labels" %}
+        </a>
+    </li>
+
+    <li class='list-group-item' title='{% trans "Reports" %}'>
+        <a href='#' class='nav-toggle' id='select-user-reports'>
+            <span class='fas fa-file-pdf'></span> {% trans "Reports" %}
+        </a>
+    </li>
+
     <!--
         <li class='list-group-item' title='{% trans "Settings" %}'>
             <a href='#' class='nav-toggle' id='select-user-settings'>

--- a/InvenTree/templates/InvenTree/settings/settings.html
+++ b/InvenTree/templates/InvenTree/settings/settings.html
@@ -18,6 +18,8 @@
 {% include "InvenTree/settings/user_settings.html" %}
 {% include "InvenTree/settings/user_homepage.html" %}
 {% include "InvenTree/settings/user_search.html" %}
+{% include "InvenTree/settings/user_labels.html" %}
+{% include "InvenTree/settings/user_reports.html" %}
 
 {% if user.is_staff %}
 

--- a/InvenTree/templates/InvenTree/settings/user_labels.html
+++ b/InvenTree/templates/InvenTree/settings/user_labels.html
@@ -1,0 +1,23 @@
+{% extends "panel.html" %}
+
+{% load i18n %}
+{% load inventree_extras %}
+
+{% block label %}user-labels{% endblock %}
+
+{% block heading %}
+{% trans "Label Settings" %}
+{% endblock %}
+
+{% block content %}
+
+<div class='row'>
+    <table class='table table-striped table-condensed'>
+        {% include "InvenTree/settings/header.html" %}
+        <tbody>
+            {% include "InvenTree/settings/setting.html" with key="LABEL_INLINE" icon='fa-tag' user_setting=True %}
+        </tbody>
+    </table>
+</div>
+
+{% endblock %}

--- a/InvenTree/templates/InvenTree/settings/user_reports.html
+++ b/InvenTree/templates/InvenTree/settings/user_reports.html
@@ -1,0 +1,23 @@
+{% extends "panel.html" %}
+
+{% load i18n %}
+{% load inventree_extras %}
+
+{% block label %}user-reports{% endblock %}
+
+{% block heading %}
+{% trans "Label Settings" %}
+{% endblock %}
+
+{% block content %}
+
+<div class='row'>
+    <table class='table table-striped table-condensed'>
+        {% include "InvenTree/settings/header.html" %}
+        <tbody>
+            {% include "InvenTree/settings/setting.html" with key="REPORT_INLINE" icon='fa-file-pdf' user_setting=True %}
+        </tbody>
+    </table>
+</div>
+
+{% endblock %}

--- a/InvenTree/templates/InvenTree/settings/user_reports.html
+++ b/InvenTree/templates/InvenTree/settings/user_reports.html
@@ -6,7 +6,7 @@
 {% block label %}user-reports{% endblock %}
 
 {% block heading %}
-{% trans "Label Settings" %}
+{% trans "Report Settings" %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Adds user-configurable options to display labels inline or save as attachment.

Same for reports, too.

Fixes https://github.com/inventree/InvenTree/issues/1910