### PR TITLE
Localization of item.quantity removed

### DIFF
--- a/InvenTree/stock/templates/stock/item.html
+++ b/InvenTree/stock/templates/stock/item.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load inventree_extras %}
 {% load i18n %}
+{% load l10n %}
 {% load markdownify %}
 
 {% block menubar %}
@@ -152,7 +153,7 @@
         {
             stock_item: {{ item.pk }},
             part: {{ item.part.pk }},
-            quantity: {{ item.quantity }},
+            quantity: {{ item.quantity|unlocalize }},
         }
     );
 


### PR DESCRIPTION
Localization of quantity for different cultures(turkish in my case) using comma(,) instead of dot(.) leads syntax error in javascript code and prevents stock item history to load.