### PR TITLE
Update nginx.conf to use http_host rather than host fixes #1930

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -10,7 +10,7 @@ server {
         proxy_pass http://inventree-server:8000;
 
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
 
         proxy_redirect off;
 


### PR DESCRIPTION
Using proxy_set_header Host $host; does not pass through the port. This causes the /api-doc/ route to miss the port when attempting to render routes. 
This fixes: #1930