### PR TITLE
Part summary panel

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -946,6 +946,13 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
             'default': 10,
             'validator': [int, MinValueValidator(1)]
         },
+        'PART_DISPLAY_SUMMARY': {
+            'name': _('Part Summary'),
+            'description': _('Display Part Summary'),
+            'default': False,
+            'validator': bool,
+        },
+    
     }
 
     class Meta:

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -10,6 +10,42 @@
 {% endblock %}
 
 {% block page_content %}
+{% settings_value 'PART_DISPLAY_SUMMARY' user=request.user as display_summary %}
+
+{% if display_summary %}
+<div class='panel panel-default panel-inventree panel-hidden' id='panel-summary'>
+    <div class='panel-body'>
+        <div class="col-md-6">
+            {% if part.notes %}
+            <h4>{% trans "Notes" %}</h4>
+            {{ part.notes | markdownify }}
+            {% endif %}
+
+            <div style="margin-top: 20px">
+            <h4>{% trans "Parameters" %}</h4>
+            <table id='summary-parameter-table' class='table table-sm'><tbody><tr><td><p class="text-center">Loading...</p></td></tr></tbody></table>
+            </div>
+
+            <div>
+            <h4>{% trans "Attachments" %}</h4>
+            <table id='summary-attachment-table' class='table table-sm table-borderless'><tbody><tr><td><p class="text-center">Loading...</p></td></tr></tbody></table>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <h4>{% trans "Part Stock" %}</h4>
+            <table id='summary-stock-table' class='table table-sm table-bordered'>
+                <thead><tr>
+                    <th>{% trans "Stock" %}</th>
+                    <th>{% trans "Status" %}</th>
+                    <th>{% trans "Location" %}</th>
+                    <th>{% trans "Purchase Price" %}</th>
+                </tr></thead>
+                <tbody><tr><td colspan="4"><p class="text-center">Loading...</p></td></tr></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}
 
 <div class='panel panel-default panel-inventree panel-hidden' id='panel-part-stock'>
     <div class='panel-heading'>
@@ -332,6 +368,8 @@
 
 {% block js_ready %}
     {{ block.super }}
+
+{% settings_value 'PART_DISPLAY_SUMMARY' user=request.user as display_summary %}
 
     // Load the "suppliers" tab
     onPanelLoad('suppliers', function() {
@@ -1074,4 +1112,59 @@
         default: 'part-stock'
     });
 
+    {% if display_summary %}
+    $('#panel-part-parameters').trigger('fadeInStarted')
+    $('#parameter-table').on('load-success.bs.table', function(e, data) {
+        var table = $('#summary-parameter-table');
+        table.find('tbody').empty();
+        if (jQuery.isEmptyObject(data)) {
+            table.parent().hide();
+            return;
+        } else {
+            table.parent().show();
+        }
+        for (var param of data) {
+            table.find('tbody').append('<tr><td>'+param.template_detail.name+'</td><td>'+param.data+' '+param.template_detail.units+'</td></tr>');
+        }
+    })
+
+    $('#panel-part-attachments').trigger('fadeInStarted')
+    $('#attachment-table').on('load-success.bs.table', function(e, data) {
+        var table = $('#summary-attachment-table');
+        table.find('tbody').empty();
+
+        if (jQuery.isEmptyObject(data)) {
+            table.parent().hide();
+            return;
+        }
+        for (var attachment of data) {
+            var filename = attachment.attachment.split('\\').pop().split('/').pop();
+            var badge = "";
+            if (filename.indexOf('.') !== -1) {
+                var fileExt = filename.split('.').pop();
+                badge='<span class="badge">'+fileExt+'</span> '
+            }
+            table.find('tbody').append('<tr><td>'+badge+'<a href="'+attachment.attachment+'">'+(attachment.comment?attachment.comment:filename)+'</a></td></tr>');
+        };
+    })
+
+    $('#panel-part-stock').trigger('fadeInStarted')
+    $('#stock-table').on('load-success.bs.table', function(e, data) {
+        var table = $('#summary-stock-table');
+        table.find('tbody').empty();
+
+        if (data.count==0) {
+            table.parent().hide();
+            return;
+        }
+        for (var stock of data.results) {
+            table.find('tbody').append('<tr>\
+                <td class="col-md-1"><a href="/stock/item/'+stock.pk+'/">'+stock.quantity+'</a></td>\
+                <td class="col-md-1">'+stockStatusDisplay(stock.status)+'</td>\
+                <td><a href="/stock/location/'+stock.location_detail.pk+'/">'+stock.location_detail.pathstring+'</a></td>\
+                <td>'+stock.purchase_price+'</td>\
+            </tr>');
+        }
+    })
+    {% endif %}
 {% endblock %}

--- a/InvenTree/part/templates/part/navbar.html
+++ b/InvenTree/part/templates/part/navbar.html
@@ -4,6 +4,8 @@
 
 {% settings_value "PART_INTERNAL_PRICE" as show_internal_price %}
 {% settings_value 'PART_SHOW_RELATED' as show_related %}
+{% settings_value 'PART_DISPLAY_SUMMARY' user=request.user as display_summary %}
+
 
 <ul class='list-group'>
     <li class='list-group-item'>
@@ -11,6 +13,14 @@
             <span class='menu-tab-icon fas fa-expand-arrows-alt'></span>
         </a>
     </li>
+    {% if display_summary %}
+    <li class='list-group-item' title='Summary'>
+        <a href='#' id='select-summary' class='nav-toggle'>
+            <span class='menu-tab-icon fas fa-info-circle sidebar-icon'></span>
+            Summary
+        </a>
+    </li>
+    {% endif %}
     <li class='list-group-item' title='{% trans "Parameters" %}'>
         <a href='#' id='select-part-parameters' class='nav-toggle'>
             <span class='menu-tab-icon fas fa-th-list sidebar-icon'></span>

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -12,13 +12,19 @@
 
 <div class="panel panel-default panel-inventree">
     <!-- Default panel contents -->
-    <div class="panel-heading"><h3>{{ part.full_name }}</h3></div>
+<!--    <div class="panel-heading row"><h3>{{ part.full_name }}</h3></div>-->
     <div class="panel-body">
         <div class="row">
             <div class="col-sm-6">
-            {% include "part/part_thumb.html" %}
-            <div class="media-body">
-                <p> 
+                {% include "part/part_thumb.html" %}
+                <div class="media-body">
+                    <h3 style="margin-top: 0px">
+                        {{ part.full_name }}
+                    </h3>
+                    {% if part.description %}
+                    <p><em>{{ part.description }}</em></p>
+                    {% endif %}
+                    <p>
                     <h3>
                     <!-- Admin View -->
                     {% if user.is_staff and roles.part.change %}
@@ -130,8 +136,15 @@
                     </div>
                     {% endif %}
                 </div>
+                <div>
+                    <!-- Details show/hide button -->
+                    <button id="toggle-part-details" class="btn btn-primary btn-sm" data-toggle="collapse" data-target="#collapsible-part-details" value="show">
+                        <span class="fas fa-chevron-down"></span> {% trans "Show Part Details" %}
+                    </button>
+                </div>
             </div>
             </div>
+
             <div class='info-messages'>
                 {% if part.variant_of %}
                 <div class='alert alert-info alert-block' style='padding: 10px;'>
@@ -210,13 +223,6 @@
         </div>
     </div>
 
-    <p>
-        <!-- Details show/hide button -->
-        <button id="toggle-part-details" class="btn btn-primary" data-toggle="collapse" data-target="#collapsible-part-details" value="show">
-        <span class="fas fa-chevron-down"></span> {% trans "Show Part Details" %}
-        </button>
-    </p>
-        
     <div class="collapse" id="collapsible-part-details">
         <div class="card card-body">
             <!-- Details Table -->

--- a/InvenTree/templates/InvenTree/settings/navbar.html
+++ b/InvenTree/templates/InvenTree/settings/navbar.html
@@ -42,13 +42,11 @@
         </a>
     </li>
 
-    <!--
-        <li class='list-group-item' title='{% trans "Settings" %}'>
-            <a href='#' class='nav-toggle' id='select-user-settings'>
-                <span class='fas fa-cog'></span> {% trans "Settings" %}
-            </a>
-        </li>
-    -->
+    <li class='list-group-item' title='{% trans "Settings" %}'>
+        <a href='#' class='nav-toggle' id='select-user-settings'>
+            <span class='fas fa-cog'></span> {% trans "Settings" %}
+        </a>
+    </li>
 
     {% if user.is_staff %}
 

--- a/InvenTree/templates/InvenTree/settings/user_settings.html
+++ b/InvenTree/templates/InvenTree/settings/user_settings.html
@@ -14,6 +14,10 @@
 <div class='row'>
     <table class='table table-striped table-condensed'>
         {% include "InvenTree/settings/header.html" %}
+        <tbody>
+        {% include "InvenTree/settings/setting.html" with key="PART_DISPLAY_SUMMARY" user_setting=True %}
+
+        </tbody>
 
     </table>
 </div>


### PR DESCRIPTION
Implementation of mockup from #1673
![image](https://user-images.githubusercontent.com/10057327/128942717-1f5e3575-fa62-4f72-b95f-9cb857057d06.png)

My first idea was to get data right from prerendered tables but then I found `load-success.bs.table` event and decided to take all info from tables JSON. Lazy loading almost broke all my work, so just for these three tables I preload data by triggering `fadeInStarted` event. Is it ok?
I'm slightly confused by how `{% settings_value ` work, what is the scope of this variable?

@SchrodingersGat what do you think about this?