### PR TITLE
Dockerfile fix

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -32,5 +32,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           target: production
+          build-args:
+            tag: ${{ github.event.release.tag_name }}
           repository: inventree/inventree
           tags: inventree/inventree:${{ github.event.release.tag_name }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,9 @@ FROM alpine:3.13 as base
 ARG repository="https://github.com/inventree/InvenTree.git"
 ARG branch="master"
 
+# Optionally specify a particular tag to checkout
+ARG tag=""
+
 ENV PYTHONUNBUFFERED 1
 
 # InvenTree key settings
@@ -12,8 +15,9 @@ ENV PYTHONUNBUFFERED 1
 ENV INVENTREE_HOME="/home/inventree"
 
 # GitHub settings
-ENV INVENTREE_REPO="${repository}"
-ENV INVENTREE_BRANCH="${branch}"
+ENV INVENTREE_GIT_REPO="${repository}"
+ENV INVENTREE_GIT_BRANCH="${branch}"
+ENV INVENTREE_GIT_TAG="${tag}"
 
 ENV INVENTREE_LOG_LEVEL="INFO"
 ENV INVENTREE_DOCKER="true"
@@ -80,8 +84,12 @@ RUN pip install --no-cache-dir -U gunicorn
 
 FROM base as production
 # Clone source code
-RUN echo "Downloading InvenTree from ${INVENTREE_REPO}"
-RUN git clone --branch ${INVENTREE_BRANCH} --depth 1 ${INVENTREE_REPO} ${INVENTREE_HOME}
+RUN echo "Downloading InvenTree from ${INVENTREE_GIT_REPO}"
+
+RUN git clone --branch ${INVENTREE_GIT_BRANCH} --depth 1 ${INVENTREE_GIT_REPO} ${INVENTREE_HOME}
+
+# Checkout against a particular git tag
+RUN if [ -n "${INVENTREE_GIT_TAG}" ] ; then cd ${INVENTREE_HOME} && git fetch --all --tags && git checkout tags/${INVENTREE_GIT_TAG} -b v${INVENTREE_GIT_TAG}-branch ; fi
 
 # Install InvenTree packages
 RUN pip install --no-cache-dir -U -r ${INVENTREE_HOME}/requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,10 +77,7 @@ RUN apk add --no-cache postgresql postgresql-contrib postgresql-dev libpq
 RUN apk add --no-cache mariadb-connector-c mariadb-dev mariadb-client
 
 # Install required python packages
-RUN pip install --upgrade pip setuptools wheel
-RUN pip install --no-cache-dir -U invoke
 RUN pip install --no-cache-dir -U psycopg2 mysqlclient pgcli mariadb
-RUN pip install --no-cache-dir -U gunicorn
 
 FROM base as production
 # Clone source code

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
+# Basic package requirements
+setuptools>=57.4.0
+wheel>=0.37.0
 invoke>=1.4.0                   # Invoke build tool
-wheel>=0.34.2                   # Wheel
+gunicorn>=20.1.0                # Gunicorn web server
+
+# Django framework
 Django==3.2.4                     # Django package
+
 pillow==8.2.0                   # Image manipulation
 djangorestframework==3.12.4     # DRF framework
 django-cors-headers==3.2.0      # CORS headers extension for DRF
@@ -33,7 +39,6 @@ django-test-migrations==1.1.0   # Unit testing for database migrations
 python-barcode[images]==0.13.1  # Barcode generator
 qrcode[pil]==6.1                # QR code generator
 django-q==1.3.4                 # Background task scheduling
-gunicorn>=20.0.4                # Gunicorn web server
 django-formtools==2.3           # Form wizard tools
 
 inventree                       # Install the latest version of the InvenTree API python library


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/1950

When publishing to docker hub on a tagged release, the dockerfile is now passed the git "tag" reference.

This ensures that the correct tagged release code is actually pulled. Previous behavior was to always pull latest master!