### PR TITLE
Supplier part from form

### DIFF
--- a/InvenTree/InvenTree/static/css/inventree.css
+++ b/InvenTree/InvenTree/static/css/inventree.css
@@ -730,6 +730,13 @@
   padding: 10px;
 }
 
+.form-panel {
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    padding: 5px;
+}
+
+
 .modal input {
     width: 100%;
 }

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -643,7 +643,7 @@ class PartList(generics.ListCreateAPIView):
         Note: Implementation copied from DRF class CreateModelMixin
         """
 
-        #TODO: Unit tests for this function!
+        # TODO: Unit tests for this function!
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -733,9 +733,7 @@ class PartList(generics.ListCreateAPIView):
                 stock_item.save(user=request.user)
 
         # Optionally add manufacturer / supplier data to the part
-        add_supplier_info = str2bool(request.data.get('add_supplier_info', False))
-
-        if add_supplier_info:
+        if part.purchaseable and str2bool(request.data.get('add_supplier_info', False)):
 
             try:
                 manufacturer = Company.objects.get(pk=request.data.get('manufacturer', None))
@@ -780,7 +778,7 @@ class PartList(generics.ListCreateAPIView):
                         'SKU': [_("This field is required")]
                     })
 
-                supplier_part = SupplierPart.objects.create(
+                SupplierPart.objects.create(
                     part=part,
                     supplier=supplier,
                     SKU=sku,

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -693,9 +693,7 @@ class PartList(generics.ListCreateAPIView):
         if initial_stock:
             try:
 
-                print("q:", request.data.get('initial_stock_quantity'))
-
-                initial_stock_quantity = Decimal(request.data.get('initial_stock_quantity', None))
+                initial_stock_quantity = Decimal(request.data.get('initial_stock_quantity', ''))
 
                 if initial_stock_quantity <= 0:
                     raise ValidationError({

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -9,12 +9,14 @@ from django.conf.urls import url, include
 from django.urls import reverse
 from django.http import JsonResponse
 from django.db.models import Q, F, Count, Min, Max, Avg
+from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework import filters, serializers
 from rest_framework import generics
+from rest_framework.exceptions import ValidationError
 
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters import rest_framework as rest_filters
@@ -23,7 +25,7 @@ from djmoney.money import Money
 from djmoney.contrib.exchange.models import convert_money
 from djmoney.contrib.exchange.exceptions import MissingRate
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 from .models import Part, PartCategory, BomItem
 from .models import PartParameter, PartParameterTemplate
@@ -31,7 +33,9 @@ from .models import PartAttachment, PartTestTemplate
 from .models import PartSellPriceBreak, PartInternalPriceBreak
 from .models import PartCategoryParameterTemplate
 
-from stock.models import StockItem
+
+from stock.models import StockItem, StockLocation
+
 from common.models import InvenTreeSetting
 from build.models import Build
 
@@ -630,12 +634,15 @@ class PartList(generics.ListCreateAPIView):
         else:
             return Response(data)
 
+    @transaction.atomic
     def create(self, request, *args, **kwargs):
         """
         We wish to save the user who created this part!
 
         Note: Implementation copied from DRF class CreateModelMixin
         """
+
+        #TODO: Unit tests for this function!
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -680,21 +687,49 @@ class PartList(generics.ListCreateAPIView):
                 pass
 
         # Optionally create initial stock item
-        try:
-            initial_stock = Decimal(request.data.get('initial_stock', 0))
+        initial_stock = str2bool(request.data.get('initial_stock', False))
 
-            if initial_stock > 0 and part.default_location is not None:
+        if initial_stock:
+            try:
+
+                print("q:", request.data.get('initial_stock_quantity'))
+
+                initial_stock_quantity = Decimal(request.data.get('initial_stock_quantity', None))
+
+                if initial_stock_quantity <= 0:
+                    raise ValidationError({
+                        'initial_stock_quantity': [_('Must be greater than zero')],
+                    })
+            except (ValueError, InvalidOperation):  # Invalid quantity provided
+                raise ValidationError({
+                    'initial_stock_quantity': [_('Must be a valid quantity')],
+                })
+            
+            # If an initial stock quantity is specified...
+            if initial_stock_quantity > 0:
+
+                initial_stock_location = request.data.get('initial_stock_location', None)
+
+                try:
+                    initial_stock_location = StockLocation.objects.get(pk=initial_stock_location)
+                except (ValueError, StockLocation.DoesNotExist):
+                    initial_stock_location = None
+
+                if initial_stock_location is None:
+                    if part.default_location is not None:
+                        initial_stock_location = part.default_location
+                    else:
+                        raise ValidationError({
+                            'initial_stock_location': [_('Specify location for initial part stock')],
+                        })
 
                 stock_item = StockItem(
                     part=part,
-                    quantity=initial_stock,
-                    location=part.default_location,
+                    quantity=initial_stock_quantity,
+                    location=initial_stock_location,
                 )
 
                 stock_item.save(user=request.user)
-
-        except:
-            pass
 
         headers = self.get_success_headers(serializer.data)
 

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -276,6 +276,7 @@
         constructForm('{% url "api-part-list" %}', {
             method: 'POST',
             fields: fields,
+            groups: partGroups(),
             title: '{% trans "Create Part" %}',
             onSuccess: function(data) {
                 // Follow the new part

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -129,6 +129,7 @@ class PartAPITest(InvenTreeAPITestCase):
         'location',
         'bom',
         'test_templates',
+        'company',
     ]
 
     roles = [
@@ -465,6 +466,119 @@ class PartAPITest(InvenTreeAPITestCase):
         self.assertFalse(response.data['active'])
         self.assertFalse(response.data['purchaseable'])
 
+    def test_initial_stock(self):
+        """
+        Tests for initial stock quantity creation
+        """
+
+        url = reverse('api-part-list')
+
+        # Track how many parts exist at the start of this test
+        n = Part.objects.count()
+
+        # Set up required part data
+        data = {
+            'category': 1,
+            'name': "My lil' test part",
+            'description': 'A part with which to test',
+        }
+
+        # Signal that we want to add initial stock
+        data['initial_stock'] = True
+
+        # Post without a quantity
+        response = self.post(url, data, expected_code=400)
+        self.assertIn('initial_stock_quantity', response.data)
+
+        # Post with an invalid quantity
+        data['initial_stock_quantity'] = "ax"
+        response = self.post(url, data, expected_code=400)
+        self.assertIn('initial_stock_quantity', response.data)
+
+        # Post with a negative quantity
+        data['initial_stock_quantity'] = -1
+        response = self.post(url, data, expected_code=400)
+        self.assertIn('Must be greater than zero', response.data['initial_stock_quantity'])
+
+        # Post with a valid quantity
+        data['initial_stock_quantity'] = 12345
+
+        response = self.post(url, data, expected_code=400)
+        self.assertIn('initial_stock_location', response.data)
+
+        # Check that the number of parts has not increased (due to form failures)
+        self.assertEqual(Part.objects.count(), n)
+
+        # Now, set a location
+        data['initial_stock_location'] = 1
+
+        response = self.post(url, data, expected_code=201)
+
+        # Check that the part has been created
+        self.assertEqual(Part.objects.count(), n + 1)
+
+        pk = response.data['pk']
+
+        new_part = Part.objects.get(pk=pk)
+
+        self.assertEqual(new_part.total_stock, 12345)
+
+    def test_initial_supplier_data(self):
+        """
+        Tests for initial creation of supplier / manufacturer data
+        """
+
+        url = reverse('api-part-list')
+
+        n = Part.objects.count()
+
+        # Set up initial part data
+        data = {
+            'category': 1,
+            'name': 'Buy Buy Buy',
+            'description': 'A purchaseable part',
+            'purchaseable': True,
+        }
+
+        # Signal that we wish to create initial supplier data
+        data['add_supplier_info'] = True
+
+        # Specify MPN but not manufacturer
+        data['MPN'] = 'MPN-123'
+
+        response = self.post(url, data, expected_code=400)
+        self.assertIn('manufacturer', response.data)
+
+        # Specify manufacturer but not MPN
+        del data['MPN']
+        data['manufacturer'] = 1
+        response = self.post(url, data, expected_code=400)
+        self.assertIn('MPN', response.data)
+
+        # Specify SKU but not supplier
+        del data['manufacturer']
+        data['SKU'] = 'SKU-123'
+        response = self.post(url, data, expected_code=400)
+        self.assertIn('supplier', response.data)
+
+        # Specify supplier but not SKU
+        del data['SKU']
+        data['supplier'] = 1
+        response = self.post(url, data, expected_code=400)
+        self.assertIn('SKU', response.data)
+
+        # Check that no new parts have been created
+        self.assertEqual(Part.objects.count(), n)
+
+        # Now, fully specify the details
+        data['SKU'] = 'SKU-123'
+        data['supplier'] = 3
+        data['MPN'] = 'MPN-123'
+        data['manufacturer'] = 6
+
+        response = self.post(url, data, expected_code=201)
+
+        self.assertEqual(Part.objects.count(), n + 1)
 
 class PartDetailTests(InvenTreeAPITestCase):
     """

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -580,6 +580,15 @@ class PartAPITest(InvenTreeAPITestCase):
 
         self.assertEqual(Part.objects.count(), n + 1)
 
+        pk = response.data['pk']
+
+        new_part = Part.objects.get(pk=pk)
+
+        # Check that there is a new manufacturer part *and* a new supplier part
+        self.assertEqual(new_part.supplier_parts.count(), 1)
+        self.assertEqual(new_part.manufacturer_parts.count(), 1)
+        
+
 class PartDetailTests(InvenTreeAPITestCase):
     """
     Test that we can create / edit / delete Part objects via the API

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -490,6 +490,8 @@ function constructFormBody(fields, options) {
     // Attach clear callbacks (if required)
     addClearCallbacks(fields, options);
 
+    attachToggle(modal);
+
     $(modal + ' .select2-container').addClass('select-full-width');
     $(modal + ' .select2-container').css('width', '100%');
 
@@ -1699,7 +1701,7 @@ function constructInputOptions(name, classes, type, parameters) {
     }
 
     if (parameters.type == 'boolean') {
-        opts.push(`style='float: right;'`);
+        opts.push(`style='display: inline-block; width: 20px; margin-right: 20px;'`);
     }
 
     if (parameters.multiline) {
@@ -1878,7 +1880,7 @@ function constructHelpText(name, parameters, options) {
     var style = '';
 
     if (parameters.type == 'boolean') {
-        style = `style='display: inline;' `;
+        style = `style='display: inline-block; margin-left: 25px' `;
     }
 
     var html = `<div id='hint_id_${name}' ${style}class='help-block'><i>${parameters.help_text}</i></div>`;

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -490,8 +490,6 @@ function constructFormBody(fields, options) {
     // Attach clear callbacks (if required)
     addClearCallbacks(fields, options);
 
-    attachToggle(modal);
-
     $(modal + ' .select2-container').addClass('select-full-width');
     $(modal + ' .select2-container').css('width', '100%');
 
@@ -1528,12 +1526,13 @@ function constructField(name, parameters, options) {
         html += `</div>`;   // input-group
     }
 
-    // Div for error messages
-    html += `<div id='errors-${name}'></div>`;
-
     if (parameters.help_text) {
         html += constructHelpText(name, parameters, options);
     }
+
+    // Div for error messages
+    html += `<div id='errors-${name}'></div>`;
+
 
     html += `</div>`;   // controls
     html += `</div>`;   // form-group
@@ -1697,6 +1696,10 @@ function constructInputOptions(name, classes, type, parameters) {
     // Placeholder?
     if (parameters.placeholder != null) {
         opts.push(`placeholder='${parameters.placeholder}'`);
+    }
+
+    if (parameters.type == 'boolean') {
+        opts.push(`style='float: right;'`);
     }
 
     if (parameters.multiline) {
@@ -1872,7 +1875,13 @@ function constructCandyInput(name, parameters, options) {
  */
 function constructHelpText(name, parameters, options) {
     
-    var html = `<div id='hint_id_${name}' class='help-block'><i>${parameters.help_text}</i></div>`;
+    var style = '';
+
+    if (parameters.type == 'boolean') {
+        style = `style='display: inline;' `;
+    }
+
+    var html = `<div id='hint_id_${name}' ${style}class='help-block'><i>${parameters.help_text}</i></div>`;
 
     return html;
 }

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -842,10 +842,12 @@ function handleFormErrors(errors, fields, options) {
 
     var non_field_errors = $(options.modal).find('#non-field-errors');
 
+    // TODO: Display the JSON error text when hovering over the "info" icon
     non_field_errors.append(
         `<div class='alert alert-block alert-danger'>
             <b>{% trans "Form errors exist" %}</b>
-            <span id='form-errors-info' class='float-right fas fa-info-circle icon-red'></span>
+            <span id='form-errors-info' class='float-right fas fa-info-circle icon-red'>
+            </span>
         </div>`
     );
 
@@ -985,6 +987,28 @@ function initializeGroups(fields, options) {
         } else {
             $(modal).find(`#form-panel-content-${group}`).collapse("show");
         }
+
+        if (group_options.hidden) {
+            hideFormGroup(group, options);
+        }
+    }
+}
+
+// Hide a form group
+function hideFormGroup(group, options) {
+    $(options.modal).find(`#form-panel-${group}`).hide();
+}
+
+// Show a form group
+function showFormGroup(group, options) {
+    $(options.modal).find(`#form-panel-${group}`).show();
+}
+
+function setFormGroupVisibility(group, vis, options) {
+    if (vis) {
+        showFormGroup(group, options);
+    } else {
+        hideFormGroup(group, options);
     }
 }
 

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -13,6 +13,26 @@ function yesNoLabel(value) {
     }
 }
 
+
+function partGroups(options={}) {
+
+    return {
+        attributes: {
+            title: '{% trans "Part Attributes" %}',
+            collapsible: true,
+        },
+        create: {
+            title: '{% trans "Part Creation Options" %}',
+            collapsible: true,
+        },
+        duplicate: {
+            title: '{% trans "Part Duplication Options" %}',
+            collapsible: true,
+        }
+    }
+
+}
+
 // Construct fieldset for part forms
 function partFields(options={}) {
 
@@ -48,36 +68,41 @@ function partFields(options={}) {
         minimum_stock: {
             icon: 'fa-boxes',
         },
-        attributes: {
-            type: 'candy',
-            html: `<hr><h4><i>{% trans "Part Attributes" %}</i></h4><hr>`
-        },
         component: {
             value: global_settings.PART_COMPONENT,
+            group: 'attributes',
         },
         assembly: {
             value: global_settings.PART_ASSEMBLY,
+            group: 'attributes',
         },
         is_template: {
             value: global_settings.PART_TEMPLATE,
+            group: 'attributes',
         },
         trackable: {
             value: global_settings.PART_TRACKABLE,
+            group: 'attributes',
         },
         purchaseable: {
             value: global_settings.PART_PURCHASEABLE,
+            group: 'attributes',
         },
         salable: {
             value: global_settings.PART_SALABLE,
+            group: 'attributes',
         },
         virtual: {
             value: global_settings.PART_VIRTUAL,
+            group: 'attributes',
         },
     };
 
     // If editing a part, we can set the "active" status
     if (options.edit) {
-        fields.active = {};
+        fields.active = {
+            group: 'attributes'
+        };
     }
 
     // Pop expiry field
@@ -91,16 +116,12 @@ function partFields(options={}) {
         // No supplier parts available yet
         delete fields["default_supplier"];
 
-        fields.create = {
-            type: 'candy',
-            html: `<hr><h4><i>{% trans "Part Creation Options" %}</i></h4><hr>`,
-        };
-
         if (global_settings.PART_CREATE_INITIAL) {
             fields.initial_stock = {
                 type: 'decimal',
                 label: '{% trans "Initial Stock Quantity" %}',
                 help_text: '{% trans "Initialize part stock with specified quantity" %}',
+                group: 'create',
             };
         }
 
@@ -109,21 +130,18 @@ function partFields(options={}) {
             label: '{% trans "Copy Category Parameters" %}',
             help_text: '{% trans "Copy parameter templates from selected part category" %}',
             value: global_settings.PART_CATEGORY_PARAMETERS,
+            group: 'create',
         };
     }
 
     // Additional fields when "duplicating" a part
     if (options.duplicate) {
 
-        fields.duplicate = {
-            type: 'candy',
-            html: `<hr><h4><i>{% trans "Part Duplication Options" %}</i></h4><hr>`,
-        };
-
         fields.copy_from = {
             type: 'integer',
             hidden: true,
             value: options.duplicate,
+            group: 'duplicate',
         },
 
         fields.copy_image = {
@@ -131,6 +149,7 @@ function partFields(options={}) {
             label: '{% trans "Copy Image" %}',
             help_text: '{% trans "Copy image from original part" %}',
             value: true,
+            group: 'duplicate',
         },
 
         fields.copy_bom = {
@@ -138,6 +157,7 @@ function partFields(options={}) {
             label: '{% trans "Copy BOM" %}',
             help_text: '{% trans "Copy bill of materials from original part" %}',
             value: global_settings.PART_COPY_BOM,
+            group: 'duplicate',
         };
 
         fields.copy_parameters = {
@@ -145,6 +165,7 @@ function partFields(options={}) {
             label: '{% trans "Copy Parameters" %}',
             help_text: '{% trans "Copy parameter data from original part" %}',
             value: global_settings.PART_COPY_PARAMETERS,
+            group: 'duplicate',
         };
     }
 
@@ -191,8 +212,11 @@ function editPart(pk, options={}) {
         edit: true
     });
 
+    var groups = partGroups({});
+
     constructForm(url, {
         fields: fields,
+        groups: partGroups(),
         title: '{% trans "Edit Part" %}',
         reload: true,
     });
@@ -221,6 +245,7 @@ function duplicatePart(pk, options={}) {
             constructForm('{% url "api-part-list" %}', {
                 method: 'POST',
                 fields: fields,
+                groups: partGroups(),
                 title: '{% trans "Duplicate Part" %}',
                 data: data,
                 onSuccess: function(data) {

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -117,10 +117,29 @@ function partFields(options={}) {
         delete fields["default_supplier"];
 
         if (global_settings.PART_CREATE_INITIAL) {
+
             fields.initial_stock = {
+                type: 'boolean',
+                label: '{% trans "Create Initial Stock" %}',
+                help_text: '{% trans "Create an initial stock item for this part" %}',
+                group: 'create',
+            };
+
+            fields.initial_stock_quantity = {
                 type: 'decimal',
                 label: '{% trans "Initial Stock Quantity" %}',
-                help_text: '{% trans "Initialize part stock with specified quantity" %}',
+                help_text: '{% trans "Specify initial stock quantity for this part" %}',
+                group: 'create',
+            };
+
+            // TODO - Allow initial location of stock to be specified
+            fields.initial_stock_location = {
+                label: '{% trans "Location" %}',
+                help_text: '{% trans "Select destination stock location" %}',
+                type: 'related field',
+                required: true,
+                api_url: `/api/stock/location/`,
+                model: 'stocklocation',
                 group: 'create',
             };
         }

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -135,6 +135,7 @@ function partFields(options={}) {
 
             fields.initial_stock_quantity = {
                 type: 'decimal',
+                value: 1,
                 label: '{% trans "Initial Stock Quantity" %}',
                 help_text: '{% trans "Specify initial stock quantity for this part" %}',
                 group: 'create',

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -28,6 +28,11 @@ function partGroups(options={}) {
         duplicate: {
             title: '{% trans "Part Duplication Options" %}',
             collapsible: true,
+        },
+        supplier: {
+            title: '{% trans "Supplier Options" %}',
+            collapsible: true,
+            hidden: !global_settings.PART_PURCHASEABLE,
         }
     }
 
@@ -87,6 +92,9 @@ function partFields(options={}) {
         purchaseable: {
             value: global_settings.PART_PURCHASEABLE,
             group: 'attributes',
+            onEdit: function(value, name, field, options) {
+                setFormGroupVisibility('supplier', value, options);
+            }
         },
         salable: {
             value: global_settings.PART_SALABLE,
@@ -151,6 +159,53 @@ function partFields(options={}) {
             value: global_settings.PART_CATEGORY_PARAMETERS,
             group: 'create',
         };
+
+        // Supplier options
+        fields.add_supplier_info = {
+            type: 'boolean',
+            label: '{% trans "Add Supplier Data" %}',
+            help_text: '{% trans "Create initial supplier data for this part" %}',
+            group: 'supplier',
+        };
+        
+        fields.supplier = {
+            type: 'related field',
+            model: 'company',
+            label: '{% trans "Supplier" %}',
+            help_text: '{% trans "Select supplier" %}',
+            filters: {
+                'is_supplier': true,
+            },
+            api_url: '{% url "api-company-list" %}',
+            group: 'supplier',
+        };
+        
+        fields.SKU = {
+            type: 'string',
+            label: '{% trans "SKU" %}', 
+            help_text: '{% trans "Supplier stock keeping unit" %}',
+            group: 'supplier',
+        };
+        
+        fields.manufacturer = {
+            type: 'related field',
+            model: 'company',
+            label: '{% trans "Manufacturer" %}',
+            help_text: '{% trans "Select manufacturer" %}',
+            filters: {
+                'is_manufacturer': true,
+            },
+            api_url: '{% url "api-company-list" %}',
+            group: 'supplier',
+        };
+        
+        fields.MPN = {
+            type: 'string',
+            label: '{% trans "MPN" %}',
+            help_text: '{% trans "Manufacturer Part Number" %}',
+            group: 'supplier',
+        };
+
     }
 
     // Additional fields when "duplicating" a part


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/1109

- [x] Add unit tests
- [x] Add documentation
- [x] Add entry to release notes

This PR adds upon the functionality of the existing part API, allowing initial stock and initial supplier / manufacturer info to be added when creating a new part.

As there is now quite a lot of data in the Part creation form, this PR also adds the concept of "form groups" which can be dynamically toggled, as well as hidden based on other form field options:

![image](https://user-images.githubusercontent.com/10080325/129374146-8f44eaf1-d34b-48f7-8a4a-032db8ad8e00.png)

![image](https://user-images.githubusercontent.com/10080325/129374172-95fbbace-d5dd-407f-b1b0-cc3271afb780.png)

![image](https://user-images.githubusercontent.com/10080325/129374207-8eb43855-4c3f-4b02-8678-d4659694dbb4.png)

![image](https://user-images.githubusercontent.com/10080325/129374239-589b03fc-75eb-4c03-8c0c-d7072d5e5a94.png)

![image](https://user-images.githubusercontent.com/10080325/129374759-63383469-931b-473f-a724-872ffbd96f11.png)


