### PR TITLE
Cleanup docker vars for dev setup

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -213,14 +213,12 @@ if cors_opt:
 # Web URL endpoint for served static files
 STATIC_URL = '/static/'
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'InvenTree', 'static'),
-]
+STATICFILES_DIRS = []
 
 # Translated Template settings
 STATICFILES_I18_PREFIX = 'i18n'
 STATICFILES_I18_SRC = os.path.join(BASE_DIR, 'templates', 'js', 'translated')
-STATICFILES_I18_TRG = STATICFILES_DIRS[0] + '_' + STATICFILES_I18_PREFIX
+STATICFILES_I18_TRG = os.path.join(BASE_DIR, 'InvenTree', 'static_i18n')
 STATICFILES_DIRS.append(STATICFILES_I18_TRG)
 STATICFILES_I18_TRG = os.path.join(STATICFILES_I18_TRG, STATICFILES_I18_PREFIX)
 

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -169,6 +169,30 @@ else:
         logger.exception(f"Couldn't load keyfile {key_file}")
         sys.exit(-1)
 
+# The filesystem location for served static files
+STATIC_ROOT = os.path.abspath(
+    get_setting(
+        'INVENTREE_STATIC_ROOT',
+        CONFIG.get('static_root', None)
+    )
+)
+
+if STATIC_ROOT is None:
+    print("ERROR: INVENTREE_STATIC_ROOT directory not defined")
+    sys.exit(1)
+
+# The filesystem location for served static files
+MEDIA_ROOT = os.path.abspath(
+    get_setting(
+        'INVENTREE_MEDIA_ROOT',
+        CONFIG.get('media_root', None)
+    )
+)
+
+if MEDIA_ROOT is None:
+    print("ERROR: INVENTREE_MEDIA_ROOT directory is not defined")
+    sys.exit(1)
+
 # List of allowed hosts (default = allow all)
 ALLOWED_HOSTS = CONFIG.get('allowed_hosts', ['*'])
 
@@ -188,14 +212,6 @@ if cors_opt:
 
 # Web URL endpoint for served static files
 STATIC_URL = '/static/'
-
-# The filesystem location for served static files
-STATIC_ROOT = os.path.abspath(
-    get_setting(
-        'INVENTREE_STATIC_ROOT',
-        CONFIG.get('static_root', '/home/inventree/data/static')
-    )
-)
 
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'InvenTree', 'static'),
@@ -217,14 +233,6 @@ STATIC_COLOR_THEMES_DIR = os.path.join(STATIC_ROOT, 'css', 'color-themes')
 
 # Web URL endpoint for served media files
 MEDIA_URL = '/media/'
-
-# The filesystem location for served static files
-MEDIA_ROOT = os.path.abspath(
-    get_setting(
-        'INVENTREE_MEDIA_ROOT',
-        CONFIG.get('media_root', '/home/inventree/data/media')
-    )
-)
 
 if DEBUG:
     logger.info("InvenTree running in DEBUG mode")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -112,7 +112,7 @@ FROM base as dev
 # The development image requires the source code to be mounted to /home/inventree/
 # So from here, we don't actually "do" anything, apart from some file management
 
-ENV INVENTREE_DEV_DIR = "${INVENTREE_HOME}/dev"
+ENV INVENTREE_DEV_DIR="${INVENTREE_HOME}/dev"
 
 # Override default path settings
 ENV INVENTREE_STATIC_ROOT="${INVENTREE_DEV_DIR}/static"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,8 @@ ENV INVENTREE_SECRET_KEY_FILE="${INVENTREE_DATA_DIR}/secret_key.txt"
 ENV INVENTREE_GUNICORN_WORKERS="4"
 ENV INVENTREE_BACKGROUND_WORKERS="4"
 
-# Default web server port is 8000
+# Default web server address:port
+ENV INVENTREE_WEB_ADDR="0.0.0.0"
 ENV INVENTREE_WEB_PORT="8000"
 
 LABEL org.label-schema.schema-version="1.0" \

--- a/docker/dev-config.env
+++ b/docker/dev-config.env
@@ -3,6 +3,9 @@
 # Set DEBUG to False for a production environment!
 INVENTREE_DEBUG=True
 
+# Change verbosity level for debug output
+INVENTREE_DEBUG_LEVEL="INFO"
+
 # Database linking options
 INVENTREE_DB_ENGINE=sqlite3
 INVENTREE_DB_NAME=/home/inventree/dev/inventree_db.sqlite3

--- a/docker/dev-config.env
+++ b/docker/dev-config.env
@@ -1,9 +1,10 @@
+# Set DEBUG to False for a production environment!
+INVENTREE_DEBUG=true
+
+# Database linking options
 INVENTREE_DB_ENGINE=sqlite3
 INVENTREE_DB_NAME=/home/inventree/dev/inventree_db.sqlite3
-INVENTREE_MEDIA_ROOT=/home/inventree/dev/media
-INVENTREE_STATIC_ROOT=/home/inventree/dev/static
-INVENTREE_CONFIG_FILE=/home/inventree/dev/config.yaml
-INVENTREE_SECRET_KEY_FILE=/home/inventree/dev/secret_key.txt
-INVENTREE_DEBUG=true
-INVENTREE_WEB_ADDR=0.0.0.0
-INVENTREE_WEB_PORT=8000
+# INVENTREE_DB_HOST=hostaddress
+# INVENTREE_DB_PORT=5432
+# INVENTREE_DB_USERNAME=dbuser
+# INVENTREE_DB_PASSWEORD=dbpassword

--- a/docker/dev-config.env
+++ b/docker/dev-config.env
@@ -1,5 +1,7 @@
+# InvenTree environment variables for a development setup
+
 # Set DEBUG to False for a production environment!
-INVENTREE_DEBUG=true
+INVENTREE_DEBUG=True
 
 # Database linking options
 INVENTREE_DB_ENGINE=sqlite3

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -19,6 +19,7 @@ services:
             context: .
             target: dev
         ports:
+            # Expose web server on port 8000
             - 8000:8000
         volumes:
             # Ensure you specify the location of the 'src' directory at the end of this file
@@ -26,7 +27,6 @@ services:
         env_file:
             # Environment variables required for the dev server are configured in dev-config.env
             - dev-config.env
-
         restart: unless-stopped
 
     # Background worker process handles long-running or periodic tasks


### PR DESCRIPTION
There is no good reason to expose the "inner workings" of the dockerfile in the default .env file. This PR essentially simplifies the `dev-config.env` file to remove environment variables that the user shouldn't be changing anyway.