### PR TITLE
Disable table sorting when order is fixed

### DIFF
--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -890,11 +890,10 @@ function loadPartTable(table, url, options={}) {
     };
     columns.push(col);
 
-    columns.push({
+    col = {
         field: 'in_stock',
         title: '{% trans "Stock" %}',
         searchable: false,
-        sortable: true,
         formatter: function(value, row, index, field) {            
             var link = "stock";
 
@@ -921,7 +920,11 @@ function loadPartTable(table, url, options={}) {
 
             return renderLink(value, '/part/' + row.pk + "/" + link + "/");
         }
-    });
+    };
+    if (!options.params.ordering) {
+        col['sortable'] = true;
+    };
+    columns.push(col);
 
     columns.push({
         field: 'link',

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -872,8 +872,7 @@ function loadPartTable(table, url, options={}) {
         }
     });
 
-    columns.push({
-        sortable: true,
+    col = {
         sortName: 'category',
         field: 'category_detail',
         title: '{% trans "Category" %}',
@@ -885,7 +884,11 @@ function loadPartTable(table, url, options={}) {
                 return '{% trans "No category" %}';
             }
         }   
-    });
+    };
+    if (!options.params.ordering) {
+        col['sortable'] = true;
+    };
+    columns.push(col);
 
     columns.push({
         field: 'in_stock',

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -823,10 +823,9 @@ function loadPartTable(table, url, options={}) {
     };
     columns.push(col);
 
-    columns.push({
+    col = {
         field: 'name',
         title: '{% trans "Part" %}',
-        sortable: true,
         switchable: false,
         formatter: function(value, row, index, field) {
 
@@ -854,7 +853,11 @@ function loadPartTable(table, url, options={}) {
 
             return display; 
         }
-    });
+    };
+    if (!options.params.ordering) {
+        col['sortable'] = true;
+    };
+    columns.push(col);
 
     columns.push({
         field: 'description',

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -814,11 +814,14 @@ function loadPartTable(table, url, options={}) {
         });
     }
 
-    columns.push({
+    col = {
         field: 'IPN',
         title: 'IPN',
-        sortable: true,
-    }),
+    };
+    if (!options.params.ordering) {
+        col['sortable'] = true;
+    };
+    columns.push(col);
 
     columns.push({
         field: 'name',


### PR DESCRIPTION
This PR removes the option to order columns on the pre-sorted tables on the homepage.

Closes #1986