### PR TITLE
Fix for production docker environment

### DIFF
--- a/docker/prod-config.env
+++ b/docker/prod-config.env
@@ -4,7 +4,7 @@
 
 # Ensure debug is false for a production setup
 INVENTREE_DEBUG=False
-INVENTREE_LOG_LEVEL="WARNING"
+INVENTREE_LOG_LEVEL=WARNING
 
 # Database configuration
 # Note: The example setup is for a PostgreSQL database (change as required)


### PR DESCRIPTION
Values are passed as written resulting in `"WARNING"` being passed to python logger, which will complain and panic. Fix is simply to remove `"` from the value.