### PR TITLE
Disable functions in navbars

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -787,37 +787,37 @@ class InvenTreeSetting(BaseInvenTreeSetting):
         # enable/diable ui elements
         'BUILD_FUNCTION_ENABLE': {
             'name': _('Enable build'),
-            'description': _('Enable build functionally in InvenTree interface'),
+            'description': _('Enable build functionality in InvenTree interface'),
             'default': True,
             'validator': bool,
         },
         'BUY_FUNCTION_ENABLE': {
             'name': _('Enable buy'),
-            'description': _('Enable buy functionally in InvenTree interface'),
+            'description': _('Enable buy functionality in InvenTree interface'),
             'default': True,
             'validator': bool,
         },
         'SELL_FUNCTION_ENABLE': {
             'name': _('Enable sell'),
-            'description': _('Enable sell functionally in InvenTree interface'),
+            'description': _('Enable sell functionality in InvenTree interface'),
             'default': True,
             'validator': bool,
         },
         'STOCK_FUNCTION_ENABLE': {
             'name': _('Enable stock'),
-            'description': _('Enable stock functionally in InvenTree interface'),
+            'description': _('Enable stock functionality in InvenTree interface'),
             'default': True,
             'validator': bool,
         },
         'SO_FUNCTION_ENABLE': {
             'name': _('Enable SO'),
-            'description': _('Enable SO functionally in InvenTree interface'),
+            'description': _('Enable SO functionality in InvenTree interface'),
             'default': True,
             'validator': bool,
         },
         'PO_FUNCTION_ENABLE': {
             'name': _('Enable PO'),
-            'description': _('Enable PO functionally in InvenTree interface'),
+            'description': _('Enable PO functionality in InvenTree interface'),
             'default': True,
             'validator': bool,
         },

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -783,6 +783,44 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'description': _('Prefix value for purchase order reference'),
             'default': 'PO',
         },
+
+        # enable/diable ui elements
+        'BUILD_FUNCTION_ENABLE': {
+            'name': _('Enable build'),
+            'description': _('Enable build functionally in InvenTree interface'),
+            'default': True,
+            'validator': bool,
+        },
+        'BUY_FUNCTION_ENABLE': {
+            'name': _('Enable buy'),
+            'description': _('Enable buy functionally in InvenTree interface'),
+            'default': True,
+            'validator': bool,
+        },
+        'SELL_FUNCTION_ENABLE': {
+            'name': _('Enable sell'),
+            'description': _('Enable sell functionally in InvenTree interface'),
+            'default': True,
+            'validator': bool,
+        },
+        'STOCK_FUNCTION_ENABLE': {
+            'name': _('Enable stock'),
+            'description': _('Enable stock functionally in InvenTree interface'),
+            'default': True,
+            'validator': bool,
+        },
+        'SO_FUNCTION_ENABLE': {
+            'name': _('Enable SO'),
+            'description': _('Enable SO functionally in InvenTree interface'),
+            'default': True,
+            'validator': bool,
+        },
+        'PO_FUNCTION_ENABLE': {
+            'name': _('Enable PO'),
+            'description': _('Enable PO functionally in InvenTree interface'),
+            'default': True,
+            'validator': bool,
+        },
     }
 
     class Meta:

--- a/InvenTree/company/templates/company/navbar.html
+++ b/InvenTree/company/templates/company/navbar.html
@@ -2,6 +2,10 @@
 {% load static %}
 {% load inventree_extras %}
 
+{% settings_value 'STOCK_FUNCTION_ENABLE' as enable_stock %}
+{% settings_value 'SO_FUNCTION_ENABLE' as enable_so %}
+{% settings_value 'PO_FUNCTION_ENABLE' as enable_po %}
+    
 <ul class='list-group'>
     <li class='list-group-item'>
         <a href='#' id='company-menu-toggle'>
@@ -28,6 +32,7 @@
     {% endif %}
 
     {% if company.is_manufacturer or company.is_supplier %}
+    {% if enable_stock %}
     <li class='list-group-item' title='{% trans "Stock Items" %}'>
         <a href='#' id='select-company-stock' class='nav-toggle'>
             <span class='fas fa-boxes sidebar-icon'></span>
@@ -35,8 +40,9 @@
         </a>
     </li>
     {% endif %}
+    {% endif %}
 
-    {% if company.is_supplier %}
+    {% if company.is_supplier and enable_po %}
     <li class='list-group-item' title='{% trans "Purchase Orders" %}'>
         <a href='#' id='select-purchase-orders' class='nav-toggle'>
             <span class='fas fa-shopping-cart sidebar-icon'></span>
@@ -45,7 +51,7 @@
     </li>
     {% endif %}
 
-    {% if company.is_customer %}
+    {% if company.is_customer and enable_so %}
     <li class='list-group-item' title='{% trans "Sales Orders" %}'>
         <a href='#' id='select-sales-orders' class='nav-toggle'>
             <span class='fas fa-truck sidebar-icon'></span>

--- a/InvenTree/part/templates/part/navbar.html
+++ b/InvenTree/part/templates/part/navbar.html
@@ -4,6 +4,12 @@
 
 {% settings_value "PART_INTERNAL_PRICE" as show_internal_price %}
 {% settings_value 'PART_SHOW_RELATED' as show_related %}
+{% settings_value 'BUILD_FUNCTION_ENABLE' as enable_build %}
+{% settings_value 'STOCK_FUNCTION_ENABLE' as enable_stock %}
+{% settings_value 'PO_FUNCTION_ENABLE' as enable_po %}
+{% settings_value 'SO_FUNCTION_ENABLE' as enable_so %}
+{% settings_value 'BUY_FUNCTION_ENABLE' as enable_buy %}
+{% settings_value 'SELL_FUNCTION_ENABLE' as enable_sell %}
 
 <ul class='list-group'>
     <li class='list-group-item'>
@@ -25,12 +31,14 @@
         </a>
     </li>
     {% endif %}
+    {% if enable_stock %}
     <li class='list-group-item' title='{% trans "Stock Items" %}'>
         <a href='#' id='select-part-stock' class='nav-toggle'>
             <span class='menu-tab-icon fas fa-boxes sidebar-icon'></span>
             {% trans "Stock" %}
         </a>
     </li>
+    {% endif %}
     {% if part.assembly %}
     <li class='list-group-item' title='{% trans "Bill of Materials" %}'>
         <a href='#' id='select-bom' class='nav-toggle'>
@@ -38,7 +46,7 @@
             {% trans "Bill of Materials" %}
         </a>
     </li>
-    {% if roles.build.view %}
+    {% if roles.build.view and enable_build %}
     <li class='list-group-item ' title='{% trans "Build Orders" %}'>
         <a href='#' id='select-build-orders' class='nav-toggle'>
             <span class='menu-tab-icon fas fa-tools sidebar-icon'></span>
@@ -55,19 +63,22 @@
         </a>
     </li>
     {% endif %}
+    {% if enable_buy or enable_sell %}
     <li class='list-group-item' title='{% trans "Pricing Information" %}'>
         <a href='#' id='select-pricing' class='nav-toggle'>
             <span class='menu-tab-icon fas fa-dollar-sign sidebar-icon'></span>
             {% trans "Prices" %}
         </a>
     </li>
-    {% if part.purchaseable and roles.purchase_order.view %}
+    {% endif %}
+    {% if part.purchaseable and roles.purchase_order.view and enable_buy %}
     <li class='list-group-item' title='{% trans "Suppliers" %}'>
         <a href='#' id='select-suppliers' class='nav-toggle'>
             <span class='menu-tab-icon fas fa-building sidebar-icon'></span>
             {% trans "Suppliers" %}
         </a>
     </li>
+    {% if enable_po %}
     <li class='list-group-item' title='{% trans "Purchase Orders" %}'>
         <a href='#' id='select-purchase-orders' class='nav-toggle'>
             <span class='menu-tab-icon fas fa-shopping-cart sidebar-icon'></span>
@@ -75,7 +86,8 @@
         </a>
     </li>
     {% endif %}
-    {% if roles.sales_order.view %}
+    {% endif %}
+    {% if roles.sales_order.view and enable_sell and enable_so %}
     <li class='list-group-item' title='{% trans "Sales Orders" %}'>
         <a href='#' id='select-sales-orders' class='nav-toggle'>
             <span class='menu-tab-icon fas fa-truck sidebar-icon'></span>

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -10,6 +10,11 @@
 
 {% block content %}
 
+{% settings_value 'BUY_FUNCTION_ENABLE' as enable_buy %}
+{% settings_value 'SELL_FUNCTION_ENABLE' as enable_sell %}
+{% settings_value 'PO_FUNCTION_ENABLE' as enable_po %}
+{% settings_value 'STOCK_FUNCTION_ENABLE' as enable_stock %}
+
 <div class="panel panel-default panel-inventree">
     <!-- Default panel contents -->
     <div class="panel-heading"><h3>{{ part.full_name }}</h3></div>
@@ -80,10 +85,12 @@
                     </div>
                     {% endif %}
                     {% if part.active %}
+                    {% if enable_buy or enable_sell  %}
                     <button type='button' class='btn btn-default' id='price-button' title='{% trans "Show pricing information" %}'>
                         <span id='part-price-icon' class='fas fa-dollar-sign'/>
                     </button>
-                    {% if roles.stock.change %}
+                    {% endif %}
+                    {% if roles.stock.change and enable_stock %}
                     <div class='btn-group'>
                         <button id='stock-actions' title='{% trans "Stock actions" %}' class='btn btn-default dropdown-toggle' type='button' data-toggle='dropdown'>
                             <span class='fas fa-boxes'></span> <span class='caret'></span>
@@ -104,8 +111,8 @@
                         </ul>
                     </div>
                     {% endif %}
-                    {% if part.purchaseable %}
-                    {% if roles.purchase_order.add %}
+                    {% if part.purchaseable and roles.purchase_order.add %}
+                    {% if enable_buy and enable_po %}
                     <button type='button' class='btn btn-default' id='part-order' title='{% trans "Order part" %}'>
                         <span id='part-order-icon' class='fas fa-shopping-cart'/>
                     </button>

--- a/InvenTree/templates/InvenTree/settings/build.html
+++ b/InvenTree/templates/InvenTree/settings/build.html
@@ -13,6 +13,8 @@
 <table class='table table-striped table-condensed'>
     {% include "InvenTree/settings/header.html" %}
     <tbody>
+        {% include "InvenTree/settings/setting.html" with key="BUILD_FUNCTION_ENABLE" icon="fa-check" %}
+        <tr><td colspan='5'></td></tr>
         {% include "InvenTree/settings/setting.html" with key="BUILDORDER_REFERENCE_PREFIX" %}
         {% include "InvenTree/settings/setting.html" with key="BUILDORDER_REFERENCE_REGEX" %}
     </tbody>

--- a/InvenTree/templates/InvenTree/settings/po.html
+++ b/InvenTree/templates/InvenTree/settings/po.html
@@ -11,6 +11,9 @@
 <table class='table table-striped table-condensed'>
     {% include "InvenTree/settings/header.html" %}
     <tbody>
+        {% include "InvenTree/settings/setting.html" with key="PO_FUNCTION_ENABLE" icon="fa-check" %}
+        {% include "InvenTree/settings/setting.html" with key="BUY_FUNCTION_ENABLE" icon="fa-check" %}
+        <tr><td colspan='5'></td></tr>
         {% include "InvenTree/settings/setting.html" with key="PURCHASEORDER_REFERENCE_PREFIX" %}
     </tbody>
 </table>

--- a/InvenTree/templates/InvenTree/settings/so.html
+++ b/InvenTree/templates/InvenTree/settings/so.html
@@ -12,6 +12,9 @@
 <table class='table table-striped table-condensed'>
     {% include "InvenTree/settings/header.html" %}
     <tbody>
+        {% include "InvenTree/settings/setting.html" with key="SO_FUNCTION_ENABLE" icon="fa-check" %}
+        {% include "InvenTree/settings/setting.html" with key="SELL_FUNCTION_ENABLE" icon="fa-check" %}
+        <tr><td colspan='5'></td></tr>
         {% include "InvenTree/settings/setting.html" with key="SALESORDER_REFERENCE_PREFIX" %}
     </tbody>
 </table>

--- a/InvenTree/templates/InvenTree/settings/stock.html
+++ b/InvenTree/templates/InvenTree/settings/stock.html
@@ -12,6 +12,8 @@
 <table class='table table-striped table-condensed'>
     {% include "InvenTree/settings/header.html" %}
     <tbody>
+        {% include "InvenTree/settings/setting.html" with key="STOCK_FUNCTION_ENABLE" icon="fa-check" %}
+        <tr><td colspan='5'></td></tr>
         {% include "InvenTree/settings/setting.html" with key="STOCK_GROUP_BY_PART" icon="fa-layer-group" %}
         {% include "InvenTree/settings/setting.html" with key="STOCK_ENABLE_EXPIRY" icon="fa-stopwatch" %}
         {% include "InvenTree/settings/setting.html" with key="STOCK_STALE_DAYS" icon="fa-calendar" %}

--- a/InvenTree/templates/navbar.html
+++ b/InvenTree/templates/navbar.html
@@ -3,6 +3,12 @@
 {% load i18n %}
 
 {% settings_value 'BARCODE_ENABLE' as barcodes %}
+{% settings_value 'BUILD_FUNCTION_ENABLE' as enable_build %}
+{% settings_value 'BUY_FUNCTION_ENABLE' as enable_buy %}
+{% settings_value 'SELL_FUNCTION_ENABLE' as enable_sell %}
+{% settings_value 'STOCK_FUNCTION_ENABLE' as enable_stock %}
+{% settings_value 'SO_FUNCTION_ENABLE' as enable_so %}
+{% settings_value 'PO_FUNCTION_ENABLE' as enable_po %}
 
 <nav class="navbar navbar-xs navbar-default navbar-fixed-top ">
   <div class="container-fluid">
@@ -22,28 +28,32 @@
         {% if roles.part.view %}
         <li><a href="{% url 'part-index' %}"><span class='fas fa-shapes icon-header'></span>{% trans "Parts" %}</a></li>
         {% endif %}
-        {% if roles.stock.view %}
+        {% if roles.stock.view and enable_stock %}
         <li><a href="{% url 'stock-index' %}"><span class='fas fa-boxes icon-header'></span>{% trans "Stock" %}</a></li>
         {% endif %}
-        {% if roles.build.view %}
+        {% if roles.build.view and enable_build %}
         <li><a href="{% url 'build-index' %}"><span class='fas fa-tools icon-header'></span>{% trans "Build" %}</a></li>
         {% endif %}
-        {% if roles.purchase_order.view %}
+        {% if roles.purchase_order.view and enable_buy %}
         <li class='nav navbar-nav'>
           <a class='dropdown-toggle' data-toggle='dropdown' href='#'><span class='fas fa-shopping-cart icon-header'></span>{% trans "Buy" %}</a>
           <ul class='dropdown-menu'>
             <li><a href="{% url 'supplier-index' %}"><span class='fas fa-building icon-header'></span>{% trans "Suppliers" %}</a></li>
             <li><a href="{% url 'manufacturer-index' %}"><span class='fas fa-industry icon-header'></span>{% trans "Manufacturers" %}</a></li>
+            {% if enable_po %}
             <li><a href="{% url 'po-index' %}"><span class='fas fa-list icon-header'></span>{% trans "Purchase Orders" %}</a></li>
+            {% endif %}
           </ul>
         </li>
         {% endif %}
-        {% if roles.sales_order.view %}
+        {% if roles.sales_order.view and enable_sell %}
         <li class='nav navbar-nav'>
           <a class='dropdown-toggle' data-toggle='dropdown' href='#'><span class='fas fa-truck icon-header'></span>{% trans "Sell" %}</a>
           <ul class='dropdown-menu'>
             <li><a href="{% url 'customer-index' %}"><span class='fas fa-user-tie icon-header'></span>{% trans "Customers" %}</a>
+            {% if enable_so %}
             <li><a href="{% url 'so-index' %}"><span class='fas fa-list icon-header'></span>{% trans "Sales Orders" %}</a></li>
+            {% endif %}
           </ul>
         </li>
         {% endif %}


### PR DESCRIPTION
This PR enables disabling some core in the navbars. It just stops showing stuff as a link - really shutting down stuff in the backend would be a major change and refactor if done right.

Closes #1945