### PR TITLE
Updated color of `new` and `add` UI buttons

### DIFF
--- a/InvenTree/company/templates/company/detail.html
+++ b/InvenTree/company/templates/company/detail.html
@@ -105,7 +105,7 @@
         {% if roles.purchase_order.add %}
         <div id='po-button-bar'>
             <div class='button-toolbar container-fluid' style='float: right;'>
-                <button class='btn btn-primary' type='button' id='company-order2' title='{% trans "Create new purchase order" %}'>
+                <button class='btn btn-success' type='button' id='company-order2' title='{% trans "Create new purchase order" %}'>
                     <span class='fas fa-plus-circle'></span> {% trans "New Purchase Order" %}</button>
                 <div class='filter-list' id='filter-list-purchaseorder'>
                     <!-- Empty div -->
@@ -127,7 +127,7 @@
         {% if roles.sales_order.add %}
         <div id='so-button-bar'>
             <div class='button-toolbar container-fluid' style='float: right;'>
-                <button class='btn btn-primary' type='button' id='new-sales-order' title='{% trans "Create new sales order" %}'>
+                <button class='btn btn-success' type='button' id='new-sales-order' title='{% trans "Create new sales order" %}'>
                     <div class='fas fa-plus-circle'></div> {% trans "New Sales Order" %}
                 </button>
                 <div class='filter-list' id='filter-list-salesorder'>

--- a/InvenTree/company/templates/company/supplier_part.html
+++ b/InvenTree/company/templates/company/supplier_part.html
@@ -160,7 +160,7 @@ src="{% static 'img/blank_image.png' %}"
     <div class='panel-content'>
         {% if roles.purchase_order.add %}
         <div id='price-break-toolbar' class='btn-group'>
-            <button class='btn btn-primary' id='new-price-break' type='button'>
+            <button class='btn btn-success' id='new-price-break' type='button'>
                 <span class='fas fa-plus-circle'></span> {% trans "Add Price Break" %}
             </button>
         </div>

--- a/InvenTree/order/templates/order/purchase_order_detail.html
+++ b/InvenTree/order/templates/order/purchase_order_detail.html
@@ -19,7 +19,7 @@
     <div class='panel-content'>
         <div id='order-toolbar-buttons' class='btn-group' style='float: right;'>
             {% if order.status == PurchaseOrderStatus.PENDING and roles.purchase_order.change %}
-            <button type='button' class='btn btn-primary' id='new-po-line'>
+            <button type='button' class='btn btn-success' id='new-po-line'>
                 <span class='fas fa-plus-circle'></span> {% trans "Add Line Item" %}
             </button>
             <a class='btn btn-primary' href='{% url "po-upload" order.id %}' role='button'>

--- a/InvenTree/order/templates/order/purchase_orders.html
+++ b/InvenTree/order/templates/order/purchase_orders.html
@@ -17,7 +17,7 @@
     <div class='button-toolbar container-fluid' style='float: right;'>
         <div class='btn-group'>
             {% if roles.purchase_order.add %}
-            <button class='btn btn-primary' type='button' id='po-create' title='{% trans "Create new purchase order" %}'>
+            <button class='btn btn-success' type='button' id='po-create' title='{% trans "Create new purchase order" %}'>
                 <span class='fas fa-plus-circle'></span> {% trans "New Purchase Order" %}
             </button>
             {% endif %}

--- a/InvenTree/order/templates/order/sales_orders.html
+++ b/InvenTree/order/templates/order/sales_orders.html
@@ -17,7 +17,7 @@
     <div class='button-toolbar container-fluid' style='float: right;'>
         <div class='btn-group'>
             {% if roles.sales_order.add %}
-            <button class='btn btn-primary' type='button' id='so-create' title='{% trans "Create new sales order" %}'>
+            <button class='btn btn-success' type='button' id='so-create' title='{% trans "Create new sales order" %}'>
                 <span class='fas fa-plus-circle'></span> {% trans "New Sales Order" %}
             </button>
             {% endif %}

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -185,7 +185,7 @@
         <div id='related-button-bar'>
             <div class='button-toolbar container-fluid' style='float: left;'>
                 {% if roles.part.change %}
-                <button class='btn btn-primary' type='button' id='add-related-part' title='{% trans "Add Related" %}'>{% trans "Add Related" %}</button>
+                <button class='btn btn-success' type='button' id='add-related-part' title='{% trans "Add Related" %}'>{% trans "Add Related" %}</button>
                 <div class='filter-list' id='filter-list-related'>
                     <!-- An empty div in which the filter list will be constructed -->
                 </div>

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -74,7 +74,7 @@
         <div id='so-button-bar'>
             <div class='button-toolbar container-fluid' style='float: right;'>
                 {% if 0 %}
-                <button class='btn btn-primary' type='button' id='part-order2' title='{% trans "New sales order" %}'>{% trans "New Order" %}</button>
+                <button class='btn btn-success' type='button' id='part-order2' title='{% trans "New sales order" %}'>{% trans "New Order" %}</button>
                 {% endif %}
                 <div class='filter-list' id='filter-list-salesorder'>
                     <!-- An empty div in which the filter list will be constructed -->

--- a/InvenTree/part/templates/part/prices.html
+++ b/InvenTree/part/templates/part/prices.html
@@ -211,7 +211,7 @@
         </div>
         <div class="col col-md-4">
             <div id='internal-price-break-toolbar' class='btn-group'>
-                <button class='btn btn-primary' id='new-internal-price-break' type='button'>
+                <button class='btn btn-success' id='new-internal-price-break' type='button'>
                     <span class='fas fa-plus-circle'></span> {% trans "Add Internal Price Break" %}
                 </button>
             </div>
@@ -267,7 +267,7 @@
         </div>
         <div class="col col-md-4">
             <div id='price-break-toolbar' class='btn-group'>
-                <button class='btn btn-primary' id='new-price-break' type='button'>
+                <button class='btn btn-success' id='new-price-break' type='button'>
                     <span class='fas fa-plus-circle'></span> {% trans "Add Price Break" %}
                 </button>
             </div>


### PR DESCRIPTION
While working on the doc for orders (ref https://github.com/inventree/inventree-docs/pull/158) I noticed the color of "New Order" buttons was set to blue (primary CSS class) instead of green (success CSS class) like in the rest of the UI for all other elements (parts, categories, stock, locations, build, companies).
Trying to make the UI color coding more consistent :smiley: 

EDIT: also updated the color of all "add" buttons to green/success class