### PR TITLE
RFC: Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug, question
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Deployment Method**
+Docker
+Bare Metal
+
+**Version Information**
+You can get this by going to the "About InvenTree" section in the upper right corner and cicking on to the "copy version information"

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FR]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request the result of a bug?.**
+Please link it here.
+
+**Problem**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Suggested solution**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Examples of other systems**
+Show how other software handles your FR if you have examples.
+
+**Do you want to develop this?**
+If so please describe breifly how you would like to implement it (so we can give advice) and if you have experience in the needed technology (you do not need to be a pro - this is just as a information for us).


### PR DESCRIPTION
This PR is meant as a RFC regarding issue templates for creating more concise and faster to triage issues on GitHub.

Please place your suggestions as review comments or open a PR against the `template` branch in my fork.