### PR TITLE
Fix OPTIONS request lookup time

### DIFF
--- a/InvenTree/InvenTree/metadata.py
+++ b/InvenTree/InvenTree/metadata.py
@@ -105,7 +105,6 @@ class InvenTreeMetadata(SimpleMetadata):
 
             model_fields = model_meta.get_field_info(model_class)
 
-
             # Iterate through simple fields
             for name, field in model_fields.fields.items():
 

--- a/InvenTree/InvenTree/metadata.py
+++ b/InvenTree/InvenTree/metadata.py
@@ -98,10 +98,13 @@ class InvenTreeMetadata(SimpleMetadata):
 
         serializer_info = super().get_serializer_info(serializer)
 
-        try:
-            ModelClass = serializer.Meta.model
+        model_class = None
 
-            model_fields = model_meta.get_field_info(ModelClass)
+        try:
+            model_class = serializer.Meta.model
+
+            model_fields = model_meta.get_field_info(model_class)
+
 
             # Iterate through simple fields
             for name, field in model_fields.fields.items():
@@ -146,11 +149,23 @@ class InvenTreeMetadata(SimpleMetadata):
         if hasattr(serializer, 'instance'):
             instance = serializer.instance
         
-        if instance is None:
-            try:
-                instance = self.view.get_object()
-            except:
-                pass
+        if instance is None and model_class is not None:
+            # Attempt to find the instance based on kwargs lookup
+            kwargs = getattr(self.view, 'kwargs', None)
+
+            if kwargs:
+                pk = None
+
+                for field in ['pk', 'id', 'PK', 'ID']:
+                    if field in kwargs:
+                        pk = kwargs[field]
+                        break
+
+                if pk is not None:
+                    try:
+                        instance = model_class.objects.get(pk=pk)
+                    except (ValueError, model_class.DoesNotExist):
+                        pass
 
         if instance is not None:
             """


### PR DESCRIPTION
**Issue:** Launching a "New BOM Item" form takes > 20 seconds to perform an OPTIONS request!!

| Before | After |
| --- | --- |
| > 20s | < 0.5s |

- Improve instance lookup for metadata layer
- Existing call to get_object() could take > 20 seconds in some cases
- Not really sure why, some issue with the DRF library
- Was probably parsing the entire queryset rather than doing a PK lookup
- Instead, directly use the provided pk to get the model

