### PR TITLE
Improve 'health status' warnings

### DIFF
--- a/InvenTree/InvenTree/context.py
+++ b/InvenTree/InvenTree/context.py
@@ -36,9 +36,14 @@ def health_status(request):
         'email_configured': InvenTree.status.is_email_configured(),
     }
 
+    # The following keys are required to denote system health
+    health_keys = [
+        'django_q_running',
+    ]
+
     all_healthy = True
 
-    for k in status.keys():
+    for k in health_keys:
         if status[k] is not True:
             all_healthy = False
 

--- a/InvenTree/templates/navbar.html
+++ b/InvenTree/templates/navbar.html
@@ -71,11 +71,7 @@
             <a class='dropdown-toggle' data-toggle='dropdown' href="#">
               {% if user.is_staff %}
               {% if not system_healthy %}
-                {% if not django_q_running %}
                 <span class='fas fa-exclamation-triangle icon-red'></span>
-                {% else %}
-                <span class='fas fa-exclamation-triangle icon-orange'></span>
-                {% endif %}
               {% elif not up_to_date %}
               <span class='fas fa-info-circle icon-green'></span>
               {% endif %}
@@ -96,11 +92,7 @@
                   {% if system_healthy or not user.is_staff %}
                   <span class='fas fa-server'></span>
                   {% else %}
-                    {% if not django_q_running %}
-                    <span class='fas fa-server icon-red'></span>
-                    {% else %}
-                    <span class='fas fa-server icon-orange'></span>
-                    {% endif %}
+                  <span class='fas fa-server icon-red'></span>
                   {% endif %}
                   </span> {% trans "System Information" %}
                 </a></li>


### PR DESCRIPTION
- Don't show error message if only non-critical warnings present

Fixes https://github.com/inventree/InvenTree/issues/2057