### PR TITLE
Default supplier fix

### DIFF
--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -94,7 +94,12 @@ function partFields(options={}) {
         },
         default_location: {
         },
-        default_supplier: {},
+        default_supplier: {
+            filters: {
+                part_detail: true,
+                supplier_detail: true,
+            }
+        },
         default_expiry: {
             icon: 'fa-calendar-alt',
         },
@@ -314,6 +319,9 @@ function editPart(pk) {
     var fields = partFields({
         edit: true
     });
+
+    // Filter supplied parts by the Part ID
+    fields.default_supplier.filters.part = pk;
 
     var groups = partGroups({});
 

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -346,6 +346,9 @@ function duplicatePart(pk, options={}) {
                 duplicate: pk,
             });
 
+            // Remove "default_supplier" field
+            delete fields['default_supplier'];
+
             // If we are making a "variant" part
             if (options.variant) {
 


### PR DESCRIPTION
Fixes a bug which prevented the "default supplier" field being edited for the "Part" model.

This is a relatively simple fix, just needed to adjust some of the API filter values.