### PR TITLE
Override the "delete" behaviour for StockItem API

### DIFF
--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -109,6 +109,17 @@ class StockDetail(generics.RetrieveUpdateDestroyAPIView):
 
         return super().update(request, *args, **kwargs)
 
+    def perform_destroy(self, instance):
+        """
+        Instead of "deleting" the StockItem
+        (which may take a long time)
+        we instead schedule it for deletion at a later date.
+        
+        The background worker will delete these in the future
+        """
+
+        instance.mark_for_deletion()
+
 
 class StockAdjust(APIView):
     """

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -1650,9 +1650,6 @@ def before_delete_stock_item(sender, instance, using, **kwargs):
         child.parent = instance.parent
         child.save()
 
-    # Rebuild the MPTT tree
-    StockItem.objects.rebuild()
-
 
 class StockItemAttachment(InvenTreeAttachment):
     """

--- a/InvenTree/stock/test_api.py
+++ b/InvenTree/stock/test_api.py
@@ -18,6 +18,7 @@ from InvenTree.api_tester import InvenTreeAPITestCase
 from common.models import InvenTreeSetting
 
 from .models import StockItem, StockLocation
+from .tasks import delete_old_stock_items
 
 
 class StockAPITestCase(InvenTreeAPITestCase):
@@ -37,6 +38,7 @@ class StockAPITestCase(InvenTreeAPITestCase):
         'stock.add',
         'stock_location.change',
         'stock_location.add',
+        'stock.delete',
     ]
 
     def setUp(self):
@@ -590,6 +592,61 @@ class StocktakeTest(StockAPITestCase):
         response = self.post(url, data)
         self.assertContains(response, 'Valid location must be specified', status_code=status.HTTP_400_BAD_REQUEST)
 
+
+class StockItemDeletionTest(StockAPITestCase):
+    """
+    Tests for stock item deletion via the API
+    """
+
+    def test_delete(self):
+
+        # Check there are no stock items scheduled for deletion
+        self.assertEqual(
+            StockItem.objects.filter(scheduled_for_deletion=True).count(),
+            0
+        )
+
+        # Create and then delete a bunch of stock items
+        for idx in range(10):
+
+            # Create new StockItem via the API
+            response = self.post(
+                reverse('api-stock-list'),
+                {
+                    'part': 1,
+                    'location': 1,
+                    'quantity': idx,
+                },
+                expected_code=201
+            )
+
+            pk = response.data['pk']
+
+            item = StockItem.objects.get(pk=pk)
+
+            self.assertFalse(item.scheduled_for_deletion)
+
+            url = reverse('api-stock-detail', kwargs={'pk': pk})
+
+            # Request deletion via the API
+            self.delete(
+                reverse('api-stock-detail', kwargs={'pk': pk}),
+                expected_code=204
+            )
+
+        # There should be 100x StockItem objects marked for deletion
+        self.assertEqual(
+            StockItem.objects.filter(scheduled_for_deletion=True).count(),
+            10
+        )
+
+        # Perform the actual delete (will take some time)
+        delete_old_stock_items()
+
+        self.assertEqual(
+            StockItem.objects.filter(scheduled_for_deletion=True).count(),
+            0
+        )
 
 class StockTestResultTest(StockAPITestCase):
 

--- a/InvenTree/stock/test_api.py
+++ b/InvenTree/stock/test_api.py
@@ -626,8 +626,6 @@ class StockItemDeletionTest(StockAPITestCase):
 
             self.assertFalse(item.scheduled_for_deletion)
 
-            url = reverse('api-stock-detail', kwargs={'pk': pk})
-
             # Request deletion via the API
             self.delete(
                 reverse('api-stock-detail', kwargs={'pk': pk}),
@@ -647,6 +645,7 @@ class StockItemDeletionTest(StockAPITestCase):
             StockItem.objects.filter(scheduled_for_deletion=True).count(),
             0
         )
+
 
 class StockTestResultTest(StockAPITestCase):
 


### PR DESCRIPTION
- Mark for deletion instead of calling database delete
- Returns (almost) instantly instead of hanging
- Much better UI experience when performing bulk delete operations

Note: Also discovered that the entire StockItem MPTT tree was being rebuilt *every time* a StockItem was deleted. Removing this call reduced the time taken to delete a single StockItem by 98.7%