### PR TITLE
Fix for search page

### DIFF
--- a/InvenTree/templates/InvenTree/search.html
+++ b/InvenTree/templates/InvenTree/search.html
@@ -126,24 +126,10 @@
 
     addItem('category', '{% trans "Part Categories" %}', 'fa-sitemap');
 
-    $("#table-category").inventreeTable({
-        url: "{% url 'api-part-category-list' %}",
-        queryParams: {
+    loadPartCategoryTable($("#table-category"), {
+        params: {
             original_search: "{{ query }}",
-        },
-        columns: [
-            {
-                field: 'name',
-                title: '{% trans "Name" %}',
-                formatter: function(value, row, index, field) {
-                    return renderLink(value, '/part/category/' + row.pk + '/');
-                },
-            },
-            {
-                field: 'description',
-                title: '{% trans "Description" %}',
-            },
-        ],
+        }
     });
 
     addItem('manufacturer-part', '{% trans "Manufacturer Parts" %}', 'fa-toolbox');

--- a/InvenTree/templates/InvenTree/search.html
+++ b/InvenTree/templates/InvenTree/search.html
@@ -117,7 +117,7 @@
         "{% url 'api-part-list' %}",
         {
             params: {
-                search: "{{ query }}",
+                original_search: "{{ query }}",
             },
             checkbox: false,
             disableFilters: true,
@@ -129,7 +129,7 @@
     $("#table-category").inventreeTable({
         url: "{% url 'api-part-category-list' %}",
         queryParams: {
-            search: "{{ query }}",
+            original_search: "{{ query }}",
         },
         columns: [
             {
@@ -153,7 +153,7 @@
         "{% url 'api-manufacturer-part-list' %}",
         {
             params: {
-                search: "{{ query }}",
+                original_search: "{{ query }}",
                 part_detail: true,
                 supplier_detail: true,
                 manufacturer_detail: true
@@ -168,7 +168,7 @@
         "{% url 'api-supplier-part-list' %}",
         {
             params: {
-                search: "{{ query }}",
+                original_search: "{{ query }}",
                 part_detail: true,
                 supplier_detail: true,
                 manufacturer_detail: true
@@ -186,7 +186,7 @@
 
     loadBuildTable('#table-build-order', {
         params: {
-            search: '{{ query }}',
+            original_search: '{{ query }}',
         }
     });
 
@@ -200,7 +200,7 @@
     $('#table-stock').inventreeTable({
         url: "{% url 'api-stock-list' %}",
         queryParams: {
-            search: "{{ query }}",
+            original_search: "{{ query }}",
             part_detail: true,
             location_detail: true,
         },
@@ -281,7 +281,7 @@
     $("#table-location").inventreeTable({
         url: "{% url 'api-location-list' %}",
         queryParams: {
-            search: "{{ query }}",
+            original_search: "{{ query }}",
         },
         columns: [
             {
@@ -307,7 +307,7 @@
 
     loadCompanyTable('#table-manufacturer', "{% url 'api-company-list' %}", {
         params: {
-            search: "{{ query }}",
+            original_search: "{{ query }}",
             is_manufacturer: "true",
         }
     });
@@ -317,7 +317,7 @@
 
     loadCompanyTable('#table-supplier', "{% url 'api-company-list' %}", {
         params: {
-            search: "{{ query }}",
+            original_search: "{{ query }}",
             is_supplier: "true",
         }
     });
@@ -326,7 +326,7 @@
 
     loadPurchaseOrderTable('#table-purchase-order', {
         params: {
-            search: '{{ query }}',
+            original_search: '{{ query }}',
         }
     });
 
@@ -337,7 +337,7 @@
 
     loadCompanyTable('#table-customer', "{% url 'api-company-list' %}", {
         params: {
-            search: "{{ query }}",
+            original_search: "{{ query }}",
             is_customer: "true",
         }
     });
@@ -346,7 +346,7 @@
 
     loadSalesOrderTable('#table-sales-orders', {
         params: {
-            search: '{{ query }}',
+            original_search: '{{ query }}',
         }
     });
 

--- a/InvenTree/templates/InvenTree/search.html
+++ b/InvenTree/templates/InvenTree/search.html
@@ -183,105 +183,23 @@
 
     addItem('stock', '{% trans "Stock Items" %}', 'fa-boxes');
 
-    $('#table-stock').inventreeTable({
+    loadStockTable($('#table-stock'), {
+        filterKey: 'stocksearch',
         url: "{% url 'api-stock-list' %}",
-        queryParams: {
+        params: {
             original_search: "{{ query }}",
             part_detail: true,
-            location_detail: true,
-        },
-        columns: [
-            {
-                field: 'part',
-                title: "{% trans "Part" %}",
-                sortable: true,
-                formatter: function(value, row) {
-                    var url = `/stock/item/${row.pk}/`;
-                    var thumb = row.part_detail.thumbnail;
-                    var name = row.part_detail.full_name;
-
-                    html = imageHoverIcon(thumb) + renderLink(name, url);
-
-                    return html;
-                }
-            },
-            {
-                field: 'part_description',
-                title: '{% trans "Description" %}',
-                sortable: true,
-                formatter: function(value, row, index, field) {
-                    return row.part_detail.description;
-                }
-            },
-            {
-                field: 'quantity',
-                title: '{% trans "Stock" %}',
-                sortable: true,
-                formatter: function(value, row, index, field) {
-
-                    var val = parseFloat(value);
-
-                    // If there is a single unit with a serial number, use the serial number
-                    if (row.serial && row.quantity == 1) {
-                        val = '# ' + row.serial;
-                    } else {
-                        val = +val.toFixed(5);
-                    }
-
-                    var html = renderLink(val, `/stock/item/${row.pk}/`);
-
-                    return html;
-                }
-            },
-            {
-                field: 'status',
-                title: '{% trans "Status" %}',
-                sortable: 'true',
-                formatter: function(value, row, index, field) {
-                    return stockStatusDisplay(value);
-                },
-            },
-            {
-                field: 'location_detail.pathstring',
-                title: '{% trans "Location" %}',
-                sortable: true,
-                formatter: function(value, row, index, field) {
-                    if (value) {
-                        return renderLink(value, `/stock/location/${row.location}/`);
-                    }
-                    else {
-                        if (row.customer) {
-                            var text = "{% trans "Shipped to customer" %}";
-                            return renderLink(text, `/company/${row.customer}/assigned-stock/`);
-                        } else {
-                            return '<em>{% trans "No stock location set" %}</em>';
-                        }
-                    }
-                }
-            },
-        ]
+            location_detail: true
+        }
     });
 
     addItem('location', '{% trans "Stock Locations" %}', 'fa-map-marker-alt');
 
-    $("#table-location").inventreeTable({
-        url: "{% url 'api-location-list' %}",
-        queryParams: {
+    loadStockLocationTable($("#table-location"), {
+        filterKey: 'locationsearch',
+        params: {
             original_search: "{{ query }}",
         },
-        columns: [
-            {
-                field: 'name',
-                title: '{% trans "Name" %}',
-                formatter: function(value, row, index, field) {
-                    return renderLink(row.pathstring, '/stock/location/' + row.pk + '/');
-                },
-            },
-            {
-                field: 'description',
-                title: '{% trans "Description" %}',
-            },
-        ],
     });
 
     {% endif %}

--- a/InvenTree/templates/js/translated/company.js
+++ b/InvenTree/templates/js/translated/company.js
@@ -469,6 +469,7 @@ function loadManufacturerPartTable(table, url, options) {
         method: 'get',
         original: params,
         queryParams: filters,
+        sidePagination: 'server',
         name: 'manufacturerparts',
         groupBy: false,
         formatNoMatches: function() {

--- a/InvenTree/templates/js/translated/company.js
+++ b/InvenTree/templates/js/translated/company.js
@@ -724,6 +724,7 @@ function loadSupplierPartTable(table, url, options) {
         url: url,
         method: 'get',
         original: params,
+        sidePagination: 'server',
         queryParams: filters,
         name: 'supplierparts',
         groupBy: false,

--- a/InvenTree/templates/js/translated/company.js
+++ b/InvenTree/templates/js/translated/company.js
@@ -361,7 +361,7 @@ function loadCompanyTable(table, url, options={}) {
             field: 'parts_supplied',
             title: '{% trans "Parts Supplied" %}',
             formatter: function(value, row) {
-                return renderLink(value, `/company/${row.pk}/parts/`);
+                return renderLink(value, `/company/${row.pk}/?display=supplier-parts`);
             }
         });
     } else if (options.pagetype == 'manufacturers') {
@@ -370,7 +370,7 @@ function loadCompanyTable(table, url, options={}) {
             field: 'parts_manufactured',
             title: '{% trans "Parts Manufactured" %}',
             formatter: function(value, row) {
-                return renderLink(value, `/company/${row.pk}/parts/`);
+                return renderLink(value, `/company/${row.pk}/?display=manufacturer-parts`);
             }
         });
     }

--- a/InvenTree/templates/js/translated/tables.js
+++ b/InvenTree/templates/js/translated/tables.js
@@ -181,6 +181,15 @@ function convertQueryParameters(params, filters) {
     if ('sortable' in params) {
         delete params['sortable'];
     }
+
+    // If "original_search" parameter is provided, add it to the "search"
+    if ('original_search' in params) {
+        var search = params['search'] || '';
+
+        params['search'] = search + ' ' + params['original_search'];
+
+        delete params['original_search'];
+    }
     
     return params;
 }


### PR DESCRIPTION
This PR fixes a bug where tables displayed on the "search results" pages could not be filtered any further by a search term.

The original search term overrides the new one!

So, this PR introduces a concept of "original_search" which is combined with the "search" parameter at actual query time.

Also a few other smaller issues uncovered and fixed.