### PR TITLE
Fixes for build output tables

### DIFF
--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -292,6 +292,7 @@ loadStockTable($("#build-stock-table"), {
         location_detail: true,
         part_detail: true,
         build: {{ build.id }},
+        is_building: false,
     },
     groupByField: 'location',
     buttons: [

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -64,6 +64,7 @@ class StockItemSerializerBrief(InvenTreeModelSerializer):
             'location',
             'location_name',
             'quantity',
+            'serial',
         ]
 
 

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -623,8 +623,15 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
 
                             var url = '';
 
-                            if (row.serial && row.quantity == 1) {
-                                text = `{% trans "Serial Number" %}: ${row.serial}`;
+
+                            var serial = row.serial;
+
+                            if (row.stock_item_detail) {
+                                serial = row.stock_item_detail.serial;
+                            }
+
+                            if (serial && row.quantity == 1) {
+                                text = `{% trans "Serial Number" %}: ${serial}`;
                             } else {
                                 text = `{% trans "Quantity" %}: ${row.quantity}`;
                             }


### PR DESCRIPTION
- Only show "completed" builds in the "completed builds" table (should be obvious)
- Display "serial number" appropriately in build output allocation table