### PR TITLE
Auto-focus on the 'sub_part' field

### DIFF
--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -552,6 +552,7 @@
                 fields: fields,
                 method: 'POST',
                 title: '{% trans "Create BOM Item" %}',
+                focus: 'sub_part',
                 onSuccess: function() {
                     $('#bom-table').bootstrapTable('refresh');
                 }

--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -576,6 +576,7 @@ function loadBomTable(table, options) {
             constructForm(`/api/bom/${pk}/`, {
                 fields: fields,
                 title: '{% trans "Edit BOM Item" %}',
+                focus: 'sub_part',
                 onSuccess: function() {
                     reloadBomTable(table);
                 }


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/2125

Still have to press "enter" to activate the drop-down menu, but saves a lot of mouse work.