### PR TITLE
re-simplify the documentation URL

### DIFF
--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -301,7 +301,9 @@ def send_email(subject, body, recipients, from_email=None):
 
     offload_task(
         'django.core.mail.send_mail',
-        subject, body,
+        subject,
+        body,
         from_email,
         recipients,
+        fail_silently=False,
     )

--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -11,11 +11,6 @@ import common.models
 # InvenTree software version
 INVENTREE_SW_VERSION = "0.6.0 dev"
 
-# InvenTree documentation version
-# For 'dev' branch this must read "latest"
-# For 'stable' branch this must match INVENTREE_SW_VERSION
-INVENTREE_DOCS_VERSION = "latest"
-
 # InvenTree API version
 INVENTREE_API_VERSION = 15
 
@@ -119,7 +114,10 @@ def inventreeDocsVersion():
     
     """
 
-    return INVENTREE_DOCS_VERSION
+    if isInvenTreeDevelopmentVersion():
+        return "latest"
+    else:
+        return INVENTREE_SW_VERSION
 
 
 def isInvenTreeUpToDate():

--- a/ci/check_version_number.py
+++ b/ci/check_version_number.py
@@ -18,7 +18,6 @@ if __name__ == '__main__':
     version_file = os.path.join(here, '..', 'InvenTree', 'InvenTree', 'version.py')
 
     version = None
-    docs_version = None
 
     with open(version_file, 'r') as f:
 
@@ -33,17 +32,7 @@ if __name__ == '__main__':
 
         version = results[0]
 
-        # Extract the documentation version
-        results = re.findall(r'INVENTREE_DOCS_VERSION = "(.*)"', text)
-
-        if not len(results) == 1:
-            print(f"Could not find INVENTREE_DOCS_VERSION in '{version_file}'")
-            sys.exit(1)
-
-        docs_version = results[0]
-
     print(f"InvenTree Version: '{version}'")
-    print(f"Documentation Version: '{docs_version}'")
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-t', '--tag', help='Compare against specified version tag', action='store')
@@ -86,11 +75,6 @@ if __name__ == '__main__':
             print(f"Version number '{version}' does not match required pattern for development branch")
             sys.exit(1)
 
-        # The docs version must be 'latest'
-        if docs_version != 'latest':
-            print(f"Documentation version must be 'latest' for development branch")
-            sys.exit(1)
-
     elif args.release:
         """
         Check that the current version number matches the "release" format
@@ -111,15 +95,5 @@ if __name__ == '__main__':
         if not args.tag == version:
             print(f"Release tag '{args.tag}' does not match INVENTREE_SW_VERSION '{version}'")
             sys.exit(1)
-
-    # Check that the documentation URL is available
-    url = f"https://inventree.readthedocs.io/en/{docs_version}"
-
-    response = requests.get(url)
-    print(f"Checking documentation url: {url} - Response {response.status_code}")
-
-    if response.status_code != 200:
-        print(f"ERROR: Received status code {response.status_code}")
-        sys.exit(1)
 
 sys.exit(0)


### PR DESCRIPTION
- dev version = "latest"
- stable version = "x.y.z"
- Requires an explicit docs version release for every software release