### PR TITLE
Tag specific version of cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ python-barcode[images]==0.13.1  # Barcode generator
 qrcode[pil]==6.1                # QR code generator
 django-q==1.3.4                 # Background task scheduling
 django-formtools==2.3           # Form wizard tools
+cryptography==3.4.8             # Cryptography support
 django-allauth==0.45.0          # SSO for external providers via OpenID
 
 inventree                       # Install the latest version of the InvenTree API python library


### PR DESCRIPTION
Trying to fix issues with long-running (> 6 hour!!!!) docker builds on github actions.