### PR TITLE
Exclude parts from API

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -814,6 +814,27 @@ class PartList(generics.ListCreateAPIView):
             except (ValueError, Part.DoesNotExist):
                 pass
 
+        # Exclude specific part ID values?
+        exclude_id = []
+
+        for key in ['exclude_id', 'exclude_id[]']:
+            if key in params:
+                exclude_id += params.getlist(key, [])
+
+        if exclude_id:
+
+            id_values = []
+
+            for val in exclude_id:
+                try:
+                    # pk values must be integer castable
+                    val = int(val)
+                    id_values.append(val)
+                except ValueError:
+                    pass
+            
+            queryset = queryset.exclude(pk__in=id_values)
+
         # Exclude part variant tree?
         exclude_tree = params.get('exclude_tree', None)
 

--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -263,6 +263,12 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
 
                     var subs = getSubstituteIdValues(opts.modal);
 
+                    // Also exclude the "master" part (if provided)
+                    if (options.sub_part) {
+                        subs.push(options.sub_part);
+                        console.log("sub_part:", options.sub_part);
+                    }
+
                     if (subs.length > 0) {
                         query.exclude_id = subs;
                     }
@@ -824,6 +830,7 @@ function loadBomTable(table, options) {
                 subs,
                 {
                     table: table,
+                    sub_part: row.sub_part,
                 }
             );
         });

--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -157,6 +157,19 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
         }
     }
 
+    // Extract a list of all existing "substitute" id values
+    function getSubstituteIdValues(modal) {
+
+        var id_values = [];
+
+        $(modal).find('.substitute-row').each(function(el) {
+            var part = $(this).attr('part');
+            id_values.push(part);
+        });
+
+        return id_values;
+    }
+
     function renderSubstituteRow(substitute) {
 
         var pk = substitute.pk;
@@ -171,7 +184,7 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
 
         // Render a single row
         var html = `
-        <tr id='substitute-row-${pk}' class='substitute-row'>
+        <tr id='substitute-row-${pk}' class='substitute-row' part='${substitute.part}'>
             <td id='part-${pk}'>
                 <a href='/part/${part.pk}/'>
                     ${thumb} ${part.full_name}
@@ -246,6 +259,16 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
             },
             part: {
                 required: false,
+                adjustFilters: function(query, opts) {
+
+                    var subs = getSubstituteIdValues(opts.modal);
+
+                    if (subs.length > 0) {
+                        query.exclude_id = subs;
+                    }
+
+                    return query;
+                }
             },
         },
         preFormContent: html,

--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -266,7 +266,6 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
                     // Also exclude the "master" part (if provided)
                     if (options.sub_part) {
                         subs.push(options.sub_part);
-                        console.log("sub_part:", options.sub_part);
                     }
 
                     if (subs.length > 0) {

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -1349,7 +1349,7 @@ function initializeRelatedField(field, fields, options) {
                 
                 // Allow custom run-time filter augmentation
                 if ('adjustFilters' in field) {
-                    query = field.adjustFilters(query);
+                    query = field.adjustFilters(query, options);
                 }
 
                 return query;


### PR DESCRIPTION
Adds a generic method to exclude specific (or multiple) parts from an API query

Currently used in the "substitutes" dialog to exclude parts which have already been selected!