### PR TITLE
Move part detail toggle button

### DIFF
--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -128,6 +128,13 @@
                     </div>
                     {% endif %}
                 </div>
+
+                <p>
+                    <!-- Details show/hide button -->
+                    <button id="toggle-part-details" class="btn btn-primary" data-toggle="collapse" data-target="#collapsible-part-details" value="show">
+                    <span class="fas fa-chevron-down"></span> {% trans "Show Part Details" %}
+                    </button>
+                </p>
             </div>
             </div>
             <div class='info-messages'>
@@ -208,13 +215,6 @@
         </div>
     </div>
 
-    <p>
-        <!-- Details show/hide button -->
-        <button id="toggle-part-details" class="btn btn-primary" data-toggle="collapse" data-target="#collapsible-part-details" value="show">
-        <span class="fas fa-chevron-down"></span> {% trans "Show Part Details" %}
-        </button>
-    </p>
-        
     <div class="collapse" id="collapsible-part-details">
         <div class="card card-body">
             <!-- Details Table -->


### PR DESCRIPTION
This PR moves the part detail toggle button under the action buttons to save vertical space when the detail panel is closed.

![grafik](https://user-images.githubusercontent.com/66015116/138573686-d7faa7c3-21f0-4d4f-b521-c1d836b964dd.png)
