### PR TITLE
Add definition for Gitpod.io

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,14 +1,19 @@
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - init: |
-      export PIP_USER=no
+ - name: Setup django
+   command: |
       python3 -m venv venv
       source venv/bin/activate
       pip install invoke
+      inv install
+   env:
+      PIP_USER: 'no'
+ - name: Start server
+   command: |
       inv update
       echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'test@test.com', 'inventree')" | python InvenTree/manage.py shell
       inv server
-    env:
+   env:
       INVENTREE_DB_ENGINE: 'sqlite3'
       INVENTREE_DB_NAME: '/workspace/data/database.sqlite3'
       INVENTREE_MEDIA_ROOT: '/workspace/data/media'

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -32,3 +32,11 @@ tasks:
 ports:
   - port: 8000
     onOpen: open-preview
+
+github:
+  prebuilds:
+    master: true
+    pullRequests: false
+    pullRequestsFromForks: true
+    addBadge: true
+    addLabel: gitpod-ready

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
  - name: Setup django
-   before: |
+   init: |
       export INVENTREE_DB_ENGINE='sqlite3'
       export INVENTREE_DB_NAME='/workspace/InvenTree/dev/database.sqlite3'
       export INVENTREE_MEDIA_ROOT='/workspace/InvenTree/inventree-data/media'
@@ -21,7 +21,6 @@ tasks:
       gp sync-done setup_server
 
  - name: Start server
-   init: gp sync-await setup_server
    command: |
       gp sync-await setup_server
       export INVENTREE_DB_ENGINE='sqlite3'

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
  - name: Setup django
-   init: |
+   before: |
       export INVENTREE_DB_ENGINE='sqlite3'
       export INVENTREE_DB_NAME='/workspace/InvenTree/dev/database.sqlite3'
       export INVENTREE_MEDIA_ROOT='/workspace/InvenTree/inventree-data/media'
@@ -21,6 +21,7 @@ tasks:
       gp sync-done setup_server
 
  - name: Start server
+   init: gp sync-await setup_server
    command: |
       gp sync-await setup_server
       export INVENTREE_DB_ENGINE='sqlite3'

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,6 +15,7 @@ tasks:
       mkdir dev
       inv update
       echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'test@test.com', 'inventree')" | python InvenTree/manage.py shell
+      gp sync-done setup_server
    env:
       INVENTREE_DB_ENGINE: 'sqlite3'
       INVENTREE_DB_NAME: '/workspace/data/database.sqlite3'
@@ -24,6 +25,8 @@ tasks:
 
  - name: Start server
    command: |
+      gp sync-await setup_server
+      source venv/bin/activate
       inv server
    env:
       INVENTREE_DB_ENGINE: 'sqlite3'

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,3 @@
-# Below the RSA fingerprint for github is hard-encoded. If that does not match in the next few years GH had a bad day.
 tasks:
  - name: Setup django
    before: |
@@ -12,13 +11,8 @@ tasks:
       source venv/bin/activate
       pip install invoke
       inv install
-      echo 'nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8'  >> ~/.ssh/known_hosts
-      git clone git@github.com:inventree/demo-dataset.git /workspace/InvenTree/inventree-data
       mkdir dev
       inv update
-      invoke delete-data -f
-      invoke import-records -f /workspace/InvenTree/inventree-data/inventree_data.json
-
       gp sync-done setup_server
 
  - name: Start server
@@ -31,6 +25,11 @@ tasks:
       export INVENTREE_STATIC_ROOT='/workspace/InvenTree/dev/static'
 
       source venv/bin/activate
+      rm /workspace/InvenTree/inventree-data -r
+      git clone https://github.com/inventree/demo-dataset /workspace/InvenTree/inventree-data
+      invoke delete-data -f
+      invoke import-records -f /workspace/InvenTree/inventree-data/inventree_data.json
+      
       inv server
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -43,3 +43,4 @@ github:
     pullRequestsFromForks: true
     addBadge: true
     addLabel: gitpod-ready
+    addCheck: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,6 +2,12 @@
 tasks:
  - name: Setup django and start server
    command: |
+      export INVENTREE_DB_ENGINE='sqlite3'
+      export  INVENTREE_DB_NAME='/workspace/data/database.sqlite3'
+      export  INVENTREE_MEDIA_ROOT='/workspace/data/media'
+      export INVENTREE_STATIC_ROOT='/workspace/data/static'
+      export PIP_USER='no'
+
       python3 -m venv venv
       source venv/bin/activate
       pip install invoke

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@ tasks:
    init: |
       export INVENTREE_DB_ENGINE='sqlite3'
       export INVENTREE_DB_NAME='/workspace/InvenTree/dev/database.sqlite3'
-      export INVENTREE_MEDIA_ROOT='/workspace/InvenTree/dev/media'
+      export INVENTREE_MEDIA_ROOT='/workspace/InvenTree/inventree-data/media'
       export INVENTREE_STATIC_ROOT='/workspace/InvenTree/dev/static'
       export PIP_USER='no'
 
@@ -14,7 +14,10 @@ tasks:
       inv install
       mkdir dev
       inv update
-      echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'test@test.com', 'inventree')" | python InvenTree/manage.py shell
+      git clone git@github.com:inventree/demo-dataset.git /workspace/InvenTree/inventree-data
+      invoke delete-data
+      invoke import-records -f /workspace/InvenTree/inventree-data/inventree_data.json
+
       gp sync-done setup_server
 
  - name: Start server
@@ -22,7 +25,7 @@ tasks:
       gp sync-await setup_server
       export INVENTREE_DB_ENGINE='sqlite3'
       export INVENTREE_DB_NAME='/workspace/InvenTree/dev/database.sqlite3'
-      export INVENTREE_MEDIA_ROOT='/workspace/InvenTree/dev/media'
+      export INVENTREE_MEDIA_ROOT='/workspace/InvenTree/inventree-data/media'
       export INVENTREE_STATIC_ROOT='/workspace/InvenTree/dev/static'
 
       source venv/bin/activate

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,7 +15,7 @@ tasks:
       mkdir dev
       inv update
       git clone git@github.com:inventree/demo-dataset.git /workspace/InvenTree/inventree-data
-      invoke delete-data
+      invoke delete-data -f
       invoke import-records -f /workspace/InvenTree/inventree-data/inventree_data.json
 
       gp sync-done setup_server

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
- - name: Setup django and start server
-   command: |
+ - name: Setup django
+   init: |
       export INVENTREE_DB_ENGINE='sqlite3'
       export  INVENTREE_DB_NAME='/workspace/InvenTree/dev/database.sqlite3'
       export  INVENTREE_MEDIA_ROOT='/workspace/InvenTree/dev/media'
@@ -15,6 +15,15 @@ tasks:
       mkdir dev
       inv update
       echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'test@test.com', 'inventree')" | python InvenTree/manage.py shell
+   env:
+      INVENTREE_DB_ENGINE: 'sqlite3'
+      INVENTREE_DB_NAME: '/workspace/data/database.sqlite3'
+      INVENTREE_MEDIA_ROOT: '/workspace/data/media'
+      INVENTREE_STATIC_ROOT: '/workspace/data/static'
+      PIP_USER: 'no'
+
+ - name: Start server
+   command: |
       inv server
    env:
       INVENTREE_DB_ENGINE: 'sqlite3'

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+# Below the RSA fingerprint for github is hard-encoded. If that does not match in the next few years GH had a bad day.
 tasks:
  - name: Setup django
    before: |
@@ -12,6 +12,7 @@ tasks:
       source venv/bin/activate
       pip install invoke
       inv install
+      echo 'nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8'  >> ~/.ssh/known_hosts
       git clone git@github.com:inventree/demo-dataset.git /workspace/InvenTree/inventree-data
       mkdir dev
       inv update

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,20 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: |
+      export PIP_USER=no
+      python3 -m venv venv
+      source venv/bin/activate
+      pip install invoke
+      inv update
+      echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'test@test.com', 'inventree')" | python InvenTree/manage.py shell
+      inv server
+    env:
+      INVENTREE_DB_ENGINE: 'sqlite3'
+      INVENTREE_DB_NAME: '/workspace/data/database.sqlite3'
+      INVENTREE_MEDIA_ROOT: '/workspace/data/media'
+      INVENTREE_STATIC_ROOT: '/workspace/data/static'
+
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 8000
+    onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,15 +1,11 @@
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
- - name: Setup django
+ - name: Setup django and start server
    command: |
       python3 -m venv venv
       source venv/bin/activate
       pip install invoke
       inv install
-   env:
-      PIP_USER: 'no'
- - name: Start server
-   command: |
       inv update
       echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'test@test.com', 'inventree')" | python InvenTree/manage.py shell
       inv server
@@ -18,6 +14,7 @@ tasks:
       INVENTREE_DB_NAME: '/workspace/data/database.sqlite3'
       INVENTREE_MEDIA_ROOT: '/workspace/data/media'
       INVENTREE_STATIC_ROOT: '/workspace/data/static'
+      PIP_USER: 'no'
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,8 +3,8 @@ tasks:
  - name: Setup django
    init: |
       export INVENTREE_DB_ENGINE='sqlite3'
-      export  INVENTREE_DB_NAME='/workspace/InvenTree/dev/database.sqlite3'
-      export  INVENTREE_MEDIA_ROOT='/workspace/InvenTree/dev/media'
+      export INVENTREE_DB_NAME='/workspace/InvenTree/dev/database.sqlite3'
+      export INVENTREE_MEDIA_ROOT='/workspace/InvenTree/dev/media'
       export INVENTREE_STATIC_ROOT='/workspace/InvenTree/dev/static'
       export PIP_USER='no'
 
@@ -16,24 +16,17 @@ tasks:
       inv update
       echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'test@test.com', 'inventree')" | python InvenTree/manage.py shell
       gp sync-done setup_server
-   env:
-      INVENTREE_DB_ENGINE: 'sqlite3'
-      INVENTREE_DB_NAME: '/workspace/data/database.sqlite3'
-      INVENTREE_MEDIA_ROOT: '/workspace/data/media'
-      INVENTREE_STATIC_ROOT: '/workspace/data/static'
-      PIP_USER: 'no'
 
  - name: Start server
    command: |
       gp sync-await setup_server
+      export INVENTREE_DB_ENGINE='sqlite3'
+      export INVENTREE_DB_NAME='/workspace/InvenTree/dev/database.sqlite3'
+      export INVENTREE_MEDIA_ROOT='/workspace/InvenTree/dev/media'
+      export INVENTREE_STATIC_ROOT='/workspace/InvenTree/dev/static'
+
       source venv/bin/activate
       inv server
-   env:
-      INVENTREE_DB_ENGINE: 'sqlite3'
-      INVENTREE_DB_NAME: '/workspace/data/database.sqlite3'
-      INVENTREE_MEDIA_ROOT: '/workspace/data/media'
-      INVENTREE_STATIC_ROOT: '/workspace/data/static'
-      PIP_USER: 'no'
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,15 +3,16 @@ tasks:
  - name: Setup django and start server
    command: |
       export INVENTREE_DB_ENGINE='sqlite3'
-      export  INVENTREE_DB_NAME='/workspace/data/database.sqlite3'
-      export  INVENTREE_MEDIA_ROOT='/workspace/data/media'
-      export INVENTREE_STATIC_ROOT='/workspace/data/static'
+      export  INVENTREE_DB_NAME='/workspace/InvenTree/dev/database.sqlite3'
+      export  INVENTREE_MEDIA_ROOT='/workspace/InvenTree/dev/media'
+      export INVENTREE_STATIC_ROOT='/workspace/InvenTree/dev/static'
       export PIP_USER='no'
 
       python3 -m venv venv
       source venv/bin/activate
       pip install invoke
       inv install
+      mkdir dev
       inv update
       echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'test@test.com', 'inventree')" | python InvenTree/manage.py shell
       inv server


### PR DESCRIPTION
This PR adds a definition so that gitpod.io starts a functional InvenTree instance in a gitpod - complete with debugging and vs-code in browser.
I saw that service on another repo and it is really great if you want to check out a PR without pulling it / when you are on the road. Even works on an IPad.

To test just copy the link for this PR or from the original branch and open a new tab with 'gitpod.io/#' and paste the link after the hashtag. Check out the result [here](https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2206)

There would also be an github app that adds buttons / comments to PRs to open the PRs result in a browser.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2206"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

