### PR TITLE
Small UI tweaks

### DIFF
--- a/InvenTree/InvenTree/static/css/inventree.css
+++ b/InvenTree/InvenTree/static/css/inventree.css
@@ -539,7 +539,6 @@
 .inventree-body {
     width: 100%;
     padding: 5px;
-    margin-top: 10px;
 }
 
 .inventree-pre-content {
@@ -554,10 +553,6 @@
     max-width: 100%;
     display: inline-block;
     transition: 0.1s;
-}
-
-.body {
-    padding-top: 50px;
 }
 
 .modal {

--- a/InvenTree/templates/InvenTree/index.html
+++ b/InvenTree/templates/InvenTree/index.html
@@ -7,6 +7,8 @@
 {% inventree_title %} | {% trans "Index" %}
 {% endblock %}
 
+{% block breadcrumb_list %}
+{% endblock %}
 
 {% block sidebar %}
 <!-- Sidebar data is filled dynamically for the index page-->

--- a/InvenTree/templates/InvenTree/search.html
+++ b/InvenTree/templates/InvenTree/search.html
@@ -8,6 +8,9 @@
 {% inventree_title %} | {% trans "Search Results" %}
 {% endblock %}
 
+{% block breadcrumb_list %}
+{% endblock %}
+
 {% block content %}
 
 <div class='panel panel-inventree'>

--- a/InvenTree/templates/navbar.html
+++ b/InvenTree/templates/navbar.html
@@ -10,7 +10,10 @@
     <div class="navbar-header clearfix content-heading">
       <a class="navbar-brand" id='logo' href="{% url 'index' %}" style="padding-top: 7px; padding-bottom: 5px;"><img src="{% static 'img/inventree.png' %}" width="32" height="32" style="display:block; margin: auto;"/></a>
     </div>
-    <div class="navbar-collapse collapse">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-objects" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="navbar-collapse collapse" id="navbar-objects">
       <ul class="navbar-nav">
         {% if roles.part.view %}
         <li class='nav-item'>
@@ -59,7 +62,7 @@
       </ul>
     </div>
     {% include "search_form.html" %}
-    <ul class='navbar-nav'>
+     <ul class='navbar-nav'>
       {% if barcodes %}
       <li id='navbar-barcode-li'>
         <button id='barcode-scan' class='btn btn-secondary' title='{% trans "Scan Barcode" %}'>

--- a/InvenTree/templates/navbar.html
+++ b/InvenTree/templates/navbar.html
@@ -62,7 +62,9 @@
       </ul>
     </div>
      <ul class='navbar-nav'>
-      <li>{% include "search_form.html" %}</li>
+      <li class='nav-item'>
+        {% include "search_form.html" %}
+      </li>
       {% if barcodes %}
       <li id='navbar-barcode-li'>
         <button id='barcode-scan' class='btn btn-secondary' title='{% trans "Scan Barcode" %}'>

--- a/InvenTree/templates/navbar.html
+++ b/InvenTree/templates/navbar.html
@@ -61,8 +61,8 @@
         {% endif %}
       </ul>
     </div>
-    {% include "search_form.html" %}
      <ul class='navbar-nav'>
+      <li>{% include "search_form.html" %}</li>
       {% if barcodes %}
       <li id='navbar-barcode-li'>
         <button id='barcode-scan' class='btn btn-secondary' title='{% trans "Scan Barcode" %}'>

--- a/InvenTree/templates/page_base.html
+++ b/InvenTree/templates/page_base.html
@@ -3,6 +3,9 @@
 {% load static %}
 {% load i18n %}
 
+{% block breadcrumb_list %}
+{% endblock %}
+
 {% block content %}
 
 <div class='panel'>

--- a/InvenTree/templates/sidebar_header.html
+++ b/InvenTree/templates/sidebar_header.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<span title='{% trans text %}' class="list-group-item sidebar-list-group-item border-end-0 d-inline-block text-truncate" data-bs-parent="#sidebar">
+<span title='{% trans text %}' class="list-group-item sidebar-list-group-item border-end-0 d-inline-block text-truncate bg-light" data-bs-parent="#sidebar">
     <h6>
         <i class="bi bi-bootstrap"></i>
         {% if icon %}<span class='sidebar-item-icon fas {{ icon }}'></span>{% endif %}


### PR DESCRIPTION
This PR:
- reduces the empty vertical space
- adds a toggler to access collapsed elements
- makes navbar declarations more standard
- makes headers in sidebars more distinct with another color
- removes breadcrumb div where it is not used (reduces unneeded vertical space)

Before:

![grafik](https://user-images.githubusercontent.com/66015116/139538788-3d70a4b7-f77c-4384-bade-66e6c26c59aa.png)
![grafik](https://user-images.githubusercontent.com/66015116/139538773-4f471618-aefc-4334-9374-231af785fc20.png)

After:
![grafik](https://user-images.githubusercontent.com/66015116/139538827-1f5c3765-deef-4c4a-8feb-408ced16d1ed.png)
![grafik](https://user-images.githubusercontent.com/66015116/139538756-660a1556-3bdf-4f6d-ba87-85c4ce53e52b.png)


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2216"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

