### PR TITLE
setting sidebar ui tweaks

### DIFF
--- a/InvenTree/templates/sidebar_header.html
+++ b/InvenTree/templates/sidebar_header.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<span title='{% trans text %}' class="list-group-item sidebar-list-group-item border-end-0 d-inline-block text-truncate" data-bs-parent="#sidebar">
+<span title='{% trans text %}' class="list-group-item sidebar-list-group-item border-end-0 d-inline-block text-truncate bg-light" data-bs-parent="#sidebar">
     <h6>
         <i class="bi bi-bootstrap"></i>
         {% if icon %}<span class='sidebar-item-icon fas {{ icon }}'></span>{% endif %}


### PR DESCRIPTION
The setting sidebar header should have a different colour than the items to make it easier to differentiate them.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2223"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

