### PR TITLE
Fix navbar spacing when "sticky-header" is enabled

### DIFF
--- a/InvenTree/InvenTree/static/css/inventree.css
+++ b/InvenTree/InvenTree/static/css/inventree.css
@@ -141,6 +141,10 @@
     float: left;
 }
 
+.navbar-spacer {
+    height: 40px;
+}
+
 #navbar-barcode-li {
     border-left: none;
     border-right: none;

--- a/InvenTree/templates/navbar.html
+++ b/InvenTree/templates/navbar.html
@@ -111,3 +111,7 @@
 
   </div>
 </nav>
+
+{% if sticky %}
+<div class='navbar-spacer'></div>
+{% endif %}


### PR DESCRIPTION
Prevents navbar hiding part of the page when 'sticky header' is enabled:

![image](https://user-images.githubusercontent.com/10080325/139608419-ea4c73e3-96aa-4147-9fd5-a4d60d8de6e4.png)
