### PR TITLE
Small fixes for bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,4 +28,4 @@ Docker
 Bare Metal
 
 **Version Information**
-You can get this by going to the "About InvenTree" section in the upper right corner and cicking on to the "copy version information"
+You can get this by going to the "About InvenTree" section in the upper right corner and clicking on to the "copy version information"

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,31 +1,47 @@
 ---
-name: Bug report
-about: Create a bug report to help us improve InvenTree
+name: Bug
+about: Create a bug report to help us improve InvenTree!
 title: "[BUG] Enter bug description"
 labels: bug, question
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+<!---
+Everything inside these brackets is hidden - please remove them where you fill out information.
+--->
 
-**To Reproduce**
+
+**Describe the bug**
+<!---
+A clear and concise description of what the bug is.
+--->
+
+**Steps to Reproduce**
+
 Steps to reproduce the behavior:
+<!---
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+--->
 
 **Expected behavior**
+<!---
 A clear and concise description of what you expected to happen.
+--->
 
+<!---
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
+--->
 
 **Deployment Method**
-Docker
-Bare Metal
+- [ ] Docker
+- [ ] Bare Metal
 
 **Version Information**
+<!---
 You can get this by going to the "About InvenTree" section in the upper right corner and clicking on to the "copy version information"
+--->


### PR DESCRIPTION
This PR:
- Fixes a spelling error
- hides the info blocks by default so they do not get submitted by default

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2242"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

