### PR TITLE
Allow escape key on barcode modal

### DIFF
--- a/InvenTree/templates/js/translated/barcode.js
+++ b/InvenTree/templates/js/translated/barcode.js
@@ -257,7 +257,7 @@ function barcodeDialog(title, options={}) {
 
     $(modal).modal({
         backdrop: 'static',
-        keyboard: false,
+        keyboard: user_settings.FORMS_CLOSE_USING_ESCAPE,
     });
 
     if (options.preShow) {


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/2256

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2259"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

