### PR TITLE
Add unit test to check an "empty" (null) barcode can be supplied

### DIFF
--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -242,6 +242,7 @@ class POLineItemReceiveSerializer(serializers.Serializer):
         help_text=_('Unique identifier field'),
         default='',
         required=False,
+        allow_null=True,
         allow_blank=True,
     )
 

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -349,6 +349,31 @@ class PurchaseOrderReceiveTest(OrderTest):
         # No new stock items have been created
         self.assertEqual(self.n, StockItem.objects.count())
 
+    def test_null_barcode(self):
+        """
+        Test than a "null" barcode field can be provided
+        """
+
+        # Set stock item barcode
+        item = StockItem.objects.get(pk=1)
+        item.save()
+
+        # Test with "null" value
+        self.post(
+            self.url,
+            {
+                'items': [
+                    {
+                        'line_item': 1,
+                        'quantity': 50,
+                        'barcode': None,
+                    }
+                ],
+                'location': 1,
+            },
+            expected_code=201
+        )
+
     def test_invalid_barcodes(self):
         """
         Tests for checking in items with invalid barcodes:


### PR DESCRIPTION
Previously passing a "null" value to the barcode field would error out

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2274"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

