### PR TITLE
Improve options for installing a part into another part

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1392,6 +1392,28 @@ class Part(MPTTModel):
 
         return BomItem.objects.filter(self.get_bom_item_filter(include_inherited=include_inherited))
 
+    def get_installed_part_options(self, include_inherited=True, include_variants=True):
+        """
+        Return a set of all Parts which can be "installed" into this part, based on the BOM.
+
+        arguments:
+            include_inherited - If set, include BomItem entries defined for parent parts
+            include_variants - If set, include variant parts for BomItems which allow variants
+        """
+
+        parts = set()
+
+        for bom_item in self.get_bom_items.all(include_inherited=include_inherited):
+
+            if include_variants and bom_item.allow_variants:
+                for part in bom_item.sub_part.get_descendants(include_self=True):
+                    parts.add(part)
+            else:
+                parts.add(bom_item.sub_part)
+
+        return parts
+
+
     def get_used_in_filter(self, include_inherited=True):
         """
         Return a query filter for all parts that this part is used in.

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1413,7 +1413,6 @@ class Part(MPTTModel):
 
         return parts
 
-
     def get_used_in_filter(self, include_inherited=True):
         """
         Return a query filter for all parts that this part is used in.

--- a/InvenTree/stock/views.py
+++ b/InvenTree/stock/views.py
@@ -560,9 +560,8 @@ class StockItemInstall(AjaxUpdateView):
 
             # Filter for parts to install in this item
             if self.install_item:
-                # Get parts used in this part's BOM
-                bom_items = self.part.get_bom_items()
-                allowed_parts = [item.sub_part for item in bom_items]
+                # Get all parts which can be installed into this part
+                allowed_parts = self.part.get_installed_part_options()
                 # Filter
                 items = items.filter(part__in=allowed_parts)
 


### PR DESCRIPTION
- Allow "variant" parts when the BOM specifies that variants are allowed for a particular BOM item

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2283"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

