### PR TITLE
remove empty breadcrumb space in settings

### DIFF
--- a/InvenTree/templates/InvenTree/settings/settings.html
+++ b/InvenTree/templates/InvenTree/settings/settings.html
@@ -4,6 +4,9 @@
 {% load static %}
 {% load inventree_extras %}
 
+{% block breadcrumb_list %}
+{% endblock %}
+
 {% block page_title %}
 {% inventree_title %} | {% trans "Settings" %}
 {% endblock %}


### PR DESCRIPTION
This PR removes the empty breadcrumb margin in the settings. This lines up the upper borders:
![grafik](https://user-images.githubusercontent.com/66015116/141210085-cde52bbd-78ec-4e6d-af45-2a286eaa6526.png)


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2289"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

