### PR TITLE
allow admin buttons to be assigned by class

### DIFF
--- a/InvenTree/InvenTree/static/script/inventree/inventree.js
+++ b/InvenTree/InvenTree/static/script/inventree/inventree.js
@@ -208,7 +208,7 @@ function inventreeDocReady() {
     });
 
     // Callback for "admin view" button
-    $('#admin-button').click(function() {
+    $('#admin-button, .admin-button').click(function() {
         var url = $(this).attr('url');
 
         location.href = url;


### PR DESCRIPTION
This PR extends the js that appends callbacks to admin actions to also use css classes

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2333"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

