### PR TITLE
fix language name

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -664,7 +664,7 @@ LANGUAGES = [
     ('el', _('Greek')),
     ('en', _('English')),
     ('es', _('Spanish')),
-    ('es-mx', _('Spanish (Mexican')),
+    ('es-mx', _('Spanish (Mexican)')),
     ('fr', _('French')),
     ('he', _('Hebrew')),
     ('it', _('Italian')),


### PR DESCRIPTION
This PR fixes a missing closing bracket in the language name translation base

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2338"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

