### PR TITLE
Bug fix: "validated" filter in BomItem API

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1081,6 +1081,14 @@ class BomFilter(rest_filters.FilterSet):
     inherited = rest_filters.BooleanFilter(label='BOM line is inherited')
     allow_variants = rest_filters.BooleanFilter(label='Variants are allowed')
 
+    # Filters for linked 'part'
+    part_active = rest_filters.BooleanFilter(label='Master part is active', field_name='part__active')
+    part_trackable = rest_filters.BooleanFilter(label='Master part is trackable', field_name='part__trackable')
+
+    # Filters for linked 'sub_part'
+    sub_part_trackable = rest_filters.BooleanFilter(label='Sub part is trackable', field_name='sub_part__trackable')
+    sub_part_assembly = rest_filters.BooleanFilter(label='Sub part is an assembly', field_name='sub_part__assembly')
+
     validated = rest_filters.BooleanFilter(label='BOM line has been validated', method='filter_validated')
 
     def filter_validated(self, queryset, name, value):
@@ -1098,14 +1106,6 @@ class BomFilter(rest_filters.FilterSet):
             queryset = queryset.exclude(pk__in=pks)
 
         return queryset
-
-    # Filters for linked 'part'
-    part_active = rest_filters.BooleanFilter(label='Master part is active', field_name='part__active')
-    part_trackable = rest_filters.BooleanFilter(label='Master part is trackable', field_name='part__trackable')
-
-    # Filters for linked 'sub_part'
-    sub_part_trackable = rest_filters.BooleanFilter(label='Sub part is trackable', field_name='sub_part__trackable')
-    sub_part_assembly = rest_filters.BooleanFilter(label='Sub part is an assembly', field_name='sub_part__assembly')
 
 
 class BomList(generics.ListCreateAPIView):

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1096,11 +1096,17 @@ class BomFilter(rest_filters.FilterSet):
         # Work out which lines have actually been validated
         pks = []
 
+        value = str2bool(value)
+
+        # Shortcut for quicker filtering - BomItem with empty 'checksum' values are not validated
+        if value:
+            queryset = queryset.exclude(checksum=None).exclude(checksum='')
+
         for bom_item in queryset.all():
-            if bom_item.is_line_valid():
+            if bom_item.is_line_valid:
                 pks.append(bom_item.pk)
 
-        if str2bool(value):
+        if value:
             queryset = queryset.filter(pk__in=pks)
         else:
             queryset = queryset.exclude(pk__in=pks)

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -934,6 +934,38 @@ class BomItemTest(InvenTreeAPITestCase):
             expected_code=200,
         )
 
+        # Should be zero validated results
+        self.assertEqual(len(response.data), 0)
+
+        # Now filter by "not validated"
+        response = self.get(
+            url,
+            data={
+                'validated': False,
+            },
+            expected_code=200
+        )
+
+        # There should be at least one non-validated item
+        self.assertTrue(len(response.data) > 0)
+
+        # Now, let's validate an item
+        bom_item = BomItem.objects.first()
+
+        bom_item.validate_hash()
+
+        response = self.get(
+            url,
+            data={
+                'validated': True,
+            },
+            expected_code=200
+        )
+
+        # Check that the expected response is returned
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['pk'], bom_item.pk)
+
     def test_get_bom_detail(self):
         """
         Get the detail view for a single BomItem object

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -925,7 +925,14 @@ class BomItemTest(InvenTreeAPITestCase):
             expected_code=200
         )
 
-        print("results:", len(response.data))
+        # Filter by "validated"
+        response = self.get(
+            url,
+            data={
+                'validated': True,
+            },
+            expected_code=200,
+        )
 
     def test_get_bom_detail(self):
         """


### PR DESCRIPTION
Filtering BomItem list by "validated" parameter currently throws an error.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2355"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

