### PR TITLE
Add autocomplete fields to admin views

### DIFF
--- a/InvenTree/build/admin.py
+++ b/InvenTree/build/admin.py
@@ -29,6 +29,14 @@ class BuildAdmin(ImportExportModelAdmin):
         'part__description',
     ]
 
+    autocomplete_fields = [
+        'parent',
+        'part',
+        'sales_order',
+        'take_from',
+        'destination',
+    ]
+
 
 class BuildItemAdmin(admin.ModelAdmin):
 
@@ -37,6 +45,13 @@ class BuildItemAdmin(admin.ModelAdmin):
         'stock_item',
         'quantity'
     )
+
+    autocomplete_fields = [
+        'build',
+        'bom_item',
+        'stock_item',
+        'install_into',
+    ]
 
 
 admin.site.register(Build, BuildAdmin)

--- a/InvenTree/company/admin.py
+++ b/InvenTree/company/admin.py
@@ -71,6 +71,8 @@ class SupplierPartAdmin(ImportExportModelAdmin):
         'SKU',
     ]
 
+    autocomplete_fields = ('part', 'supplier', 'manufacturer_part',)
+
 
 class ManufacturerPartResource(ModelResource):
     """
@@ -92,23 +94,6 @@ class ManufacturerPartResource(ModelResource):
         clean_model_instances = True
 
 
-class ManufacturerPartParameterInline(admin.TabularInline):
-    """
-    Inline for editing ManufacturerPartParameter objects,
-    directly from the ManufacturerPart admin view.
-    """
-
-    model = ManufacturerPartParameter
-
-
-class SupplierPartInline(admin.TabularInline):
-    """
-    Inline for the SupplierPart model
-    """
-
-    model = SupplierPart
-
-
 class ManufacturerPartAdmin(ImportExportModelAdmin):
     """
     Admin class for ManufacturerPart model
@@ -124,10 +109,7 @@ class ManufacturerPartAdmin(ImportExportModelAdmin):
         'MPN',
     ]
 
-    inlines = [
-        SupplierPartInline,
-        ManufacturerPartParameterInline,
-    ]
+    autocomplete_fields = ('part', 'manufacturer',)
 
 
 class ManufacturerPartParameterResource(ModelResource):
@@ -157,6 +139,8 @@ class ManufacturerPartParameterAdmin(ImportExportModelAdmin):
         'value'
     ]
 
+    autocomplete_fields = ('manufacturer_part',)
+
 
 class SupplierPriceBreakResource(ModelResource):
     """ Class for managing SupplierPriceBreak data import/export """
@@ -185,6 +169,8 @@ class SupplierPriceBreakAdmin(ImportExportModelAdmin):
     resource_class = SupplierPriceBreakResource
 
     list_display = ('part', 'quantity', 'price')
+
+    autocomplete_fields = ('part',)
 
 
 admin.site.register(Company, CompanyAdmin)

--- a/InvenTree/order/admin.py
+++ b/InvenTree/order/admin.py
@@ -42,6 +42,8 @@ class PurchaseOrderAdmin(ImportExportModelAdmin):
         PurchaseOrderLineItemInlineAdmin
     ]
 
+    autocomplete_fields = ('supplier',)
+
 
 class SalesOrderAdmin(ImportExportModelAdmin):
 
@@ -62,6 +64,8 @@ class SalesOrderAdmin(ImportExportModelAdmin):
         'customer__name',
         'description',
     ]
+
+    autocomplete_fields = ('customer',)
 
 
 class POLineItemResource(ModelResource):
@@ -124,6 +128,10 @@ class PurchaseOrderLineItemAdmin(ImportExportModelAdmin):
         'reference'
     )
 
+    search_fields = ('reference',)
+
+    autocomplete_fields = ('order', 'part', 'destination',)
+
 
 class SalesOrderLineItemAdmin(ImportExportModelAdmin):
 
@@ -136,6 +144,15 @@ class SalesOrderLineItemAdmin(ImportExportModelAdmin):
         'reference'
     )
 
+    search_fields = [
+        'part__name',
+        'order__reference',
+        'order__customer__name',
+        'reference',
+    ]
+
+    autocomplete_fields = ('order', 'part',)
+
 
 class SalesOrderShipmentAdmin(ImportExportModelAdmin):
 
@@ -145,6 +162,14 @@ class SalesOrderShipmentAdmin(ImportExportModelAdmin):
         'reference',
     ]
 
+    search_fields = [
+        'reference',
+        'order__reference',
+        'order__customer__name',
+    ]
+
+    autocomplete_fields = ('order',)
+
 
 class SalesOrderAllocationAdmin(ImportExportModelAdmin):
 
@@ -153,6 +178,8 @@ class SalesOrderAllocationAdmin(ImportExportModelAdmin):
         'item',
         'quantity'
     )
+
+    autocomplete_fields = ('line', 'shipment', 'item',)
 
 
 admin.site.register(PurchaseOrder, PurchaseOrderAdmin)

--- a/InvenTree/part/admin.py
+++ b/InvenTree/part/admin.py
@@ -126,7 +126,7 @@ class PartRelatedAdmin(admin.ModelAdmin):
     """
     Class to manage PartRelated objects
     """
-        
+
     autocomplete_fields = ('part_1', 'part_2')
 
 
@@ -147,7 +147,7 @@ class PartStarAdmin(admin.ModelAdmin):
 class PartCategoryStarAdmin(admin.ModelAdmin):
 
     list_display = ('category', 'user')
-    
+
     autocomplete_fields = ('category',)
 
 

--- a/InvenTree/part/admin.py
+++ b/InvenTree/part/admin.py
@@ -8,10 +8,9 @@ from import_export.resources import ModelResource
 from import_export.fields import Field
 import import_export.widgets as widgets
 
-import part.models as models
-
-from stock.models import StockLocation
 from company.models import SupplierPart
+import part.models as models
+from stock.models import StockLocation
 
 
 class PartResource(ModelResource):
@@ -76,6 +75,13 @@ class PartAdmin(ImportExportModelAdmin):
 
     search_fields = ('name', 'description', 'category__name', 'category__description', 'IPN')
 
+    autocomplete_fields = [
+        'variant_of',
+        'category',
+        'default_location',
+        'default_supplier',
+    ]
+
 
 class PartCategoryResource(ModelResource):
     """ Class for managing PartCategory data import/export """
@@ -105,13 +111,6 @@ class PartCategoryResource(ModelResource):
         models.PartCategory.objects.rebuild()
 
 
-class PartCategoryInline(admin.TabularInline):
-    """
-    Inline for PartCategory model
-    """
-    model = models.PartCategory
-
-
 class PartCategoryAdmin(ImportExportModelAdmin):
 
     resource_class = PartCategoryResource
@@ -120,34 +119,43 @@ class PartCategoryAdmin(ImportExportModelAdmin):
 
     search_fields = ('name', 'description')
 
-    inlines = [
-        PartCategoryInline,
-    ]
+    autocomplete_fields = ('parent', 'default_location',)
 
 
 class PartRelatedAdmin(admin.ModelAdmin):
-    ''' Class to manage PartRelated objects '''
-    pass
+    """
+    Class to manage PartRelated objects
+    """
+        
+    autocomplete_fields = ('part_1', 'part_2')
 
 
 class PartAttachmentAdmin(admin.ModelAdmin):
 
     list_display = ('part', 'attachment', 'comment')
 
+    autocomplete_fields = ('part',)
+
 
 class PartStarAdmin(admin.ModelAdmin):
 
     list_display = ('part', 'user')
 
+    autocomplete_fields = ('part',)
+
 
 class PartCategoryStarAdmin(admin.ModelAdmin):
 
     list_display = ('category', 'user')
+    
+    autocomplete_fields = ('category',)
 
 
 class PartTestTemplateAdmin(admin.ModelAdmin):
 
     list_display = ('part', 'test_name', 'required')
+
+    autocomplete_fields = ('part',)
 
 
 class BomItemResource(ModelResource):
@@ -253,9 +261,13 @@ class BomItemAdmin(ImportExportModelAdmin):
 
     search_fields = ('part__name', 'part__description', 'sub_part__name', 'sub_part__description')
 
+    autocomplete_fields = ('part', 'sub_part',)
+
 
 class ParameterTemplateAdmin(ImportExportModelAdmin):
     list_display = ('name', 'units')
+
+    search_fields = ('name', 'units')
 
 
 class ParameterResource(ModelResource):
@@ -282,10 +294,12 @@ class ParameterAdmin(ImportExportModelAdmin):
 
     list_display = ('part', 'template', 'data')
 
+    autocomplete_fields = ('part', 'template')
+
 
 class PartCategoryParameterAdmin(admin.ModelAdmin):
 
-    pass
+    autocomplete_fields = ('category', 'parameter_template',)
 
 
 class PartSellPriceBreakAdmin(admin.ModelAdmin):
@@ -302,6 +316,8 @@ class PartInternalPriceBreakAdmin(admin.ModelAdmin):
         model = models.PartInternalPriceBreak
 
     list_display = ('part', 'quantity', 'price',)
+
+    autocomplete_fields = ('part',)
 
 
 admin.site.register(models.Part, PartAdmin)

--- a/InvenTree/stock/admin.py
+++ b/InvenTree/stock/admin.py
@@ -63,6 +63,10 @@ class LocationAdmin(ImportExportModelAdmin):
         LocationInline,
     ]
 
+    autocomplete_fields = [
+        'parent',
+    ]
+
 
 class StockItemResource(ModelResource):
     """ Class for managing StockItem data import/export """
@@ -136,19 +140,44 @@ class StockItemAdmin(ImportExportModelAdmin):
         'batch',
     ]
 
+    autocomplete_fields = [
+        'belongs_to',
+        'build',
+        'customer',
+        'location',
+        'parent',
+        'part',
+        'purchase_order',
+        'sales_order',
+        'stocktake_user',
+        'supplier_part',
+    ]
+
 
 class StockAttachmentAdmin(admin.ModelAdmin):
 
     list_display = ('stock_item', 'attachment', 'comment')
 
+    autocomplete_fields = [
+        'stock_item',
+    ]
+
 
 class StockTrackingAdmin(ImportExportModelAdmin):
     list_display = ('item', 'date', 'label')
+
+    autocomplete_fields = [
+        'item',
+    ]
 
 
 class StockItemTestResultAdmin(admin.ModelAdmin):
 
     list_display = ('stock_item', 'test', 'result', 'value')
+
+    autocomplete_fields = [
+        'stock_item',
+    ]
 
 
 admin.site.register(StockLocation, LocationAdmin)


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/1005

Using auto-complete fields in the admin views drastically improves load times, when there are a large number (> 1000) of foreign key records:

| Table | Before (s) | After (s) |
| --- | --- | --- |
| Part | 5.4 | 1.5 |
| Stock Item | 19.6 | 1.5 |
| Part Parametesr | 9.12 | 0.9 |