### PR TITLE
Q_CLUSTER is using the database for its broker

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -558,7 +558,7 @@ _cache_port = _cache_config.get(
 if _cache_host:
     # We are going to rely upon a possibly non-localhost for our cache,
     # so don't wait too long for the cache as nothing in the cache should be
-    # irreplacable.  Django Q Cluster will just try again later.
+    # irreplacable.
     _cache_options = {
         "CLIENT_CLASS": "django_redis.client.DefaultClient",
         "SOCKET_CONNECT_TIMEOUT": int(os.getenv("CACHE_CONNECT_TIMEOUT", "2")),
@@ -584,15 +584,9 @@ if _cache_host:
         },
     }
     CACHES = {
-        # Connection configuration for Django Q Cluster
-        "worker": {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": f"redis://{_cache_host}:{_cache_port}/0",
-            "OPTIONS": _cache_options,
-        },
         "default": {
             "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": f"redis://{_cache_host}:{_cache_port}/1",
+            "LOCATION": f"redis://{_cache_host}:{_cache_port}/0",
             "OPTIONS": _cache_options,
         },
     }


### PR DESCRIPTION
This change partially reverts the changes of redis as cache because Q_CLUSTER is not using redis as the broker and doesn't need to.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2426"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

