### PR TITLE
Swallow Serialization failure while updating exchange rates

### DIFF
--- a/InvenTree/InvenTree/exchange.py
+++ b/InvenTree/InvenTree/exchange.py
@@ -2,6 +2,7 @@ from common.settings import currency_code_default, currency_codes
 from urllib.error import HTTPError, URLError
 
 from djmoney.contrib.exchange.backends.base import SimpleExchangeBackend
+from django.db.utils import OperationalError
 
 
 class InvenTreeExchange(SimpleExchangeBackend):
@@ -32,3 +33,12 @@ class InvenTreeExchange(SimpleExchangeBackend):
         # catch connection errors
         except (HTTPError, URLError):
             print('Encountered connection error while updating')
+        except OperationalError as e:
+            if 'SerializationFailure' in e.__cause__.__class__.__name__:
+                print('Serialization Failure while updating exchange rates')
+                # We are just going to swallow this exception because the
+                # exchange rates will be updated later by the scheduled task
+            else:
+                # Other operational errors probably are still show stoppers
+                # so reraise them so that the log contains the stacktrace
+                raise


### PR DESCRIPTION
We can swallow the serialization exception because there is a scheduled
task that will update these later anyway.

Fixes #2241

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2427"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

