### PR TITLE
Calculate how many items to assign to sales order

### DIFF
--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -1658,7 +1658,7 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
                             var available = Math.max((data.quantity || 0) - (data.allocated || 0), 0);
 
                             // Remaining quantity to be allocated?
-                            var remaining = opts.quantity || available;
+                            var remaining = Math.max(line_item.quantity - line_item.shipped - line_item.allocated, 0);
 
                             // Maximum amount that we need
                             var desired = Math.min(available, remaining);


### PR DESCRIPTION
- Do not over-allocate by default

Fixes https://github.com/inventree/InvenTree/issues/2444

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2446"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

