### PR TITLE
Correctly allow "inherited" BOM items to be allocated to a build order

### DIFF
--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -1150,7 +1150,7 @@ class BuildItem(models.Model):
 
         bom_item_valid = False
 
-        if self.bom_item:
+        if self.bom_item and self.build:
             """
             A BomItem object has already been assigned. This is valid if:
 
@@ -1162,9 +1162,12 @@ class BuildItem(models.Model):
                 iii) The Part referenced by the StockItem is a valid substitute for the BomItem
             """
 
-            if self.build and self.build.part == self.bom_item.part:
-
+            if self.build.part == self.bom_item.part:
                 bom_item_valid = self.bom_item.is_stock_item_valid(self.stock_item)
+
+            elif self.bom_item.inherited:
+                if self.build.part in self.bom_item.part.get_descendants(include_self=False):
+                    bom_item_valid = self.bom_item.is_stock_item_valid(self.stock_item)
 
         # If the existing BomItem is *not* valid, try to find a match
         if not bom_item_valid:

--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -309,14 +309,20 @@ class BuildAllocationItemSerializer(serializers.Serializer):
     )
 
     def validate_bom_item(self, bom_item):
-
-        # TODO: Fix this validation - allow for variants and substitutes!
+        """
+        Check if the parts match!
+        """
 
         build = self.context['build']
 
-        # BomItem must point to the same 'part' as the parent build
+        # BomItem should point to the same 'part' as the parent build
         if build.part != bom_item.part:
-            raise ValidationError(_("bom_item.part must point to the same part as the build order"))
+
+            # If not, it may be marked as "inherited" from a parent part
+            if bom_item.inherited and build.part in bom_item.part.get_descendants(include_self=False):
+                pass
+            else:
+                raise ValidationError(_("bom_item.part must point to the same part as the build order"))
 
         return bom_item
 

--- a/InvenTree/build/templates/build/build_base.html
+++ b/InvenTree/build/templates/build/build_base.html
@@ -78,6 +78,11 @@ src="{% static 'img/blank_image.png' %}"
         <td><a href="{% url 'part-detail' build.part.id %}?display=build-orders">{{ build.part.full_name }}</a></td>
     </tr>
     <tr>
+        <td></td>
+        <td>{% trans "Quantity" %}</td>
+        <td>{{ build.quantity }}</td>
+    </tr>
+    <tr>
         <td><span class='fas fa-info-circle'></span></td>
         <td>{% trans "Build Description" %}</td>
         <td>{{ build.title }}</td>
@@ -127,11 +132,6 @@ src="{% static 'img/blank_image.png' %}"
 {% block details_right %}
 <table class='table table-striped table-condensed'>
     <col width='25'>
-    <tr>
-        <td></td>
-        <td>{% trans "Quantity" %}</td>
-        <td>{{ build.quantity }}</td>
-    </tr>
     <tr>
         <td><span class='fas fa-info'></span></td>
         <td>{% trans "Status" %}</td>


### PR DESCRIPTION
- Some back-end logic was not running correctly

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2448"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

