### PR TITLE
Subcategory treeview improvements

### DIFF
--- a/InvenTree/templates/js/dynamic/nav.js
+++ b/InvenTree/templates/js/dynamic/nav.js
@@ -218,7 +218,6 @@ function enableBreadcrumbTree(options) {
                     collapseIcon: 'fa fa-chevron-down',
                 });
 
-                setBreadcrumbTreeState(label, state);
             }
         }
     );
@@ -226,26 +225,11 @@ function enableBreadcrumbTree(options) {
     $('#breadcrumb-tree-toggle').click(function() {
         // Add callback to "collapse" and "expand" the sidebar
 
-        // By default, the menu is "expanded"
-        var state = localStorage.getItem(`inventree-tree-state-${label}`) || 'expanded';
+        // Toggle treeview visibilty
+		$('#breadcrumb-tree-collapse').toggle();
         
-        // We wish to "toggle" the state!
-        setBreadcrumbTreeState(label, state == 'expanded' ? 'collapsed' : 'expanded');
     });
 
-    // Set the initial state (default = expanded)
-    var state = localStorage.getItem(`inventree-tree-state-${label}`) || 'expanded';
-
-    function setBreadcrumbTreeState(label, state) {
-
-        if (state == 'collapsed') {
-            $('#breadcrumb-tree-collapse').hide(100);
-        } else {
-            $('#breadcrumb-tree-collapse').show(100);
-        }
-
-        localStorage.setItem(`inventree-tree-state-${label}`, state);
-    }
 }
 
 /*

--- a/InvenTree/templates/js/dynamic/nav.js
+++ b/InvenTree/templates/js/dynamic/nav.js
@@ -192,17 +192,17 @@ function enableBreadcrumbTree(options) {
                     node = data[i];
 
                     if (node.parent != null) {
-						if (nodes[node.parent].nodes) {
-							nodes[node.parent].nodes.push(node);
-						} else {
-							nodes[node.parent].nodes = [node];
-						}
+                        if (nodes[node.parent].nodes) {
+                            nodes[node.parent].nodes.push(node);
+                        } else {
+                            nodes[node.parent].nodes = [node];
+                        }
 
                         if (node.state.expanded) {
-							while (node.parent != null) {
-								nodes[node.parent].state.expanded = true;
-								node = nodes[node.parent]
-							}
+                            while (node.parent != null) {
+                                nodes[node.parent].state.expanded = true;
+                                node = nodes[node.parent];
+                            }
                         }
                         
                     } else {
@@ -226,7 +226,7 @@ function enableBreadcrumbTree(options) {
         // Add callback to "collapse" and "expand" the sidebar
 
         // Toggle treeview visibilty
-		$('#breadcrumb-tree-collapse').toggle();
+        $('#breadcrumb-tree-collapse').toggle();
         
     });
 

--- a/InvenTree/templates/js/dynamic/nav.js
+++ b/InvenTree/templates/js/dynamic/nav.js
@@ -175,7 +175,6 @@ function enableBreadcrumbTree(options) {
 
                 for (var i = 0; i < data.length; i++) {
                     node = data[i];
-                    node.nodes = [];
                     nodes[node.pk] = node;
                     node.selectable = false;
 
@@ -193,7 +192,11 @@ function enableBreadcrumbTree(options) {
                     node = data[i];
 
                     if (node.parent != null) {
-                        nodes[node.parent].nodes.push(node);
+						if (nodes[node.parent].nodes) {
+							nodes[node.parent].nodes.push(node);
+						} else {
+							nodes[node.parent].nodes = [node];
+						}
 
                         if (node.state.expanded) {
                             nodes[node.parent].state.expanded = true;

--- a/InvenTree/templates/js/dynamic/nav.js
+++ b/InvenTree/templates/js/dynamic/nav.js
@@ -199,7 +199,10 @@ function enableBreadcrumbTree(options) {
 						}
 
                         if (node.state.expanded) {
-                            nodes[node.parent].state.expanded = true;
+							while (node.parent != null) {
+								nodes[node.parent].state.expanded = true;
+								node = nodes[node.parent]
+							}
                         }
                         
                     } else {


### PR DESCRIPTION
A couple of improvements for #2445
* Do not show icons for childless categories
* Propagate expanded state all the way to the root

@SchrodingersGat , current implementation of collapse/expand tracking does not allow me to implement the following usecase:
1. Click "hamburger" button to open tree
2. Find needed category, click on it.
3. New category is opened with **tree collapsed**

I don't see any point for tree to be always open because it consumes almost all my screen space. While for sidebar it was OK to have it always open.

What do you think about removing treeview state saving and make it collapsed by default?

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2451"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

