### PR TITLE
Dont localize item.quantity in JS Code

### DIFF
--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -3,6 +3,7 @@
 {% load inventree_extras %}
 {% load status_codes %}
 {% load i18n %}
+{% load l10n %}
 
 {% block page_title %}
 {% inventree_title %} | {% trans "Stock Item" %} - {{ item }}
@@ -429,7 +430,7 @@ $("#stock-serialize").click(function() {
         part: {{ item.part.pk }},
         reload: true,
         data: {
-            quantity: {{ item.quantity }},
+            quantity: {{ item.quantity|unlocalize }},
             {% if item.location %}
             destination: {{ item.location.pk }},
             {% elif item.part.default_location %}


### PR DESCRIPTION
Fixes #2505 

Fixes a Javascript SyntaxError on different locales with "," as decimal seperator

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2506"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

