### PR TITLE
Switch Maint Mode to use default storage backend

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -172,12 +172,6 @@ if MEDIA_ROOT is None:
     print("ERROR: INVENTREE_MEDIA_ROOT directory is not defined")
     sys.exit(1)
 
-# Options for django-maintenance-mode : https://pypi.org/project/django-maintenance-mode/
-MAINTENANCE_MODE_STATE_FILE_PATH = os.path.join(
-    config_dir,
-    'maintenance_mode_state.txt',
-)
-
 # List of allowed hosts (default = allow all)
 ALLOWED_HOSTS = CONFIG.get('allowed_hosts', ['*'])
 
@@ -870,6 +864,7 @@ MARKDOWNIFY_BLEACH = False
 
 # Maintenance mode
 MAINTENANCE_MODE_RETRY_AFTER = 60
+MAINTENANCE_MODE_STATE_BACKEND = 'maintenance_mode.backends.DefaultStorageBackend'
 
 # Are plugins enabled?
 PLUGINS_ENABLED = _is_true(get_setting(


### PR DESCRIPTION
It seems that Maintance Mode also fiddles with the filesystem directly. This changes the backed that Maintance Mode uses so that it will put the flag file into wherever the media files are stored, currently this is the media directory on disk as there is no way to configure the default storages in inventree.

#2585

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2586"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

