### PR TITLE
Skips some specific steps when importing data

### DIFF
--- a/InvenTree/InvenTree/ready.py
+++ b/InvenTree/InvenTree/ready.py
@@ -6,10 +6,16 @@ def isInTestMode():
     Returns True if the database is in testing mode
     """
 
-    if 'test' in sys.argv:
-        return True
+    return 'test' in sys.argv
 
-    return False
+
+def isImportingData():
+    """
+    Returns True if the database is currently importing data,
+    e.g. 'loaddata' command is performed
+    """
+
+    return 'loaddata' in sys.argv
 
 
 def canAppAccessDatabase(allow_test=False):

--- a/InvenTree/build/tasks.py
+++ b/InvenTree/build/tasks.py
@@ -12,6 +12,8 @@ from allauth.account.models import EmailAddress
 import build.models
 import InvenTree.helpers
 import InvenTree.tasks
+from InvenTree.ready import isImportingData
+
 import part.models as part_models
 
 
@@ -23,6 +25,10 @@ def check_build_stock(build: build.models.Build):
     Check the required stock for a newly created build order,
     and send an email out to any subscribed users if stock is low.
     """
+
+    # Do not notify if we are importing data
+    if isImportingData():
+        return
 
     # Iterate through each of the parts required for this build
 

--- a/InvenTree/part/tasks.py
+++ b/InvenTree/part/tasks.py
@@ -13,6 +13,7 @@ from common.models import NotificationEntry
 
 import InvenTree.helpers
 import InvenTree.tasks
+from InvenTree.ready import isImportingData
 
 import part.models
 
@@ -23,6 +24,10 @@ def notify_low_stock(part: part.models.Part):
     """
     Notify users who have starred a part when its stock quantity falls below the minimum threshold
     """
+
+    # Do not notify if we are importing data
+    if isImportingData():
+        return
 
     # Check if we have notified recently...
     delta = timedelta(days=1)

--- a/InvenTree/plugin/apps.py
+++ b/InvenTree/plugin/apps.py
@@ -8,6 +8,7 @@ from django.conf import settings
 
 from maintenance_mode.core import set_maintenance_mode
 
+from InvenTree.ready import isImportingData
 from plugin import registry
 
 
@@ -19,13 +20,17 @@ class PluginAppConfig(AppConfig):
 
     def ready(self):
         if settings.PLUGINS_ENABLED:
-            logger.info('Loading InvenTree plugins')
+            
+            if isImportingData():
+                logger.info('Skipping plugin loading for data import')
+            else:
+                logger.info('Loading InvenTree plugins')
 
-            if not registry.is_loading:
-                # this is the first startup
-                registry.collect_plugins()
-                registry.load_plugins()
+                if not registry.is_loading:
+                    # this is the first startup
+                    registry.collect_plugins()
+                    registry.load_plugins()
 
-                # drop out of maintenance
-                # makes sure we did not have an error in reloading and maintenance is still active
-                set_maintenance_mode(False)
+                    # drop out of maintenance
+                    # makes sure we did not have an error in reloading and maintenance is still active
+                    set_maintenance_mode(False)

--- a/InvenTree/plugin/apps.py
+++ b/InvenTree/plugin/apps.py
@@ -20,7 +20,7 @@ class PluginAppConfig(AppConfig):
 
     def ready(self):
         if settings.PLUGINS_ENABLED:
-            
+
             if isImportingData():
                 logger.info('Skipping plugin loading for data import')
             else:


### PR DESCRIPTION
- We need to prevent certain operations from running when we are importing data
- This is to prevent unique database constraints from being violated

- Do not register plugins during data import
- Do not launch notification events

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2598"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

