### PR TITLE
Hide part pricing history

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -776,6 +776,18 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'validator': bool,
         },
 
+        # 2022-02-03
+        # This setting exists as an interim solution for extremely slow part page load times when the part has a complex BOM
+        # In an upcoming release, pricing history (and BOM pricing) will be cached,
+        # rather than having to be re-calculated every time the page is loaded!
+        # For now, we will simply hide part pricing by default
+        'PART_SHOW_PRICE_HISTORY': {
+            'name': _('Show Price History'),
+            'description': _('Display historical pricing for Part'),
+            'default': False,
+            'validator': bool,
+        },
+
         'PART_SHOW_RELATED': {
             'name': _('Show related parts'),
             'description': _('Display related parts for a part'),

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -126,9 +126,12 @@
     </div>
 </div>
 
+{% settings_value "PART_SHOW_PRICE_HISTORY" as show_price_history %}
+{% if show_price_history %}
 <div class='panel panel-hidden' id='panel-pricing'>
     {% include "part/prices.html" %}
 </div>
+{% endif %}
 
 <div class='panel panel-hidden' id='panel-part-notes'>
     <div class='panel-heading'>

--- a/InvenTree/part/templates/part/part_sidebar.html
+++ b/InvenTree/part/templates/part/part_sidebar.html
@@ -4,6 +4,7 @@
 
 {% settings_value "PART_INTERNAL_PRICE" as show_internal_price %}
 {% settings_value 'PART_SHOW_RELATED' as show_related %}
+{% settings_value "PART_SHOW_PRICE_HISTORY" as show_price_history %}
 
 {% trans "Parameters" as text %}
 {% include "sidebar_item.html" with label="part-parameters" text=text icon="fa-th-list" %}
@@ -25,8 +26,10 @@
 {% trans "Used In" as text %}
 {% include "sidebar_item.html" with label="used-in" text=text icon="fa-layer-group" %}
 {% endif %}
+{% if show_price_history %}
 {% trans "Pricing" as text %}
 {% include "sidebar_item.html" with label="pricing" text=text icon="fa-dollar-sign" %}
+{% endif %}
 {% if part.salable or part.component %}
 {% trans "Allocations" as text %}
 {% include "sidebar_item.html" with label="allocations" text=text icon="fa-bookmark" %}

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -395,10 +395,11 @@ class PartDetail(InvenTreeRoleMixin, DetailView):
         context.update(**ctx)
 
         # Pricing information
-        ctx = self.get_pricing(self.get_quantity())
-        ctx['form'] = self.form_class(initial=self.get_initials())
+        if InvenTreeSetting.get_setting('PART_SHOW_PRICE_HISTORY', False):
+            ctx = self.get_pricing(self.get_quantity())
+            ctx['form'] = self.form_class(initial=self.get_initials())
 
-        context.update(ctx)
+            context.update(ctx)
 
         return context
 

--- a/InvenTree/templates/InvenTree/settings/part.html
+++ b/InvenTree/templates/InvenTree/settings/part.html
@@ -15,6 +15,7 @@
         {% include "InvenTree/settings/setting.html" with key="PART_ALLOW_DUPLICATE_IPN" %}
         {% include "InvenTree/settings/setting.html" with key="PART_ALLOW_EDIT_IPN" %}
         {% include "InvenTree/settings/setting.html" with key="PART_NAME_FORMAT" %}
+        {% include "InvenTree/settings/setting.html" with key="PART_SHOW_PRICE_HISTORY" icon="fa-history" %}
         {% include "InvenTree/settings/setting.html" with key="PART_SHOW_PRICE_IN_FORMS" icon="fa-dollar-sign" %}
         {% include "InvenTree/settings/setting.html" with key="PART_SHOW_PRICE_IN_BOM" icon="fa-dollar-sign" %}
         {% include "InvenTree/settings/setting.html" with key="PART_SHOW_RELATED" icon="fa-random" %}

--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -778,6 +778,11 @@ function loadBomTable(table, options={}) {
     // This function may be called recursively for multi-level BOMs
     function requestSubItems(bom_pk, part_pk) {
 
+        // TODO: 2022-02-03 Currently, multi-level BOMs are not actually displayed.
+
+        // Re-enable this function once multi-level display has been re-deployed
+        return;
+
         inventreeGet(
             options.bom_url,
             {


### PR DESCRIPTION
Due to the many outstanding issues with part "pricing", the "Part" detail page can take a very long time (> 10 seconds) just to load templates if it has a complex (multi-level) Bill of Materials.

Pricing is getting a major refactor in 0.7.x release.

For now, this PR adds an option to hide pricing history (and calculation of pricing data) from the part detail page.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2599"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

