### PR TITLE
Fix for BOM import

### DIFF
--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -960,6 +960,9 @@ class BomExtractSerializer(serializers.Serializer):
             """
             quantity = self.find_matching_data(row, 'quantity', self.dataset.headers)
 
+            # Ensure quantity field is provided
+            row['quantity'] = quantity
+
             if quantity is None:
                 row_error['quantity'] = _('Quantity not provided')
             else:


### PR DESCRIPTION
Enforce proper formatting for 'quantity' field when importing BOM data.

Note: More substantial refactor for BOM import is incoming.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2626"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

