### PR TITLE
Build output allocation tweak

### DIFF
--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1515,7 +1515,21 @@ function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
     // ID of the associated "build output" (or null)
     var output_id = options.output || null;
 
+    var auto_fill_filters = {};
+
     var source_location = options.source_location;
+
+    if (output_id) {
+        // Request information on the particular build output (stock item)
+        inventreeGet(`/api/stock/${output_id}/`, {}, {
+            success: function(output) {
+                if (output.quantity == 1 && output.serial != null) {
+                    auto_fill_filters.serial = output.serial;
+                }
+            },
+            async: false,
+        });
+    }
 
     function renderBomItemRow(bom_item, quantity) {
 
@@ -1703,7 +1717,9 @@ function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
                         required: true,
                         render_part_detail: true,
                         render_location_detail: true,
+                        render_stock_id: false,
                         auto_fill: true,
+                        auto_fill_filters: auto_fill_filters,
                         onSelect: function(data, field, opts) {
                             // Adjust the 'quantity' field based on availability
 

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -1696,13 +1696,19 @@ function initializeRelatedField(field, fields, options={}) {
     } else if (field.auto_fill) {
         // Attempt to auto-fill the field
 
-        var filters = field.filters || {};
+        var filters = {};
+
+        // Update with nominal field fields
+        Object.assign(filters, field.filters || {});
+
+        // Update with filters only used for initial filtering
+        Object.assign(filters, field.auto_fill_filters || {});
 
         // Enforce pagination, limit to a single return (for fast query)
         filters.limit = 1;
         filters.offset = 0;
 
-        inventreeGet(field.api_url, field.filters || {}, {
+        inventreeGet(field.api_url, filters || {}, {
             success: function(data) {
 
                 // Only a single result is available, given the provided filters


### PR DESCRIPTION
Automatically select Bom Items with matching serial numbers when allocating stock to a build order output

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2632"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

