### PR TITLE
Create and continue

### DIFF
--- a/InvenTree/InvenTree/static/script/inventree/notification.js
+++ b/InvenTree/InvenTree/static/script/inventree/notification.js
@@ -37,7 +37,6 @@ function showAlertOrCache(message, cache, options={}) {
     if (cache) {
         addCachedAlert(message, options);
     } else {
-
         showMessage(message, options);
     }
 }
@@ -82,6 +81,8 @@ function showMessage(message, options={}) {
 
     var timeout = options.timeout || 5000;
 
+    var target = options.target || $('#alerts');
+
     var details = '';
 
     if (options.details) {
@@ -111,7 +112,7 @@ function showMessage(message, options={}) {
     </div>
     `;
 
-    $('#alerts').append(html);
+    target.append(html);
 
     // Remove the alert automatically after a specified period of time
     $(`#alert-${id}`).delay(timeout).slideUp(200, function() {

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -313,6 +313,10 @@
             fields: fields,
             groups: partGroups(),
             title: '{% trans "Create Part" %}',
+            reloadFormAfterSuccess: true,
+            persist: true,
+            persistMessage: '{% trans "Create another part after this one" %}',
+            successMessage: '{% trans "Part created successfully" %}',
             onSuccess: function(data) {
                 // Follow the new part
                 location.href = `/part/${data.pk}/`;

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -942,9 +942,22 @@ function handleFormSuccess(response, options) {
         cache = false;
     }
 
+    var msg_target = null;
+
+    if (options.modal && options.reloadFormAfterSuccess) {
+        // If the modal is persistant, the target for any messages should be the modal!
+        msg_target = $(options.modal).find('#pre-form-content');
+    }
+
     // Display any messages
     if (response && (response.success || options.successMessage)) {
-        showAlertOrCache(response.success || options.successMessage, cache, {style: 'success'});
+        showAlertOrCache(
+            response.success || options.successMessage,
+            cache,
+            {
+                style: 'success',
+                target: msg_target,
+            });
     }
     
     if (response && response.info) {

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -934,15 +934,13 @@ function getFormFieldValue(name, field={}, options={}) {
  */
 function handleFormSuccess(response, options) {
 
-    // Close the modal
-    if (!options.preventClose) {
-        // Note: The modal will be deleted automatically after closing
-        $(options.modal).modal('hide');
-    }
-
     // Display any required messages
     // Should we show alerts immediately or cache them?
     var cache = (options.follow && response.url) || options.redirect || options.reload;
+
+    if (options.reloadFormAfterSuccess) {
+        cache = false;
+    }
 
     // Display any messages
     if (response && (response.success || options.successMessage)) {
@@ -960,21 +958,42 @@ function handleFormSuccess(response, options) {
     if (response && response.danger) {
         showAlertOrCache(response.danger, cache, {style: 'danger'});
     }
-
+    
     if (options.onSuccess) {
         // Callback function
         options.onSuccess(response, options);
     }
 
-    if (options.follow && response.url) {
-        // Follow the returned URL
-        window.location.href = response.url;
-    } else if (options.reload) {
-        // Reload the current page
-        location.reload();
-    } else if (options.redirect) {
-        // Redirect to a specified URL
-        window.location.href = options.redirect;
+    if (options.reloadFormAfterSuccess) {
+        // Instead of closing the form and going somewhere else,
+        // reload (empty) the form so the user can input more data
+        
+        // Reset the status of the "submit" button
+        if (options.modal) {
+            $(options.modal).find('#modal-form-submit').prop('disabled', false);
+        }
+
+        // Remove any error flags from the form
+        clearFormErrors(options);
+
+    } else {
+
+        // Close the modal
+        if (!options.preventClose) {
+            // Note: The modal will be deleted automatically after closing
+            $(options.modal).modal('hide');
+        }
+
+        if (options.follow && response.url) {
+            // Follow the returned URL
+            window.location.href = response.url;
+        } else if (options.reload) {
+            // Reload the current page
+            location.reload();
+        } else if (options.redirect) {
+            // Redirect to a specified URL
+            window.location.href = options.redirect;
+        }
     }
 }
 
@@ -988,6 +1007,8 @@ function clearFormErrors(options={}) {
     if (options && options.modal) {
         // Remove the individual error messages
         $(options.modal).find('.form-error-message').remove();
+    
+        $(options.modal).find('.modal-content').removeClass('modal-error');
 
         // Remove the "has error" class
         $(options.modal).find('.form-field-error').removeClass('form-field-error');

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -542,6 +542,11 @@ function constructFormBody(fields, options) {
         insertConfirmButton(options);
     }
 
+    // Insert "persist" button (if required)
+    if (options.persist) {
+        insertPersistButton(options);
+    }
+
     // Display the modal
     $(modal).modal('show');
 
@@ -613,6 +618,22 @@ function insertConfirmButton(options) {
 
         $(options.modal).find('#modal-form-submit').prop('disabled', !enabled);
     });
+}
+
+
+/* Add a checkbox to select if the modal will stay open after success */
+function insertPersistButton(options) {
+
+    var message = options.persistMessage || '{% trans "Keep this form open" %}';
+
+    var html = `
+    <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="modal-persist">
+        <label class="form-check-label" for="modal-persist">${message}</label>
+    </div>
+    `;
+
+    $(options.modal).find('#modal-footer-buttons').append(html);
 }
 
 
@@ -938,13 +959,23 @@ function handleFormSuccess(response, options) {
     // Should we show alerts immediately or cache them?
     var cache = (options.follow && response.url) || options.redirect || options.reload;
 
-    if (options.reloadFormAfterSuccess) {
+    // Should the form "persist"?
+    var persist = false;
+
+    if (options.persist && options.modal) {
+        // Determine if this form should "persist", or be dismissed?
+        var chk = $(options.modal).find('#modal-persist');
+
+        persist = chk.exists() && chk.prop('checked');
+    }
+
+    if (persist) {
         cache = false;
     }
 
     var msg_target = null;
 
-    if (options.modal && options.reloadFormAfterSuccess) {
+    if (persist) {
         // If the modal is persistant, the target for any messages should be the modal!
         msg_target = $(options.modal).find('#pre-form-content');
     }
@@ -971,13 +1002,8 @@ function handleFormSuccess(response, options) {
     if (response && response.danger) {
         showAlertOrCache(response.danger, cache, {style: 'danger'});
     }
-    
-    if (options.onSuccess) {
-        // Callback function
-        options.onSuccess(response, options);
-    }
 
-    if (options.reloadFormAfterSuccess) {
+    if (persist) {
         // Instead of closing the form and going somewhere else,
         // reload (empty) the form so the user can input more data
         
@@ -995,6 +1021,11 @@ function handleFormSuccess(response, options) {
         if (!options.preventClose) {
             // Note: The modal will be deleted automatically after closing
             $(options.modal).modal('hide');
+        }
+
+        if (options.onSuccess) {
+            // Callback function
+            options.onSuccess(response, options);
         }
 
         if (options.follow && response.url) {


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/2642

Adds an option to "persist" modal dialogs after they are successful.

This lets the same form be "used" in quick succession, for example creating multiple parts at once.