### PR TITLE
Bug fix for BuildOrder.bom_items

### DIFF
--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -383,9 +383,7 @@ class Build(MPTTModel, ReferenceIndexingMixin):
         Returns the BOM items for the part referenced by this BuildOrder
         """
 
-        return self.part.bom_items.all().prefetch_related(
-            'sub_part'
-        )
+        return self.part.get_bom_items()
 
     @property
     def tracked_bom_items(self):

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1453,7 +1453,9 @@ class Part(MPTTModel):
         By default, will include inherited BOM items
         """
 
-        return BomItem.objects.filter(self.get_bom_item_filter(include_inherited=include_inherited))
+        queryset = BomItem.objects.filter(self.get_bom_item_filter(include_inherited=include_inherited))
+
+        return queryset.prefetch_related('sub_part')
 
     def get_installed_part_options(self, include_inherited=True, include_variants=True):
         """


### PR DESCRIPTION
Fixes a bug which resulted in the incorrect result from the function `BuildOrder.are_untracked_parts_allocated`

- Now uses the query generator provided by the Part model
- No more code duplication
- More importantly, no more code duplication which is WRONG!

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2697"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

