### PR TITLE
Adds "duplicate line item" button to orders

### DIFF
--- a/InvenTree/order/templates/order/purchase_order_detail.html
+++ b/InvenTree/order/templates/order/purchase_order_detail.html
@@ -152,32 +152,16 @@
 {% if order.status == PurchaseOrderStatus.PENDING %}
 $('#new-po-line').click(function() {
 
+    var fields = poLineItemFields({
+        order: {{ order.pk }},
+        supplier: {{ order.supplier.pk }},
+        {% if order.supplier.currency %}
+        currency: '{{ order.supplier.currency }}',
+        {% endif %}
+    });
 
     constructForm('{% url "api-po-line-list" %}', {
-        fields: {
-            order: {
-                value: {{ order.pk }},
-                hidden: true,
-            },
-            part: {
-                filters: {
-                    part_detail: true,
-                    supplier_detail: true,
-                    supplier: {{ order.supplier.pk }},
-                },
-            },
-            quantity: {},
-            reference: {},
-            purchase_price: {},
-            purchase_price_currency: {
-                {% if order.supplier.currency %}
-                value: '{{ order.supplier.currency }}',
-                {% endif %}
-            },
-            target_date: {},
-            destination: {},
-            notes: {},
-        },
+        fields: fields,
         method: 'POST',
         title: '{% trans "Add Line Item" %}',
         onSuccess: function() {

--- a/InvenTree/order/templates/order/sales_order_detail.html
+++ b/InvenTree/order/templates/order/sales_order_detail.html
@@ -221,29 +221,19 @@
         },
     });
 
-    function reloadTable() {
-        $("#so-lines-table").bootstrapTable("refresh");
-    }
-
     $("#new-so-line").click(function() {
 
+        var fields = soLineItemFields({
+            order: {{ order.pk }},
+        });
+
         constructForm('{% url "api-so-line-list" %}', {
-            fields: {
-                order: {
-                    value: {{ order.pk }},
-                    hidden: true,
-                },
-                part: {},
-                quantity: {},
-                reference: {},
-                sale_price: {},
-                sale_price_currency: {},
-                target_date: {},
-                notes: {},
-            },
+            fields: fields,
             method: 'POST',
             title: '{% trans "Add Line Item" %}',
-            onSuccess: reloadTable,
+            onSuccess: function() {
+                $("#so-lines-table").bootstrapTable("refresh");
+            },
         });
     });
 

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -1051,7 +1051,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
     
     var target = options.filter_target || '#filter-list-purchase-order-lines';
 
-    setupFilterList('purchaseorderlineitem', $(table), target);
+    setupFilterList('purchaseorderlineitem', $(table), target, {download: true});
 
     function setupCallbacks() {
         if (options.allow_edit) {
@@ -1078,7 +1078,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                         });
                     }
                 });
-            })
+            });
 
             // Callback for "edit" button
             $(table).find('.button-line-edit').click(function() {
@@ -2583,7 +2583,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                         fields: fields,
                         data: data,
                         title: '{% trans "Duplicate Line Item" %}',
-                        onSuccess: function(response)  {
+                        onSuccess: function(response) {
                             $(table).bootstrapTable('refresh');
                         }
                     });

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -281,6 +281,65 @@ function createPurchaseOrder(options={}) {
 }
 
 
+/* Construct a set of fields for the SalesOrderLineItem form */
+function soLineItemFields(options={}) {
+
+    var fields = {
+        order: {
+            hidden: true,
+        },
+        part: {},
+        quantity: {},
+        reference: {},
+        sale_price: {},
+        sale_price_currency: {},
+        target_date: {},
+        notes: {},
+    };
+
+    if (options.order) {
+        fields.order.value = options.order;
+    }
+
+    return fields;
+}
+
+
+/* Construct a set of fields for the PurchaseOrderLineItem form */
+function poLineItemFields(options={}) {
+
+    var fields = {
+        order: {
+            hidden: true,
+        },
+        part: {
+            filters: {
+                part_detail: true,
+                supplier_detail: true,
+                supplier: options.supplier,
+            }
+        },
+        quantity: {},
+        reference: {},
+        purchase_price: {},
+        purchase_price_currency: {},
+        target_date: {},
+        destination: {},
+        notes: {},
+    };
+
+    if (options.order) {
+        fields.order.value = options.order;
+    }
+
+    if (options.currency) {
+        fields.purchase_price_currency.value = options.currency;
+    }
+
+    return fields;
+}
+
+
 function removeOrderRowFromOrderWizard(e) {
     /* Remove a part selection from an order form. */
 
@@ -292,6 +351,7 @@ function removeOrderRowFromOrderWizard(e) {
 
     $('#' + row).remove();
 }
+
 
 function newSupplierPartFromOrderWizard(e) {
     /* Create a new supplier part directly from an order form.
@@ -995,6 +1055,32 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
 
     function setupCallbacks() {
         if (options.allow_edit) {
+
+            // Callback for "duplicate" button
+            $(table).find('.button-line-duplicate').click(function() {
+                var pk = $(this).attr('pk');
+
+                inventreeGet(`/api/order/po-line/${pk}/`, {}, {
+                    success: function(data) {
+
+                        var fields = poLineItemFields({
+                            supplier: options.supplier,
+                        });
+
+                        constructForm('{% url "api-po-line-list" %}', {
+                            method: 'POST',
+                            fields: fields,
+                            data: data,
+                            title: '{% trans "Duplicate Line Item" %}',
+                            onSuccess: function(response) {
+                                $(table).bootstrapTable('refresh');
+                            }
+                        });
+                    }
+                });
+            })
+
+            // Callback for "edit" button
             $(table).find('.button-line-edit').click(function() {
                 var pk = $(this).attr('pk');
 
@@ -1022,6 +1108,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                 });
             });
 
+            // Callback for "delete" button
             $(table).find('.button-line-delete').click(function() {
                 var pk = $(this).attr('pk');
 
@@ -1270,6 +1357,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                     }
 
                     if (options.allow_edit) {
+                        html += makeIconButton('fa-clone', 'button-line-duplicate', pk, '{% trans "Duplicate line item" %}');
                         html += makeIconButton('fa-edit icon-blue', 'button-line-edit', pk, '{% trans "Edit line item" %}');
                         html += makeIconButton('fa-trash-alt icon-red', 'button-line-delete', pk, '{% trans "Delete line item" %}');
                     }
@@ -2449,6 +2537,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                     html += makeIconButton('fa-dollar-sign icon-green', 'button-price', pk, '{% trans "Calculate price" %}');
                 }
 
+                html += makeIconButton('fa-clone', 'button-duplicate', pk, '{% trans "Duplicate line item" %}');
                 html += makeIconButton('fa-edit icon-blue', 'button-edit', pk, '{% trans "Edit line item" %}');
 
                 var delete_disabled = false;
@@ -2479,6 +2568,28 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
     // Configure callback functions once the table is loaded
     function setupCallbacks() {
+
+        // Callback for duplicating line items
+        $(table).find('.button-duplicate').click(function() {
+            var pk = $(this).attr('pk');
+
+            inventreeGet(`/api/order/so-line/${pk}/`, {}, {
+                success: function(data) {
+
+                    var fields = soLineItemFields();
+
+                    constructForm('{% url "api-so-line-list" %}', {
+                        method: 'POST',
+                        fields: fields,
+                        data: data,
+                        title: '{% trans "Duplicate Line Item" %}',
+                        onSuccess: function(response)  {
+                            $(table).bootstrapTable('refresh');
+                        }
+                    });
+                }
+            });
+        });
 
         // Callback for editing line items
         $(table).find('.button-edit').click(function() {


### PR DESCRIPTION
Lets users quickly duplicate line items for sales orders or purchase orders

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2710"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

