### PR TITLE
Adds "Auto allocate" feature for build orders

### DIFF
--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -12,10 +12,14 @@ import common.models
 INVENTREE_SW_VERSION = "0.7.0 dev"
 
 # InvenTree API version
-INVENTREE_API_VERSION = 27
+INVENTREE_API_VERSION = 28
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v28 -> 2022-03-04
+    - Adds an API endpoint for auto allocation of stock items against a build order
+    - Ref: https://github.com/inventree/InvenTree/pull/2713
 
 v27 -> 2022-02-28
     - Adds target_date field to individual line items for purchase orders and sales orders

--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -25,6 +25,8 @@ from markdownx.models import MarkdownxField
 from mptt.models import MPTTModel, TreeForeignKey
 from mptt.exceptions import InvalidMove
 
+from rest_framework import serializers
+
 from InvenTree.status_codes import BuildStatus, StockStatus, StockHistoryCode
 from InvenTree.helpers import increment, getSetting, normalize, MakeBarcode
 from InvenTree.models import InvenTreeAttachment, ReferenceIndexingMixin
@@ -822,6 +824,86 @@ class Build(MPTTModel, ReferenceIndexingMixin):
         self.completed += output.quantity
 
         self.save()
+
+    @transaction.atomic
+    def auto_allocate_stock(self, user, **kwargs):
+        """
+        Automatically allocate stock items against this build order,
+        following a number of 'guidelines':
+
+        - Only "untracked" BOM items are considered (tracked BOM items must be manually allocated)
+        - If a particular BOM item is already fully allocated, it is skipped
+        - Extract all available stock items for the BOM part
+            - If variant stock is allowed, extract stock for those too
+            - If substitute parts are available, extract stock for those also
+        - If a single stock item is found, we can allocate that and move on!
+        - If multiple stock items are found, we *may* be able to allocate:
+            - If the calling function has specified that items are interchangeable
+        """
+
+        location = kwargs.get('location', None)
+        interchangeable = kwargs.get('interchangeable', False)
+        substitutes = kwargs.get('substitutes', True)
+
+        # Get a list of all 'untracked' BOM items
+        for bom_item in self.untracked_bom_items:
+            
+            unallocated_quantity = self.unallocated_quantity(bom_item)
+
+            if unallocated_quantity <= 0:
+                # This BomItem is fully allocated, we can continue
+                continue
+
+            # Check which parts we can "use" (may include variants and substitutes)
+            available_parts = bom_item.get_valid_parts_for_allocation(
+                allow_variants=True,
+                allow_substitutes=substitutes,
+            )
+
+            # Look for available stock items
+            available_stock = StockModels.StockItem.objects.filter(StockModels.StockItem.IN_STOCK_FILTER)
+
+            # Filter by list of available parts
+            available_stock = available_stock.filter(
+                part__in=[p for p in available_parts],
+            )
+
+            if location:
+                # Filter only stock items located "below" the specified location
+                sublocations = location.get_descendants(include_self=True)
+                available_stock = available_stock.filter(location__in=[loc for loc in sublocations])
+
+            if available_stock.count() == 0:
+                # No stock items are available
+                continue
+            elif available_stock.count() == 1 or interchangeable:
+                # Either there is only a single stock item available,
+                # or all items are "interchangeable" and we don't care where we take stock from
+
+                for stock_item in available_stock:
+                    # How much of the stock item is "available" for allocation?
+                    quantity = min(unallocated_quantity, stock_item.unallocated_quantity())
+
+                    if quantity > 0:
+
+                        try:
+                            BuildItem.objects.create(
+                                build=self,
+                                bom_item=bom_item,
+                                stock_item=stock_item,
+                                quantity=quantity,
+                            )
+
+                            # Subtract the required quantity
+                            unallocated_quantity -= quantity
+
+                        except (ValidationError, serializers.ValidationError) as exc:
+                            # Catch model errors and re-throw as DRF errors
+                            raise ValidationError(detail=serializers.as_serializer_error(exc))
+
+                    if unallocated_quantity <= 0:
+                        # We have now fully-allocated this BomItem - no need to continue!
+                        break
 
     def required_quantity(self, bom_item, output=None):
         """

--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -826,7 +826,7 @@ class Build(MPTTModel, ReferenceIndexingMixin):
         self.save()
 
     @transaction.atomic
-    def auto_allocate_stock(self, user, **kwargs):
+    def auto_allocate_stock(self, **kwargs):
         """
         Automatically allocate stock items against this build order,
         following a number of 'guidelines':
@@ -847,9 +847,8 @@ class Build(MPTTModel, ReferenceIndexingMixin):
 
         # Get a list of all 'untracked' BOM items
         for bom_item in self.untracked_bom_items:
-            
+
             variant_parts = bom_item.sub_part.get_descendants(include_self=False)
-            substitute_parts = [p for p in bom_item.substitutes.all()]
 
             unallocated_quantity = self.unallocated_quantity(bom_item)
 
@@ -891,7 +890,7 @@ class Build(MPTTModel, ReferenceIndexingMixin):
                     return 2
                 else:
                     return 3
-                
+
             available_stock = sorted(available_stock, key=stock_sort)
 
             if len(available_stock) == 0:

--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -709,6 +709,54 @@ class BuildAllocationSerializer(serializers.Serializer):
                     raise ValidationError(detail=serializers.as_serializer_error(exc))
 
 
+class BuildAutoAllocationSerializer(serializers.Serializer):
+    """
+    DRF serializer for auto allocating stock items against a build order
+    """
+
+    class Meta:
+        fields = [
+            'location',
+            'interchangeable',
+            'substitutes',
+        ]
+
+    location = serializers.PrimaryKeyRelatedField(
+        queryset=StockLocation.objects.all(),
+        many=False,
+        allow_null=True,
+        required=False,
+        label=_('Source Location'),
+        help_text=_('Stock location where parts are to be sourced (leave blank to take from any location)'),
+    )
+
+    interchangeable = serializers.BooleanField(
+        default=False,
+        label=_('Interchangeable Stock'),
+        help_text=_('Stock items in multiple locations can be used interchangeably'),
+    )
+
+    substitutes = serializers.BooleanField(
+        default=True,
+        label=_('Substitute Stock'),
+        help_text=_('Allow allocation of substitute parts'),
+    )
+
+    def save(self):
+
+        data = self.validated_data
+
+        request = self.context['request']
+        build = self.context['build']
+
+        build.auto_allocate_stock(
+            request.user,
+            location=data.get('location', None),
+            interchangeable=data['interchangeable'],
+            substitutes=data['substitutes'],
+        )
+
+
 class BuildItemSerializer(InvenTreeModelSerializer):
     """ Serializes a BuildItem object """
 

--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -746,11 +746,9 @@ class BuildAutoAllocationSerializer(serializers.Serializer):
 
         data = self.validated_data
 
-        request = self.context['request']
         build = self.context['build']
 
         build.auto_allocate_stock(
-            request.user,
             location=data.get('location', None),
             interchangeable=data['interchangeable'],
             substitutes=data['substitutes'],

--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -177,7 +177,10 @@
                 <button class='btn btn-danger' type='button' id='btn-unallocate' title='{% trans "Unallocate stock" %}'>
                     <span class='fas fa-minus-circle'></span> {% trans "Unallocate Stock" %}
                 </button>
-                <button class='btn btn-success' type='button' id='btn-auto-allocate' title='{% trans "Allocate stock to build" %}'>
+                <button class='btn btn-primary' type='button' id='btn-auto-allocate' title='{% trans "Automatically allocate stock to build" %}'>
+                    <span class='fas fa-magic'></span> {% trans "Auto Allocate" %}
+                </button>
+                <button class='btn btn-success' type='button' id='btn-allocate' title='{% trans "Manually allocate stock to build" %}'>
                     <span class='fas fa-sign-in-alt'></span> {% trans "Allocate Stock" %}
                 </button>
                 <!--
@@ -485,7 +488,21 @@ function reloadTable() {
 }
 
 {% if build.active %}
+
 $("#btn-auto-allocate").on('click', function() {
+
+    autoAllocateStockToBuild(
+        {{ build.pk }},
+        [],
+        {
+            {% if build.take_from %}
+            location: {{ build.take_from.pk }},
+            {% endif %}
+        }
+    );
+});
+
+$("#btn-allocate").on('click', function() {
 
     var bom_items = $("#allocation-table-untracked").bootstrapTable("getData");
 

--- a/InvenTree/build/test_build.py
+++ b/InvenTree/build/test_build.py
@@ -8,11 +8,11 @@ from django.db.utils import IntegrityError
 from InvenTree import status_codes as status
 
 from build.models import Build, BuildItem, get_next_build_number
-from part.models import Part, BomItem
+from part.models import Part, BomItem, BomItemSubstitute
 from stock.models import StockItem
 
 
-class BuildTest(TestCase):
+class BuildTestBase(TestCase):
     """
     Run some tests to ensure that the Build model is working properly.
     """
@@ -107,12 +107,19 @@ class BuildTest(TestCase):
         )
 
         # Create some stock items to assign to the build
-        self.stock_1_1 = StockItem.objects.create(part=self.sub_part_1, quantity=1000)
+        self.stock_1_1 = StockItem.objects.create(part=self.sub_part_1, quantity=3)
         self.stock_1_2 = StockItem.objects.create(part=self.sub_part_1, quantity=100)
 
-        self.stock_2_1 = StockItem.objects.create(part=self.sub_part_2, quantity=5000)
+        self.stock_2_1 = StockItem.objects.create(part=self.sub_part_2, quantity=5)
+        self.stock_2_2 = StockItem.objects.create(part=self.sub_part_2, quantity=5)
+        self.stock_2_2 = StockItem.objects.create(part=self.sub_part_2, quantity=5)
+        self.stock_2_2 = StockItem.objects.create(part=self.sub_part_2, quantity=5)
+        self.stock_2_2 = StockItem.objects.create(part=self.sub_part_2, quantity=5)
 
         self.stock_3_1 = StockItem.objects.create(part=self.sub_part_3, quantity=1000)
+
+
+class BuildTest(BuildTestBase):
 
     def test_ref_int(self):
         """
@@ -369,3 +376,108 @@ class BuildTest(TestCase):
 
         for output in outputs:
             self.assertFalse(output.is_building)
+
+
+class AutoAllocationTests(BuildTestBase):
+    """
+    Tests for auto allocating stock against a build order
+    """
+
+    def setUp(self):
+
+        super().setUp()
+
+        # Add a "substitute" part for bom_item_2
+        alt_part = Part.objects.create(
+            name="alt part",
+            description="An alternative part!",
+            component=True,
+        )
+
+        BomItemSubstitute.objects.create(
+            bom_item=self.bom_item_2,
+            part=alt_part,
+        )
+
+        StockItem.objects.create(
+            part=alt_part,
+            quantity=500,
+        )
+
+    def test_auto_allocate(self):
+        """
+        Run the 'auto-allocate' function. What do we expect to happen?
+
+        There are two "untracked" parts:
+            - sub_part_1 (quantity 5 per BOM = 50 required total) / 103 in stock (2 items)
+            - sub_part_2 (quantity 3 per BOM = 30 required total) / 25 in stock (5 items)
+
+        A "fully auto" allocation should allocate *all* of these stock items to the build
+        """
+
+        # No build item allocations have been made against the build
+        self.assertEqual(self.build.allocated_stock.count(), 0)
+
+        self.assertFalse(self.build.are_untracked_parts_allocated())
+
+        # Stock is not interchangeable, nothing will happen
+        self.build.auto_allocate_stock(
+            interchangeable=False,
+            substitutes=False,
+        )
+
+        self.assertFalse(self.build.are_untracked_parts_allocated())
+
+        self.assertEqual(self.build.allocated_stock.count(), 0)
+
+        self.assertFalse(self.build.is_bom_item_allocated(self.bom_item_1))
+        self.assertFalse(self.build.is_bom_item_allocated(self.bom_item_2))
+
+        self.assertEqual(self.build.unallocated_quantity(self.bom_item_1), 50)
+        self.assertEqual(self.build.unallocated_quantity(self.bom_item_2), 30)
+
+        # This time we expect stock to be allocated!
+        self.build.auto_allocate_stock(
+            interchangeable=True,
+            substitutes=False,
+        )
+
+        self.assertFalse(self.build.are_untracked_parts_allocated())
+
+        self.assertEqual(self.build.allocated_stock.count(), 7)
+
+        self.assertTrue(self.build.is_bom_item_allocated(self.bom_item_1))
+        self.assertFalse(self.build.is_bom_item_allocated(self.bom_item_2))
+
+        self.assertEqual(self.build.unallocated_quantity(self.bom_item_1), 0)
+        self.assertEqual(self.build.unallocated_quantity(self.bom_item_2), 5)
+
+        # This time, allow substitue parts to be used!
+        self.build.auto_allocate_stock(
+            interchangeable=True,
+            substitutes=True,
+        )
+
+        # self.assertTrue(self.build.are_untracked_parts_allocated())
+
+        # self.assertEqual(self.build.allocated_stock.count(), 8)
+        self.assertEqual(self.build.unallocated_quantity(self.bom_item_1), 0)
+        self.assertEqual(self.build.unallocated_quantity(self.bom_item_2), 0)
+
+        self.assertTrue(self.build.is_bom_item_allocated(self.bom_item_1))
+        self.assertTrue(self.build.is_bom_item_allocated(self.bom_item_2))
+
+    def test_fully_auto(self):
+        """
+        We should be able to auto-allocate against a build in a single go
+        """
+
+        self.build.auto_allocate_stock(
+            interchangeable=True,
+            substitutes=True
+        )
+
+        self.assertTrue(self.build.are_untracked_parts_allocated())
+
+        self.assertEqual(self.build.unallocated_quantity(self.bom_item_1), 0)
+        self.assertEqual(self.build.unallocated_quantity(self.bom_item_2), 0)

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2651,7 +2651,7 @@ class BomItem(models.Model, DataImportMixin):
     def get_api_url():
         return reverse('api-bom-list')
 
-    def get_valid_parts_for_allocation(self):
+    def get_valid_parts_for_allocation(self, allow_variants=True, allow_substitutes=True):
         """
         Return a list of valid parts which can be allocated against this BomItem:
 
@@ -2666,13 +2666,14 @@ class BomItem(models.Model, DataImportMixin):
         parts.add(self.sub_part)
 
         # Variant parts (if allowed)
-        if self.allow_variants:
+        if allow_variants and self.allow_variants:
             for variant in self.sub_part.get_descendants(include_self=False):
                 parts.add(variant)
 
         # Substitute parts
-        for sub in self.substitutes.all():
-            parts.add(sub.part)
+        if allow_substitutes:
+            for sub in self.substitutes.all():
+                parts.add(sub.part)
 
         return parts
 

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -244,7 +244,7 @@
 
     {% for allocation in item.allocations.all %}
     <div class='alert alert-block alert-info'>
-        {% object_link 'build-detail' allocation.build.id allocation.build %}
+        {% object_link 'build-detail' allocation.build.id allocation.build as link %}
         {% decimal allocation.quantity as qty %}
         {% trans "This stock item is allocated to Build Order" %} {{ link }} {% if qty < item.quantity %}({% trans "Quantity" %}: {{ qty }}){% endif %}
     </div>

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -20,6 +20,7 @@
 
 /* exported
     allocateStockToBuild,
+    autoAllocateStockToBuild,
     completeBuildOrder,
     createBuildOutput,
     editBuildOrder,
@@ -1840,6 +1841,34 @@ function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
                 }
             );
         },
+    });
+}
+
+
+/**
+ * Automatically allocate stock items to a build
+ */
+function autoAllocateStockToBuild(build_id, bom_items=[], options={}) {
+
+    var html = '';
+
+    var fields = {
+        location: {
+            value: options.location,
+        },
+        interchangeable: {},
+        substitutes: {},
+    }
+
+    constructForm(`/api/build/${build_id}/auto-allocate/`, {
+        method: 'POST',
+        fields: fields,
+        title: '{% trans "Allocate Stock Items" %}',
+        confirm: true,
+        preFormContent: html,
+        onSuccess: function(response) {
+            // TODO - Reload the allocation table
+        }
     });
 }
 

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1513,6 +1513,16 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
  */
 function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
 
+    if (bom_items.length == 0) {
+
+        showAlertDialog(
+            '{% trans "Select Parts" %}',
+            '{% trans "You must select at least one part to allocate" %}',
+        );
+
+        return;
+    }
+
     // ID of the associated "build output" (or null)
     var output_id = options.output || null;
 
@@ -1627,8 +1637,8 @@ function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
     if (table_entries.length == 0) {
 
         showAlertDialog(
-            '{% trans "Select Parts" %}',
-            '{% trans "You must select at least one part to allocate" %}',
+            '{% trans "All Parts Allocated" %}',
+            '{% trans "All selected parts have been fully allocated" %}',
         );
 
         return;

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -755,7 +755,7 @@ function loadBuildOutputTable(build_info, options={}) {
         filters[key] = params[key];
     }
 
-    // TODO: Initialize filter list
+    setupFilterList('builditems', $(table), options.filterTarget || '#filter-list-incompletebuilditems');
 
     function setupBuildOutputButtonCallbacks() {
         
@@ -1000,7 +1000,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
         filters[key] = params[key];
     }
 
-    setupFilterList('builditems', $(table), options.filterTarget || null);
+    setupFilterList('builditems', $(table), options.filterTarget);
 
     // If an "output" is specified, then only "trackable" parts are allocated
     // Otherwise, only "untrackable" parts are allowed

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1872,7 +1872,7 @@ function autoAllocateStockToBuild(build_id, bom_items=[], options={}) {
         substitutes: {
             value: true,
         },
-    }
+    };
 
     constructForm(`/api/build/${build_id}/auto-allocate/`, {
         method: 'POST',

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1850,14 +1850,28 @@ function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
  */
 function autoAllocateStockToBuild(build_id, bom_items=[], options={}) {
 
-    var html = '';
+    var html = `
+    <div class='alert alert-block alert-info'>
+    <strong>{% trans "Automatic Stock Allocation" %}</strong><br>
+    {% trans "Stock items will be automatically allocated to this build order, according to the provided guidelines" %}:
+    <ul>
+        <li>{% trans "If a location is specifed, stock will only be allocated from that location" %}</li>
+        <li>{% trans "If stock is considered interchangeable, it will be allocated from the first location it is found" %}</li>
+        <li>{% trans "If substitute stock is allowed, it will be used where stock of the primary part cannot be found" %}</li>
+    </ul>
+    </div>
+    `;
 
     var fields = {
         location: {
             value: options.location,
         },
-        interchangeable: {},
-        substitutes: {},
+        interchangeable: {
+            value: true,
+        },
+        substitutes: {
+            value: true,
+        },
     }
 
     constructForm(`/api/build/${build_id}/auto-allocate/`, {
@@ -1867,7 +1881,7 @@ function autoAllocateStockToBuild(build_id, bom_items=[], options={}) {
         confirm: true,
         preFormContent: html,
         onSuccess: function(response) {
-            // TODO - Reload the allocation table
+            $('#allocation-table-untracked').bootstrapTable('refresh');
         }
     });
 }


### PR DESCRIPTION
Can significantly reduce the user effort required to allocate stock items against a build order.

However, there are some caveats!

Docs incoming...

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2713"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

