### PR TITLE
Bug fix for stock serial numbers:

### DIFF
--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -350,7 +350,7 @@ class StockItem(MPTTModel):
     @property
     def serialized(self):
         """ Return True if this StockItem is serialized """
-        return self.serial is not None and self.quantity == 1
+        return self.serial is not None and len(str(self.serial).strip()) > 0 and self.quantity == 1
 
     def validate_unique(self, exclude=None):
         """

--- a/InvenTree/stock/tests.py
+++ b/InvenTree/stock/tests.py
@@ -346,6 +346,40 @@ class StockTest(TestCase):
         with self.assertRaises(StockItem.DoesNotExist):
             w2 = StockItem.objects.get(pk=101)
 
+    def test_serials(self):
+        """
+        Tests for stock serialization
+        """
+
+        p = Part.objects.create(
+            name='trackable part',
+            description='trackable part',
+            trackable=True,
+        )
+
+        item = StockItem.objects.create(
+            part=p,
+            quantity=1,
+        )
+
+        self.assertFalse(item.serialized)
+
+        item.serial = None
+        item.save()
+        self.assertFalse(item.serialized)
+
+        item.serial = '    '
+        item.save()
+        self.assertFalse(item.serialized)
+
+        item.serial = ''
+        item.save()
+        self.assertFalse(item.serialized)
+
+        item.serial = '1'
+        item.save()
+        self.assertTrue(item.serialized)
+
     def test_serialize_stock_invalid(self):
         """
         Test manual serialization of parts.


### PR DESCRIPTION
- empty strings do not count as a valid serial number

Fixes https://github.com/inventree/InvenTree/issues/2716

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2717"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

