### PR TITLE
Category parameters

### DIFF
--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -12,10 +12,15 @@ import common.models
 INVENTREE_SW_VERSION = "0.7.0 dev"
 
 # InvenTree API version
-INVENTREE_API_VERSION = 31
+INVENTREE_API_VERSION = 32
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v32 -> 2022-03-19
+    - Adds "parameters" detail to Part API endpoint (use &parameters=true)
+    - Adds ability to filter PartParameterTemplate API by Part instance
+    - Adds ability to filter PartParameterTemplate API by PartCategory instance
 
 v31 -> 2022-03-14
     - Adds "updated" field to SupplierPriceBreakList and SupplierPriceBreakDetail API endpoints

--- a/InvenTree/common/settings.py
+++ b/InvenTree/common/settings.py
@@ -17,7 +17,7 @@ def currency_code_default():
     from common.models import InvenTreeSetting
 
     try:
-        code = InvenTreeSetting.get_setting('INVENTREE_DEFAULT_CURRENCY')
+        code = InvenTreeSetting.get_setting('INVENTREE_DEFAULT_CURRENCY', create=False)
     except ProgrammingError:  # pragma: no cover
         # database is not initialized yet
         code = ''

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1434,12 +1434,12 @@ class PartParameterTemplateList(generics.ListCreateAPIView):
                 queryset = queryset.filter(pk__in=[el[0] for el in template_ids])
             except (ValueError, Part.DoesNotExist):
                 pass
-        
+
         # Filtering against a "PartCategory" - return only parameter templates which are referenced by parts in this category
         category = params.get('category', None)
 
         if category is not None:
-            
+
             try:
                 category = PartCategory.objects.get(pk=category)
                 cats = category.get_descendants(include_self=True)

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -855,6 +855,14 @@ class PartList(generics.ListCreateAPIView):
 
         kwargs['starred_parts'] = self.starred_parts
 
+        try:
+            params = self.request.query_params
+
+            kwargs['parameters'] = str2bool(params.get('parameters', None))
+
+        except AttributeError:
+            pass
+
         return self.serializer_class(*args, **kwargs)
 
     def list(self, request, *args, **kwargs):

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -211,6 +211,34 @@ class PartThumbSerializerUpdate(InvenTreeModelSerializer):
         ]
 
 
+class PartParameterTemplateSerializer(InvenTreeModelSerializer):
+    """ JSON serializer for the PartParameterTemplate model """
+
+    class Meta:
+        model = PartParameterTemplate
+        fields = [
+            'pk',
+            'name',
+            'units',
+        ]
+
+
+class PartParameterSerializer(InvenTreeModelSerializer):
+    """ JSON serializers for the PartParameter model """
+
+    template_detail = PartParameterTemplateSerializer(source='template', many=False, read_only=True)
+
+    class Meta:
+        model = PartParameter
+        fields = [
+            'pk',
+            'part',
+            'template',
+            'template_detail',
+            'data'
+        ]
+
+
 class PartBriefSerializer(InvenTreeModelSerializer):
     """ Serializer for Part (brief detail) """
 
@@ -259,10 +287,15 @@ class PartSerializer(InvenTreeModelSerializer):
 
         category_detail = kwargs.pop('category_detail', False)
 
+        parameters = kwargs.pop('parameters', False)
+
         super().__init__(*args, **kwargs)
 
         if category_detail is not True:
             self.fields.pop('category_detail')
+
+        if parameters is not True:
+            self.fields.pop('parameters')
 
     @staticmethod
     def annotate_queryset(queryset):
@@ -356,19 +389,18 @@ class PartSerializer(InvenTreeModelSerializer):
     # PrimaryKeyRelated fields (Note: enforcing field type here results in much faster queries, somehow...)
     category = serializers.PrimaryKeyRelatedField(queryset=PartCategory.objects.all())
 
-    # TODO - Include annotation for the following fields:
-    # allocated_stock = serializers.FloatField(source='allocation_count', read_only=True)
-    # bom_items = serializers.IntegerField(source='bom_count', read_only=True)
-    # used_in = serializers.IntegerField(source='used_in_count', read_only=True)
+    parameters = PartParameterSerializer(
+        many=True,
+        read_only=True,
+    )
 
     class Meta:
         model = Part
         partial = True
         fields = [
             'active',
-            # 'allocated_stock',
+
             'assembly',
-            # 'bom_items',
             'category',
             'category_detail',
             'component',
@@ -388,6 +420,7 @@ class PartSerializer(InvenTreeModelSerializer):
             'minimum_stock',
             'name',
             'notes',
+            'parameters',
             'pk',
             'purchaseable',
             'revision',
@@ -398,7 +431,6 @@ class PartSerializer(InvenTreeModelSerializer):
             'thumbnail',
             'trackable',
             'units',
-            # 'used_in',
             'variant_of',
             'virtual',
         ]
@@ -597,34 +629,6 @@ class BomItemSerializer(InvenTreeModelSerializer):
             'substitutes',
             'price_range',
             'validated',
-        ]
-
-
-class PartParameterTemplateSerializer(InvenTreeModelSerializer):
-    """ JSON serializer for the PartParameterTemplate model """
-
-    class Meta:
-        model = PartParameterTemplate
-        fields = [
-            'pk',
-            'name',
-            'units',
-        ]
-
-
-class PartParameterSerializer(InvenTreeModelSerializer):
-    """ JSON serializers for the PartParameter model """
-
-    template_detail = PartParameterTemplateSerializer(source='template', many=False, read_only=True)
-
-    class Meta:
-        model = PartParameter
-        fields = [
-            'pk',
-            'part',
-            'template',
-            'template_detail',
-            'data'
         ]
 
 

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -240,9 +240,6 @@
 
     {% endif %}
 
-    // Enable left-hand navigation sidebar
-    enableSidebar('category');
-
     // Enable breadcrumb tree view
     enableBreadcrumbTree({
         label: 'category',
@@ -258,18 +255,20 @@
         }
     });
 
-    loadPartCategoryTable(
-        $('#subcategory-table'), {
-            params: {
-                {% if category %}
-                parent: {{ category.pk }},
-                {% else %}
-                parent: null,
-                {% endif %}
-            },
-            allowTreeView: true,
-        }
-    );
+    onPanelLoad('subcategories', function() {
+        loadPartCategoryTable(
+            $('#subcategory-table'), {
+                params: {
+                    {% if category %}
+                    parent: {{ category.pk }},
+                    {% else %}
+                    parent: null,
+                    {% endif %}
+                },
+                allowTreeView: true,
+            }
+        );
+    });
 
     $("#cat-create").click(function() {
 
@@ -339,19 +338,24 @@
 
     {% endif %}
 
-    loadPartTable(
-        "#part-table",
-        "{% url 'api-part-list' %}",
-        {
-            params: {
-                {% if category %}category: {{ category.id }},
-                {% else %}category: "null",
-                {% endif %}
+    onPanelLoad('parts', function() {
+        loadPartTable(
+            "#part-table",
+            "{% url 'api-part-list' %}",
+            {
+                params: {
+                    {% if category %}category: {{ category.id }},
+                    {% else %}category: "null",
+                    {% endif %}
+                },
+                buttons: ['#part-options'],
+                checkbox: true,
+                gridView: true,
             },
-            buttons: ['#part-options'],
-            checkbox: true,
-            gridView: true,
-        },
-    );
+        );
+    });
+
+    // Enable left-hand navigation sidebar
+    enableSidebar('category');
 
 {% endblock %}

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -227,8 +227,7 @@
         loadParametricPartTable(
             "#parametric-part-table",
             { 
-                headers: {{ headers|safe }},
-                data: {{ parameters|safe }},
+                category: {{ category.pk }},
             }
         );
     });

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -223,13 +223,15 @@
 {{ block.super }}
 
     {% if category %}
-    loadParametricPartTable(
-        "#parametric-part-table",
-        { 
-            headers: {{ headers|safe }},
-            data: {{ parameters|safe }},
-        }
-    );
+    onPanelLoad('parameters', function() {
+        loadParametricPartTable(
+            "#parametric-part-table",
+            { 
+                headers: {{ headers|safe }},
+                data: {{ parameters|safe }},
+            }
+        );
+    });
 
     $("#toggle-starred").click(function() {
         toggleStar({

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -988,22 +988,6 @@ class CategoryDetail(InvenTreeRoleMixin, DetailView):
         category = kwargs.get('object', None)
 
         if category:
-            cascade = kwargs.get('cascade', True)
-
-            # Prefetch parts parameters
-            parts_parameters = category.prefetch_parts_parameters(cascade=cascade)
-
-            # Get table headers (unique parameters names)
-            context['headers'] = category.get_unique_parameters(cascade=cascade,
-                                                                prefetch=parts_parameters)
-
-            # Insert part information
-            context['headers'].insert(0, 'description')
-            context['headers'].insert(0, 'part')
-
-            # Get parameters data
-            context['parameters'] = category.get_parts_parameters(cascade=cascade,
-                                                                  prefetch=parts_parameters)
 
             # Insert "starred" information
             context['starred'] = category.is_starred_by(self.request.user)

--- a/InvenTree/stock/templates/stock/location.html
+++ b/InvenTree/stock/templates/stock/location.html
@@ -202,15 +202,17 @@
 {% block js_ready %}
 {{ block.super }}
 
-    loadStockLocationTable($('#sublocation-table'), {
-        params: {
-            {% if location %}
-            parent: {{ location.pk }},
-            {% else %}
-            parent: 'null',
-            {% endif %}
-        },
-        allowTreeView: true,
+    onPanelLoad('sublocations', function() {
+        loadStockLocationTable($('#sublocation-table'), {
+            params: {
+                {% if location %}
+                parent: {{ location.pk }},
+                {% else %}
+                parent: 'null',
+                {% endif %}
+            },
+            allowTreeView: true,
+        });
     });
     
     linkButtonsToSelection(
@@ -325,19 +327,21 @@
         });
     });
 
-    loadStockTable($("#stock-table"), {
-        buttons: [
-            '#stock-options',
-        ],
-        params: {
-            {% if location %}
-            location: {{ location.pk }},
-            {% endif %}
-            part_detail: true,
-            location_detail: true,
-            supplier_part_detail: true,
-        },
-        url: "{% url 'api-stock-list' %}",
+    onPanelLoad('stock', function() {
+        loadStockTable($("#stock-table"), {
+            buttons: [
+                '#stock-options',
+            ],
+            params: {
+                {% if location %}
+                location: {{ location.pk }},
+                {% endif %}
+                part_detail: true,
+                location_detail: true,
+                supplier_part_detail: true,
+            },
+            url: "{% url 'api-stock-list' %}",
+        });
     });
 
     enableSidebar('stocklocation');

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -312,7 +312,13 @@ function renderPartCategory(name, data, parameters, options) {
 // eslint-disable-next-line no-unused-vars
 function renderPartParameterTemplate(name, data, parameters, options) {
 
-    var html = `<span>${data.name} - [${data.units}]</span>`;
+    var units = '';
+
+    if (data.units) {
+        units = ` [${data.units}]`;
+    }
+    
+    var html = `<span>${data.name}${units}</span>`;
 
     return html;
 }


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/2760

This PR provides a major improvement to how part "parameters" are displayed within a part category. The table now uses the API, so the requests are paginated and not "pre loaded" on the server.

For categories with lots of parts (or parameters) this should result in a much more responsive user experience.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2761"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

