### PR TITLE
Check for empty string when rendering dates

### DIFF
--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -57,6 +57,13 @@ def render_date(context, date_object):
         return None
 
     if type(date_object) == str:
+
+        date_object = date_object.strip()
+
+        # Check for empty string
+        if len(date_object) == 0:
+            return None
+
         # If a string is passed, first convert it to a datetime
         date_object = date.fromisoformat(date_object)
 

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -8,6 +8,7 @@ over and above the built-in Django tags.
 from datetime import date, datetime
 import os
 import sys
+import logging
 
 from django.utils.html import format_html
 
@@ -29,6 +30,9 @@ from common.settings import currency_code_default
 from plugin.models import PluginSetting
 
 register = template.Library()
+
+
+logger = logging.getLogger('inventree')
 
 
 @register.simple_tag()
@@ -65,7 +69,11 @@ def render_date(context, date_object):
             return None
 
         # If a string is passed, first convert it to a datetime
-        date_object = date.fromisoformat(date_object)
+        try:
+            date_object = date.fromisoformat(date_object)
+        except ValueError:
+            logger.warning(f"Tried to convert invalid date string: {date_object}")
+            return None
 
     # We may have already pre-cached the date format by calling this already!
     user_date_format = context.get('user_date_format', None)

--- a/InvenTree/plugin/events.py
+++ b/InvenTree/plugin/events.py
@@ -59,14 +59,23 @@ def register_event(event, *args, **kwargs):
 
     logger.debug(f"Registering triggered event: '{event}'")
 
+    print("register_event")
+
     # Determine if there are any plugins which are interested in responding
     if settings.PLUGIN_TESTING or InvenTreeSetting.get_setting('ENABLE_PLUGINS_EVENTS'):
+
+        print("checking plugins")
 
         with transaction.atomic():
 
             for slug, plugin in registry.plugins.items():
 
+                print("slug:", slug)
+                print("plugin:", plugin)
+
                 if plugin.mixin_enabled('events'):
+
+                    print("events are enabled for this plugin!")
 
                     config = plugin.plugin_config()
 

--- a/InvenTree/plugin/events.py
+++ b/InvenTree/plugin/events.py
@@ -59,12 +59,8 @@ def register_event(event, *args, **kwargs):
 
     logger.debug(f"Registering triggered event: '{event}'")
 
-    print("register_event")
-
     # Determine if there are any plugins which are interested in responding
     if settings.PLUGIN_TESTING or InvenTreeSetting.get_setting('ENABLE_PLUGINS_EVENTS'):
-
-        print("checking plugins")
 
         with transaction.atomic():
 

--- a/InvenTree/plugin/events.py
+++ b/InvenTree/plugin/events.py
@@ -70,12 +70,7 @@ def register_event(event, *args, **kwargs):
 
             for slug, plugin in registry.plugins.items():
 
-                print("slug:", slug)
-                print("plugin:", plugin)
-
                 if plugin.mixin_enabled('events'):
-
-                    print("events are enabled for this plugin!")
 
                     config = plugin.plugin_config()
 


### PR DESCRIPTION
Fixes a bug where dates represented as an empty string would cause a template error to be thrown.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2767"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

