### PR TITLE
Label printing plugin

### DIFF
--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -258,6 +258,19 @@
                             </a></li>
                         </ul>
                     </div>
+
+                    <!-- Label Printing Actions -->
+                    <div class='btn-group'>
+                        <button id='output-print-options' class='btn btn-primary dropdown-toggle' type='button' data-bs-toggle='dropdown' title='{% trans "Printing Actions" %}'>
+                            <span class='fas fa-print'></span> <span class='caret'></span>
+                        </button>
+                        <ul class='dropdown-menu'>
+                            <li><a class='dropdown-item' href='#' id='incomplete-output-print-label' title='{% trans "Print labels" %}'>
+                                <span class='fas fa-tags'></span> {% trans "Print labels" %}
+                            </a></li>
+                        </ul>
+                    </div>
+
                     {% include "filter_list.html" with id='incompletebuilditems' %}
                 </div>
                 {% endif %}
@@ -466,6 +479,23 @@ inventreeGet(
                         }
                     }
                 )
+            });
+
+            $('#incomplete-output-print-label').click(function() {
+                var outputs = $('#build-output-table').bootstrapTable('getSelections');
+
+                if  (outputs.length == 0) {
+                    outputs = $('#build-output-table').bootstrapTable('getData');
+                }
+
+                var stock_id_values = [];
+
+                outputs.forEach(function(output) {
+                    stock_id_values.push(output.pk);
+                });
+
+                printStockItemLabels(stock_id_values);
+
             });
 
             {% endif %}

--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from io import BytesIO
+from PIL import Image
+
 from django.utils.translation import ugettext_lazy as _
 
 from django.conf import settings
 from django.conf.urls import url, include
 from django.core.exceptions import ValidationError, FieldError
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 
 from django_filters.rest_framework import DjangoFilterBackend
 
@@ -14,6 +17,7 @@ from rest_framework import generics, filters
 from rest_framework.response import Response
 
 import InvenTree.helpers
+from InvenTree.tasks import offload_task
 import common.models
 
 from plugin.registry import registry
@@ -102,12 +106,16 @@ class LabelPrintMixin:
 
         label_name = "label.pdf"
 
+        label_names = []
+
         # Merge one or more PDF files into a single download
         for item in items_to_print:
             label = self.get_object()
             label.object_to_print = item
 
             label_name = label.generate_filename(request)
+
+            label_names.append(label_name)
 
             if debug_mode:
                 outputs.append(label.render_as_string(request))
@@ -117,7 +125,46 @@ class LabelPrintMixin:
         if not label_name.endswith(".pdf"):
             label_name += ".pdf"
 
-        if debug_mode:
+        if plugin is not None:
+            """
+            Label printing is to be handled by a plugin,
+            rather than being exported to PDF.
+
+            In this case, we do the following:
+            
+            - Individually generate each label, exporting as an image file
+            - Pass all the images through to the label printing plugin
+            - Return a JSON response indicating that the printing has been offloaded
+            
+            """
+
+            for output in outputs:
+                """
+                For each output, we generate a temporary image file,
+                which will then get sent to the printer
+                """
+
+                # Generate a png image at 300dpi
+                (img_data, w, h) = output.get_document().write_png(resolution=300)
+
+                # Construct a BytesIO object, which can be read by pillow
+                img_bytes = BytesIO(img_data)
+
+                image = Image.open(img_bytes)
+
+                # Offload a background task to print the provided label
+                offload_task(
+                    'plugin.events.print_label',
+                    plugin.plugin_slug(),
+                    image
+                )
+
+            return JsonResponse({
+                'plugin': plugin.plugin_slug(),
+                'labels': label_names,
+            })
+
+        elif debug_mode:
             """
             Contatenate all rendered templates into a single HTML string,
             and return the string as a HTML response.
@@ -126,6 +173,7 @@ class LabelPrintMixin:
             html = "\n".join(outputs)
 
             return HttpResponse(html)
+
         else:
             """
             Concatenate all rendered pages into a single PDF object,

--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -131,11 +131,11 @@ class LabelPrintMixin:
             rather than being exported to PDF.
 
             In this case, we do the following:
-            
+
             - Individually generate each label, exporting as an image file
             - Pass all the images through to the label printing plugin
             - Return a JSON response indicating that the printing has been offloaded
-            
+
             """
 
             for output in outputs:

--- a/InvenTree/label/templates/label/label_base.html
+++ b/InvenTree/label/templates/label/label_base.html
@@ -13,6 +13,8 @@
         body {
             font-family: Arial, Helvetica, sans-serif;
             margin: 0mm;
+            color: #000;
+            background-color: #FFF;
         }
 
         img {

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -397,8 +397,9 @@ class LabelPrintingMixin:
     """
     Mixin which enables direct printing of stock labels.
 
-    Each plugin should provide a PRINTER_NAME attribute,
-    and also implement the print_label() function
+    Each plugin must provide a PLUGIN_NAME attribute, which is used to uniquely identify the printer.
+
+    The plugin must also implement the print_label() function
     """
 
     class MixinMeta:
@@ -409,17 +410,7 @@ class LabelPrintingMixin:
 
     def __init__(self):
         super().__init__()
-        self.add_mixin('labels', 'has_label_printing', __class__)
-
-    @property
-    def has_label_printing(self):
-
-        if not bool(self.PRINTER_NAME):
-            raise ValueError("PRINTER_NAME must be defined")
-        
-        return True
-
-    PRINTER_NAME = "LabelPrinter"
+        self.add_mixin('labels', True, __class__)
 
     def get_printer_name(self):
         return self.PRINTER_NAME

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -393,6 +393,59 @@ class AppMixin:
         return True
 
 
+class LabelPrintingMixin:
+    """
+    Mixin which enables direct printing of stock labels.
+
+    Each plugin should provide a PRINTER_NAME attribute,
+    and also implement the print_label() function
+    """
+
+    class MixinMeta:
+        """
+        Meta options for this mixin
+        """
+        MIXIN_NAME = 'Label printing'
+
+    def __init__(self):
+        super().__init__()
+        self.add_mixin('labels', 'has_label_printing', __class__)
+
+    @property
+    def has_label_printing(self):
+
+        if not bool(self.PRINTER_NAME):
+            raise ValueError("PRINTER_NAME must be defined")
+        
+        return True
+
+    PRINTER_NAME = "LabelPrinter"
+
+    def get_printer_name(self):
+        return self.PRINTER_NAME
+
+    def print_labels(self, labels, **kwargs):
+        """
+        Print multiple labels.
+        Default implementation is to call print_label() for each label,
+        but it can be overridden if desired.
+        """
+        for label in labels:
+            self.print_label(label, **kwargs)
+
+    def print_label(self, label, **kwargs):
+        """
+        Callback to print a single label
+
+        Arguments:
+            label: A black-and-white pillow Image object
+
+        """
+
+        # Unimplemented (to be implemented by the particular plugin class)
+        ...
+
+
 class APICallMixin:
     """
     Mixin that enables easier API calls for a plugin

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -415,15 +415,6 @@ class LabelPrintingMixin:
     def get_printer_name(self):
         return self.PRINTER_NAME
 
-    def print_labels(self, labels, **kwargs):
-        """
-        Print multiple labels.
-        Default implementation is to call print_label() for each label,
-        but it can be overridden if desired.
-        """
-        for label in labels:
-            self.print_label(label, **kwargs)
-
     def print_label(self, label, **kwargs):
         """
         Callback to print a single label

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -412,9 +412,6 @@ class LabelPrintingMixin:
         super().__init__()
         self.add_mixin('labels', True, __class__)
 
-    def get_printer_name(self):
-        return self.PRINTER_NAME
-
     def print_label(self, label, **kwargs):
         """
         Callback to print a single label

--- a/InvenTree/plugin/events.py
+++ b/InvenTree/plugin/events.py
@@ -96,7 +96,7 @@ def process_event(plugin_slug, event, *args, **kwargs):
     logger.info(f"Plugin '{plugin_slug}' is processing triggered event '{event}'")
 
     plugin = registry.plugins.get(plugin_slug, None)
-    
+
     if plugin is None:
         logger.error(f"Could not find matching plugin for '{plugin_slug}'")
         return
@@ -206,7 +206,7 @@ def print_label(plugin_slug, label_image, **kwargs):
     logger.info(f"Plugin '{plugin_slug}' is printing a label")
 
     plugin = registry.plugins.get(plugin_slug, None)
-    
+
     if plugin is None:
         logger.error(f"Could not find matching plugin for '{plugin_slug}'")
         return

--- a/InvenTree/plugin/events.py
+++ b/InvenTree/plugin/events.py
@@ -95,7 +95,11 @@ def process_event(plugin_slug, event, *args, **kwargs):
 
     logger.info(f"Plugin '{plugin_slug}' is processing triggered event '{event}'")
 
-    plugin = registry.plugins[plugin_slug]
+    plugin = registry.plugins.get(plugin_slug, None)
+    
+    if plugin is None:
+        logger.error(f"Could not find matching plugin for '{plugin_slug}'")
+        return
 
     plugin.process_event(event, *args, **kwargs)
 
@@ -186,3 +190,25 @@ def after_delete(sender, instance, **kwargs):
         model=sender.__name__,
         table=table,
     )
+
+
+def print_label(plugin_slug, label_image, **kwargs):
+    """
+    Print label with the provided plugin.
+
+    This task is nominally handled by the background worker.
+
+    Arguments:
+        plugin_slug: The unique slug (key) of the plugin
+        label_image: A PIL.Image image object to be printed
+    """
+
+    logger.info(f"Plugin '{plugin_slug}' is printing a label")
+
+    plugin = registry.plugins.get(plugin_slug, None)
+    
+    if plugin is None:
+        logger.error(f"Could not find matching plugin for '{plugin_slug}'")
+        return
+
+    plugin.print_label(label_image)

--- a/InvenTree/plugin/mixins/__init__.py
+++ b/InvenTree/plugin/mixins/__init__.py
@@ -2,7 +2,8 @@
 Utility class to enable simpler imports
 """
 
-from ..builtin.integration.mixins import APICallMixin, AppMixin, SettingsMixin, EventMixin, ScheduleMixin, UrlsMixin, NavigationMixin
+from ..builtin.integration.mixins import APICallMixin, AppMixin, LabelPrintingMixin, SettingsMixin, EventMixin, ScheduleMixin, UrlsMixin, NavigationMixin
+
 from ..builtin.action.mixins import ActionMixin
 from ..builtin.barcode.mixins import BarcodeMixin
 
@@ -10,6 +11,7 @@ __all__ = [
     'APICallMixin',
     'AppMixin',
     'EventMixin',
+    'LabelPrintingMixin',
     'NavigationMixin',
     'ScheduleMixin',
     'SettingsMixin',

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -10,12 +10,13 @@ import pathlib
 import logging
 import os
 import subprocess
+
 from typing import OrderedDict
 from importlib import reload
 
 from django.apps import apps
 from django.conf import settings
-from django.db.utils import OperationalError, ProgrammingError
+from django.db.utils import OperationalError, ProgrammingError, IntegrityError
 from django.conf.urls import url, include
 from django.urls import clear_url_caches
 from django.contrib import admin
@@ -282,6 +283,8 @@ class PluginsRegistry:
                 if not settings.PLUGIN_TESTING:
                     raise error  # pragma: no cover
                 plugin_db_setting = None
+            except (IntegrityError) as error:
+                logger.error(f"Error initializing plugin: {error}")
 
             # Always activate if testing
             if settings.PLUGIN_TESTING or (plugin_db_setting and plugin_db_setting.active):

--- a/InvenTree/templates/js/translated/label.js
+++ b/InvenTree/templates/js/translated/label.js
@@ -222,7 +222,8 @@ function selectLabel(labels, items, options={}) {
             async: false,
             success: function(response) {
                 response.forEach(function(plugin) {
-                    if (plugin.mixins && plugin.mixins.labels) {
+                    // Look for active plugins which implement the 'labels' mixin class
+                    if (plugin.active && plugin.mixins && plugin.mixins.labels) {
                         // This plugin supports label printing
                         plugins.push(plugin);
                     }

--- a/InvenTree/templates/js/translated/label.js
+++ b/InvenTree/templates/js/translated/label.js
@@ -14,10 +14,40 @@
 */
 
 /* exported
+    printLabels,
     printPartLabels,
     printStockItemLabels,
     printStockLocationLabels,
 */
+
+
+/*
+ * Perform the "print" action.
+ */
+function printLabels(url, plugin=null) {
+
+    if (plugin) {
+        // If a plugin is provided, do not redirect the browser.
+        // Instead, perform an API request and display a message
+
+        url = url + `plugin=${plugin}`;
+
+        inventreeGet(url, {}, {
+            success: function(response) {
+                showMessage(
+                    '{% trans "Labels sent to printer" %}',
+                    {
+                        style: 'success',
+                    }
+                );
+            }
+        });
+    } else {
+        window.location.href = url;
+    }
+
+}
+
 
 function printStockItemLabels(items) {
     /**
@@ -67,11 +97,7 @@ function printStockItemLabels(items) {
                                 href += `items[]=${item}&`;
                             });
 
-                            if (data.plugin) {
-                                href += `plugin=${data.plugin}`;
-                            }
-
-                            window.location.href = href;
+                            printLabels(href, data.plugin);
                         }
                     }
                 );
@@ -79,6 +105,7 @@ function printStockItemLabels(items) {
         }
     );
 }
+
 
 function printStockLocationLabels(locations) {
 
@@ -124,11 +151,7 @@ function printStockLocationLabels(locations) {
                                 href += `locations[]=${location}&`;
                             });
 
-                            if (data.plugin) {
-                                href += `plugin=${data.plugin}`;
-                            }
-
-                            window.location.href = href;
+                            printLabels(href, data.plugin);
                         }
                     }
                 );
@@ -186,11 +209,7 @@ function printPartLabels(parts) {
                                 url += `parts[]=${part}&`;
                             });
 
-                            if (data.plugin) {
-                                href += `plugin=${data.plugin}`;
-                            }
-
-                            window.location.href = url;
+                            printLabels(href, data.plugin);
                         }
                     }
                 );
@@ -233,7 +252,6 @@ function selectLabel(labels, items, options={}) {
     );
 
     var plugin_selection = '';
-    
     
     if (plugins.length > 0) {
         plugin_selection =`

--- a/InvenTree/templates/js/translated/label.js
+++ b/InvenTree/templates/js/translated/label.js
@@ -233,7 +233,7 @@ function selectLabel(labels, items, options={}) {
 
     // Request a list of available label printing plugins from the server
     inventreeGet(
-        `/api/plugins/`,
+        `/api/plugin/`,
         {},
         {
             async: false,

--- a/InvenTree/templates/js/translated/label.js
+++ b/InvenTree/templates/js/translated/label.js
@@ -233,10 +233,8 @@ function selectLabel(labels, items, options={}) {
 
     // Request a list of available label printing plugins from the server
     inventreeGet(
-        '{% url "api-plugin-list" %}',
-        {
-
-        },
+        `/api/plugins/`,
+        {},
         {
             async: false,
             success: function(response) {

--- a/InvenTree/templates/js/translated/label.js
+++ b/InvenTree/templates/js/translated/label.js
@@ -203,10 +203,10 @@ function printPartLabels(parts) {
 
                             var pk = data.label;
 
-                            var url = `/api/label/part/${pk}/print/?`;
+                            var href = `/api/label/part/${pk}/print/?`;
 
                             parts.forEach(function(part) {
-                                url += `parts[]=${part}&`;
+                                href += `parts[]=${part}&`;
                             });
 
                             printLabels(href, data.plugin);


### PR DESCRIPTION
This PR adds a new plugin mixin class, specifically for label printing.

Currently, the "print labels" button only exports to PDF for download.

However, users may wish to implement direct printing to a network connected (or something else) label printer.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2768"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

I have a working implementation using the [Brother PT-P750W](https://www.brother.com.au/en/products/all-labellers/labellers/pt-p750w) printer via the [brother_ql](https://github.com/pklaus/brother_ql) python library.