### PR TITLE
Send notification if printing fails

### DIFF
--- a/InvenTree/common/notifications.py
+++ b/InvenTree/common/notifications.py
@@ -154,10 +154,17 @@ class UIMessageNotification(SingleNotificationMethod):
         return True
 
 
-def trigger_notifaction(obj, category=None, obj_ref='pk', targets=None, target_fnc=None, target_args=[], target_kwargs={}, context={}):
+def trigger_notifaction(obj, category=None, obj_ref='pk', **kwargs):
     """
     Send out a notification
     """
+
+    targets = kwargs.get('targets', None)
+    target_fnc = kwargs.get('target_fnc', None)
+    target_args = kwargs.get('target_args', [])
+    target_kwargs = kwargs.get('target_kwargs', {})
+    context = kwargs.get('context', {})
+    delivery_methods = kwargs.get('delivery_methods', None)
 
     # Check if data is importing currently
     if isImportingData():
@@ -190,7 +197,8 @@ def trigger_notifaction(obj, category=None, obj_ref='pk', targets=None, target_f
         logger.info(f"Sending notification '{category}' for '{str(obj)}'")
 
         # Collect possible methods
-        delivery_methods = inheritors(NotificationMethod)
+        if delivery_methods is None:
+            delivery_methods = inheritors(NotificationMethod)
 
         for method in [a for a in delivery_methods if a not in [SingleNotificationMethod, BulkNotificationMethod]]:
             logger.info(f"Triggering method '{method.METHOD_NAME}'")

--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -138,6 +138,9 @@ class LabelPrintMixin:
 
             """
 
+            # Label instance
+            label_instance = self.get_object()
+
             for output in outputs:
                 """
                 For each output, we generate a temporary image file,
@@ -156,7 +159,9 @@ class LabelPrintMixin:
                 offload_task(
                     'plugin.events.print_label',
                     plugin.plugin_slug(),
-                    image
+                    image,
+                    label_instance=label_instance,
+                    user=request.user,
                 )
 
             return JsonResponse({

--- a/InvenTree/part/tasks.py
+++ b/InvenTree/part/tasks.py
@@ -5,7 +5,6 @@ import logging
 
 from django.utils.translation import ugettext_lazy as _
 
-
 import InvenTree.helpers
 import InvenTree.tasks
 import common.notifications

--- a/InvenTree/plugin/events.py
+++ b/InvenTree/plugin/events.py
@@ -233,4 +233,5 @@ def print_label(plugin_slug, label_image, label_instance=None, user=None):
             'label.printing_failed',
             targets=[user],
             context=ctx,
+            delivery_methods=[common.notifications.UIMessageNotification]
         )


### PR DESCRIPTION
If label printing fails (due to a plugin error) then the user is notified.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2772"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

