### PR TITLE
Plugin api permissions

### DIFF
--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -12,10 +12,13 @@ import common.models
 INVENTREE_SW_VERSION = "0.7.0 dev"
 
 # InvenTree API version
-INVENTREE_API_VERSION = 33
+INVENTREE_API_VERSION = 34
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v34 -> 2022-03-25
+    - Change permissions for "plugin list" API endpoint (now allows any authenticated user)
 
 v33 -> 2022-03-24
     - Adds "plugins_enabled" information to root API endpoint

--- a/InvenTree/plugin/api.py
+++ b/InvenTree/plugin/api.py
@@ -25,7 +25,7 @@ class PluginList(generics.ListAPIView):
 
     # Allow any logged in user to read this endpoint
     # This is necessary to allow certain functionality,
-    # e.g. determining which label printing plugins are available 
+    # e.g. determining which label printing plugins are available
     permission_classes = [permissions.IsAuthenticated]
 
     serializer_class = PluginSerializers.PluginConfigSerializer

--- a/InvenTree/plugin/api.py
+++ b/InvenTree/plugin/api.py
@@ -9,6 +9,7 @@ from django.conf.urls import url, include
 
 from rest_framework import generics
 from rest_framework import status
+from rest_framework import permissions
 from rest_framework.response import Response
 
 from common.api import GlobalSettingsPermissions
@@ -21,6 +22,11 @@ class PluginList(generics.ListAPIView):
 
     - GET: Return a list of all PluginConfig objects
     """
+
+    # Allow any logged in user to read this endpoint
+    # This is necessary to allow certain functionality,
+    # e.g. determining which label printing plugins are available 
+    permission_classes = [permissions.IsAuthenticated]
 
     serializer_class = PluginSerializers.PluginConfigSerializer
     queryset = PluginConfig.objects.all()


### PR DESCRIPTION
Overrides *view* permission for the plugin list endpoint

- It is necessary for *any* logged in user to view this endpoint
- This is how the user determines which plugins are available (e.g. for label printing!)

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2773"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

