### PR TITLE
Pin setuptools version

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,7 +1,7 @@
 # Base python requirements for docker containers
 
 # Basic package requirements
-setuptools>=57.4.0
+setuptools>=57.4.0<=60.1.0
 wheel>=0.37.0
 invoke>=1.4.0                   # Invoke build tool
 

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,7 +1,7 @@
 # Base python requirements for docker containers
 
 # Basic package requirements
-setuptools>=57.4.0<=60.1.0
+setuptools>=57.4.0,<=60.1.0
 wheel>=0.37.0
 invoke>=1.4.0                   # Invoke build tool
 


### PR DESCRIPTION
- Automated docker builds are failing
- [Recent update](https://pypi.org/project/setuptools/61.0.0/) seems to have borked it

![image](https://user-images.githubusercontent.com/10080325/160106290-08332944-b4d2-45a3-b5b9-817a29aad6e4.png)


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2774"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

