### PR TITLE
Updated setuptools version

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,7 +1,7 @@
 # Base python requirements for docker containers
 
 # Basic package requirements
-setuptools>=57.4.0,<=60.1.0
+setuptools==60.0.5
 wheel>=0.37.0
 invoke>=1.4.0                   # Invoke build tool
 


### PR DESCRIPTION
While creating new docker deployment, we were getting this error:
AttributeError: module '_distutils_hack' has no attribute 'ensure_shim'.
This update removes this error and ensures smooth deployment

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2786"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

