### PR TITLE
Fix translation on delete_build form

### DIFF
--- a/InvenTree/build/templates/build/delete_build.html
+++ b/InvenTree/build/templates/build/delete_build.html
@@ -1,5 +1,7 @@
 {% extends "modal_delete_form.html" %}
-
+{% load i18n %}
 {% block pre_form_content %}
-Are you sure you want to delete this build?
+
+{% trans "Are you sure you want to delete this build?" %}
+
 {% endblock %}


### PR DESCRIPTION
Fix missing translation on delete_build form

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2793"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

