### PR TITLE
Use new unallocated_stock quantity in the part table and in the search results

### DIFF
--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -12,10 +12,13 @@ import common.models
 INVENTREE_SW_VERSION = "0.7.0 dev"
 
 # InvenTree API version
-INVENTREE_API_VERSION = 35
+INVENTREE_API_VERSION = 36
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v36 -> 2022-04-03
+    - Adds ability to filter part list endpoint by unallocated_stock argument
 
 v35 -> 2022-04-01 : https://github.com/inventree/InvenTree/pull/2797
     - Adds stock allocation information to the Part API

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -798,6 +798,20 @@ class PartFilter(rest_filters.FilterSet):
 
         return queryset
 
+    # unallocated_stock filter
+    unallocated_stock = rest_filters.BooleanFilter(label='Unallocated stock', method='filter_unallocated_stock')
+
+    def filter_unallocated_stock(self, queryset, name, value):
+
+        value = str2bool(value)
+
+        if value:
+            queryset = queryset.filter(Q(unallocated_stock__gt=0))
+        else:
+            queryset = queryset.filter(Q(unallocated_stock__lte=0))
+
+        return queryset
+
     is_template = rest_filters.BooleanFilter()
 
     assembly = rest_filters.BooleanFilter()

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -494,7 +494,11 @@ function duplicateBom(part_id, options={}) {
 function partStockLabel(part, options={}) {
 
     if (part.in_stock) {
-        return `<span class='badge rounded-pill bg-success ${options.classes}'>{% trans "Stock" %}: ${part.in_stock}</span>`;
+        if (part.unallocated_stock) {
+            return `<span class='badge rounded-pill bg-success ${options.classes}'>{% trans "Available" %}: ${part.unallocated_stock}/${part.in_stock}</span>`;
+        } else {
+            return `<span class='badge rounded-pill bg-warning ${options.classes}'>{% trans "Available" %}: ${part.unallocated_stock}/${part.in_stock}</span>`;
+        }
     } else {
         return `<span class='badge rounded-pill bg-danger ${options.classes}'>{% trans "No Stock" %}</span>`;
     }

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -494,14 +494,40 @@ function duplicateBom(part_id, options={}) {
 function partStockLabel(part, options={}) {
 
     if (part.in_stock) {
-        if (part.unallocated_stock) {
-            return `<span class='badge rounded-pill bg-success ${options.classes}'>{% trans "Available" %}: ${part.unallocated_stock}/${part.in_stock}</span>`;
+        // There IS stock available for this part
+
+        // Is stock "low" (below the 'minimum_stock' quantity)?
+        if (part.minimum_stock && part.minimum_stock > part.in_stock) {
+            return `<span class='badge rounded-pill bg-warning ${options.classes}'>{% trans "Low stock" %}: ${part.in_stock}${part.units}</span>`;
+        } else if (part.unallocated_stock == 0) {
+            if (part.ordering) {
+                // There is no available stock, but stock is on order
+                return `<span class='badge rounded-pill bg-info ${options.classes}'>{% trans "On Order" %}: ${part.ordering}${part.units}</span>`;
+            } else if (part.building) {
+                // There is no available stock, but stock is being built
+                return `<span class='badge rounded-pill bg-info ${options.classes}'>{% trans "Building" %}: ${part.building}${part.units}</span>`;
+            } else {
+                // There is no available stock
+                return `<span class='badge rounded-pill bg-warning ${options.classes}'>{% trans "Available" %}: 0/${part.in_stock}${part.units}</span>`;
+            }
         } else {
-            return `<span class='badge rounded-pill bg-warning ${options.classes}'>{% trans "Available" %}: ${part.unallocated_stock}/${part.in_stock}</span>`;
+            return `<span class='badge rounded-pill bg-success ${options.classes}'>{% trans "Available" %}: ${part.unallocated_stock}/${part.in_stock}${part.units}</span>`;
         }
     } else {
-        return `<span class='badge rounded-pill bg-danger ${options.classes}'>{% trans "No Stock" %}</span>`;
+        // There IS NO stock available for this part
+
+        if (part.ordering) {
+            // There is no stock, but stock is on order
+            return `<span class='badge rounded-pill bg-info ${options.classes}'>{% trans "On Order" %}: ${part.ordering}${part.units}</span>`;
+        } else if (part.building) {
+            // There is no stock, but stock is being built
+            return `<span class='badge rounded-pill bg-info ${options.classes}'>{% trans "Building" %}: ${part.building}${part.units}</span>`;
+        } else {
+            // There is no stock
+            return `<span class='badge rounded-pill bg-danger ${options.classes}'>{% trans "No Stock" %}</span>`;
+        }
     }
+
 }
 
 

--- a/InvenTree/templates/js/translated/table_filters.js
+++ b/InvenTree/templates/js/translated/table_filters.js
@@ -427,11 +427,15 @@ function getAvailableTableFilters(tableKey) {
             },
             has_stock: {
                 type: 'bool',
-                title: '{% trans "Stock available" %}',
+                title: '{% trans "In stock" %}',
             },
             low_stock: {
                 type: 'bool',
                 title: '{% trans "Low stock" %}',
+            },
+            unallocated_stock: {
+                type: 'bool',
+                title: '{% trans "Available stock" %}',
             },
             assembly: {
                 type: 'bool',


### PR DESCRIPTION
Display available quantities in part table instead of in_stock quantities.
Also enhance the stock badge to show No Stock / Not available / Building xxx / On order xxx in the table.
Render the badge used in the search results using the same principle, but showing available/in stock quantities.


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2801"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

