### PR TITLE
Fix search errors

### DIFF
--- a/InvenTree/templates/js/translated/api.js
+++ b/InvenTree/templates/js/translated/api.js
@@ -179,6 +179,11 @@ function showApiError(xhr, url) {
     var title = null;
     var message = null;
 
+    if (xhr.statusText == 'abort') {
+        // Don't show errors for requests which were intentionally aborted
+        return;
+    }
+
     switch (xhr.status || 0) {
     // No response
     case 0:


### PR DESCRIPTION
- Do not show API error messages for requests which were intentionally aborted
- Prevents a large number of error messages being displayed when search text is changed

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2808"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

