### PR TITLE
re-add plugin on startup switch

### DIFF
--- a/InvenTree/templates/InvenTree/settings/plugin.html
+++ b/InvenTree/templates/InvenTree/settings/plugin.html
@@ -24,6 +24,7 @@
         {% include "InvenTree/settings/setting.html" with key="ENABLE_PLUGINS_URL" icon="fa-link" %}
         {% include "InvenTree/settings/setting.html" with key="ENABLE_PLUGINS_NAVIGATION" icon="fa-sitemap" %}
         {% include "InvenTree/settings/setting.html" with key="ENABLE_PLUGINS_APP" icon="fa-rocket" %}
+        {% include "InvenTree/settings/setting.html" with key="PLUGIN_ON_STARTUP" %}
     </tbody>
 </table>
 </div>


### PR DESCRIPTION
Add a setting back into the UI that got lost somehow.
Closes Inventree/inventree-brother-plugin/issues/3

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2824"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

