### PR TITLE
Adds ability to include tests results from "installed items"

### DIFF
--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -12,10 +12,13 @@ import common.models
 INVENTREE_SW_VERSION = "0.7.0 dev"
 
 # InvenTree API version
-INVENTREE_API_VERSION = 37
+INVENTREE_API_VERSION = 38
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v38 -> 2022-04-14 : https://github.com/inventree/InvenTree/pull/2828
+    - Adds the ability to include stock test results for "installed items"
 
 v37 -> 2022-04-07 : https://github.com/inventree/InvenTree/pull/2806
     - Adds extra stock availability information to the BomItem serializer

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -1137,7 +1137,7 @@ class StockItemTestResultList(generics.ListCreateAPIView):
                     installed_items = item.get_installed_items(cascade=True)
 
                     items += [it for it in installed_items]
-                
+
                 queryset = queryset.filter(stock_item__in=items)
 
             except (ValueError, StockItem.DoesNotExist):

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -1105,7 +1105,6 @@ class StockItemTestResultList(generics.ListCreateAPIView):
     ]
 
     filter_fields = [
-        'stock_item',
         'test',
         'user',
         'result',
@@ -1113,6 +1112,38 @@ class StockItemTestResultList(generics.ListCreateAPIView):
     ]
 
     ordering = 'date'
+
+    def filter_queryset(self, queryset):
+
+        params = self.request.query_params
+
+        queryset = super().filter_queryset(queryset)
+
+        # Filter by stock item
+        item = params.get('stock_item', None)
+
+        if item is not None:
+            try:
+                item = StockItem.objects.get(pk=item)
+
+                items = [item]
+
+                # Do we wish to also include test results for 'installed' items?
+                include_installed = str2bool(params.get('include_installed', False))
+
+                if include_installed:
+                    # Include items which are installed "underneath" this item
+                    # Note that this function is recursive!
+                    installed_items = item.get_installed_items(cascade=True)
+
+                    items += [it for it in installed_items]
+                
+                queryset = queryset.filter(stock_item__in=items)
+
+            except (ValueError, StockItem.DoesNotExist):
+                pass
+
+        return queryset
 
     def get_serializer(self, *args, **kwargs):
         try:

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -34,8 +34,8 @@
 // Should the ID be rendered for this string
 function renderId(title, pk, parameters={}) {
 
-    // Default = true
-    var render = true;
+    // Default = do not display
+    var render = false;
 
     if ('render_pk' in parameters) {
         render = parameters['render_pk'];

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -1331,14 +1331,27 @@ function loadStockTestResultsTable(table, options) {
             });
 
             // Once the test template data are loaded, query for test results
+
+            var filters = loadTableFilters(filterKey);
+
+            var query_params = {
+                stock_item: options.stock_item,
+                user_detail: true,
+                attachment_detail: true,
+                ordering: '-date',
+            };
+
+            if ('result' in filters) {
+                query_params.result = filters.result;
+            }
+
+            if ('include_installed' in filters) {
+                query_params.include_installed = filters.include_installed;
+            }
+
             inventreeGet(
                 '{% url "api-stock-test-result-list" %}',
-                {
-                    stock_item: options.stock_item,
-                    user_detail: true,
-                    attachment_detail: true,
-                    ordering: '-date',
-                },
+                query_params,
                 {
                     success: function(data) {
                         // Iterate through the returned test data

--- a/InvenTree/templates/js/translated/table_filters.js
+++ b/InvenTree/templates/js/translated/table_filters.js
@@ -265,7 +265,16 @@ function getAvailableTableFilters(tableKey) {
 
     // Filters for the 'stock test' table
     if (tableKey == 'stocktests') {
-        return {};
+        return {
+            result: {
+                type: 'bool',
+                title: '{% trans "Test Passed" %}',
+            },
+            include_installed: {
+                type: 'bool',
+                title: '{% trans "Include Installed Items" %}',
+            }
+        };
     }
 
     // Filters for the 'part test template' table


### PR DESCRIPTION
e.g. if an assembly has test results, but also has installed child stock items, which also have test results, we'd like to be able to optionally see those in the test result table for the master assembly.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2828"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

