### PR TITLE
Fixes loading of SO table on company page

### DIFF
--- a/InvenTree/company/templates/company/detail.html
+++ b/InvenTree/company/templates/company/detail.html
@@ -238,7 +238,7 @@
     });
 
     {% if company.is_customer %}
-    onPanelLoad('panel-sales-orders', function() {
+    onPanelLoad('sales-orders', function() {
         loadSalesOrderTable("#sales-order-table", {
             url: "{% url 'api-so-list' %}",
             params: {


### PR DESCRIPTION
Fixes a small typo which prevents loading of sales order table on company page

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2834"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

