### PR TITLE
Revert location of init.sh for Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,8 +110,7 @@ RUN pip3 install --user --no-cache-dir --disable-pip-version-check -r ${INVENTRE
 WORKDIR ${INVENTREE_MNG_DIR}
 
 # Server init entrypoint
-COPY init.sh ${INVENTREE_HOME}/init.sh
-ENTRYPOINT ["/bin/bash", "${INVENTREE_HOME}/init.sh"]
+ENTRYPOINT ["/bin/bash", "../docker/init.sh"]
 
 # Launch the production server
 # TODO: Work out why environment variables cannot be interpolated in this command


### PR DESCRIPTION
Reverting line which caused a bug with production dockerfile

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2858"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

