### PR TITLE
Implement proxy based auth

### DIFF
--- a/InvenTree/InvenTree/middleware.py
+++ b/InvenTree/InvenTree/middleware.py
@@ -2,6 +2,9 @@ from django.shortcuts import HttpResponseRedirect
 from django.urls import reverse_lazy, Resolver404
 from django.shortcuts import redirect
 from django.conf.urls import include, url
+from django.conf import settings
+from django.contrib.auth.middleware import PersistentRemoteUserMiddleware
+
 import logging
 
 from rest_framework.authtoken.models import Token
@@ -112,3 +115,16 @@ class CustomAllauthTwoFactorMiddleware(AllauthTwoFactorMiddleware):
                 super().process_request(request)
         except Resolver404:
             pass
+
+
+class InvenTreeRemoteUserMiddleware(PersistentRemoteUserMiddleware):
+    """
+    Middleware to check if HTTP-header based auth is enabled and to set it up
+    """
+    header = settings.REMOTE_LOGIN_HEADER
+
+    def process_request(self, request):
+        if not settings.REMOTE_LOGIN:
+            return
+
+        return super().process_request(request)

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -289,6 +289,7 @@ MIDDLEWARE = CONFIG.get('middleware', [
     'django.middleware.csrf.CsrfViewMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'InvenTree.middleware.InvenTreeRemoteUserMiddleware',       # Remote / proxy auth
     'django_otp.middleware.OTPMiddleware',                      # MFA support
     'InvenTree.middleware.CustomAllauthTwoFactorMiddleware',    # Flow control for allauth
     'django.contrib.messages.middleware.MessageMiddleware',
@@ -302,6 +303,7 @@ MIDDLEWARE = CONFIG.get('middleware', [
 MIDDLEWARE.append('error_report.middleware.ExceptionProcessor')
 
 AUTHENTICATION_BACKENDS = CONFIG.get('authentication_backends', [
+    'django.contrib.auth.backends.RemoteUserBackend',           # proxy login
     'django.contrib.auth.backends.ModelBackend',
     'allauth.account.auth_backends.AuthenticationBackend',      # SSO login via external providers
 ])
@@ -852,6 +854,10 @@ ACCOUNT_FORMS = {
 
 SOCIALACCOUNT_ADAPTER = 'InvenTree.forms.CustomSocialAccountAdapter'
 ACCOUNT_ADAPTER = 'InvenTree.forms.CustomAccountAdapter'
+
+# login settings
+REMOTE_LOGIN = get_setting('INVENTREE_REMOTE_LOGIN', CONFIG.get('remote_login', False))
+REMOTE_LOGIN_HEADER = get_setting('INVENTREE_REMOTE_LOGIN_HEADER', CONFIG.get('remote_login_header', 'REMOTE_USER'))
 
 # Markdownx configuration
 # Ref: https://neutronx.github.io/django-markdownx/customization/

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -154,6 +154,14 @@ static_root: '/home/inventree/data/static'
 # Use environment variable INVENTREE_LOGIN_ATTEMPTS
 #login_attempts: 5
 
+# Remote / proxy login
+# These settings can introduce security problems if configured incorrectly. Please read
+# https://docs.djangoproject.com/en/4.0/howto/auth-remote-user/ for more details
+# Use environment variable INVENTREE_REMOTE_LOGIN
+# remote_login: True
+# Use environment variable INVENTREE_REMOTE_LOGIN_HEADER
+# remote_login_header: REMOTE_USER
+
 # Add new user on first startup
 #admin_user: admin
 #admin_email: info@example.com


### PR DESCRIPTION
This PR adds proxy-based auth by HTTP header via the Django-native AuthBackend / Middleware.

Note: This is an old but still often used (mostly in enterprise) option. Similar was possible with a few lines before - this PR adds specific settings for adaptations users could do with overriding the auth and middleware stack. By default, it is turned off so no changes to default behaviour should be noticed.
Fixes #1693 

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2865"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

