### PR TITLE
Adds 'variant_of' filter back into Part API

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -4,10 +4,13 @@ InvenTree API version information
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 40
+INVENTREE_API_VERSION = 41
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v41 -> 2022-04-26
+    - Fixes 'variant_of' filter for Part list endpoint
 
 v40 -> 2022-04-19
     - Adds ability to filter StockItem list by "tracked" parameter

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1351,10 +1351,6 @@ class PartList(generics.ListCreateAPIView):
         filters.OrderingFilter,
     ]
 
-    filter_fields = [
-        'variant_of',
-    ]
-
     ordering_fields = [
         'name',
         'creation_date',

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1175,6 +1175,18 @@ class PartList(generics.ListCreateAPIView):
             except (ValueError, Part.DoesNotExist):
                 pass
 
+        # Filter by 'variant_of'
+        # Note that this is subtly different from 'ancestor' filter (above)
+        variant_of = params.get('variant_of', None)
+
+        if variant_of is not None:
+            try:
+                template = Part.objects.get(pk=variant_of)
+                variants = template.get_children()
+                queryset = queryset.filter(pk__in=[v.pk for v in variants])
+            except (ValueError, Part.DoesNotExist):
+                pass
+
         # Filter only parts which are in the "BOM" for a given part
         in_bom_for = params.get('in_bom_for', None)
 

--- a/InvenTree/part/fixtures/part.yaml
+++ b/InvenTree/part/fixtures/part.yaml
@@ -177,6 +177,7 @@
   fields:
     name: 'Green chair variant'
     variant_of: 10003
+    is_template: true
     category: 7
     trackable: true
     tree_id: 1


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/2868

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2869"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

