### PR TITLE
Fix for 'auto-allocate' stock to build orders

### DIFF
--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -871,6 +871,9 @@ class Build(MPTTModel, ReferenceIndexingMixin):
                 part__in=[p for p in available_parts],
             )
 
+            # Filter out "serialized" stock items, these cannot be auto-allocated
+            available_stock = available_stock.filter(Q(serial=None) | Q(serial=''))
+
             if location:
                 # Filter only stock items located "below" the specified location
                 sublocations = location.get_descendants(include_self=True)


### PR DESCRIPTION
- Allocation of serialized stock items would cause issue
- Exclude serialized stock from auto allocation process

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2873"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

