### PR TITLE
Add gdk-pixbuf

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,8 +65,8 @@ RUN apk add --no-cache git make bash \
     libjpeg-turbo libjpeg-turbo-dev jpeg jpeg-dev \
     libffi libffi-dev \
     zlib zlib-dev \
-    # Cairo deps for WeasyPrint (these will be deprecated once WeasyPrint drops cairo requirement)
-    cairo cairo-dev pango pango-dev \
+    # Special deps for WeasyPrint (these will be deprecated once WeasyPrint drops cairo requirement)
+    cairo cairo-dev pango pango-dev gdk-pixbuf \
     # Fonts
     fontconfig ttf-droid ttf-liberation ttf-dejavu ttf-opensans ttf-ubuntu-font-family font-croscore font-noto \
     # Core python


### PR DESCRIPTION
- Required for weasyprint (reports) to render jpg files

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2881"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

