### PR TITLE
Build output table improvements

### DIFF
--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -442,6 +442,18 @@ class BuildItemList(generics.ListCreateAPIView):
         if part_pk:
             queryset = queryset.filter(stock_item__part=part_pk)
 
+        # Filter by "tracked" status
+        # Tracked means that the item is "installed" into a build output (stock item)
+        tracked = params.get('tracked', None)
+
+        if tracked is not None:
+            tracked = str2bool(tracked)
+
+            if tracked:
+                queryset = queryset.exclude(install_into=None)
+            else:
+                queryset = queryest.filter(install_into=None)
+
         # Filter by output target
         output = params.get('output', None)
 

--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -96,6 +96,7 @@ class BuildList(generics.ListCreateAPIView):
         'target_date',
         'completion_date',
         'quantity',
+        'completed',
         'issued_by',
         'responsible',
     ]

--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -452,7 +452,7 @@ class BuildItemList(generics.ListCreateAPIView):
             if tracked:
                 queryset = queryset.exclude(install_into=None)
             else:
-                queryset = queryest.filter(install_into=None)
+                queryset = queryset.filter(install_into=None)
 
         # Filter by output target
         output = params.get('output', None)

--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -1260,7 +1260,7 @@ class BuildItem(models.Model):
             })
 
     @transaction.atomic
-    def complete_allocation(self, user):
+    def complete_allocation(self, user, notes=''):
         """
         Complete the allocation of this BuildItem into the output stock item.
 
@@ -1286,8 +1286,13 @@ class BuildItem(models.Model):
                 self.save()
 
             # Install the stock item into the output
-            item.belongs_to = self.install_into
-            item.save()
+            self.install_into.installStockItem(
+                item,
+                self.quantity,
+                user,
+                notes
+            )
+            
         else:
             # Simply remove the items from stock
             item.take_stock(

--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -1292,7 +1292,7 @@ class BuildItem(models.Model):
                 user,
                 notes
             )
-            
+
         else:
             # Simply remove the items from stock
             item.take_stock(

--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -161,7 +161,12 @@ class BuildOutputSerializer(serializers.Serializer):
 
             # The build output must have all tracked parts allocated
             if not build.is_fully_allocated(output):
-                raise ValidationError(_("This build output is not fully allocated"))
+
+                # Check if the user has specified that incomplete allocations are ok
+                accept_incomplete = InvenTree.helpers.str2bool(self.context['request'].data.get('accept_incomplete_allocation', False))
+
+                if not accept_incomplete:
+                    raise ValidationError(_("This build output is not fully allocated"))
 
         return output
 
@@ -355,6 +360,7 @@ class BuildOutputCompleteSerializer(serializers.Serializer):
             'outputs',
             'location',
             'status',
+            'accept_incomplete_allocation',
             'notes',
         ]
 
@@ -375,6 +381,13 @@ class BuildOutputCompleteSerializer(serializers.Serializer):
         choices=list(StockStatus.items()),
         default=StockStatus.OK,
         label=_("Status"),
+    )
+
+    accept_incomplete_allocation = serializers.BooleanField(
+        default=False,
+        required=False,
+        label=_('Accept Incomplete Allocation'),
+        help_text=_('Complete ouputs if stock has not been fully allocated'),
     )
 
     notes = serializers.CharField(

--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -401,110 +401,107 @@ function reloadTable() {
     $('#allocation-table-untracked').bootstrapTable('refresh');
 }
 
-// Get the list of BOM items required for this build
-inventreeGet(
-    '{% url "api-bom-list" %}',
-    {
+onPanelLoad('outputs', function() {
+    {% if build.active %}
+
+    var build_info = {
+        pk: {{ build.pk }},
         part: {{ build.part.pk }},
-        sub_part_detail: true,
-    },
-    {
-        success: function(response) {
+        quantity: {{ build.quantity }},
+        {% if build.take_from %}
+        source_location: {{ build.take_from.pk }},
+        {% endif %}
+        tracked_parts: true,
+    };
 
-            var build_info = {
-                pk: {{ build.pk }},
-                part: {{ build.part.pk }},
-                quantity: {{ build.quantity }},
-                bom_items: response,
-                {% if build.take_from %}
-                source_location: {{ build.take_from.pk }},
-                {% endif %}
-                {% if build.has_tracked_bom_items %}
-                tracked_parts: true,
-                {% else %}
-                tracked_parts: false,
-                {% endif %}
-            };
+    loadBuildOutputTable(build_info);
 
-            {% if build.active %}
-            loadBuildOutputTable(build_info);
-            linkButtonsToSelection(
-                '#build-output-table',
-                [
-                    '#output-options',
-                    '#multi-output-complete',
-                    '#multi-output-delete',
-                ]
-            );
+    linkButtonsToSelection(
+        '#build-output-table',
+        [
+            '#output-options',
+            '#multi-output-complete',
+            '#multi-output-delete',
+        ]
+    );
 
-            $('#multi-output-complete').click(function() {
-                var outputs = $('#build-output-table').bootstrapTable('getSelections');
+    $('#multi-output-complete').click(function() {
+        var outputs = $('#build-output-table').bootstrapTable('getSelections');
 
-                completeBuildOutputs(
-                    build_info.pk,
-                    outputs,
-                    {
-                        success: function() {
-                            // Reload the "in progress" table
-                            $('#build-output-table').bootstrapTable('refresh');
+        completeBuildOutputs(
+            build_info.pk,
+            outputs,
+            {
+                success: function() {
+                    // Reload the "in progress" table
+                    $('#build-output-table').bootstrapTable('refresh');
 
-                            // Reload the "completed" table
-                            $('#build-stock-table').bootstrapTable('refresh');
-                        }
-                    }
-                );
-            });
-
-            $('#multi-output-delete').click(function() {
-                var outputs = $('#build-output-table').bootstrapTable('getSelections');
-
-                deleteBuildOutputs(
-                    build_info.pk,
-                    outputs,
-                    {
-                        success: function() {
-                            // Reload the "in progress" table
-                            $('#build-output-table').bootstrapTable('refresh');
-
-                            // Reload the "completed" table
-                            $('#build-stock-table').bootstrapTable('refresh');
-                        }
-                    }
-                )
-            });
-
-            $('#incomplete-output-print-label').click(function() {
-                var outputs = $('#build-output-table').bootstrapTable('getSelections');
-
-                if  (outputs.length == 0) {
-                    outputs = $('#build-output-table').bootstrapTable('getData');
+                    // Reload the "completed" table
+                    $('#build-stock-table').bootstrapTable('refresh');
                 }
+            }
+        );
+    });
 
-                var stock_id_values = [];
+    $('#multi-output-delete').click(function() {
+        var outputs = $('#build-output-table').bootstrapTable('getSelections');
 
-                outputs.forEach(function(output) {
-                    stock_id_values.push(output.pk);
-                });
+        deleteBuildOutputs(
+            build_info.pk,
+            outputs,
+            {
+                success: function() {
+                    // Reload the "in progress" table
+                    $('#build-output-table').bootstrapTable('refresh');
 
-                printStockItemLabels(stock_id_values);
-
-            });
-
-            {% endif %}
-        
-            {% if build.active and build.has_untracked_bom_items %}
-            // Load allocation table for un-tracked parts
-            loadBuildOutputAllocationTable(
-                build_info,
-                null,
-                {
-                    search: true,
+                    // Reload the "completed" table
+                    $('#build-stock-table').bootstrapTable('refresh');
                 }
-            );
-            {% endif %}
+            }
+        )
+    });
+
+    $('#incomplete-output-print-label').click(function() {
+        var outputs = $('#build-output-table').bootstrapTable('getSelections');
+
+        if  (outputs.length == 0) {
+            outputs = $('#build-output-table').bootstrapTable('getData');
         }
+
+        var stock_id_values = [];
+
+        outputs.forEach(function(output) {
+            stock_id_values.push(output.pk);
+        });
+
+        printStockItemLabels(stock_id_values);
+
+    });
+
+    {% endif %}
+});
+
+{% if build.active and build.has_untracked_bom_items %}
+
+var build_info = {
+    pk: {{ build.pk }},
+    part: {{ build.part.pk }},
+    quantity: {{ build.quantity }},
+    {% if build.take_from %}
+    source_location: {{ build.take_from.pk }},
+    {% endif %}
+    tracked_parts: false,
+};
+
+// Load allocation table for un-tracked parts
+loadBuildOutputAllocationTable(
+    build_info,
+    null,
+    {
+        search: true,
     }
 );
+{% endif %}
 
 $('#btn-create-output').click(function() {
 

--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -270,6 +270,16 @@
                         </ul>
                     </div>
 
+                    {% if build.has_tracked_bom_items %}
+                    <button id='outputs-expand' class='btn btn-outline-secondary' type='button' title='{% trans "Expand all build output rows" %}'>
+                        <span class='fas fa-expand'></span>
+                    </button>
+
+                    <button id='outputs-collapse' class='btn btn-outline-secondary' type='button' title='{% trans "Collapse all build output rows" %}'>
+                        <span class='fas fa-compress'></span>
+                    </button>
+                    {% endif %}
+
                     {% include "filter_list.html" with id='incompletebuilditems' %}
                 </div>
                 {% endif %}
@@ -415,68 +425,6 @@ onPanelLoad('outputs', function() {
     };
 
     loadBuildOutputTable(build_info);
-
-    linkButtonsToSelection(
-        '#build-output-table',
-        [
-            '#output-options',
-            '#multi-output-complete',
-            '#multi-output-delete',
-        ]
-    );
-
-    $('#multi-output-complete').click(function() {
-        var outputs = $('#build-output-table').bootstrapTable('getSelections');
-
-        completeBuildOutputs(
-            build_info.pk,
-            outputs,
-            {
-                success: function() {
-                    // Reload the "in progress" table
-                    $('#build-output-table').bootstrapTable('refresh');
-
-                    // Reload the "completed" table
-                    $('#build-stock-table').bootstrapTable('refresh');
-                }
-            }
-        );
-    });
-
-    $('#multi-output-delete').click(function() {
-        var outputs = $('#build-output-table').bootstrapTable('getSelections');
-
-        deleteBuildOutputs(
-            build_info.pk,
-            outputs,
-            {
-                success: function() {
-                    // Reload the "in progress" table
-                    $('#build-output-table').bootstrapTable('refresh');
-
-                    // Reload the "completed" table
-                    $('#build-stock-table').bootstrapTable('refresh');
-                }
-            }
-        )
-    });
-
-    $('#incomplete-output-print-label').click(function() {
-        var outputs = $('#build-output-table').bootstrapTable('getSelections');
-
-        if  (outputs.length == 0) {
-            outputs = $('#build-output-table').bootstrapTable('getData');
-        }
-
-        var stock_id_values = [];
-
-        outputs.forEach(function(output) {
-            stock_id_values.push(output.pk);
-        });
-
-        printStockItemLabels(stock_id_values);
-
-    });
 
     {% endif %}
 });

--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -431,24 +431,32 @@ onPanelLoad('outputs', function() {
 
 {% if build.active and build.has_untracked_bom_items %}
 
-var build_info = {
-    pk: {{ build.pk }},
-    part: {{ build.part.pk }},
-    quantity: {{ build.quantity }},
-    {% if build.take_from %}
-    source_location: {{ build.take_from.pk }},
-    {% endif %}
-    tracked_parts: false,
-};
+function loadUntrackedStockTable() {
 
-// Load allocation table for un-tracked parts
-loadBuildOutputAllocationTable(
-    build_info,
-    null,
-    {
-        search: true,
-    }
-);
+    var build_info = {
+        pk: {{ build.pk }},
+        part: {{ build.part.pk }},
+        quantity: {{ build.quantity }},
+        {% if build.take_from %}
+        source_location: {{ build.take_from.pk }},
+        {% endif %}
+        tracked_parts: false,
+    };
+    
+    $('#allocation-table-untracked').bootstrapTable('destroy');
+
+    // Load allocation table for un-tracked parts
+    loadBuildOutputAllocationTable(
+        build_info,
+        null,
+        {
+            search: true,
+        }
+    );
+}
+
+loadUntrackedStockTable();
+
 {% endif %}
 
 $('#btn-create-output').click(function() {
@@ -472,6 +480,7 @@ $("#btn-auto-allocate").on('click', function() {
             {% if build.take_from %}
             location: {{ build.take_from.pk }},
             {% endif %}
+            onSuccess: loadUntrackedStockTable,
         }
     );
 });
@@ -503,9 +512,7 @@ $("#btn-allocate").on('click', function() {
                 {% if build.take_from %}
                 source_location: {{ build.take_from.pk }},
                 {% endif %}
-                success: function(data) {
-                    $('#allocation-table-untracked').bootstrapTable('refresh');
-                }
+                success: loadUntrackedStockTable,
             }
         );
     }
@@ -514,6 +521,7 @@ $("#btn-allocate").on('click', function() {
 $('#btn-unallocate').on('click', function() {
     unallocateStock({{ build.id }}, {
         table: '#allocation-table-untracked',
+        onSuccess: loadUntrackedStockTable,
     });
 });
 
@@ -533,9 +541,7 @@ $('#allocate-selected-items').click(function() {
             {% if build.take_from %}
             source_location: {{ build.take_from.pk }},
             {% endif %}
-            success: function(data) {
-                $('#allocation-table-untracked').bootstrapTable('refresh');
-            }
+            success: loadUntrackedStockTable,
         }
     );
 });

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -383,7 +383,7 @@ class PartTestTemplateList(generics.ListCreateAPIView):
         required = params.get('required', None)
 
         if required is not None:
-            queryset = queryset.filter(required=required)
+            queryset = queryset.filter(required=str2bool(required))
 
         return queryset
 

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -1165,7 +1165,7 @@ class StockItemTestResultList(generics.ListCreateAPIView):
         build = params.get('build', None)
 
         if build is not None:
-            
+
             try:
                 build = Build.objects.get(pk=build)
 
@@ -1173,7 +1173,6 @@ class StockItemTestResultList(generics.ListCreateAPIView):
 
             except (ValueError, Build.DoesNotExist):
                 pass
-
 
         # Filter by stock item
         item = params.get('stock_item', None)

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -23,6 +23,8 @@ from rest_framework.serializers import ValidationError
 from rest_framework.response import Response
 from rest_framework import generics, filters
 
+from build.models import Build
+
 import common.settings
 import common.models
 
@@ -1158,6 +1160,20 @@ class StockItemTestResultList(generics.ListCreateAPIView):
         params = self.request.query_params
 
         queryset = super().filter_queryset(queryset)
+
+        # Filter by 'build'
+        build = params.get('build', None)
+
+        if build is not None:
+            
+            try:
+                build = Build.objects.get(pk=build)
+
+                queryset = queryset.filter(stock_item__build=build)
+
+            except (ValueError, Build.DoesNotExist):
+                pass
+
 
         # Filter by stock item
         item = params.get('stock_item', None)

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1233,6 +1233,79 @@ function loadBuildOutputTable(build_info, options={}) {
     $(table).on('collapse-row.bs.table', function(detail, index, row) {
         $(`#button-output-allocate-${row.pk}`).prop('disabled', true);
     });
+
+    // Add callbacks for the various table menubar buttons
+
+    // Complete multiple outputs
+    $('#multi-output-complete').click(function() {
+        var outputs = $(table).bootstrapTable('getSelections');
+
+        if (outputs.length == 0) {
+            outputs = $(table).bootstrapTable('getData');
+        }
+
+        completeBuildOutputs(
+            build_info.pk,
+            outputs,
+            {
+                success: function() {
+                    // Reload the "in progress" table
+                    $('#build-output-table').bootstrapTable('refresh');
+
+                    // Reload the "completed" table
+                    $('#build-stock-table').bootstrapTable('refresh');
+                }
+            }
+        );
+    });
+
+    // Delete multiple build outputs
+    $('#multi-output-delete').click(function() {
+        var outputs = $(table).bootstrapTable('getSelections');
+
+        if (outputs.length == 0) {
+            outputs = $(table).bootstrapTable('getData');
+        }
+
+        deleteBuildOutputs(
+            build_info.pk,
+            outputs,
+            {
+                success: function() {
+                    // Reload the "in progress" table
+                    $('#build-output-table').bootstrapTable('refresh');
+
+                    // Reload the "completed" table
+                    $('#build-stock-table').bootstrapTable('refresh');
+                }
+            }
+        )
+    });
+
+    // Print stock item labels
+    $('#incomplete-output-print-label').click(function() {
+        var outputs = $(table).bootstrapTable('getSelections');
+
+        if  (outputs.length == 0) {
+            outputs = $(table).bootstrapTable('getData');
+        }
+
+        var stock_id_values = [];
+
+        outputs.forEach(function(output) {
+            stock_id_values.push(output.pk);
+        });
+
+        printStockItemLabels(stock_id_values);
+    });
+
+    $('#outputs-expand').click(function() {
+        $(table).bootstrapTable('expandAllRows');
+    });
+
+    $('#outputs-collapse').click(function() {
+        $(table).bootstrapTable('collapseAllRows');
+    });
 }
 
 

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1121,7 +1121,7 @@ function loadBuildOutputTable(build_info, options={}) {
             {
                 field: 'quantity',
                 title: '{% trans "Build Output" %}',
-                switchable: true,
+                switchable: false,
                 sortable: true,
                 formatter: function(value, row) {
 
@@ -1834,12 +1834,12 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
 
                     // Handle the case where both ratios are equal
                     if (progressA == progressB) {
-                        return (qA < qB) ? 1 : -1;
+                        return (qA > qB) ? 1 : -1;
                     }
 
                     if (progressA == progressB) return 0;
 
-                    return (progressA < progressB) ? 1 : -1;
+                    return (progressA > progressB) ? 1 : -1;
                 }
             },
             {
@@ -2374,8 +2374,8 @@ function loadBuildTable(table, options) {
                 }
             },
             {
-                field: 'quantity',
-                title: '{% trans "Completed" %}',
+                field: 'completed',
+                title: '{% trans "Progress" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     return makeProgressBar(

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -2270,7 +2270,9 @@ function autoAllocateStockToBuild(build_id, bom_items=[], options={}) {
         confirm: true,
         preFormContent: html,
         onSuccess: function(response) {
-            $('#allocation-table-untracked').bootstrapTable('refresh');
+            if (options.onSuccess) {
+                options.onSuccess(response);
+            }
         }
     });
 }

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -867,7 +867,7 @@ function loadBuildOutputTable(build_info, options={}) {
     // List of "tracked bom items" required for this build order
     var bom_items = null;
 
-     // Request list of BOM data for this build order
+    // Request list of BOM data for this build order
     inventreeGet(
         '{% url "api-bom-list" %}',
         {
@@ -962,7 +962,7 @@ function loadBuildOutputTable(build_info, options={}) {
 
                             var output_progress_bar = $(`#output-progress-${row.pk}`);
 
-                            if  (output_progress_bar.exists()) {
+                            if (output_progress_bar.exists()) {
                                 output_progress_bar.html(
                                     makeProgressBar(
                                         n_completed_lines,
@@ -977,7 +977,7 @@ function loadBuildOutputTable(build_info, options={}) {
                     });
                 }
             }
-        )
+        );
     }
 
     var part_tests = null;
@@ -1283,14 +1283,14 @@ function loadBuildOutputTable(build_info, options={}) {
                     $('#build-stock-table').bootstrapTable('refresh');
                 }
             }
-        )
+        );
     });
 
     // Print stock item labels
     $('#incomplete-output-print-label').click(function() {
         var outputs = $(table).bootstrapTable('getSelections');
 
-        if  (outputs.length == 0) {
+        if (outputs.length == 0) {
             outputs = $(table).bootstrapTable('getData');
         }
 
@@ -1375,10 +1375,6 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
 
     setupFilterList('builditems', $(table), options.filterTarget);
 
-    // If an "output" is specified, then only "trackable" parts are allocated
-    // Otherwise, only "untrackable" parts are allowed
-    var trackable = ! !output;
-
     var allocated_items = output == null ? null : output.allocations;
 
     function redrawAllocationData() {
@@ -1445,11 +1441,6 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
         reloadAllocationData(false);
     } else {
         redrawAllocationData();
-    }
-
-    function reloadTable() {
-        // Reload the entire build allocation table
-        $(table).bootstrapTable('refresh');
     }
 
     function requiredQuantity(row) {
@@ -1812,7 +1803,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                 sortable: true,
                 formatter: function(value, row) {
                     var allocated = allocatedQuantity(row);
-                    var required = requiredQuantity(row)
+                    var required = requiredQuantity(row);
                     return makeProgressBar(allocated, required);
                 },
                 sorter: function(valA, valB, rowA, rowB) {

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1135,6 +1135,10 @@ function loadBuildOutputTable(build_info, options={}) {
                         text = `{% trans "Quantity" %}: ${row.quantity}`;
                     }
 
+                    if (row.batch) {
+                        text += ` <small>({% trans "Batch" %}: ${row.batch})</small>`;
+                    }
+
                     return renderLink(text, url);
                 },
                 sorter: function(a, b, row_a, row_b) {

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -264,7 +264,7 @@ function makeBuildOutputButtons(output_id, build_info, options={}) {
     var html = `<div class='btn-group float-right' role='group'>`;
 
     // Tracked parts? Must be individually allocated
-    if (build_info.tracked_parts) {
+    if (options.has_bom_items) {
 
         // Add a button to allocate stock against this build output
         html += makeIconButton(
@@ -1085,9 +1085,9 @@ function loadBuildOutputTable(build_info, options={}) {
         sortable: true,
         search: false,
         sidePagination: 'client',
-        detailView: true,
+        detailView: bom_items.length > 0,
         detailFilter: function(index, row) {
-            return true;
+            return bom_items.length > 0;
         },
         detailFormatter: function(index, row, element) {
             constructBuildOutputSubTable(index, row, element);
@@ -1159,10 +1159,14 @@ function loadBuildOutputTable(build_info, options={}) {
             {
                 field: 'allocated',
                 title: '{% trans "Allocated Stock" %}',
-                visible: true,
+                visible: bom_items.length > 0,
                 switchable: false,
                 sortable: true,
                 formatter: function(value, row) {
+
+                    if (bom_items.length == 0) {
+                        return `<div id='output-progress-${row.pk}'><em><small>{% trans "No tracked BOM items for this build" %}</small></em></div>`;
+                    }
 
                     var progressBar = makeProgressBar(
                         countAllocatedLines(row),
@@ -1188,7 +1192,7 @@ function loadBuildOutputTable(build_info, options={}) {
                 switchable: true,
                 formatter: function(value, row) {
                     if (part_tests == null || part_tests.length == 0) {
-                        return `<em>{% trans "No tests found " %}</em>`;
+                        return `<em><small>{% trans "No required tests for this build" %}</small></em>`;
                     }
 
                     var n_passed = countPassedTests(row);
@@ -1218,6 +1222,9 @@ function loadBuildOutputTable(build_info, options={}) {
                     return makeBuildOutputButtons(
                         row.pk,
                         build_info,
+                        {
+                            has_bom_items: bom_items.length > 0,
+                        }
                     );
                 }
             }

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -786,7 +786,7 @@ function loadBuildOutputTable(build_info, options={}) {
                     }
                 );
             } else {
-                console.log(`WARNING: Could not locate sub-table for output ${pk}`);
+                console.warn(`Could not locate sub-table for output ${pk}`);
             }
         });
 
@@ -869,7 +869,7 @@ function loadBuildOutputTable(build_info, options={}) {
         url: '{% url "api-stock-list" %}',
         queryParams: filters,
         original: params,
-        showColumns: false,
+        showColumns: true,
         uniqueId: 'pk',
         name: 'build-outputs',
         sortable: true,
@@ -901,6 +901,7 @@ function loadBuildOutputTable(build_info, options={}) {
             {
                 field: 'part',
                 title: '{% trans "Part" %}',
+                switchable: true,
                 formatter: function(value, row) {
                     var thumb = row.part_detail.thumbnail;
 
@@ -909,7 +910,9 @@ function loadBuildOutputTable(build_info, options={}) {
             },
             {
                 field: 'quantity',
-                title: '{% trans "Quantity" %}',
+                title: '{% trans "Build Output" %}',
+                switchable: true,
+                sortable: true,
                 formatter: function(value, row) {
 
                     var url = `/stock/item/${row.pk}/`;
@@ -1079,7 +1082,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
             var row = $(table).bootstrapTable('getRowByUniqueId', pk);
 
             if (!row) {
-                console.log('WARNING: getRowByUniqueId returned null');
+                console.warn('getRowByUniqueId returned null');
                 return;
             }
 
@@ -1269,7 +1272,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                             }
     
                         } else {
-                            console.log(`WARNING: Could not find progress bar for output ${outputId}`);
+                            console.warn(`Could not find progress bar for output ${outputId}`);
                         }
                     }
                 }

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -874,7 +874,7 @@ function loadBuildOutputTable(build_info, options={}) {
         name: 'build-outputs',
         sortable: true,
         search: false,
-        sidePagination: 'server',
+        sidePagination: 'client',
         detailView: has_tracked_items,
         detailFilter: function(index, row) {
             return true;
@@ -913,7 +913,6 @@ function loadBuildOutputTable(build_info, options={}) {
                 title: '{% trans "Build Output" %}',
                 switchable: true,
                 sortable: true,
-                sortName: 'stock', // This will sort by quantity -> serial_int -> serial
                 formatter: function(value, row) {
 
                     var url = `/stock/item/${row.pk}/`;
@@ -928,6 +927,21 @@ function loadBuildOutputTable(build_info, options={}) {
 
                     return renderLink(text, url);
                 },
+                sorter: function(a, b, row_a, row_b) {
+                    // Sort first by quantity, and then by serial number
+                    if ((row_a.quantity > 1) || (row_b.quantity > 1)) {
+                        return row_a.quantity > row_b.quantity ? 1 : -1;
+                    }
+
+                    if ((row_a.serial != null) && (row_b.serial != null)) {
+                        var sn_a = Number.parseInt(row_a.serial) || 0;
+                        var sn_b = Number.parseInt(row_b.serial) || 0;
+
+                        return sn_a > sn_b ? 1 : -1;
+                    }
+
+                    return 0;
+                }
             },
             {
                 field: 'allocated',

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -913,6 +913,7 @@ function loadBuildOutputTable(build_info, options={}) {
                 title: '{% trans "Build Output" %}',
                 switchable: true,
                 sortable: true,
+                sortName: 'stock', // This will sort by quantity -> serial_int -> serial
                 formatter: function(value, row) {
 
                     var url = `/stock/item/${row.pk}/`;
@@ -926,7 +927,7 @@ function loadBuildOutputTable(build_info, options={}) {
                     }
 
                     return renderLink(text, url);
-                }
+                },
             },
             {
                 field: 'allocated',

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1050,7 +1050,7 @@ function loadBuildOutputTable(build_info, options={}) {
             {
                 field: 'tests',
                 title: '{% trans "Tests" %}',
-                sortable: false,
+                sortable: true,
                 switchable: true,
                 formatter: function(value, row) {
                     if (part_tests == null || part_tests.length == 0) {

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -741,18 +741,6 @@ function loadBuildOutputTable(build_info, options={}) {
     params.is_building = true;
     params.build = build_info.pk;
 
-    // Construct a list of "tracked" BOM items
-    var tracked_bom_items = [];
-
-    var has_tracked_items = false;
-
-    build_info.bom_items.forEach(function(bom_item) {
-        if (bom_item.sub_part_detail.trackable) {
-            tracked_bom_items.push(bom_item);
-            has_tracked_items = true;
-        };
-    });
-
     var filters = {};
 
     for (var key in params) {
@@ -1031,7 +1019,7 @@ function loadBuildOutputTable(build_info, options={}) {
         sortable: true,
         search: false,
         sidePagination: 'client',
-        detailView: has_tracked_items,
+        detailView: true,
         detailFilter: function(index, row) {
             return true;
         },
@@ -1105,7 +1093,7 @@ function loadBuildOutputTable(build_info, options={}) {
             {
                 field: 'allocated',
                 title: '{% trans "Allocated Stock" %}',
-                visible: has_tracked_items,
+                visible: true,
                 switchable: false,
                 formatter: function(value, row) {
                     return `<div id='output-progress-${row.pk}'><span class='fas fa-spin fa-spinner'></span></div>`;

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1982,7 +1982,7 @@ function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
         // var stock_input = constructRelatedFieldInput(`items_stock_item_${pk}`);
 
         var html = `
-        <tr id='allocation_row_${pk}' class='part-allocation-row'>
+        <tr id='items_${pk}' class='part-allocation-row'>
             <td id='part_${pk}'>
                 ${thumb} ${sub_part.full_name}
             </td>
@@ -2167,7 +2167,7 @@ function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
             $(options.modal).find('.button-row-remove').click(function() {
                 var pk = $(this).attr('pk');
 
-                $(options.modal).find(`#allocation_row_${pk}`).remove();
+                $(options.modal).find(`#items_${pk}`).remove();
             });
         },
         onSubmit: function(fields, opts) {

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1347,7 +1347,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
             {
                 part: partId,
                 sub_part_detail: true,
-                sub_part_trackable: trackable,
+                sub_part_trackable: buildInfo.tracked_parts,
             },
             {
                 async: false,

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -427,6 +427,8 @@ function completeBuildOutputs(build_id, outputs, options={}) {
         fields: {
             status: {},
             location: {},
+            notes: {},
+            accept_incomplete_allocation: {},
         },
         confirm: true,
         title: '{% trans "Complete Build Outputs" %}',
@@ -445,6 +447,8 @@ function completeBuildOutputs(build_id, outputs, options={}) {
                 outputs: [],
                 status: getFormFieldValue('status', {}, opts),
                 location: getFormFieldValue('location', {}, opts),
+                notes: getFormFieldValue('notes', {}, opts),
+                accept_incomplete_allocation: getFormFieldValue('accept_incomplete_allocation', {type: 'boolean'}, opts),
             };
 
             var output_pk_values = [];
@@ -1896,8 +1900,6 @@ function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
         method: 'POST',
         fields: {},
         preFormContent: html,
-        confirm: true,
-        confirmMessage: '{% trans "Confirm stock allocation" %}',
         title: '{% trans "Allocate Stock Items to Build Order" %}',
         afterRender: function(fields, options) {
 

--- a/InvenTree/templates/js/translated/helpers.js
+++ b/InvenTree/templates/js/translated/helpers.js
@@ -163,27 +163,29 @@ function makeProgressBar(value, maximum, opts={}) {
 
     var style = options.style || '';
 
-    var text = '';
+    var text = options.text;
+    
+    if (!text) {
+        if (style == 'percent') {
+            // Display e.g. "50%"
 
-    if (style == 'percent') {
-        // Display e.g. "50%"
+            text = `${percent}%`;
+        } else if (style == 'max') {
+            // Display just the maximum value
+            text = `${maximum}`;
+        } else if (style == 'value') {
+            // Display just the current value
+            text = `${value}`;
+        } else if (style == 'blank') {
+            // No display!
+            text = '';
+        } else {
+            /* Default style
+            * Display e.g. "5 / 10"
+            */
 
-        text = `${percent}%`;
-    } else if (style == 'max') {
-        // Display just the maximum value
-        text = `${maximum}`;
-    } else if (style == 'value') {
-        // Display just the current value
-        text = `${value}`;
-    } else if (style == 'blank') {
-        // No display!
-        text = '';
-    } else {
-        /* Default style
-        * Display e.g. "5 / 10"
-        */
-
-        text = `${value} / ${maximum}`;
+            text = `${value} / ${maximum}`;
+        }
     }
 
     var id = options.id || 'progress-bar';

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -113,8 +113,6 @@ function renderStockItem(name, data, parameters={}, options={}) {
         }
     }
 
-
-
     var html = `
     <span>
         ${part_detail}
@@ -146,7 +144,7 @@ function renderStockLocation(name, data, parameters={}, options={}) {
         html += ` - <i>${data.description}</i>`;
     }
 
-    html += `<span class='float-right'><small>{% trans "Location ID" %}: ${data.pk}</small></span>`;
+    html += renderId('{% trans "Location ID" %}', data.pk, parameters);
 
     return html;
 }
@@ -162,10 +160,9 @@ function renderBuild(name, data, parameters={}, options={}) {
 
     var html = select2Thumbnail(image);
 
-    html += `<span><b>${data.reference}</b></span> - ${data.quantity} x ${data.part_detail.full_name}`;
-    html += `<span class='float-right'><small>{% trans "Build ID" %}: ${data.pk}</span></span>`;
+    html += `<span><b>${data.reference}</b> - ${data.quantity} x ${data.part_detail.full_name}</span>`;
 
-    html += `<p><i>${data.title}</i></p>`;
+    html += renderId('{% trans "Build ID" %}', data.pk, parameters);
 
     return html;
 }
@@ -300,12 +297,9 @@ function renderSalesOrderShipment(name, data, parameters={}, options={}) {
 
     var so_prefix = global_settings.SALESORDER_REFERENCE_PREFIX;
 
-    var html = `
-    <span>${so_prefix}${data.order_detail.reference} - {% trans "Shipment" %} ${data.reference}</span>
-    <span class='float-right'>
-        <small>{% trans "Shipment ID" %}: ${data.pk}</small>
-    </span>
-    `;
+    var html = `<span>${so_prefix}${data.order_detail.reference} - {% trans "Shipment" %} ${data.reference}</span>`;
+
+    html += renderId('{% trans "Shipment ID" %}', data.pk, parameters);
 
     return html;
 }
@@ -323,7 +317,7 @@ function renderPartCategory(name, data, parameters={}, options={}) {
         html += ` - <i>${data.description}</i>`;
     }
 
-    html += `<span class='float-right'><small>{% trans "Category ID" %}: ${data.pk}</small></span>`;
+    html += renderId('{% trans "Category ID" %}', data.pk, parameters);
 
     return html;
 }
@@ -366,7 +360,7 @@ function renderManufacturerPart(name, data, parameters={}, options={}) {
     html += ` <span><b>${data.manufacturer_detail.name}</b> - ${data.MPN}</span>`;
     html += ` - <i>${data.part_detail.full_name}</i>`;
 
-    html += `<span class='float-right'><small>{% trans "Manufacturer Part ID" %}: ${data.pk}</small></span>`;
+    html += renderId('{% trans "Manufacturer Part ID" %}', data.pk, parameters);
 
     return html;
 }
@@ -395,9 +389,7 @@ function renderSupplierPart(name, data, parameters={}, options={}) {
     html += ` <span><b>${data.supplier_detail.name}</b> - ${data.SKU}</span>`;
     html += ` - <i>${data.part_detail.full_name}</i>`;
 
-    html += `<span class='float-right'><small>{% trans "Supplier Part ID" %}: ${data.pk}</small></span>`;
-
+    html += renderId('{% trans "Supplier Part ID" %}', data.pk, parameters);
 
     return html;
-
 }


### PR DESCRIPTION
Significant overhaul of the "build output" screen:

- Displays "completed tests" for each build output
- Major speed improvement by optimizing API queries
- Table is more "responsive" (does not reload the entire table on every action)

**Example Page Load Speed Improvement**

- Old method: Approx. 6 seconds
- New method: Approx. 3 seconds

*(Using the same dataset)*

**Screenshot**

![image](https://user-images.githubusercontent.com/10080325/165790220-f089000a-d78d-434b-a159-8e8af9d01585.png)

**Future Improvements**

The API queries should still be optimized here, there are probably some other improvements that could be made to improve page load speed.


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2893"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

