### PR TITLE
Use the tablename when generating automatic model events

### DIFF
--- a/InvenTree/plugin/events.py
+++ b/InvenTree/plugin/events.py
@@ -163,17 +163,15 @@ def after_save(sender, instance, created, **kwargs):
 
     if created:
         trigger_event(
-            'instance.created',
+            f'{table}.created',
             id=instance.id,
             model=sender.__name__,
-            table=table,
         )
     else:
         trigger_event(
-            'instance.saved',
+            f'{table}.saved',
             id=instance.id,
             model=sender.__name__,
-            table=table,
         )
 
 
@@ -189,9 +187,8 @@ def after_delete(sender, instance, **kwargs):
         return
 
     trigger_event(
-        'instance.deleted',
+        f'{table}.deleted',
         model=sender.__name__,
-        table=table,
     )
 
 


### PR DESCRIPTION
Currently when a model instance is created / updated / deleted, an "instance.created" / "instance.saved" / "instance.deleted" event is triggered, which can be captured by a plugin and processed.

This PR changes this behaviour to use the name of the table as the event name, for better filtering by plugins.

e.g. creating a new stock item will generate a `stock_stockitem.created` event

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2926"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

