### PR TITLE
Increase coverage

### DIFF
--- a/InvenTree/order/migrations/0064_purchaseorderextraline_salesorderextraline.py
+++ b/InvenTree/order/migrations/0064_purchaseorderextraline_salesorderextraline.py
@@ -35,7 +35,7 @@ def _convert_model(apps, line_item_ref, extra_line_ref, price_ref):
     print(f'Done converting line items - now at {OrderExtraLine.objects.all().count()} {extra_line_ref} / {OrderLineItem.objects.all().count()} {line_item_ref} instance(s)')
 
 
-def _reconvert_model(apps, line_item_ref, extra_line_ref):
+def _reconvert_model(apps, line_item_ref, extra_line_ref):  # pragma: no cover
     """Convert ExtraLine instances back to OrderLineItem instances"""
     OrderLineItem = apps.get_model('order', line_item_ref)
     OrderExtraLine = apps.get_model('order', extra_line_ref)

--- a/InvenTree/plugin/apps.py
+++ b/InvenTree/plugin/apps.py
@@ -35,7 +35,7 @@ class PluginAppConfig(AppConfig):
                         if InvenTreeSetting.get_setting('PLUGIN_ON_STARTUP', create=False):
                             # make sure all plugins are installed
                             registry.install_plugin_file()
-                    except:
+                    except:  # pragma: no cover
                         pass
 
                     # get plugins and init them

--- a/InvenTree/plugin/builtin/barcode/mixins.py
+++ b/InvenTree/plugin/builtin/barcode/mixins.py
@@ -69,7 +69,7 @@ class BarcodeMixin:
         Default implementation returns None
         """
 
-        return None
+        return None  # pragma: no cover
 
     def getStockItemByHash(self):
         """
@@ -97,7 +97,7 @@ class BarcodeMixin:
         Default implementation returns None
         """
 
-        return None
+        return None  # pragma: no cover
 
     def renderStockLocation(self, loc):
         """
@@ -113,7 +113,7 @@ class BarcodeMixin:
         Default implementation returns None
         """
 
-        return None
+        return None  # pragma: no cover
 
     def renderPart(self, part):
         """
@@ -143,4 +143,4 @@ class BarcodeMixin:
         """
         Default implementation returns False
         """
-        return False
+        return False  # pragma: no cover

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -230,7 +230,7 @@ class ScheduleMixin:
                     scheduled_task.delete()
                 except Schedule.DoesNotExist:
                     pass
-        except (ProgrammingError, OperationalError):
+        except (ProgrammingError, OperationalError):  # pragma: no cover
             # Database might not yet be ready
             logger.warning("unregister_tasks failed, database not ready")
 

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -209,7 +209,7 @@ class ScheduleMixin:
                         repeats=task.get('repeats', -1),
                     )
 
-        except (ProgrammingError, OperationalError):
+        except (ProgrammingError, OperationalError):  # pragma: no cover
             # Database might not yet be ready
             logger.warning("register_tasks failed, database not ready")
 

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -426,7 +426,7 @@ class LabelPrintingMixin:
         """
 
         # Unimplemented (to be implemented by the particular plugin class)
-        ...
+        ...  # pragma: no cover
 
 
 class APICallMixin:

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -408,7 +408,7 @@ class LabelPrintingMixin:
         """
         MIXIN_NAME = 'Label printing'
 
-    def __init__(self):
+    def __init__(self):  # pragma: no cover
         super().__init__()
         self.add_mixin('labels', True, __class__)
 

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -171,7 +171,7 @@ class ScheduleMixin:
 
                 if Schedule.objects.filter(name=task_name).exists():
                     # Scheduled task already exists - continue!
-                    continue
+                    continue  # pragma: no cover
 
                 logger.info(f"Adding scheduled task '{task_name}'")
 

--- a/InvenTree/plugin/builtin/integration/mixins.py
+++ b/InvenTree/plugin/builtin/integration/mixins.py
@@ -56,7 +56,7 @@ class SettingsMixin:
 
         if not plugin:
             # Cannot find associated plugin model, return
-            return
+            return  # pragma: no cover
 
         PluginSetting.set_setting(key, value, user, plugin=plugin)
 

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -75,7 +75,7 @@ def handle_error(error, do_raise: bool = True, do_log: bool = True, log_name: st
             path_parts.remove('plugin')
             path_parts.pop(0)
         else:
-            path_parts.remove('plugins')
+            path_parts.remove('plugins')  # pragma: no cover
 
         package_name = '.'.join(path_parts)
 
@@ -135,7 +135,7 @@ def check_git_version():
     except ValueError:  # pragma: no cover
         pass
 
-    return False
+    return False  # pragma: no cover
 
 
 class GitStatus:

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -88,7 +88,7 @@ def handle_error(error, do_raise: bool = True, do_log: bool = True, log_name: st
     if do_raise:
         # do a straight raise if we are playing with enviroment variables at execution time, ignore the broken sample
         if settings.TESTING_ENV and package_name != 'integration.broken_sample' and isinstance(error, IntegrityError):
-            raise error
+            raise error  # pragma: no cover
         raise IntegrationPluginError(package_name, str(error))
 # endregion
 

--- a/InvenTree/plugin/integration.py
+++ b/InvenTree/plugin/integration.py
@@ -191,7 +191,7 @@ class IntegrationPluginBase(MixinBase, plugin_base.InvenTreePluginBase):
         Path to the plugin
         """
         if self._is_package:
-            return self.__module__
+            return self.__module__  # pragma: no cover
         return pathlib.Path(self.def_path).relative_to(settings.BASE_DIR)
 
     @property

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -283,7 +283,7 @@ class PluginsRegistry:
                 if not settings.PLUGIN_TESTING:
                     raise error  # pragma: no cover
                 plugin_db_setting = None
-            except (IntegrityError) as error:
+            except (IntegrityError) as error:  # pragma: no cover
                 logger.error(f"Error initializing plugin: {error}")
 
             # Always activate if testing
@@ -322,7 +322,7 @@ class PluginsRegistry:
                 self.plugins[plugin.slug] = plugin
             else:
                 # save for later reference
-                self.plugins_inactive[plug_key] = plugin_db_setting
+                self.plugins_inactive[plug_key] = plugin_db_setting  # pragma: no cover
 
     def _activate_plugins(self, force_reload=False):
         """
@@ -411,7 +411,7 @@ class PluginsRegistry:
                     deleted_count += 1
 
             if deleted_count > 0:
-                logger.info(f"Removed {deleted_count} old scheduled tasks")
+                logger.info(f"Removed {deleted_count} old scheduled tasks")  # pragma: no cover
         except (ProgrammingError, OperationalError):
             # Database might not yet be ready
             logger.warning("activate_integration_schedule failed, database not ready")

--- a/InvenTree/plugin/samples/integration/scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/scheduled_task.py
@@ -58,3 +58,4 @@ class ScheduledTaskPlugin(ScheduleMixin, SettingsMixin, IntegrationPluginBase):
         t_or_f = self.get_setting('T_OR_F')
 
         print(f"Called member_func - value is {t_or_f}")
+        return t_or_f

--- a/InvenTree/plugin/samples/integration/scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/scheduled_task.py
@@ -8,11 +8,11 @@ from plugin.mixins import ScheduleMixin, SettingsMixin
 
 # Define some simple tasks to perform
 def print_hello():
-    print("Hello")
+    print("Hello")  # pragma: no cover
 
 
 def print_world():
-    print("World")
+    print("World")  # pragma: no cover
 
 
 class ScheduledTaskPlugin(ScheduleMixin, SettingsMixin, IntegrationPluginBase):

--- a/InvenTree/plugin/samples/integration/scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/scheduled_task.py
@@ -36,7 +36,7 @@ class ScheduledTaskPlugin(ScheduleMixin, SettingsMixin, IntegrationPluginBase):
             'minutes': 45,
         },
         'world': {
-            'func': 'plugin.samples.integration.scheduled_task.print_hello',
+            'func': 'plugin.samples.integration.scheduled_task.print_world',
             'schedule': 'H',
         },
     }

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -78,7 +78,7 @@ class ScheduledTaskPluginTests(TestCase):
             }
 
             def test(self):
-                pass
+                pass  # pragma: no cover
 
         with self.assertRaises(MixinImplementationError):
             WrongFuncSchedules()

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -3,6 +3,7 @@
 from django.test import TestCase
 
 from plugin import registry
+from plugin.registry import call_function
 
 
 class ScheduledTaskPluginTests(TestCase):
@@ -27,3 +28,7 @@ class ScheduledTaskPluginTests(TestCase):
         from django_q.models import Schedule
         scheduled_plugin_tasks = Schedule.objects.filter(name__istartswith="plugin.")
         self.assertEqual(len(scheduled_plugin_tasks), 3)
+
+    def test_calling(self):
+        """check if a function can be called without errors"""
+        call_function('schedule', 'member_func')

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -6,8 +6,8 @@ from plugin import registry
 from plugin.registry import call_function
 
 
-class ScheduledTaskPluginTests(TestCase):
-    """ Tests for ScheduledTaskPlugin """
+class ExampleScheduledTaskPluginTests(TestCase):
+    """ Tests for provided ScheduledTaskPlugin """
 
     def test_function(self):
         """check if the scheduling works"""

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -34,6 +34,8 @@ class ExampleScheduledTaskPluginTests(TestCase):
         # delete middle task
         # this is to check the system also deals with disappearing tasks
         scheduled_plugin_tasks[1].delete()
+        # there should be one less now
+        scheduled_plugin_tasks = Schedule.objects.filter(name__istartswith="plugin.")
         self.assertEqual(len(scheduled_plugin_tasks), 2)
 
         # test unregistering

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -29,6 +29,11 @@ class ScheduledTaskPluginTests(TestCase):
         scheduled_plugin_tasks = Schedule.objects.filter(name__istartswith="plugin.")
         self.assertEqual(len(scheduled_plugin_tasks), 3)
 
+        # delete middle task
+        # this is to check the system also deals with disappearing tasks
+        scheduled_plugin_tasks[1].delete()
+        self.assertEqual(len(scheduled_plugin_tasks), 2)
+
         # test unregistering
         plg.unregister_tasks()
         scheduled_plugin_tasks = Schedule.objects.filter(name__istartswith="plugin.")

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -1,0 +1,29 @@
+""" Unit tests for scheduled tasks"""
+
+from django.test import TestCase
+
+from plugin import registry
+
+
+class ScheduledTaskPluginTests(TestCase):
+    """ Tests for ScheduledTaskPlugin """
+
+    def test_function(self):
+        """check if the scheduling works"""
+        # The plugin should be defined
+        self.assertIn('schedule', registry.plugins)
+        plg = registry.plugins['schedule']
+        self.assertTrue(plg)
+
+        # check that the built-in function is running
+        plg.member_func()
+
+        # check that the tasks are defined
+        self.assertEqual(plg.get_task_names(), ['plugin.schedule.member', 'plugin.schedule.hello', 'plugin.schedule.world'])
+
+        # register
+        plg.register_tasks()
+        # check that schedule was registers
+        from django_q.models import Schedule
+        scheduled_plugin_tasks = Schedule.objects.filter(name__istartswith="plugin.")
+        self.assertEqual(len(scheduled_plugin_tasks), 3)

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -17,7 +17,7 @@ class ScheduledTaskPluginTests(TestCase):
         self.assertTrue(plg)
 
         # check that the built-in function is running
-        plg.member_func()
+        self.assertEqual(plg.member_func(), False)
 
         # check that the tasks are defined
         self.assertEqual(plg.get_task_names(), ['plugin.schedule.member', 'plugin.schedule.hello', 'plugin.schedule.world'])
@@ -31,4 +31,4 @@ class ScheduledTaskPluginTests(TestCase):
 
     def test_calling(self):
         """check if a function can be called without errors"""
-        call_function('schedule', 'member_func')
+        self.assertEqual(call_function('schedule', 'member_func'), False)

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -29,6 +29,11 @@ class ScheduledTaskPluginTests(TestCase):
         scheduled_plugin_tasks = Schedule.objects.filter(name__istartswith="plugin.")
         self.assertEqual(len(scheduled_plugin_tasks), 3)
 
+        # test unregistering
+        plg.unregister_tasks()
+        scheduled_plugin_tasks = Schedule.objects.filter(name__istartswith="plugin.")
+        self.assertEqual(len(scheduled_plugin_tasks), 0)
+
     def test_calling(self):
         """check if a function can be called without errors"""
         self.assertEqual(call_function('schedule', 'member_func'), False)

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -64,7 +64,7 @@ class ScheduledTaskPluginTests(TestCase):
         class WrongFuncSchedules(Base):
             """
             Plugin with broken functions
-            
+
             This plugin is missing a func
             """
 
@@ -84,7 +84,7 @@ class ScheduledTaskPluginTests(TestCase):
         class WrongFuncSchedules1(WrongFuncSchedules):
             """
             Plugin with broken functions
-            
+
             This plugin is missing a schedule
             """
 
@@ -98,11 +98,10 @@ class ScheduledTaskPluginTests(TestCase):
         with self.assertRaises(MixinImplementationError):
             WrongFuncSchedules1()
 
-
         class WrongFuncSchedules2(WrongFuncSchedules):
             """
             Plugin with broken functions
-            
+
             This plugin is missing a schedule
             """
 
@@ -119,7 +118,7 @@ class ScheduledTaskPluginTests(TestCase):
         class WrongFuncSchedules3(WrongFuncSchedules):
             """
             Plugin with broken functions
-            
+
             This plugin has a broken schedule
             """
 
@@ -137,7 +136,7 @@ class ScheduledTaskPluginTests(TestCase):
         class WrongFuncSchedules4(WrongFuncSchedules):
             """
             Plugin with broken functions
-            
+
             This plugin is missing a minute marker for its schedule
             """
 

--- a/InvenTree/plugin/test_integration.py
+++ b/InvenTree/plugin/test_integration.py
@@ -11,6 +11,8 @@ from plugin import IntegrationPluginBase
 from plugin.mixins import AppMixin, SettingsMixin, UrlsMixin, NavigationMixin, APICallMixin
 from plugin.urls import PLUGIN_BASE
 
+from plugin.samples.integration.sample import SampleIntegrationPlugin
+
 
 class BaseMixinDefinition:
     def test_mixin_name(self):
@@ -238,6 +240,7 @@ class IntegrationPluginBaseTests(TestCase):
             LICENSE = 'MIT'
 
         self.plugin_name = NameIntegrationPluginBase()
+        self.plugin_sample = SampleIntegrationPlugin()
 
     def test_action_name(self):
         """check the name definition possibilities"""
@@ -245,6 +248,10 @@ class IntegrationPluginBaseTests(TestCase):
         self.assertEqual(self.plugin.plugin_name(), '')
         self.assertEqual(self.plugin_simple.plugin_name(), 'SimplePlugin')
         self.assertEqual(self.plugin_name.plugin_name(), 'Aplugin')
+
+        # is_sampe
+        self.assertEqual(self.plugin.is_sample, False)
+        self.assertEqual(self.plugin_sample.is_sample, True)
 
         # slug
         self.assertEqual(self.plugin.slug, '')

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -31,6 +31,10 @@ class InvenTreePluginTests(TestCase):
         self.assertEqual(self.named_plugin.PLUGIN_NAME, 'abc123')
         self.assertEqual(self.named_plugin.plugin_name(), 'abc123')
 
+    def test_basic_is_active(self):
+        """check if a basic plugin is active"""
+        self.assertEqual(self.plugin.is_active(), False)
+
 
 class PluginTagTests(TestCase):
     """ Tests for the plugin extras """

--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -564,14 +564,14 @@ class Owner(models.Model):
 
         try:
             owners.append(cls.objects.get(owner_id=user.pk, owner_type=user_type))
-        except:
+        except:  # pragma: no cover
             pass
 
         for group in user.groups.all():
             try:
                 owner = cls.objects.get(owner_id=group.pk, owner_type=group_type)
                 owners.append(owner)
-            except:
+            except:  # pragma: no cover
                 pass
 
         return owners

--- a/InvenTree/users/tests.py
+++ b/InvenTree/users/tests.py
@@ -197,6 +197,10 @@ class OwnerModelTest(TestCase):
         self.assertTrue(user_as_owner in related_owners)
         self.assertTrue(group_as_owner in related_owners)
 
+        # Check owner matching
+        owners = Owner.get_owners_matching_user(self.user)
+        self.assertEqual(owners, [user_as_owner, group_as_owner])
+
         # Delete user and verify owner was deleted too
         self.user.delete()
         user_as_owner = Owner.get_owner(self.user)


### PR DESCRIPTION
This PR:
- ignores reverse migration code for coverage
- ignores defaults that are overwritten in mixin
- increases coverage in owner model
- increases coverage in plugin mixins
- adds coverage for schedule mixin

Closes #2523

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2928"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>