### PR TITLE
Fix permissions for global settings API

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -4,10 +4,14 @@ InvenTree API version information
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 45
+INVENTREE_API_VERSION = 46
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v46 -> 2022-05-09
+    - Fixes read permissions on settings API
+    - Allows non-staff users to read global settings via the API
 
 v45 -> 2022-05-08 : https://github.com/inventree/InvenTree/pull/2944
     - Settings are now accessed via the API using their unique key, not their PK

--- a/InvenTree/common/api.py
+++ b/InvenTree/common/api.py
@@ -146,7 +146,12 @@ class GlobalSettingsPermissions(permissions.BasePermission):
         try:
             user = request.user
 
-            return user.is_staff
+            if request.method in ['GET', 'HEAD', 'OPTIONS']:
+                return True
+            else:
+                # Any other methods require staff access permissions
+                return user.is_staff
+
         except AttributeError:  # pragma: no cover
             return False
 
@@ -175,6 +180,7 @@ class GlobalSettingsDetail(generics.RetrieveUpdateAPIView):
         return common.models.InvenTreeSetting.get_setting_object(key)
 
     permission_classes = [
+        permissions.IsAuthenticated,
         GlobalSettingsPermissions,
     ]
 


### PR DESCRIPTION
Allows read-only access of the GlobalSettings detail API endpoint