### PR TITLE
Mark inventree home directory as safe for git.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,6 +95,9 @@ RUN echo "Downloading InvenTree from ${INVENTREE_GIT_REPO}"
 
 RUN git clone --branch ${INVENTREE_GIT_BRANCH} --depth 1 ${INVENTREE_GIT_REPO} ${INVENTREE_HOME}
 
+# Ref: https://github.blog/2022-04-12-git-security-vulnerability-announced/
+RUN git config --global --add safe.directory ${INVENTREE_HOME}
+
 # Checkout against a particular git tag
 RUN if [ -n "${INVENTREE_GIT_TAG}" ] ; then cd ${INVENTREE_HOME} && git fetch --all --tags && git checkout tags/${INVENTREE_GIT_TAG} -b v${INVENTREE_GIT_TAG}-branch ; fi
 


### PR DESCRIPTION
Ref: https://github.blog/2022-04-12-git-security-vulnerability-announced/

Discovered as recent release build failed, git version in docker image had been updated!

https://github.com/inventree/InvenTree/runs/6370417523?check_suite_focus=true