### PR TITLE
postgresql and mysql checks only run on push

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -196,6 +196,7 @@ jobs:
     name: Postgres
     needs: ['javascript', 'html']
     runs-on: ubuntu-latest
+    on: github.event_name == 'push'
 
     env:
       INVENTREE_DB_ENGINE: django.db.backends.postgresql
@@ -253,6 +254,8 @@ jobs:
     name: MySql
     needs: ['javascript', 'html']
     runs-on: ubuntu-latest
+    on: github.event_name == 'push'
+
     env:
       # Database backend configuration
       INVENTREE_DB_ENGINE: django.db.backends.mysql

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -196,7 +196,7 @@ jobs:
     name: Postgres
     needs: ['javascript', 'html']
     runs-on: ubuntu-latest
-    on: github.event_name == 'push'
+    if: github.event_name == 'push'
 
     env:
       INVENTREE_DB_ENGINE: django.db.backends.postgresql
@@ -254,7 +254,7 @@ jobs:
     name: MySql
     needs: ['javascript', 'html']
     runs-on: ubuntu-latest
-    on: github.event_name == 'push'
+    if: github.event_name == 'push'
 
     env:
       # Database backend configuration


### PR DESCRIPTION
- sqlite and coverage still runs on pull_request
- should speed up CI checks / reduce redundant CI server load

Ref: https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/6