### PR TITLE
Do not redirect requests for media / static / api / js files

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -157,7 +157,7 @@ jobs:
         run: |
           cd ${{ env.wrapper_name }}
           invoke check-server
-          coverage run -m unittest -s test/
+          coverage run -m unittest discover -s test/
 
   coverage:
     name: Sqlite / coverage

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -124,6 +124,16 @@ jobs:
 
     env:
       wrapper_name: inventree-python
+      INVENTREE_DB_ENGINE: django.db.backends.sqlite3
+      INVENTREE_DB_NAME: ../inventree_unit_test_db.sqlite3
+      INVENTREE_MEDIA_ROOT: ../test_inventree_media
+      INVENTREE_STATIC_ROOT: ../test_inventree_static
+      INVENTREE_ADMIN_USER: testuser
+      INVENTREE_ADMIN_PASSWORD: testpassword
+      INVENTREE_ADMIN_EMAIL: test@test.com
+      INVENTREE_PYTHON_TEST_SERVER: http://localhost:12345
+      INVENTREE_PYTHON_TEST_USERNAME: testuser
+      INVENTREE_PYTHON_TEST_PASSWORD: testpassword
 
     steps:
       - name: Checkout Code
@@ -140,13 +150,14 @@ jobs:
           git clone --depth 1 https://github.com/inventree/${{ env.wrapper_name }} ./${{ env.wrapper_name }}
       - name: Start Server
         run: |
-          invoke import-records -f ./${{ env.wrapper_name }}/test/test_data.json
-          invoke server -a 127.0.0.1:8000 &
-          sleep ${{ env.server_start_sleep }}
+          invoke delete-data -f
+          invoke import-fixtures
+          invoke server -a 127.0.0.1:12345 &
       - name: Run Tests
         run: |
           cd ${{ env.wrapper_name }}
-          invoke test
+          invoke check-server
+          coverage run -m unittest -s test/
 
   coverage:
     name: Sqlite / coverage

--- a/InvenTree/InvenTree/middleware.py
+++ b/InvenTree/InvenTree/middleware.py
@@ -1,9 +1,12 @@
-from django.shortcuts import HttpResponseRedirect
-from django.urls import reverse_lazy, Resolver404
-from django.shortcuts import redirect
-from django.urls import include, re_path
+# -*- coding: utf-8 -*-
+
 from django.conf import settings
 from django.contrib.auth.middleware import PersistentRemoteUserMiddleware
+from django.http import HttpResponse
+from django.shortcuts import HttpResponseRedirect
+from django.shortcuts import redirect
+from django.urls import reverse_lazy, Resolver404
+from django.urls import include, re_path
 
 import logging
 
@@ -82,10 +85,22 @@ class AuthRequiredMiddleware(object):
                     reverse_lazy('admin:logout'),
                 ]
 
-                if path not in urls and not path.startswith('/api/'):
+                # Do not redirect requests to any of these paths
+                paths_ignore = [
+                    '/api/',
+                    '/js/',
+                    '/media/',
+                    '/static/',
+                ]
+
+                if path not in urls and not any([path.startswith(p) for p in paths_ignore]):
                     # Save the 'next' parameter to pass through to the login view
 
                     return redirect('{}?next={}'.format(reverse_lazy('account_login'), request.path))
+
+                else:
+                    # Return a 401 (Unauthorized) response code for this request
+                    return HttpResponse('Unauthorized', status=401)
 
         response = self.get_response(request)
 


### PR DESCRIPTION
- For these paths, just return a 401
- This is necessary to stop unauthorized calls to the API or to request media files from redirecting to the login page

Recent testing for the inventree python bindings revealed some shortcomings, in particular trying to download a file (when no authenticated) returned a 200 status and redirected to the login page.

A redirect should only happen for web views which are being loaded by an actual user.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2976"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

