### PR TITLE
Adding "download" buttons for more tables

### DIFF
--- a/InvenTree/InvenTree/api.py
+++ b/InvenTree/InvenTree/api.py
@@ -61,6 +61,44 @@ class NotFoundView(AjaxView):
         return JsonResponse(data, status=404)
 
 
+class APIDownloadMixin:
+    """
+    Mixin for enabling a LIST endpoint to be downloaded a file.
+
+    To download the data, add the ?export=<fmt> to the query string.
+
+    The implementing class must provided a download_queryset method,
+    e.g.
+
+    def download_queryset(self, queryset, export_format):
+        dataset = StockItemResource().export(queryset=queryset)
+
+        filedata = dataset.export(export_format)
+
+        filename = 'InvenTree_Stocktake_{date}.{fmt}'.format(
+            date=datetime.now().strftime("%d-%b-%Y"),
+            fmt=export_format
+        )
+
+        return DownloadFile(filedata, filename)
+    """
+
+    def get(self, request, *args, **kwargs):
+
+        export_format = request.query_params.get('export', None)
+
+        if export_format:
+            queryset = self.filter_queryset(self.get_queryset())
+            return self.download_queryset(queryset, export_format)
+
+        else:
+            # Default to the parent class implementation
+            return super().get(request, *args, **kwargs)
+
+    def download_queryset(self, queryset, export_format):
+        raise NotImplementedError("download_queryset method not implemented!")
+
+
 class AttachmentMixin:
     """
     Mixin for creating attachment objects,

--- a/InvenTree/InvenTree/api.py
+++ b/InvenTree/InvenTree/api.py
@@ -87,7 +87,7 @@ class APIDownloadMixin:
 
         export_format = request.query_params.get('export', None)
 
-        if export_format:
+        if export_format and export_format in ['csv', 'tsv', 'xls', 'xlsx']:
             queryset = self.filter_queryset(self.get_queryset())
             return self.download_queryset(queryset, export_format)
 

--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -4,10 +4,15 @@ InvenTree API version information
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 47
+INVENTREE_API_VERSION = 48
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v48 -> 2022-05-12 : https://github.com/inventree/InvenTree/pull/2977
+    - Adds "export to file" functionality for PurchaseOrder API endpoint
+    - Adds "export to file" functionality for SalesOrder API endpoint
+    - Adds "export to file" functionality for BuildOrder API endpoint
 
 v47 -> 2022-05-10 : https://github.com/inventree/InvenTree/pull/2964
     - Fixes barcode API error response when scanning a StockItem which does not exist

--- a/InvenTree/build/admin.py
+++ b/InvenTree/build/admin.py
@@ -16,7 +16,7 @@ import part.models
 class BuildResource(ModelResource):
     """Class for managing import/export of Build data"""
     # For some reason, we need to specify the fields individually for this ModelResource,
-    # but we don't for other ones. 
+    # but we don't for other ones.
     # TODO: 2022-05-12 - Need to investigate why this is the case!
 
     pk = Field(attribute='pk')
@@ -49,7 +49,6 @@ class BuildResource(ModelResource):
         exclude = [
             'lft', 'rght', 'tree_id', 'level',
         ]
-
 
 
 class BuildAdmin(ImportExportModelAdmin):

--- a/InvenTree/build/admin.py
+++ b/InvenTree/build/admin.py
@@ -2,9 +2,54 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
-from import_export.admin import ImportExportModelAdmin
 
-from .models import Build, BuildItem
+from import_export.admin import ImportExportModelAdmin
+from import_export.fields import Field
+from import_export.resources import ModelResource
+import import_export.widgets as widgets
+
+from build.models import Build, BuildItem
+
+import part.models
+
+
+class BuildResource(ModelResource):
+    """Class for managing import/export of Build data"""
+    # For some reason, we need to specify the fields individually for this ModelResource,
+    # but we don't for other ones. 
+    # TODO: 2022-05-12 - Need to investigate why this is the case!
+
+    pk = Field(attribute='pk')
+
+    reference = Field(attribute='reference')
+
+    title = Field(attribute='title')
+
+    part = Field(attribute='part', widget=widgets.ForeignKeyWidget(part.models.Part))
+
+    part_name = Field(attribute='part__full_name', readonly=True)
+
+    overdue = Field(attribute='is_overdue', readonly=True, widget=widgets.BooleanWidget())
+
+    completed = Field(attribute='completed', readonly=True)
+
+    quantity = Field(attribute='quantity')
+
+    status = Field(attribute='status')
+
+    batch = Field(attribute='batch')
+
+    notes = Field(attribute='notes')
+
+    class Meta:
+        models = Build
+        skip_unchanged = True
+        report_skipped = False
+        clean_model_instances = True
+        exclude = [
+            'lft', 'rght', 'tree_id', 'level',
+        ]
+
 
 
 class BuildAdmin(ImportExportModelAdmin):

--- a/InvenTree/order/admin.py
+++ b/InvenTree/order/admin.py
@@ -135,6 +135,23 @@ class PurchaseOrderExtraLineResource(ModelResource):
         model = PurchaseOrderExtraLine
 
 
+class SalesOrderResource(ModelResource):
+    """
+    Class for managing import / export of SalesOrder data
+    """
+
+    # Add number of line items
+    line_items = Field(attribute='line_count', widget=widgets.IntegerWidget(), readonly=True)
+
+    # Is this order overdue?
+    overdue = Field(attribute='is_overdue', widget=widgets.BooleanWidget(), readonly=True)
+
+    class Meta:
+        model = SalesOrder
+        skip_unchanged = True
+        clean_model_instances = True
+
+
 class SalesOrderLineItemResource(ModelResource):
     """
     Class for managing import / export of SalesOrderLineItem data

--- a/InvenTree/order/admin.py
+++ b/InvenTree/order/admin.py
@@ -5,8 +5,9 @@ from django.contrib import admin
 
 from import_export.admin import ImportExportModelAdmin
 
-from import_export.resources import ModelResource
 from import_export.fields import Field
+from import_export.resources import ModelResource
+import import_export.widgets as widgets
 
 from .models import PurchaseOrder, PurchaseOrderLineItem, PurchaseOrderExtraLine
 from .models import SalesOrder, SalesOrderLineItem, SalesOrderExtraLine
@@ -90,6 +91,23 @@ class SalesOrderAdmin(ImportExportModelAdmin):
     ]
 
     autocomplete_fields = ('customer',)
+
+
+class PurchaseOrderResource(ModelResource):
+    """
+    Class for managing import / export of PurchaseOrder data
+    """
+
+    # Add number of line items
+    line_items = Field(attribute='line_count', widget=widgets.IntegerWidget(), readonly=True)
+
+    # Is this order overdue?
+    overdue = Field(attribute='is_overdue', widget=widgets.BooleanWidget(), readonly=True)
+
+    class Meta:
+        model = PurchaseOrder
+        skip_unchanged = True
+        clean_model_instances = True
 
 
 class PurchaseOrderLineItemResource(ModelResource):

--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -21,6 +21,7 @@ from InvenTree.api import AttachmentMixin, APIDownloadMixin
 from InvenTree.status_codes import PurchaseOrderStatus, SalesOrderStatus
 
 from order.admin import PurchaseOrderResource, PurchaseOrderLineItemResource
+from order.admin import SalesOrderResource
 import order.models as models
 import order.serializers as serializers
 from part.models import Part
@@ -583,7 +584,7 @@ class SalesOrderAttachmentDetail(generics.RetrieveUpdateDestroyAPIView, Attachme
     serializer_class = serializers.SalesOrderAttachmentSerializer
 
 
-class SalesOrderList(generics.ListCreateAPIView):
+class SalesOrderList(APIDownloadMixin, generics.ListCreateAPIView):
     """
     API endpoint for accessing a list of SalesOrder objects.
 
@@ -632,6 +633,15 @@ class SalesOrderList(generics.ListCreateAPIView):
         queryset = serializers.SalesOrderSerializer.annotate_queryset(queryset)
 
         return queryset
+
+    def download_queryset(self, queryset, export_format):
+        dataset = SalesOrderResource().export(queryset=queryset)
+
+        filedata = dataset.export(export_format)
+
+        filename = f"InvenTree_SalesOrders.{export_format}"
+
+        return DownloadFile(filedata, filename)
 
     def filter_queryset(self, queryset):
         """

--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -20,7 +20,7 @@ from InvenTree.helpers import str2bool, DownloadFile
 from InvenTree.api import AttachmentMixin, APIDownloadMixin
 from InvenTree.status_codes import PurchaseOrderStatus, SalesOrderStatus
 
-from order.admin import PurchaseOrderLineItemResource
+from order.admin import PurchaseOrderResource, PurchaseOrderLineItemResource
 import order.models as models
 import order.serializers as serializers
 from part.models import Part
@@ -110,7 +110,7 @@ class PurchaseOrderFilter(rest_filters.FilterSet):
         ]
 
 
-class PurchaseOrderList(generics.ListCreateAPIView):
+class PurchaseOrderList(APIDownloadMixin, generics.ListCreateAPIView):
     """ API endpoint for accessing a list of PurchaseOrder objects
 
     - GET: Return list of PurchaseOrder objects (with filters)
@@ -159,6 +159,15 @@ class PurchaseOrderList(generics.ListCreateAPIView):
         queryset = serializers.PurchaseOrderSerializer.annotate_queryset(queryset)
 
         return queryset
+
+    def download_queryset(self, queryset, export_format):
+        dataset = PurchaseOrderResource().export(queryset=queryset)
+
+        filedata = dataset.export(export_format)
+
+        filename = f"InvenTree_PurchaseOrders.{export_format}"
+
+        return DownloadFile(filedata, filename)
 
     def filter_queryset(self, queryset):
 

--- a/InvenTree/part/admin.py
+++ b/InvenTree/part/admin.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 from django.contrib import admin
 
 from import_export.admin import ImportExportModelAdmin
-from import_export.resources import ModelResource
 from import_export.fields import Field
+from import_export.resources import ModelResource
 import import_export.widgets as widgets
 
 from company.models import SupplierPart

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -901,7 +901,6 @@ class PartList(APIDownloadMixin, generics.ListCreateAPIView):
         dataset = PartResource().export(queryset=queryset)
 
         filedata = dataset.export(export_format)
-
         filename = f"InvenTree_Parts.{export_format}"
 
         return DownloadFile(filedata, filename)

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -2355,7 +2355,7 @@ function loadBuildTable(table, options) {
 
     var filterTarget = options.filterTarget || null;
 
-    setupFilterList('build', table, filterTarget);
+    setupFilterList('build', table, filterTarget, {download: true});
 
     $(table).inventreeTable({
         method: 'get',

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2093,7 +2093,9 @@ function loadSalesOrderTable(table, options) {
 
     options.url = options.url || '{% url "api-so-list" %}';
 
-    setupFilterList('salesorder', $(table));
+    var target = '#filter-list-salesorder';
+
+    setupFilterList('salesorder', $(table), target, {download: true});
 
     $(table).inventreeTable({
         url: options.url,

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -1394,7 +1394,9 @@ function loadPurchaseOrderTable(table, options) {
         filters[key] = options.params[key];
     }
 
-    setupFilterList('purchaseorder', $(table));
+    var target = '#filter-list-purchaseorder';
+
+    setupFilterList('purchaseorder', $(table), target, {download: true});
 
     $(table).inventreeTable({
         url: '{% url "api-po-list" %}',


### PR DESCRIPTION
This PR refactors the existing "download queryset" (which exists for a small number of tables) into a mixin class, allowing it to be implemented easily for a given API endpoint.

Also adds download buttons for:

- BuildOrder table
- PurchaseOrder table
- SalesOrder table

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2977"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

