### PR TITLE
Convert to variant fix

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2233,7 +2233,7 @@ class Part(MPTTModel):
         for child in children:
             parts.append(child)
 
-        # Immediate parent
+        # Immediate parent, and siblings
         if self.variant_of:
             parts.append(self.variant_of)
 

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -556,7 +556,14 @@ class StockItem(MPTTModel):
 
         # If the item points to a build, check that the Part references match
         if self.build:
-            if not self.part == self.build.part:
+
+            if self.part == self.build.part:
+                # Part references match exactly
+                pass
+            elif self.part in self.build.part.get_conversion_options():
+                # Part reference is one of the valid conversion options for the build output
+                pass
+            else:
                 raise ValidationError({
                     'build': _("Build reference does not point to the same part object")
                 })


### PR DESCRIPTION
- If the stock item had been created as part of a Build Order, and subsequently "converted" to a variant part, the conversion operation will fail
- Patch allows the build reference to be linked based on either the base part, or any conversion options