### PR TITLE
Add settings which reference *model instances* allowing better lookup of models

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -144,7 +144,7 @@ class BaseInvenTreeSetting(models.Model):
 
         This is necessary to abtract the settings object
         from the implementing class (e.g plugins)
-        
+
         Subclasses should override this function to ensure the kwargs are correctly set.
         """
 
@@ -601,7 +601,7 @@ class BaseInvenTreeSetting(models.Model):
 
         if not model_name:
             return None
-        
+
         try:
             (app, mdl) = model_name.strip().split('.')
         except ValueError:
@@ -637,7 +637,7 @@ class BaseInvenTreeSetting(models.Model):
                 return model_class.get_api_url()
             except:
                 pass
-        
+
         return None
 
     def is_bool(self):

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -136,6 +136,19 @@ class BaseInvenTreeSetting(models.Model):
 
         return settings
 
+    def get_kwargs(self):
+        """
+        Construct kwargs for doing class-based settings lookup,
+        depending on *which* class we are.
+
+        This is necessary to abtract the settings object
+        from the implementing class (e.g plugins)
+        
+        Subclasses should override this function to ensure the kwargs are correctly set.
+        """
+
+        return {}
+
     @classmethod
     def get_setting_definition(cls, key, **kwargs):
         """
@@ -319,11 +332,11 @@ class BaseInvenTreeSetting(models.Model):
             value = setting.value
 
             # Cast to boolean if necessary
-            if setting.is_bool(**kwargs):
+            if setting.is_bool():
                 value = InvenTree.helpers.str2bool(value)
 
             # Cast to integer if necessary
-            if setting.is_int(**kwargs):
+            if setting.is_int():
                 try:
                     value = int(value)
                 except (ValueError, TypeError):
@@ -390,19 +403,19 @@ class BaseInvenTreeSetting(models.Model):
 
     @property
     def name(self):
-        return self.__class__.get_setting_name(self.key)
+        return self.__class__.get_setting_name(self.key, **self.get_kwargs())
 
     @property
     def default_value(self):
-        return self.__class__.get_setting_default(self.key)
+        return self.__class__.get_setting_default(self.key, **self.get_kwargs())
 
     @property
     def description(self):
-        return self.__class__.get_setting_description(self.key)
+        return self.__class__.get_setting_description(self.key, **self.get_kwargs())
 
     @property
     def units(self):
-        return self.__class__.get_setting_units(self.key)
+        return self.__class__.get_setting_units(self.key, **self.get_kwargs())
 
     def clean(self, **kwargs):
         """
@@ -512,12 +525,12 @@ class BaseInvenTreeSetting(models.Model):
         except self.DoesNotExist:
             pass
 
-    def choices(self, **kwargs):
+    def choices(self):
         """
         Return the available choices for this setting (or None if no choices are defined)
         """
 
-        return self.__class__.get_setting_choices(self.key, **kwargs)
+        return self.__class__.get_setting_choices(self.key, **self.get_kwargs())
 
     def valid_options(self):
         """
@@ -531,14 +544,14 @@ class BaseInvenTreeSetting(models.Model):
 
         return [opt[0] for opt in choices]
 
-    def is_choice(self, **kwargs):
+    def is_choice(self):
         """
         Check if this setting is a "choice" field
         """
 
-        return self.__class__.get_setting_choices(self.key, **kwargs) is not None
+        return self.__class__.get_setting_choices(self.key, **self.get_kwargs()) is not None
 
-    def as_choice(self, **kwargs):
+    def as_choice(self):
         """
         Render this setting as the "display" value of a choice field,
         e.g. if the choices are:
@@ -547,7 +560,7 @@ class BaseInvenTreeSetting(models.Model):
         then display 'A4 paper'
         """
 
-        choices = self.get_setting_choices(self.key, **kwargs)
+        choices = self.get_setting_choices(self.key, **self.get_kwargs())
 
         if not choices:
             return self.value
@@ -558,12 +571,28 @@ class BaseInvenTreeSetting(models.Model):
 
         return self.value
 
-    def is_bool(self, **kwargs):
+    def is_model(self):
+        """
+        Check if this setting references a model instance in the database
+        """
+
+        return self.model_name() is not None
+
+    def model_name(self):
+        """
+        Return the model name associated with this setting
+        """
+
+        setting = self.get_setting_definition(self.key, **self.get_kwargs())
+
+        return setting.get('model', None)
+
+    def is_bool(self):
         """
         Check if this setting is required to be a boolean value
         """
 
-        validator = self.__class__.get_setting_validator(self.key, **kwargs)
+        validator = self.__class__.get_setting_validator(self.key, **self.get_kwargs())
 
         return self.__class__.validator_is_bool(validator)
 
@@ -576,16 +605,19 @@ class BaseInvenTreeSetting(models.Model):
 
         return InvenTree.helpers.str2bool(self.value)
 
-    def setting_type(self, **kwargs):
+    def setting_type(self):
         """
         Return the field type identifier for this setting object
         """
 
-        if self.is_bool(**kwargs):
+        if self.is_bool():
             return 'boolean'
 
-        elif self.is_int(**kwargs):
+        elif self.is_int():
             return 'integer'
+
+        elif self.is_model():
+            return 'model'
 
         else:
             return 'string'
@@ -603,12 +635,12 @@ class BaseInvenTreeSetting(models.Model):
 
         return False
 
-    def is_int(self, **kwargs):
+    def is_int(self,):
         """
         Check if the setting is required to be an integer value:
         """
 
-        validator = self.__class__.get_setting_validator(self.key, **kwargs)
+        validator = self.__class__.get_setting_validator(self.key, **self.get_kwargs())
 
         return self.__class__.validator_is_int(validator)
 
@@ -651,88 +683,7 @@ class BaseInvenTreeSetting(models.Model):
 
     @property
     def protected(self):
-        return self.__class__.is_protected(self.key)
-
-
-class GenericReferencedSettingClass:
-    """
-    This mixin can be used to add reference keys to static properties
-
-    Sample:
-    ```python
-    class SampleSetting(GenericReferencedSettingClass, common.models.BaseInvenTreeSetting):
-        class Meta:
-            unique_together = [
-                ('sample', 'key'),
-            ]
-
-        REFERENCE_NAME = 'sample'
-
-        @classmethod
-        def get_setting_definition(cls, key, **kwargs):
-            # mysampledict contains the dict with all settings for this SettingClass - this could also be a dynamic lookup
-
-            kwargs['settings'] = mysampledict
-            return super().get_setting_definition(key, **kwargs)
-
-        sample = models.charKey(  # the name for this field is the additonal key and must be set in the Meta class an REFERENCE_NAME
-            max_length=256,
-            verbose_name=_('sample')
-        )
-    ```
-    """
-
-    REFERENCE_NAME = None
-
-    def _get_reference(self):
-        """
-        Returns dict that can be used as an argument for kwargs calls.
-        Helps to make overriden calls generic for simple reuse.
-
-        Usage:
-        ```python
-        some_random_function(argument0, kwarg1=value1, **self._get_reference())
-        ```
-        """
-        return {
-            self.REFERENCE_NAME: getattr(self, self.REFERENCE_NAME)
-        }
-
-    """
-    We override the following class methods,
-    so that we can pass the modified key instance as an additional argument
-    """
-
-    def clean(self, **kwargs):
-
-        kwargs[self.REFERENCE_NAME] = getattr(self, self.REFERENCE_NAME)
-
-        super().clean(**kwargs)
-
-    def is_bool(self, **kwargs):
-
-        kwargs[self.REFERENCE_NAME] = getattr(self, self.REFERENCE_NAME)
-
-        return super().is_bool(**kwargs)
-
-    @property
-    def name(self):
-        return self.__class__.get_setting_name(self.key, **self._get_reference())
-
-    @property
-    def default_value(self):
-        return self.__class__.get_setting_default(self.key, **self._get_reference())
-
-    @property
-    def description(self):
-        return self.__class__.get_setting_description(self.key, **self._get_reference())
-
-    @property
-    def units(self):
-        return self.__class__.get_setting_units(self.key, **self._get_reference())
-
-    def choices(self):
-        return self.__class__.get_setting_choices(self.key, **self._get_reference())
+        return self.__class__.is_protected(self.key, **self.get_kwargs())
 
 
 def settings_group_options():
@@ -1557,6 +1508,16 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
         """
 
         return self.__class__.get_setting(self.key, user=self.user)
+
+    def get_kwargs(self):
+        """
+        Explicit kwargs required to uniquely identify a particular setting object,
+        in addition to the 'key' parameter
+        """
+
+        return {
+            'user': self.user,
+        }
 
 
 class PriceBreak(models.Model):

--- a/InvenTree/common/serializers.py
+++ b/InvenTree/common/serializers.py
@@ -28,6 +28,8 @@ class SettingsSerializer(InvenTreeModelSerializer):
 
     choices = serializers.SerializerMethodField()
 
+    model_name = serializers.CharField(read_only=True)
+
     def get_choices(self, obj):
         """
         Returns the choices available for a given item
@@ -75,6 +77,7 @@ class GlobalSettingsSerializer(SettingsSerializer):
             'description',
             'type',
             'choices',
+            'model_name',
         ]
 
 
@@ -96,6 +99,7 @@ class UserSettingsSerializer(SettingsSerializer):
             'user',
             'type',
             'choices',
+            'model_name',
         ]
 
 
@@ -124,6 +128,7 @@ class GenericReferencedSettingSerializer(SettingsSerializer):
                 'description',
                 'type',
                 'choices',
+                'model_name',
             ]
 
         # set Meta class

--- a/InvenTree/common/serializers.py
+++ b/InvenTree/common/serializers.py
@@ -30,6 +30,8 @@ class SettingsSerializer(InvenTreeModelSerializer):
 
     model_name = serializers.CharField(read_only=True)
 
+    api_url = serializers.CharField(read_only=True)
+
     def get_choices(self, obj):
         """
         Returns the choices available for a given item
@@ -78,6 +80,7 @@ class GlobalSettingsSerializer(SettingsSerializer):
             'type',
             'choices',
             'model_name',
+            'api_url',
         ]
 
 
@@ -100,6 +103,7 @@ class UserSettingsSerializer(SettingsSerializer):
             'type',
             'choices',
             'model_name',
+            'api_url',
         ]
 
 
@@ -129,6 +133,7 @@ class GenericReferencedSettingSerializer(SettingsSerializer):
                 'type',
                 'choices',
                 'model_name',
+                'api_url',
             ]
 
         # set Meta class

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -137,7 +137,7 @@ class PluginSetting(common.models.BaseInvenTreeSetting):
 
         if 'settings' not in kwargs:
 
-            plugin = kwargs.pop('plugin')
+            plugin = kwargs.pop('plugin', None)
 
             if plugin:
 

--- a/InvenTree/plugin/samples/integration/sample.py
+++ b/InvenTree/plugin/samples/integration/sample.py
@@ -65,6 +65,11 @@ class SampleIntegrationPlugin(AppMixin, SettingsMixin, UrlsMixin, NavigationMixi
             ],
             'default': 'A',
         },
+        'SELECT_COMPANY': {
+            'name': 'Company',
+            'description': 'Select a company object from the database',
+            'model': 'company.Company',
+        },
     }
 
     NAVIGATION = [

--- a/InvenTree/plugin/samples/integration/sample.py
+++ b/InvenTree/plugin/samples/integration/sample.py
@@ -68,7 +68,12 @@ class SampleIntegrationPlugin(AppMixin, SettingsMixin, UrlsMixin, NavigationMixi
         'SELECT_COMPANY': {
             'name': 'Company',
             'description': 'Select a company object from the database',
-            'model': 'company.Company',
+            'model': 'company.company',
+        },
+        'SELECT_PART': {
+            'name': 'Part',
+            'description': 'Select a part object from the database',
+            'model': 'part.part',
         },
     }
 

--- a/InvenTree/templates/InvenTree/settings/setting.html
+++ b/InvenTree/templates/InvenTree/settings/setting.html
@@ -22,6 +22,9 @@
         {{ setting.description }}
     </td>
     <td>
+        {% if setting.model_name %}
+        <b>Model name: {{ setting.model_name }}</b>
+        {% endif %}
         {% if setting.is_bool %}
         <div class='form-check form-switch'>
             <input class='form-check-input boolean-setting' fieldname='{{ setting.key.upper }}' pk='{{ setting.pk }}' setting='{{ setting.key.upper }}' id='setting-value-{{ setting.key.upper }}' type='checkbox' {% if setting.as_bool %}checked=''{% endif %} {% if plugin %}plugin='{{ plugin.slug }}'{% endif %}{% if user_setting %}user='{{request.user.id}}'{% endif %}{% if notification_setting %}notification='{{request.user.id}}'{% endif %}>

--- a/InvenTree/templates/InvenTree/settings/setting.html
+++ b/InvenTree/templates/InvenTree/settings/setting.html
@@ -22,9 +22,6 @@
         {{ setting.description }}
     </td>
     <td>
-        {% if setting.model_name %}
-        <b>Model name: {{ setting.model_name }}</b>
-        {% endif %}
         {% if setting.is_bool %}
         <div class='form-check form-switch'>
             <input class='form-check-input boolean-setting' fieldname='{{ setting.key.upper }}' pk='{{ setting.pk }}' setting='{{ setting.key.upper }}' id='setting-value-{{ setting.key.upper }}' type='checkbox' {% if setting.as_bool %}checked=''{% endif %} {% if plugin %}plugin='{{ plugin.slug }}'{% endif %}{% if user_setting %}user='{{request.user.id}}'{% endif %}{% if notification_setting %}notification='{{request.user.id}}'{% endif %}>

--- a/InvenTree/templates/js/dynamic/settings.js
+++ b/InvenTree/templates/js/dynamic/settings.js
@@ -71,8 +71,23 @@ function editSetting(key, options={}) {
                     help_text: response.description,
                     type: response.type,
                     choices: response.choices,
+                    value: response.value,
                 }
             };
+
+            // Foreign key lookup available!
+            if (response.type == 'related field') {
+                
+                if (response.model_name && response.api_url) {
+                    fields.value.type = 'related field';
+                    fields.value.model = response.model_name.split('.').at(-1);
+                    fields.value.api_url = response.api_url;
+                } else {
+                    // Unknown / unsupported model type, default to 'text' field
+                    fields.value.type = 'text';
+                    console.warn(`Unsupported model type: '${response.model_name}' for setting '${response.key}'`);
+                }
+            }
 
             constructChangeForm(fields, {
                 url: url,


### PR DESCRIPTION
As part of this PR, I have greatly simplified the various settings objects, to improve retrieval of 'parameters' from the base class

- Remove the GenericReferencedSettingsClass mixin
- Each subclass defines a very simple get_kwargs() method
- Now, at object level *and* class level we can perform lookup of settings and actually get proper data back
- Adds "model" option to setting (precursor of things to come)

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2981"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

### Example

The "sample" plugin now allows you to have plugin settings which point to models in the database, and makes use of the existing API framework to select items from the database, with very minimal effort

![image](https://user-images.githubusercontent.com/10080325/168014015-0c1ef3c8-419f-4021-8b1e-dff929910f82.png)

![image](https://user-images.githubusercontent.com/10080325/168013990-6154d112-7e93-48f7-b2c1-c2a5587719d1.png)

![image](https://user-images.githubusercontent.com/10080325/168014057-25b756fb-cc69-4003-ba26-8de33efa71c1.png)

![image](https://user-images.githubusercontent.com/10080325/168014199-8ee9d58f-5d5c-4e33-b315-7a96d00db75a.png)
