### PR TITLE
Bump python version

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -12,7 +12,7 @@ on:
       - l10*
 
 env:
-  python_version: 3.8
+  python_version: 3.9
   node_version: 16
 
   server_start_sleep: 60

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install Dependencies
         run: |
             sudo apt-get update


### PR DESCRIPTION
This PR bumps the python version for the translation workflow to fix the currently failing test.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/2994"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

