### PR TITLE
Add isort

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ flake8==3.8.3                           # PEP checking
 gunicorn>=20.1.0                        # Gunicorn web server
 importlib_metadata                      # Backport for importlib.metadata
 inventree                               # Install the latest version of the InvenTree API python library
+isort==5.10.1                           # DEV: python import sorting
 markdown==3.3.4                         # Force particular version of markdown
 pep8-naming==0.11.1                     # PEP naming convention extension
 pillow==9.0.1                           # Image manipulation

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,11 @@ max-complexity = 20
 
 [coverage:run]
 source = ./InvenTree
+
+[isort]
+src_paths=InvenTree
+skip_glob =*/migrations/*.py
+known_django=django
+import_heading_firstparty=InvenTree imports
+import_heading_thirdparty=Third-Party imports
+sections=FUTURE, STDLIB, DJANGO, THIRDPARTY, FIRSTPARTY, LOCALFOLDER


### PR DESCRIPTION
This PR adds isort - a package that auto-fixes import order. This can be run automatically with the changes in #3000
We already (kind of) follow the conventions. This tool makes it so that you never need to think about them as isort automatically enforces them.

@SchrodingersGat if this PR is to your liking I would propose to let it run once and fix all imports together with everything #3000 introduces as there are many changed lines (we only kind of followed the conventions). 

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3001"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

