### PR TITLE
Fix "fields" attribute for PurchaseOrderLineItem edit form

### DIFF
--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -1568,23 +1568,10 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
             $(table).find('.button-line-edit').click(function() {
                 var pk = $(this).attr('pk');
 
+                var fields = poLineItemFields(options);
+
                 constructForm(`/api/order/po-line/${pk}/`, {
-                    fields: {
-                        part: {
-                            filters: {
-                                part_detail: true,
-                                supplier_detail: true,
-                                supplier: options.supplier,
-                            }
-                        },
-                        quantity: {},
-                        reference: {},
-                        purchase_price: {},
-                        purchase_price_currency: {},
-                        target_date: {},
-                        destination: {},
-                        notes: {},
-                    },
+                    fields: fields,
                     title: '{% trans "Edit Line Item" %}',
                     onSuccess: function() {
                         $(table).bootstrapTable('refresh');


### PR DESCRIPTION
- The 'order' field was not being included

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3002"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

