### PR TITLE
Add required imports to plugin.events

### DIFF
--- a/InvenTree/plugin/events.py
+++ b/InvenTree/plugin/events.py
@@ -2,8 +2,10 @@
 Import helper for events
 """
 
-from plugin.base.event.events import trigger_event
+from plugin.base.event.events import process_event, register_event, trigger_event
 
 __all__ = [
+    'process_event',
+    'register_event',
     'trigger_event',
 ]


### PR DESCRIPTION
Discovered an issue with the recent plugin refactor:
