### PR TITLE
Bug Fix: Build output delete API endpoint

### DIFF
--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -282,6 +282,13 @@ class BuildOutputDelete(BuildOrderContextMixin, generics.CreateAPIView):
     API endpoint for deleting multiple build outputs
     """
 
+    def get_serializer_context(self):
+        ctx = super().get_serializer_context()
+
+        ctx['to_complete'] = False
+
+        return ctx
+
     queryset = Build.objects.none()
 
     serializer_class = build.serializers.BuildOutputDeleteSerializer

--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -199,7 +199,7 @@ class BuildOutputCreateSerializer(serializers.Serializer):
 
     def validate_quantity(self, quantity):
 
-        if quantity < 0:
+        if quantity <= 0:
             raise ValidationError(_("Quantity must be greater than zero"))
 
         part = self.get_part()
@@ -209,7 +209,7 @@ class BuildOutputCreateSerializer(serializers.Serializer):
             if part.trackable:
                 raise ValidationError(_("Integer quantity required for trackable parts"))
 
-            if part.has_trackable_parts():
+            if part.has_trackable_parts:
                 raise ValidationError(_("Integer quantity required, as the bill of materials contains trackable parts"))
 
         return quantity
@@ -232,7 +232,6 @@ class BuildOutputCreateSerializer(serializers.Serializer):
 
         serial_numbers = serial_numbers.strip()
 
-        # TODO: Field level validation necessary here?
         return serial_numbers
 
     auto_allocate = serializers.BooleanField(


### PR DESCRIPTION
The BuildOutputDelete API endpoint was not working!

This PR fixes the endpoint adds unit tests for the BuildOrder API endpoints, which were sorely lacking.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3017"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

