### PR TITLE
Catch errors when rendering custom plugin panels

### DIFF
--- a/InvenTree/plugin/views.py
+++ b/InvenTree/plugin/views.py
@@ -29,7 +29,7 @@ class InvenTreePluginViewMixin:
 
             try:
                 panels += plug.render_panels(self, self.request, ctx)
-            except Exception as exc:
+            except Exception:
                 # Prevent any plugin error from crashing the page render
                 kind, info, data = sys.exc_info()
 

--- a/InvenTree/plugin/views.py
+++ b/InvenTree/plugin/views.py
@@ -1,5 +1,10 @@
+import sys
+import traceback
 
 from django.conf import settings
+from django.views.debug import ExceptionReporter
+
+from error_report.models import Error
 
 from plugin.registry import registry
 
@@ -21,7 +26,21 @@ class InvenTreePluginViewMixin:
         panels = []
 
         for plug in registry.with_mixin('panel'):
-            panels += plug.render_panels(self, self.request, ctx)
+
+            try:
+                panels += plug.render_panels(self, self.request, ctx)
+            except Exception as exc:
+                # Prevent any plugin error from crashing the page render
+                kind, info, data = sys.exc_info()
+
+                # Log the error to the database
+                Error.objects.create(
+                    kind=kind.__name__,
+                    info=info,
+                    data='\n'.join(traceback.format_exception(kind, info, data)),
+                    path=self.request.path,
+                    html=ExceptionReporter(self.request, kind, info, data).get_traceback_html(),
+                )
 
         return panels
 


### PR DESCRIPTION
Currently if a plugin throws an error while rendering a custom panel, the entire page render is broken.

This PR adds error handling for loading custom panels. If a plugin errors out, the plugin panels are not added, and an error message is logged to the database.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3026"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

