### PR TITLE
Fix broken calls to offload_task

### DIFF
--- a/InvenTree/plugin/base/integration/mixins.py
+++ b/InvenTree/plugin/base/integration/mixins.py
@@ -13,6 +13,7 @@ import InvenTree.helpers
 
 from plugin.helpers import MixinImplementationError, MixinNotImplementedError, render_template
 from plugin.models import PluginConfig, PluginSetting
+from plugin.registry import registry
 from plugin.urls import PLUGIN_BASE
 
 
@@ -204,7 +205,7 @@ class ScheduleMixin:
 
                     Schedule.objects.create(
                         name=task_name,
-                        func='plugin.registry.call_function',
+                        func=registry.call_plugin_function,
                         args=f"'{slug}', '{func_name}'",
                         schedule_type=task['schedule'],
                         minutes=task.get('minutes', None),

--- a/InvenTree/plugin/base/locate/api.py
+++ b/InvenTree/plugin/base/locate/api.py
@@ -7,7 +7,7 @@ from rest_framework.views import APIView
 
 from InvenTree.tasks import offload_task
 
-from plugin import registry
+from plugin.registry import registry
 from stock.models import StockItem, StockLocation
 
 
@@ -53,7 +53,7 @@ class LocatePluginView(APIView):
             try:
                 StockItem.objects.get(pk=item_pk)
 
-                offload_task(registry.call_function, plugin, 'locate_stock_item', item_pk)
+                offload_task(registry.call_plugin_function, plugin, 'locate_stock_item', item_pk)
 
                 data['item'] = item_pk
 
@@ -66,7 +66,7 @@ class LocatePluginView(APIView):
             try:
                 StockLocation.objects.get(pk=location_pk)
 
-                offload_task(registry.call_function, plugin, 'locate_stock_location', location_pk)
+                offload_task(registry.call_plugin_function, plugin, 'locate_stock_location', location_pk)
 
                 data['location'] = location_pk
 


### PR DESCRIPTION
The 'locate' plugin was broken, calls to `offload_task` were passed the incorrect function handle.

@matmair another candidate for a testing framework for the plugins - the "sample" locate plugin here should be used to validate functionality.