### PR TITLE
Fix manufacturer part detail template

### DIFF
--- a/InvenTree/company/templates/company/manufacturer_part.html
+++ b/InvenTree/company/templates/company/manufacturer_part.html
@@ -94,7 +94,6 @@ src="{% static 'img/blank_image.png' %}"
             {% else %}
             <em>{% trans "No manufacturer information available" %}</em>
             {% endif %}
-            {% endif %}
         </td>
     </tr>
     <tr>

--- a/InvenTree/company/test_views.py
+++ b/InvenTree/company/test_views.py
@@ -55,3 +55,29 @@ class CompanyViewTest(CompanyViewTestBase):
 
         response = self.client.get(reverse('company-index'))
         self.assertEqual(response.status_code, 200)
+
+    def test_manufacturer_index(self):
+        """ Test the manufacturer index """
+
+        response = self.client.get(reverse('manufacturer-index'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_customer_index(self):
+        """ Test the customer index """
+
+        response = self.client.get(reverse('customer-index'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_manufacturer_part_detail_view(self):
+        """ Test the manufacturer part detail view """
+
+        response = self.client.get(reverse('manufacturer-part-detail', kwargs={'pk': 1}))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'MPN123')
+
+    def test_supplier_part_detail_view(self):
+        """ Test the supplier part detail view """
+
+        response = self.client.get(reverse('supplier-part-detail', kwargs={'pk': 10}))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'MPN456-APPEL')


### PR DESCRIPTION
This PR fixes the manufacturer part detail view which failed to render because of a typo in the template.
Also adds missing tests for company views.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3032"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

