### PR TITLE
Search Results Fix

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1428,7 +1428,7 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
             'default': True,
             'validator': bool,
         },
-        
+
         'SEARCH_HIDE_INACTIVE_PARTS': {
             'name': _("Hide Inactive Parts"),
             'description': _('Excluded inactive parts from search preview window'),

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1464,11 +1464,25 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
             'validator': bool,
         },
 
+        'SEARCH_PREVIEW_EXCLUDE_INACTIVE_PURCHASE_ORDERS': {
+            'name': _('Exclude Inactive Purchase Orders'),
+            'description': _('Exclude inactive purchase orders from search preview window'),
+            'default': True,
+            'validator': bool,
+        },
+
         'SEARCH_PREVIEW_SHOW_SALES_ORDERS': {
             'name': _('Search Sales Orders'),
             'description': _('Display sales orders in search preview window'),
             'default': True,
             'validator': bool,
+        },
+
+        'SEARCH_PREVIEW_EXCLUDE_INACTIVE_SALES_ORDERS': {
+            'name': 'Exclude Inactive Sales Orders',
+            'description': _('Exclude inactive sales orders from search preview window'),
+            'validator': bool,
+            'default': True,
         },
 
         'SEARCH_PREVIEW_RESULTS': {

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1428,6 +1428,13 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
             'default': True,
             'validator': bool,
         },
+        
+        'SEARCH_HIDE_INACTIVE_PARTS': {
+            'name': _("Hide Inactive Parts"),
+            'description': _('Excluded inactive parts from search preview window'),
+            'default': False,
+            'validator': bool,
+        },
 
         'SEARCH_PREVIEW_SHOW_CATEGORIES': {
             'name': _('Search Categories'),
@@ -1441,6 +1448,13 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
             'description': _('Display stock items in search preview window'),
             'default': True,
             'validator': bool,
+        },
+
+        'SEARCH_PREVIEW_HIDE_UNAVAILABLE_STOCK': {
+            'name': _('Hide Unavailable Stock Items'),
+            'description': _('Exclude stock items which are not available from the search preview window'),
+            'validator': bool,
+            'default': False,
         },
 
         'SEARCH_PREVIEW_SHOW_LOCATIONS': {
@@ -1479,7 +1493,7 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
         },
 
         'SEARCH_PREVIEW_EXCLUDE_INACTIVE_SALES_ORDERS': {
-            'name': 'Exclude Inactive Sales Orders',
+            'name': _('Exclude Inactive Sales Orders'),
             'description': _('Exclude inactive sales orders from search preview window'),
             'validator': bool,
             'default': True,
@@ -1490,13 +1504,6 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
             'description': _('Number of results to show in each section of the search preview window'),
             'default': 10,
             'validator': [int, MinValueValidator(1)]
-        },
-
-        'SEARCH_HIDE_INACTIVE_PARTS': {
-            'name': _("Hide Inactive Parts"),
-            'description': _('Hide inactive parts in search preview window'),
-            'default': False,
-            'validator': bool,
         },
 
         'PART_SHOW_QUANTITY_IN_FORMS': {

--- a/InvenTree/common/tests.py
+++ b/InvenTree/common/tests.py
@@ -163,10 +163,19 @@ class SettingsTest(TestCase):
         """
 
         for key, setting in InvenTreeSetting.SETTINGS.items():
-            self.run_settings_check(key, setting)
+
+            try:
+                self.run_settings_check(key, setting)
+            except Exception as exc:
+                print(f"run_settings_check failed for global setting '{key}'")
+                raise exc
 
         for key, setting in InvenTreeUserSetting.SETTINGS.items():
-            self.run_settings_check(key, setting)
+            try:
+                self.run_settings_check(key, setting)
+            except Exception as exc:
+                print(f"run_settings_check failed for user setting '{key}'")
+                raise exc
 
     def test_defaults(self):
         """

--- a/InvenTree/templates/InvenTree/settings/user_search.html
+++ b/InvenTree/templates/InvenTree/settings/user_search.html
@@ -18,6 +18,7 @@
             {% include "InvenTree/settings/setting.html" with key="SEARCH_HIDE_INACTIVE_PARTS" user_setting=True icon='fa-eye-slash' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_CATEGORIES" user_setting=True icon='fa-sitemap' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_STOCK" user_setting=True icon='fa-boxes' %}
+            {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_HIDE_UNAVAILABLE_STOCK" user_setting=True icon='fa-eye-slash' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_LOCATIONS" user_setting=True icon='fa-sitemap' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_COMPANIES" user_setting=True icon='fa-building' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_PURCHASE_ORDERS" user_setting=True icon='fa-shopping-cart' %}

--- a/InvenTree/templates/InvenTree/settings/user_search.html
+++ b/InvenTree/templates/InvenTree/settings/user_search.html
@@ -15,18 +15,18 @@
     <table class='table table-striped table-condensed'>
         <tbody>
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_PARTS" user_setting=True icon='fa-shapes' %}
+            {% include "InvenTree/settings/setting.html" with key="SEARCH_HIDE_INACTIVE_PARTS" user_setting=True icon='fa-eye-slash' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_CATEGORIES" user_setting=True icon='fa-sitemap' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_STOCK" user_setting=True icon='fa-boxes' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_LOCATIONS" user_setting=True icon='fa-sitemap' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_COMPANIES" user_setting=True icon='fa-building' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_PURCHASE_ORDERS" user_setting=True icon='fa-shopping-cart' %}
-            {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_EXCLUDE_INACTIVE_PURCHASE_ORDERS" user_setting=True icon='fa-search-minus' %}
+            {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_EXCLUDE_INACTIVE_PURCHASE_ORDERS" user_setting=True icon='fa-eye-slash' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_SALES_ORDERS" user_setting=True icon='fa-truck' %}
-            {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_EXCLUDE_INACTIVE_SALES_ORDERS" user_setting=True icon='fa-search-minus' %}
+            {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_EXCLUDE_INACTIVE_SALES_ORDERS" user_setting=True icon='fa-eye-slash' %}
             
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_RESULTS" user_setting=True icon='fa-search' %}
 
-            {% include "InvenTree/settings/setting.html" with key="SEARCH_HIDE_INACTIVE_PARTS" user_setting=True icon='fa-eye-slash' %}
         </tbody>
     </table>
 </div>

--- a/InvenTree/templates/InvenTree/settings/user_search.html
+++ b/InvenTree/templates/InvenTree/settings/user_search.html
@@ -20,7 +20,9 @@
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_LOCATIONS" user_setting=True icon='fa-sitemap' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_COMPANIES" user_setting=True icon='fa-building' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_PURCHASE_ORDERS" user_setting=True icon='fa-shopping-cart' %}
+            {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_EXCLUDE_INACTIVE_PURCHASE_ORDERS" user_setting=True icon='fa-search-minus' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_SALES_ORDERS" user_setting=True icon='fa-truck' %}
+            {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_EXCLUDE_INACTIVE_SALES_ORDERS" user_setting=True icon='fa-search-minus' %}
             
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_RESULTS" user_setting=True icon='fa-search' %}
 

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -122,14 +122,22 @@ function updateSearch() {
 
     if (user_settings.SEARCH_PREVIEW_SHOW_STOCK) {
         // Search for matching stock items
+        
+        var filters = {
+            part_detail: true,
+            location_detail: true,
+        };
+
+        if (user_settings.SEARCH_PREVIEW_HIDE_UNAVAILABLE_STOCK) {
+            // Only show 'in stock' items in the preview windoww
+            filters.in_stock = true;
+        }
+
         addSearchQuery(
             'stock',
             '{% trans "Stock Items" %}',
             '{% url "api-stock-list" %}',
-            {
-                part_detail: true,
-                location_detail: true,
-            },
+            filters,
             renderStockItem,
             {
                 url: '/stock/item',

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -170,12 +170,10 @@ function updateSearch() {
 
         var filters = {
             supplier_detail: true,
-        }
+        };
 
         if (user_settings.SEARCH_PREVIEW_EXCLUDE_INACTIVE_PURCHASE_ORDERS) {
-            var filters = {
-                outstanding: true,
-            }
+            filters.outstanding = true;
         }
 
         // Search for matching purchase orders

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -167,15 +167,23 @@ function updateSearch() {
     }
 
     if (user_settings.SEARCH_PREVIEW_SHOW_PURCHASE_ORDERS) {
+
+        var filters = {
+            supplier_detail: true,
+        }
+
+        if (user_settings.SEARCH_PREVIEW_EXCLUDE_INACTIVE_PURCHASE_ORDERS) {
+            var filters = {
+                outstanding: true,
+            }
+        }
+
         // Search for matching purchase orders
         addSearchQuery(
             'purchaseorder',
             '{% trans "Purchase Orders" %}',
             '{% url "api-po-list" %}',
-            {
-                supplier_detail: true,
-                outstanding: true,
-            },
+            filters,
             renderPurchaseOrder,
             {
                 url: '/order/purchase-order',
@@ -184,15 +192,22 @@ function updateSearch() {
     }
 
     if (user_settings.SEARCH_PREVIEW_SHOW_SALES_ORDERS) {
+
+        var filters = {
+            customer_detail: true,
+        };
+
+        // Hide inactive (not "outstanding" orders)
+        if (user_settings.SEARCH_PREVIEW_EXCLUDE_INACTIVE_SALES_ORDERS) {
+            filters.outstanding = true;
+        }
+
         // Search for matching sales orders
         addSearchQuery(
             'salesorder',
             '{% trans "Sales Orders" %}',
             '{% url "api-so-list" %}',
-            {
-                customer_detail: true,
-                outstanding: true,
-            },
+            filters,
             renderSalesOrder,
             {
                 url: '/order/sales-order',


### PR DESCRIPTION
Add extra options to control search results in preview window

- Allow user to optionally show / hide inactive purchase orders
- Allow user to optionally show / hide inactive sales orders

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3038"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

