### PR TITLE
[BUG] Remove repo name from assertation

### DIFF
--- a/InvenTree/InvenTree/tests.py
+++ b/InvenTree/InvenTree/tests.py
@@ -548,7 +548,7 @@ class TestSettings(TestCase):
 
         # with env set
         with self.in_env_context({'INVENTREE_CONFIG_FILE': 'my_special_conf.yaml'}):
-            self.assertIn('inventree/inventree/my_special_conf.yaml', config.get_config_file().lower())
+            self.assertIn('inventree/my_special_conf.yaml', config.get_config_file().lower())
 
     def test_helpers_plugin_file(self):
         # normal run - not configured


### PR DESCRIPTION
This test breaks on other runners (gitlab, azure devops) as they handle repo names in another way. No ideal, especially with enterprise customers that might mirror the repo into their enviroment for SecOps.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3044"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

