### PR TITLE
Shipment date edit

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -1205,14 +1205,23 @@ class SalesOrderShipment(models.Model):
     def is_complete(self):
         return self.shipment_date is not None
 
-    def check_can_complete(self):
+    def check_can_complete(self, raise_error=True):
 
-        if self.shipment_date:
-            # Shipment has already been sent!
-            raise ValidationError(_("Shipment has already been sent"))
+        try:
+            if self.shipment_date:
+                # Shipment has already been sent!
+                raise ValidationError(_("Shipment has already been sent"))
 
-        if self.allocations.count() == 0:
-            raise ValidationError(_("Shipment has no allocated stock items"))
+            if self.allocations.count() == 0:
+                raise ValidationError(_("Shipment has no allocated stock items"))
+
+        except ValidationError as e:
+            if raise_error:
+                raise e
+            else:
+                return False
+
+        return True
 
     @transaction.atomic
     def complete_shipment(self, user, **kwargs):

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -1235,7 +1235,7 @@ class SalesOrderShipment(models.Model):
             allocation.complete_allocation(user)
 
         # Update the "shipment" date
-        self.shipment_date = datetime.now()
+        self.shipment_date = kwargs.get('shipment_date', datetime.now())
         self.shipped_by = user
 
         # Was a tracking number provided?

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -912,7 +912,7 @@ class SalesOrderShipmentCompleteSerializer(serializers.ModelSerializer):
         if not shipment:
             raise ValidationError(_("No shipment details provided"))
 
-        shipment.check_can_complete()
+        shipment.check_can_complete(raise_error=True)
 
         return data
 
@@ -929,7 +929,7 @@ class SalesOrderShipmentCompleteSerializer(serializers.ModelSerializer):
         user = request.user
 
         # Extract provided tracking number (optional)
-        tracking_number = data.get('tracking_number', None)
+        tracking_number = data.get('tracking_number', shipment.tracking_number)
 
         # Extract shipping date (defaults to today's date)
         shipment_date = data.get('shipment_date', datetime.now())

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -2,6 +2,7 @@
 JSON serializers for the Order API
 """
 
+from datetime import datetime
 from decimal import Decimal
 
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -899,6 +900,7 @@ class SalesOrderShipmentCompleteSerializer(serializers.ModelSerializer):
 
         fields = [
             'tracking_number',
+            'shipment_date',
         ]
 
     def validate(self, data):
@@ -929,7 +931,14 @@ class SalesOrderShipmentCompleteSerializer(serializers.ModelSerializer):
         # Extract provided tracking number (optional)
         tracking_number = data.get('tracking_number', None)
 
-        shipment.complete_shipment(user, tracking_number=tracking_number)
+        # Extract shipping date (defaults to today's date)
+        shipment_date = data.get('shipment_date', datetime.now())
+
+        shipment.complete_shipment(
+            user,
+            tracking_number=tracking_number,
+            shipment_date=shipment_date,
+        )
 
 
 class SalesOrderShipmentAllocationItemSerializer(serializers.Serializer):

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -133,7 +133,7 @@ function completeShipment(shipment_id, options={}) {
                         value: shipment.tracking_number,
                     },
                     shipment_date: {
-                        value: moment().format("YYYY-MM-DD"),
+                        value: moment().format('YYYY-MM-DD'),
                     }
                 },
                 preFormContent: html,

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -130,6 +130,9 @@ function completeShipment(shipment_id, options={}) {
                 title: `{% trans "Complete Shipment" %} ${shipment.reference}`,
                 fields: {
                     tracking_number: {},
+                    shipment_date: {
+                        value: moment().format("YYYY-MM-DD"),
+                    }
                 },
                 preFormContent: html,
                 confirm: true,

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -129,7 +129,9 @@ function completeShipment(shipment_id, options={}) {
                 method: 'POST',
                 title: `{% trans "Complete Shipment" %} ${shipment.reference}`,
                 fields: {
-                    tracking_number: {},
+                    tracking_number: {
+                        value: shipment.tracking_number,
+                    },
                     shipment_date: {
                         value: moment().format("YYYY-MM-DD"),
                     }


### PR DESCRIPTION
Allows the user to optionally set the shipment date for a sales order shipment, rather than forcing the current date.

e.g. if the shipment was shipped previously and was not updated in the system.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3050"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

