### PR TITLE
Improve error management for order price calculation

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -197,7 +197,8 @@ class Order(MetadataMixin, ReferenceIndexingMixin):
 
                 logger.error(f"Missing exchange rate for '{target_currency}'")
 
-                return Money(0, target_currency)
+                # Return None to indicate the calculated price is invalid
+                return None
 
         # extra items
         for line in self.extra_lines.all():
@@ -219,7 +220,9 @@ class Order(MetadataMixin, ReferenceIndexingMixin):
                 )
 
                 logger.error(f"Missing exchange rate for '{target_currency}'")
-                return Money(0, target_currency)
+
+                # Return None to indicate the calculated price is invalid
+                return None
 
         # set decimal-places
         total.decimal_places = 4

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -21,7 +21,6 @@ from django.db.models.signals import post_save
 from django.dispatch.dispatcher import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from django.views.debug import ExceptionReporter
 
 from djmoney.contrib.exchange.models import convert_money
 from djmoney.contrib.exchange.exceptions import MissingRate
@@ -163,13 +162,13 @@ class Order(MetadataMixin, ReferenceIndexingMixin):
     def get_total_price(self, target_currency=currency_code_default()):
         """
         Calculates the total price of all order lines, and converts to the specified target currency.
-        
+
         If not specified, the default system currency is used.
 
         If currency conversion fails (e.g. there are no valid conversion rates),
         then we simply return zero, rather than attempting some other calculation.
         """
-        
+
         total = Money(0, target_currency)
 
         # gather name reference
@@ -182,7 +181,7 @@ class Order(MetadataMixin, ReferenceIndexingMixin):
 
             if not price_ref:
                 continue
-        
+
             try:
                 total += line.quantity * convert_money(price_ref, target_currency)
             except MissingRate:
@@ -197,7 +196,7 @@ class Order(MetadataMixin, ReferenceIndexingMixin):
                 )
 
                 logger.error(f"Missing exchange rate for '{target_currency}'")
-                
+
                 return Money(0, target_currency)
 
         # extra items
@@ -205,7 +204,7 @@ class Order(MetadataMixin, ReferenceIndexingMixin):
 
             if not line.price:
                 continue
-                
+
             try:
                 total += line.quantity * convert_money(line.price, target_currency)
             except MissingRate:

--- a/InvenTree/order/templates/order/order_base.html
+++ b/InvenTree/order/templates/order/order_base.html
@@ -181,7 +181,15 @@ src="{% static 'img/blank_image.png' %}"
     <tr>
         <td><span class='fas fa-dollar-sign'></span></td>
         <td>{% trans "Total cost" %}</td>
-        <td id="poTotalPrice">{{ order.get_total_price }}</td>
+        <td id="poTotalPrice">
+            {% with order.get_total_price as tp %}
+            {% if tp == None %}
+            <span class='badge bg-warning'>{% trans "Total cost could not be calculated" %}</span>
+            {% else %}
+            {{ tp }}
+            {% endif %}
+            {% endwith %}
+        </td>
     </tr>
 </table>
 {% endblock %}

--- a/InvenTree/order/templates/order/sales_order_base.html
+++ b/InvenTree/order/templates/order/sales_order_base.html
@@ -188,7 +188,15 @@ src="{% static 'img/blank_image.png' %}"
     <tr>
         <td><span class='fas fa-dollar-sign'></span></td>
         <td>{% trans "Total cost" %}</td>
-        <td id="soTotalPrice">{{ order.get_total_price }}</td>
+        <td id="soTotalPrice">
+            {% with order.get_total_price as tp %}
+            {% if tp == None %}
+            <span class='badge bg-warning'>{% trans "Total price could not be calculated" %}</span>
+            {% else %}
+            {{ tp }}
+            {% endif %}
+            {% endwith %}
+        </td>
     </tr>
 </table>
 {% endblock %}

--- a/InvenTree/order/templates/order/sales_order_base.html
+++ b/InvenTree/order/templates/order/sales_order_base.html
@@ -191,7 +191,7 @@ src="{% static 'img/blank_image.png' %}"
         <td id="soTotalPrice">
             {% with order.get_total_price as tp %}
             {% if tp == None %}
-            <span class='badge bg-warning'>{% trans "Total price could not be calculated" %}</span>
+            <span class='badge bg-warning'>{% trans "Total cost could not be calculated" %}</span>
             {% else %}
             {{ tp }}
             {% endif %}


### PR DESCRIPTION
- If there are missing exchange rates, it throws an error
- Very much an edge case

@matmair in the case where exchange rates are not available or have bugged out, there was an unhandled exception in the `get_total_price` method. I happened across it randomly after reinstalling from a fresh db.

This PR adds some error handling, but the question is - what do we return as the "total price" when exchange rates are not available?

Currently the code simply returns zero. Is this sufficient, do you think, given that this is somewhat of an edge case anyway?

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3075"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

