### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# General owner is the maintainers team
+*       @inventree/maintainer
+
+# plugins are co-owned
+InvenTree/plugin/*      @inventree/maintainer @matmair
+InvenTree/plugins/*     @inventree/maintainer @matmair

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # General owner is the maintainers team
-*       @inventree/maintainer
+*       @SchrodingersGat
 
 # plugins are co-owned
-InvenTree/plugin/*      @inventree/maintainer @matmair
-InvenTree/plugins/*     @inventree/maintainer @matmair
+/InvenTree/plugin/      @SchrodingersGat @matmair
+/InvenTree/plugins/     @SchrodingersGat @matmair


### PR DESCRIPTION
This PR adds code owners as lined out in:
https://github.blog/2017-07-06-introducing-code-owners/
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3079"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

