### PR TITLE
Add option to also reload plugin mechanisms

### DIFF
--- a/InvenTree/InvenTree/tests.py
+++ b/InvenTree/InvenTree/tests.py
@@ -522,7 +522,7 @@ class TestSettings(helpers.InvenTreeTestCase):
 
         # Set dynamic setting to True and rerun to launch install
         InvenTreeSetting.set_setting('PLUGIN_ON_STARTUP', True, self.user)
-        registry.reload_plugins()
+        registry.reload_plugins(full_reload=True)
 
         # Check that there was anotehr run
         response = registry.install_plugin_file()


### PR DESCRIPTION
This PR adds a flag (and a few docstrings) to reload all app mechanisms (needed for additional tests)

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3081"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

