### PR TITLE
Disable codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # General owner is the maintainers team
 *       @SchrodingersGat
 
+# 2022-05-27 specific rights are disabled due to current privileges setup
 # plugins are co-owned
-/InvenTree/plugin/      @SchrodingersGat @matmair
-/InvenTree/plugins/     @SchrodingersGat @matmair
+# /InvenTree/plugin/      @SchrodingersGat @matmair
+# /InvenTree/plugins/     @SchrodingersGat @matmair


### PR DESCRIPTION
the current privileges do not allow codeowners to work as github requires all codeowners to have write permissions for the file to be valid

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3086"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

