### PR TITLE
Version checker

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,6 +27,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Check out repo
         uses: actions/checkout@v2
@@ -64,4 +67,11 @@ jobs:
           push: true
           target: production
           tags: ${{ env.docker_tags }}
-          build-args: commit_hash=${{ env.git_commit_hash }},commit_date=${{ env.git_commit_date }}
+          build-args: commit_hash="${{ env.git_commit_hash }}", commit_date="${{ env.git_commit_date }}"
+      - name: Push to Stable Branch
+        uses: ad-m/github-push-action@master
+        if: env.stable_release == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: stable
+          force: true

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,7 +2,6 @@
 # This workflow runs under any of the following conditions:
 #
 # - Push to the master branch
-# - Push to the stable branch
 # - Publish release
 #
 # The following actions are performed:
@@ -21,7 +20,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'stable'
 
 jobs:
 
@@ -34,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Version Check
         run: |
-          python3 ci/check_version_number.py
+          python3 ci/version_check.py
           echo "git_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "git_commit_date=$(git show -s --format=%ci)" >> $GITHUB_ENV
       - name: Run Unit Tests
@@ -65,5 +63,5 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           target: production
-          tags: inventree/inventree:${{ env.docker_tag }}
-          build-args: commit_hash=${{ env.git_commit_hash }},commit_date=${{ env.git_commit_date }},commit_tag=${{ env.docker_tag }}
+          tags: ${{ env.docker_tags }}
+          build-args: commit_hash=${{ env.git_commit_hash }},commit_date=${{ env.git_commit_date }}

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -91,9 +91,6 @@ jobs:
         cache: 'pip'
     - name: Run pre-commit Checks
       uses: pre-commit/action@v2.0.3
-    - name: Check version number
-      run: |
-        python3 ci/check_version_number.py
 
   python:
     name: Tests - inventree-python

--- a/ci/version_check.py
+++ b/ci/version_check.py
@@ -53,7 +53,7 @@ def check_version_number(version_string):
     print(f"Checking version '{version_string}'")
 
     # Check that the version string matches the required format
-    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?: dev)$", version_string)
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?: dev)?$", version_string)
 
     if len(match.groups()) != 3:
         raise ValueError(f"Version string '{version_string}' did not match required pattern")

--- a/ci/version_check.py
+++ b/ci/version_check.py
@@ -55,7 +55,7 @@ def check_version_number(version_string):
     # Check that the version string matches the required format
     match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?: dev)?$", version_string)
 
-    if len(match.groups()) != 3:
+    if not match or len(match.groups()) != 3:
         raise ValueError(f"Version string '{version_string}' did not match required pattern")
 
     version_tuple = [int(x) for x in match.groups()]
@@ -157,7 +157,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     print(f"Version check passed for '{version}'!")
-    print(f"Docker tag: '{docker_tags}'")
+    print(f"Docker tags: '{docker_tags}'")
 
     # Ref: https://getridbug.com/python/how-to-set-environment-variables-in-github-actions-using-python/
     with open(os.getenv('GITHUB_ENV'), 'a') as env_file:

--- a/ci/version_check.py
+++ b/ci/version_check.py
@@ -168,4 +168,4 @@ if __name__ == '__main__':
         env_file.write(f"docker_tags={tags}\n")
 
         if GITHUB_REF_TYPE == 'tag' and highest_release:
-            env_file.write("stable_release=1\n")
+            env_file.write("stable_release=true\n")


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/3100

Improves the CI version check script:

- Check if the tagged version already exists
- Determine if this is the "highest" release version
- If so, push the 'latest' tag to docker
- If so, push current commit to stable

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3102"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

