### PR TITLE
Fix formatting of 'build-args' parameter for docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -67,7 +67,9 @@ jobs:
           push: true
           target: production
           tags: ${{ env.docker_tags }}
-          build-args: commit_hash="${{ env.git_commit_hash }}", commit_date="${{ env.git_commit_date }}"
+          build-args: |
+            commit_hash="${{ env.git_commit_hash }}"
+            commit_date="${{ env.git_commit_date }}"
       - name: Push to Stable Branch
         uses: ad-m/github-push-action@master
         if: env.stable_release == 'true'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -68,8 +68,8 @@ jobs:
           target: production
           tags: ${{ env.docker_tags }}
           build-args: |
-            commit_hash="${{ env.git_commit_hash }}"
-            commit_date="${{ env.git_commit_date }}"
+            commit_hash=${{ env.git_commit_hash }}
+            commit_date=${{ env.git_commit_date }}
       - name: Push to Stable Branch
         uses: ad-m/github-push-action@master
         if: env.stable_release == 'true'


### PR DESCRIPTION
Ref: https://github.com/docker/build-push-action/issues/557

Specifying multiple build-arg parameters for the docker-build-push action requires a specific format

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3105"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

