### PR TITLE
Fix filtering for purchaseorder table on supplierpart page

### DIFF
--- a/InvenTree/company/templates/company/supplier_part.html
+++ b/InvenTree/company/templates/company/supplier_part.html
@@ -309,7 +309,9 @@ $('#new-price-break').click(function() {
 });
 
 loadPurchaseOrderTable($("#purchase-order-table"), {
-    url: "{% url 'api-po-list' %}?supplier_part={{ part.id }}",
+    params: {
+        supplier_part: {{ part.id }},
+    }
 });
 
 loadStockTable($("#stock-table"), {


### PR DESCRIPTION
PurchaseOrder table on the SupplierPart page was not filtering correctly

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3115"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

