### PR TITLE
Bugfix for stockitem serializers

### DIFF
--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -90,6 +90,8 @@ class StockMetadata(generics.RetrieveUpdateAPIView):
 class StockItemContextMixin:
     """Mixin class for adding StockItem object to serializer context."""
 
+    queryset = StockItem.objects.none()
+
     def get_serializer_context(self):
         """Extend serializer context."""
         context = super().get_serializer_context()
@@ -106,7 +108,6 @@ class StockItemContextMixin:
 class StockItemSerialize(StockItemContextMixin, generics.CreateAPIView):
     """API endpoint for serializing a stock item."""
 
-    queryset = StockItem.objects.all()
     serializer_class = StockSerializers.SerializeStockItemSerializer
 
 
@@ -118,21 +119,18 @@ class StockItemInstall(StockItemContextMixin, generics.CreateAPIView):
     - stock_item must be serialized (and not belong to another item)
     """
 
-    queryset = StockItem.objects.all()
     serializer_class = StockSerializers.InstallStockItemSerializer
 
 
 class StockItemUninstall(StockItemContextMixin, generics.CreateAPIView):
     """API endpoint for removing (uninstalling) items from this item."""
 
-    queryset = StockItem.objects.all()
     serializer_class = StockSerializers.UninstallStockItemSerializer
 
 
 class StockItemReturn(StockItemContextMixin, generics.CreateAPIView):
     """API endpoint for returning a stock item from a customer"""
 
-    queryset = StockItem.objects.all()
     serializer_class = StockSerializers.ReturnStockItemSerializer
 
 


### PR DESCRIPTION
Fixes bug introduced in https://github.com/inventree/InvenTree/pull/3120

- For some reason, the reverse URL lookups would fail for stock items which were not "in stock"
- e.g. detail pages for stock items would fail to render if the stock item was "destroyed" or "quarantined"
- changing the queryset to .none() fixed this
- I do not know why...

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3125"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

