### PR TITLE
Fix has_complete_bom_pricing logic errors

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1530,16 +1530,11 @@ class Part(MetadataMixin, MPTTModel):
         return self.supplier_parts.count()
 
     @property
-    def has_pricing_info(self, internal=False):
-        """Return true if there is pricing information for this part."""
-        return self.get_price_range(internal=internal) is not None
-
-    @property
     def has_complete_bom_pricing(self):
         """Return true if there is pricing information for each item in the BOM."""
-        use_internal = common.models.get_setting('PART_BOM_USE_INTERNAL_PRICE', False)
+        use_internal = common.models.InvenTreeSetting.get_setting('PART_BOM_USE_INTERNAL_PRICE', False)
         for item in self.get_bom_items().all().select_related('sub_part'):
-            if not item.sub_part.has_pricing_info(use_internal):
+            if item.sub_part.get_price_range(internal=use_internal) is None:
                 return False
 
         return True

--- a/InvenTree/part/templates/part/part_pricing.html
+++ b/InvenTree/part/templates/part/part_pricing.html
@@ -75,7 +75,7 @@
     {% endif %}
     {% endif %}
 
-    {% if part.has_complete_bom_pricing == False %}
+    {% if not part.has_complete_bom_pricing %}
     <tr>
         <td colspan='3'>
             <span class='warning-msg'><em>{% trans 'Note: BOM pricing is incomplete for this part' %}</em></span>

--- a/InvenTree/part/templates/part/prices.html
+++ b/InvenTree/part/templates/part/prices.html
@@ -83,7 +83,7 @@
                     {% endif %}
                     {% endif %}
 
-                    {% if part.has_complete_bom_pricing == False %}
+                    {% if not part.has_complete_bom_pricing %}
                         <tr>
                             <td colspan='4'>
                                 <span class='warning-msg'><em>{% trans 'Note: BOM pricing is incomplete for this part' %}</em></span>


### PR DESCRIPTION
Closes #3139

There are two logic errors in this property method that have been present since c6fd228.

1) The get_setting method needs to be called on the InventTreeSetting class in common.models, not on the module itself.

2) You cannot call a property method directly passing an argument in Python, so the call to has_pricing_info is invalid and always fails. Given that has_complete_bom_pricing is/was the only user of that property anyway, fix this by just internalising the logic from that property in the method directly.

Also a couple of stylistic fixes to the invocation of the property in the template. 


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3140"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

