### PR TITLE
Separate unit cost and purchase price in BOM

### DIFF
--- a/InvenTree/part/templates/part/part_pricing.html
+++ b/InvenTree/part/templates/part/part_pricing.html
@@ -60,6 +60,7 @@
         <td>Max: {% include "price.html" with price=max_total_bom_price %}</td>
     </tr>
     {% endif %}
+    {% endif %}
     {% if min_total_bom_purchase_price %}
     <tr>
         <td><strong>{% trans 'Unit Purchase Price' %}</strong></td>
@@ -82,6 +83,8 @@
         </td>
     </tr>
     {% endif %}
+
+    {% if min_total_bom_price or min_total_bom_purchase_price %}
     {% else %}
     <tr>
         <td colspan='3'>
@@ -122,7 +125,7 @@
     </table>
 {% endif %}
 
-{% if min_unit_buy_price or min_unit_bom_price %}
+{% if min_unit_buy_price or min_unit_bom_price or min_unit_bom_purchase_price %}
 {% else %}
 <div class='alert alert-danger alert-block'>
     {% trans 'No pricing information is available for this part.' %}

--- a/InvenTree/part/templates/part/prices.html
+++ b/InvenTree/part/templates/part/prices.html
@@ -64,9 +64,9 @@
                             <td>Max: {% include "price.html" with price=max_total_bom_price %}</td>
                         </tr>
                     {% endif %}
+                {% endif %}
 
-
-                    {% if min_total_bom_purchase_price %}
+                {% if min_total_bom_purchase_price %}
                     <tr>
                         <td></td>
                         <td>{% trans 'Unit Purchase Price' %}</td>
@@ -81,15 +81,17 @@
                         <td>Max: {% include "price.html" with price=max_total_bom_purchase_price %}</td>
                     </tr>
                     {% endif %}
-                    {% endif %}
+                {% endif %}
 
-                    {% if part.has_complete_bom_pricing == False %}
-                        <tr>
-                            <td colspan='4'>
-                                <span class='warning-msg'><em>{% trans 'Note: BOM pricing is incomplete for this part' %}</em></span>
-                            </td>
-                        </tr>
-                    {% endif %}
+                {% if part.has_complete_bom_pricing == False %}
+                    <tr>
+                        <td colspan='4'>
+                            <span class='warning-msg'><em>{% trans 'Note: BOM pricing is incomplete for this part' %}</em></span>
+                        </td>
+                    </tr>
+                {% endif %}
+
+                {% if min_total_bom_price or min_total_bom_purchase_price %}
                 {% else %}
                     <tr>
                         <td colspan='4'>
@@ -131,7 +133,7 @@
             {% endif %}
             </table>
 
-            {% if min_unit_buy_price or min_unit_bom_price %}
+            {% if min_unit_buy_price or min_unit_bom_price or min_unit_bom_purchase_price %}
             {% else %}
                 <div class='alert alert-danger alert-block'>
                     {% trans 'No pricing information is available for this part.' %}


### PR DESCRIPTION
(not opening a bug for this, as the current behaviour may be intentional, but even if it is, I think this change is reasonable and does not break anything). 

It's possible for a part to have purchase price information, but not supplier
pricing (aka unit prices), but the current BOM price display logic will only
show the purchase prices when supplier prices are also available.

It seems reasonable to separate these two pieces of information - even when no
supplier pricing is available, seeing the purchase prices for BOM components is
useful on its own.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3141"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

