### PR TITLE
Simplify version_check script

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Version Check
         run: |
+          pip install requests
           python3 ci/version_check.py
           echo "git_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "git_commit_date=$(git show -s --format=%ci)" >> $GITHUB_ENV

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -91,6 +91,9 @@ jobs:
         cache: 'pip'
     - name: Run pre-commit Checks
       uses: pre-commit/action@v2.0.3
+    - name: Check Version
+      run: |
+        python3 ci/version_check.py
 
   python:
     name: Tests - inventree-python

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -93,6 +93,7 @@ jobs:
       uses: pre-commit/action@v2.0.3
     - name: Check Version
       run: |
+        pip install requests
         python3 ci/version_check.py
 
   python:

--- a/ci/version_check.py
+++ b/ci/version_check.py
@@ -114,15 +114,13 @@ if __name__ == '__main__':
     docker_tags = None
 
     if GITHUB_REF_TYPE == 'tag':
-        # GITHUB_REF should be of th eform /refs/heads/<tag>
+        # GITHUB_REF should be of the form /refs/heads/<tag>
         version_tag = GITHUB_REF.split('/')[-1]
         print(f"Checking requirements for tagged release - '{version_tag}':")
 
         if version_tag != version:
             print(f"Version number '{version}' does not match tag '{version_tag}'")
             sys.exit
-
-        # TODO: Check if there is already a release with this tag!
 
         if highest_release:
             docker_tags = [version_tag, 'stable']
@@ -131,17 +129,6 @@ if __name__ == '__main__':
 
     elif GITHUB_REF_TYPE == 'branch':
         # Otherwise we know we are targetting the 'master' branch
-        print("Checking requirements for 'master' development branch:")
-
-        pattern = r"^\d+(\.\d+)+ dev$"
-        result = re.match(pattern, version)
-
-        if result is None:
-            print(f"Version number '{version}' does not match required pattern for development branch")
-            sys.exit(1)
-        else:
-            print(f"Version number '{version}' matches development branch")
-
         docker_tags = ['latest']
 
     else:
@@ -153,7 +140,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     if docker_tags is None:
-        print("Docker tag could not be determined")
+        print("Docker tags could not be determined")
         sys.exit(1)
 
     print(f"Version check passed for '{version}'!")


### PR DESCRIPTION
- Allow 'x.x.x' or 'x.x.x dev' on master branch (because we need to be able to tag releases from master)
- Remove duplicate regex checks
- Fix docstrings

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3152"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

