### PR TITLE
Export records update - allow overwriting existing files without user input

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -282,8 +282,8 @@ def content_excludes():
     return output
 
 
-@task(help={'filename': "Output filename (default = 'data.json')"})
-def export_records(c, filename='data.json'):
+@task(help={'filename': "Output filename (default = 'data.json')", 'overwrite': "Overwrite existing files without asking first (default False)"})
+def export_records(c, filename='data.json', overwrite = False):
     """Export all database records to a file"""
     # Get an absolute path to the file
     if not os.path.isabs(filename):
@@ -292,7 +292,7 @@ def export_records(c, filename='data.json'):
 
     print(f"Exporting database records to file '{filename}'")
 
-    if os.path.exists(filename):
+    if os.path.exists(filename) and overwrite is False:
         response = input("Warning: file already exists. Do you want to overwrite? [y/N]: ")
         response = str(response).strip().lower()
 

--- a/tasks.py
+++ b/tasks.py
@@ -283,7 +283,7 @@ def content_excludes():
 
 
 @task(help={'filename': "Output filename (default = 'data.json')", 'overwrite': "Overwrite existing files without asking first (default False)"})
-def export_records(c, filename='data.json', overwrite = False):
+def export_records(c, filename='data.json', overwrite=False):
     """Export all database records to a file"""
     # Get an absolute path to the file
     if not os.path.isabs(filename):
@@ -329,7 +329,7 @@ def export_records(c, filename='data.json', overwrite = False):
         f_out.write(json.dumps(data, indent=2))
 
     print("Data export completed. Removing temporary files")
-    
+
     os.remove(tmpfile)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -328,7 +328,9 @@ def export_records(c, filename='data.json', overwrite = False):
     with open(filename, "w") as f_out:
         f_out.write(json.dumps(data, indent=2))
 
-    print("Data export completed")
+    print("Data export completed. Removing temporary files")
+    
+    os.remove(tmpfile)
 
 
 @task(help={'filename': 'Input filename', 'clear': 'Clear existing data before import'}, post=[rebuild_models, rebuild_thumbnails])

--- a/tasks.py
+++ b/tasks.py
@@ -224,7 +224,7 @@ def update(c):
 def style(c):
     """Run PEP style checks against InvenTree sourcecode"""
     print("Running PEP style checks...")
-    c.run('flake8 InvenTree')
+    c.run('flake8 InvenTree tasks.py')
 
 
 @task


### PR DESCRIPTION
As it is now, the export-records function can not easily be run unattended. I added a switch (-o) to the command line to signal that overwriting the existing file is OK.

Furthermore, changed the following minor things:
- I added a command to remove the temporary file after the process is finished - otherwise, the file remains in place and making any changes to it is useless.
- `invoke style` now also includes tasks.py in the checks.