### PR TITLE
Adds redis support to production docker-compose

### DIFF
--- a/docker/production/.env
+++ b/docker/production/.env
@@ -37,7 +37,7 @@ INVENTREE_DB_PORT=5432
 # Redis cache setup
 # Refer to settings.py for other cache options
 INVENTREE_CACHE_HOST=inventree-cache
-INVENTREE_CACHE_PORT=6397
+INVENTREE_CACHE_PORT=6379
 
 # Enable plugins?
 INVENTREE_PLUGINS_ENABLED=False

--- a/docker/production/.env
+++ b/docker/production/.env
@@ -34,6 +34,11 @@ INVENTREE_DB_PORT=5432
 #INVENTREE_DB_USER=pguser
 #INVENTREE_DB_PASSWORD=pgpassword
 
+# Redis cache setup
+# Refer to settings.py for other cache options
+INVENTREE_CACHE_HOST=inventree-cache
+INVENTREE_CACHE_PORT=6397
+
 # Enable plugins?
 INVENTREE_PLUGINS_ENABLED=False
 

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -121,8 +121,8 @@ services:
             - inventree-db
         env_file:
             - .env
-        expose:
-            - ${INVENTREE_CACHE_PORT:-6397}
+        ports:
+            - ${INVENTREE_CACHE_PORT:-6379}:6379
         restart: unless-stopped
 
 volumes:

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -1,10 +1,11 @@
 version: "3.8"
 
-# Docker compose recipe for InvenTree production server
+# Docker compose recipe for InvenTree production server, with the following containerized processes
 # - PostgreSQL as the database backend
 # - gunicorn as the InvenTree web server
 # - django-q as the InvenTree background worker process
 # - nginx as a reverse proxy
+# - redis as the cache manager
 
 # ---------------------
 # READ BEFORE STARTING!
@@ -110,6 +111,18 @@ services:
             - ./nginx.prod.conf:/etc/nginx/conf.d/default.conf:ro
             # nginx proxy needs access to static and media files
             - inventree_data:/var/www
+        restart: unless-stopped
+
+    # redis acts as database cache manager
+    inventree-cache:
+        container_name: inventree-cache
+        image: redis:7.0
+        depends_on:
+            - inventree-db
+        env_file:
+            - .env
+        expose:
+            - ${INVENTREE_CACHE_PORT:-6397}
         restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
This PR adds support for a redis cache container to the production docker-compose configuration

### TODO

- [x] Update docker documentation - https://github.com/inventree/inventree-docs/pull/300

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3171"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

