### PR TITLE
Sentry

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -35,8 +35,8 @@ def _is_true(x):
     return str(x).strip().lower() in ['1', 'y', 'yes', 't', 'true']
 
 
-# Default DSN
-INVENTREE_DSN = 'https://9fb6cb0b9b524fe99884360fecb213da@o1047628.ingest.sentry.io/6493900'
+# Default Sentry DSN (can be overriden if user wants custom sentry integration)
+INVENTREE_DSN = 'https://3928ccdba1d34895abde28031fd00100@o378676.ingest.sentry.io/6494600'
 
 # Determine if we are running in "test" mode e.g. "manage.py test"
 TESTING = 'test' in sys.argv

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -551,7 +551,7 @@ db_config['TEST'] = {
 
 # Set collation option for mysql test database
 if 'mysql' in db_engine:
-    db_config['TEST']['COLLATION'] = 'utf8_general_ci'
+    db_config['TEST']['COLLATION'] = 'utf8_general_ci'  # pragma: no cover
 
 DATABASES = {
     'default': db_config
@@ -891,7 +891,7 @@ MARKDOWNIFY_BLEACH = False
 SENTRY_ENABLED = get_setting('INVENTREE_SENTRY_ENABLED', CONFIG.get('sentry_enabled', False))
 SENTRY_DSN = get_setting('INVENTREE_SENTRY_DSN', CONFIG.get('sentry_dsn', INVENTREE_DSN))
 
-if SENTRY_ENABLED and SENTRY_DSN:
+if SENTRY_ENABLED and SENTRY_DSN:  # pragma: no cover
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[DjangoIntegration(), ],
@@ -950,6 +950,6 @@ CUSTOM_LOGO = get_setting(
 )
 
 # check that the logo-file exsists in media
-if CUSTOM_LOGO and not default_storage.exists(CUSTOM_LOGO):
+if CUSTOM_LOGO and not default_storage.exists(CUSTOM_LOGO):  # pragma: no cover
     CUSTOM_LOGO = False
     logger.warning("The custom logo file could not be found in the default media storage")

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -102,6 +102,14 @@ debug: True
 #       and only if InvenTree is accessed from a local IP (127.0.0.1)
 debug_toolbar: False
 
+# Set sentry_enabled to True to report errors back to the maintainers
+# Use the environment variable INVENTREE_SENTRY_ENABLED
+# sentry_enabled: True
+
+# Set sentry_dsn to your custom DSN if you want to use your own instance for error reporting
+# Use the environment variable INVENTREE_SENTRY_DSN
+# sentry_dsn: https://custom@custom.ingest.sentry.io/custom
+
 # Set this variable to True to enable InvenTree Plugins
 # Alternatively, use the environment variable INVENTREE_PLUGINS_ENABLED
 plugins_enabled: False

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,6 @@ pygments==2.7.4                         # Syntax highlighting
 python-barcode[images]==0.13.1          # Barcode generator
 qrcode[pil]==6.1                        # QR code generator
 rapidfuzz==0.7.6                        # Fuzzy string matching
+sentry-sdk==1.5.12                      # Error reporting (optional)
 tablib[xls,xlsx,yaml]                   # Support for XLS and XLSX formats
 weasyprint==55.0                        # PDF generation library


### PR DESCRIPTION
This PR adds optional sentry error tracking,
tracking has to be enabled by setting the env var 'INVENTREE_SENTRY_ENABLED' or 'sentry_enabled' in the config to true. Custom DNS is also enabled.

Heavily inspired by https://github.com/netbox-community/netbox/issues/9340 - thank you @jeremystretch for the idea and netbox

ToDo:
- [x] change DSN out for official one in InvenTree/InvenTree/settings.py:39

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3174"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

