### PR TITLE
Refactored 'OnSuccess' with 'success' for JS code

### DIFF
--- a/InvenTree/InvenTree/static/fullcalendar/main.js
+++ b/InvenTree/InvenTree/static/fullcalendar/main.js
@@ -13974,7 +13974,7 @@ var FullCalendar = (function (exports) {
             }
             return null;
         },
-        fetch: function (arg, onSuccess, onFailure) {
+        fetch: function (arg,success, onFailure) {
             var _a = arg.context, dateEnv = _a.dateEnv, options = _a.options;
             var meta = arg.eventSource.meta;
             var apiKey = meta.googleCalendarApiKey || options.googleCalendarApiKey;
@@ -13998,7 +13998,7 @@ var FullCalendar = (function (exports) {
                         });
                     }
                     else {
-                        onSuccess({
+                       success({
                             rawEvents: gcalItemsToRawEventDefs(body.items, requestParams_1.timeZone),
                             xhr: xhr,
                         });

--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -481,7 +481,7 @@ $("#btn-auto-allocate").on('click', function() {
             {% if build.take_from %}
             location: {{ build.take_from.pk }},
             {% endif %}
-            onSuccess: loadUntrackedStockTable,
+           success: loadUntrackedStockTable,
         }
     );
 });
@@ -522,7 +522,7 @@ $("#btn-allocate").on('click', function() {
 $('#btn-unallocate').on('click', function() {
     unallocateStock({{ build.id }}, {
         table: '#allocation-table-untracked',
-        onSuccess: loadUntrackedStockTable,
+       success: loadUntrackedStockTable,
     });
 });
 

--- a/InvenTree/company/templates/company/company_base.html
+++ b/InvenTree/company/templates/company/company_base.html
@@ -206,7 +206,7 @@
                     image: {},
                 },
                 title: '{% trans "Upload Image" %}',
-                onSuccess: function(data) {
+               success: function(data) {
                     reloadImage(data);
                 }
             }

--- a/InvenTree/company/templates/company/detail.html
+++ b/InvenTree/company/templates/company/detail.html
@@ -290,7 +290,7 @@
 
         createManufacturerPart({
             manufacturer: {{ company.pk }},
-            onSuccess: function() {
+           success: function() {
                 $("#part-table").bootstrapTable("refresh");
             }
         });
@@ -346,7 +346,7 @@
 
         createSupplierPart({
             supplier: {{ company.pk }},
-            onSuccess: reloadSupplierPartTable,
+           success: reloadSupplierPartTable,
         });
     });
 

--- a/InvenTree/company/templates/company/manufacturer_part.html
+++ b/InvenTree/company/templates/company/manufacturer_part.html
@@ -243,7 +243,7 @@ $('#parameter-create').click(function() {
             }
         },
         title: '{% trans "Add Parameter" %}',
-        onSuccess: reloadParameters
+       success: reloadParameters
     });
 });
 
@@ -255,7 +255,7 @@ $('#supplier-create').click(function () {
     createSupplierPart({
         manufacturer_part: {{ part.pk }},
         part: {{ part.part.pk }},
-        onSuccess: reloadSupplierPartTable,
+       success: reloadSupplierPartTable,
     });
 });
 
@@ -324,7 +324,7 @@ $('#order-part, #order-part2').click(function() {
 $('#edit-part').click(function () {
 
     editManufacturerPart({{ part.pk }}, {
-        onSuccess: function() {
+       success: function() {
             location.reload();
         }
     });

--- a/InvenTree/company/templates/company/supplier_part.html
+++ b/InvenTree/company/templates/company/supplier_part.html
@@ -248,7 +248,7 @@ $('#price-break-table').inventreeTable({
 
             constructForm(`/api/company/price-break/${pk}/`, {
                 method: 'DELETE',
-                onSuccess: reloadPriceBreaks,
+               success: reloadPriceBreaks,
                 title: '{% trans "Delete Price Break" %}',
             });
         });
@@ -262,7 +262,7 @@ $('#price-break-table').inventreeTable({
                     price: {},
                     price_currency: {},
                 },
-                onSuccess: reloadPriceBreaks,
+               success: reloadPriceBreaks,
                 title: '{% trans "Edit Price Break" %}',
             });
         });
@@ -324,7 +324,7 @@ $('#new-price-break').click(function() {
                 },
             },
             title: '{% trans "Add Price Break" %}',
-            onSuccess: reloadPriceBreaks,
+           success: reloadPriceBreaks,
         }
     );
 });
@@ -380,7 +380,7 @@ $('#update-part-availability').click(function() {
             available: {},
         },
         title: '{% trans "Update Part Availability" %}',
-        onSuccess: function() {
+       success: function() {
             location.reload();
         }
     });
@@ -389,7 +389,7 @@ $('#update-part-availability').click(function() {
 $('#edit-part').click(function () {
 
     editSupplierPart({{ part.pk }}, {
-        onSuccess: function() {
+       success: function() {
             location.reload();
         }
     });

--- a/InvenTree/order/templates/order/order_base.html
+++ b/InvenTree/order/templates/order/order_base.html
@@ -274,7 +274,7 @@ $("#complete-order").click(function() {
     completePurchaseOrder(
         {{ order.pk }},
         {
-            onSuccess: function() {
+           success: function() {
                 window.location.reload();
             }
         }
@@ -286,7 +286,7 @@ $("#cancel-order").click(function() {
     cancelPurchaseOrder(
         {{ order.pk }},
         {
-            onSuccess: function() {
+           success: function() {
                 window.location.reload();
             }
         },

--- a/InvenTree/order/templates/order/purchase_order_detail.html
+++ b/InvenTree/order/templates/order/purchase_order_detail.html
@@ -182,7 +182,7 @@ $('#new-po-line').click(function() {
         fields: fields,
         method: 'POST',
         title: '{% trans "Add Line Item" %}',
-        onSuccess: function() {
+       success: function() {
             $('#po-line-table').bootstrapTable('refresh');
         },
     });
@@ -233,7 +233,7 @@ $("#new-po-extra-line").click(function() {
         fields: fields,
         method: 'POST',
         title: '{% trans "Add Order Line" %}',
-        onSuccess: function() {
+       success: function() {
             $("#po-extra-lines-table").bootstrapTable("refresh");
         },
     });

--- a/InvenTree/order/templates/order/sales_order_detail.html
+++ b/InvenTree/order/templates/order/sales_order_detail.html
@@ -172,7 +172,7 @@
             createSalesOrderShipment({
                 order: {{ order.pk }},
                 reference: '{{ order.reference }}',
-                onSuccess: function(data) {
+               success: function(data) {
                     $('#pending-shipments-table').bootstrapTable('refresh');
                 }
             });
@@ -247,7 +247,7 @@
             fields: fields,
             method: 'POST',
             title: '{% trans "Add Line Item" %}',
-            onSuccess: function() {
+           success: function() {
                 $("#so-lines-table").bootstrapTable("refresh");
             },
         });
@@ -272,7 +272,7 @@
             fields: fields,
             method: 'POST',
             title: '{% trans "Add Extra Line" %}',
-            onSuccess: function() {
+           success: function() {
                 $("#so-extra-lines-table").bootstrapTable("refresh");
             },
         });

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -336,7 +336,7 @@
             persist: true,
             persistMessage: '{% trans "Create another part after this one" %}',
             successMessage: '{% trans "Part created successfully" %}',
-            onSuccess: function(data) {
+           success: function(data) {
                 // Follow the new part
                 location.href = `/part/${data.pk}/`;
             },

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -439,7 +439,7 @@
 
             createSupplierPart({
                 part: {{ part.pk }},
-                onSuccess: reloadSupplierPartTable,
+               success: reloadSupplierPartTable,
             });
         });
 
@@ -496,7 +496,7 @@
 
             createManufacturerPart({
                 part: {{ part.pk }},
-                onSuccess: function() {
+               success: function() {
                     $("#manufacturer-part-table").bootstrapTable("refresh");
                 }
             });
@@ -609,7 +609,7 @@
                 method: 'POST',
                 title: '{% trans "Create BOM Item" %}',
                 focus: 'sub_part',
-                onSuccess: function() {
+               success: function() {
                     $('#bom-table').bootstrapTable('refresh');
                 }
             });
@@ -660,7 +660,7 @@
                 },
                 focus: 'part_2',
                 title: '{% trans "Add Related Part" %}',
-                onSuccess: function() {
+               success: function() {
                     $('#related-parts-table').bootstrapTable('refresh');
                 }
             });
@@ -763,7 +763,7 @@
                     }
                 },
                 title: '{% trans "Add Test Result Template" %}',
-                onSuccess: function() {
+               success: function() {
                     $("#test-template-table").bootstrapTable("refresh");
                 }
             });
@@ -833,7 +833,7 @@
                     data: {},
                 },
                 title: '{% trans "Add Parameter" %}',
-                onSuccess: function() {
+               success: function() {
                     $('#parameter-table').bootstrapTable('refresh');
                 }
             });

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -463,7 +463,7 @@
                     image: {},
                 },
                 title: '{% trans "Upload Image" %}',
-                onSuccess: function(data) {
+               success: function(data) {
                     reloadImage(data);
                 }
             }

--- a/InvenTree/part/templates/part/upload_bom.html
+++ b/InvenTree/part/templates/part/upload_bom.html
@@ -88,7 +88,7 @@ $('#bom-upload').click(function() {
             clear_existing_bom: {},
         },
         title: '{% trans "Upload BOM File" %}',
-        onSuccess: function(response) {
+       success: function(response) {
 
             // Clear existing entries from the table
             $('.bom-import-row').remove();

--- a/InvenTree/stock/templates/stock/item.html
+++ b/InvenTree/stock/templates/stock/item.html
@@ -191,7 +191,7 @@
     $('#stock-item-install').click(function() {
 
         installStockItem({{ item.pk }}, {{ item.part.pk }}, {
-            onSuccess: function(response) {
+           success: function(response) {
                 $("#installed-table").bootstrapTable('refresh');
             }
         });
@@ -298,7 +298,7 @@
                         method: 'DELETE',
                         title: '{% trans "Delete Test Data" %}',
                         preFormContent: html,
-                        onSuccess: reloadTable,
+                       success: reloadTable,
                     });
                 }
             }
@@ -322,7 +322,7 @@
                 }
             },
             title: '{% trans "Add Test Result" %}',
-            onSuccess: reloadTable,
+           success: reloadTable,
         });
     });
 

--- a/InvenTree/templates/InvenTree/notifications/notifications.html
+++ b/InvenTree/templates/InvenTree/notifications/notifications.html
@@ -74,7 +74,7 @@ $('#history-delete').click(function() {
             method: 'DELETE',
             preFormContent: html,
             title: '{% trans "Delete Notifications" %}',
-            onSuccess: function() {
+            success: function() {
                 $('#history-table').bootstrapTable('refresh');
             },
             form_data: {
@@ -90,7 +90,7 @@ $("#history-table").on('click', '.notification-delete', function() {
     constructForm(`/api/notifications/${$(this).attr('pk')}/`, {
         method: 'DELETE',
         title: '{% trans "Delete Notification" %}',
-        onSuccess: function(data) {
+        success: function(data) {
             updateNotificationTables();
         }
     });

--- a/InvenTree/templates/InvenTree/settings/settings.html
+++ b/InvenTree/templates/InvenTree/settings/settings.html
@@ -286,7 +286,7 @@ $("#new-cat-param").click(function() {
             },
             default_value: {},
         },
-        onSuccess: function() {
+        success: function() {
             loadTemplateTable(pk);
         }
     });
@@ -305,7 +305,7 @@ $("#cat-param-table").on('click', '.template-edit', function() {
             },
             default_value: {},
         },
-        onSuccess: function() {
+        success: function() {
             loadTemplateTable(pk);
         }
     });
@@ -322,7 +322,7 @@ $("#cat-param-table").on('click', '.template-delete', function() {
     constructForm(`/api/part/category/parameters/${pk}/`, {
         method: 'DELETE',
         title: '{% trans "Delete Category Parameter Template" %}',
-        onSuccess: function() {
+        success: function() {
             loadTemplateTable(pk);
         }
     });
@@ -372,7 +372,7 @@ $("#new-param").click(function() {
         },
         method: 'POST',
         title: '{% trans "Create Part Parameter Template" %}',
-        onSuccess: function() {
+        success: function() {
             $("#param-table").bootstrapTable('refresh');
         },
     });
@@ -390,7 +390,7 @@ $("#param-table").on('click', '.template-edit', function() {
                 units: {},
             },
             title: '{% trans "Edit Part Parameter Template" %}',
-            onSuccess: function() {
+            success: function() {
                 $("#param-table").bootstrapTable('refresh');
             },
         }
@@ -412,7 +412,7 @@ $("#param-table").on('click', '.template-delete', function() {
             method: 'DELETE',
             preFormContent: html,
             title: '{% trans "Delete Part Parameter Template" %}',
-            onSuccess: function() {
+            success: function() {
                 $("#param-table").bootstrapTable('refresh');
             },
         }

--- a/InvenTree/templates/js/dynamic/settings.js
+++ b/InvenTree/templates/js/dynamic/settings.js
@@ -116,7 +116,7 @@ function editSetting(key, options={}) {
 
                     return data;
                 },
-                onSuccess: function(response) {
+                success: function(response) {
 
                     var setting = response.key;
 

--- a/InvenTree/templates/js/translated/attachment.js
+++ b/InvenTree/templates/js/translated/attachment.js
@@ -32,7 +32,7 @@ function addAttachmentButtonCallbacks(url, fields={}) {
         constructForm(url, {
             fields: file_fields,
             method: 'POST',
-            onSuccess: reloadAttachmentTable,
+            success: reloadAttachmentTable,
             title: '{% trans "Add Attachment" %}',
         });
     });
@@ -50,7 +50,7 @@ function addAttachmentButtonCallbacks(url, fields={}) {
         constructForm(url, {
             fields: link_fields,
             method: 'POST',
-            onSuccess: reloadAttachmentTable,
+            success: reloadAttachmentTable,
             title: '{% trans "Add Link" %}',
         });
     });
@@ -115,7 +115,7 @@ function deleteAttachments(attachments, url, options={}) {
             items: ids,
             filters: options.filters,
         },
-        onSuccess: function() {
+        success: function() {
             // Refresh the table once all attachments are deleted
             $('#attachment-table').bootstrapTable('refresh');
         }
@@ -176,7 +176,7 @@ function loadAttachmentTable(url, options) {
                             delete opts.fields.link;
                         }
                     },
-                    onSuccess: reloadAttachmentTable,
+                    success: reloadAttachmentTable,
                     title: '{% trans "Edit Attachment" %}',
                 });
             });

--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -583,7 +583,7 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
                 title: '{% trans "Remove Substitute Part" %}',
                 preFormContent: pre,
                 confirm: true,
-                onSuccess: function() {
+                success: function() {
                     $(modal).find(`#substitute-row-${pk}`).remove();
                     reloadParentTable();
                 }
@@ -625,7 +625,7 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
             addRemoveCallback(opts.modal, '.button-row-remove');
         },
         preventClose: true,
-        onSuccess: function(response, opts) {
+        success: function(response, opts) {
 
             // Clear the form
             var field = {
@@ -701,7 +701,7 @@ function deleteBomItems(items, options={}) {
             items: ids,
         },
         preFormContent: html,
-        onSuccess: options.success,
+        success: options.success,
     });
 }
 
@@ -1221,7 +1221,7 @@ function loadBomTable(table, options={}) {
                 fields: fields,
                 title: '{% trans "Edit BOM Item" %}',
                 focus: 'sub_part',
-                onSuccess: function() {
+                success: function() {
                     reloadBomTable(table);
                 }
             });

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -119,7 +119,7 @@ function newBuildOrder(options={}) {
         follow: true,
         method: 'POST',
         title: '{% trans "Create Build Order" %}',
-        onSuccess: options.onSuccess,
+        success: options.success,
     });
 }
 
@@ -159,7 +159,7 @@ function cancelBuildOrder(build_id, options={}) {
 
                 return html;
             },
-            onSuccess: function(response) {
+            success: function(response) {
                 handleFormSuccess(response, options);
             }
         }
@@ -288,7 +288,7 @@ function createBuildOutput(build_id, options) {
                     confirm: true,
                     fields: fields,
                     preFormContent: html,
-                    onSuccess: function(response) {
+                    success: function(response) {
                         location.reload();
                     },
                 });
@@ -385,9 +385,9 @@ function unallocateStock(build_id, options={}) {
             },
         },
         title: '{% trans "Unallocate Stock Items" %}',
-        onSuccess: function(response, opts) {
-            if (options.onSuccess) {
-                options.onSuccess(response, opts);
+        success: function(response, opts) {
+            if (options.success) {
+                options.success(response, opts);
             } else if (options.table) {
                 // Reload the parent table
                 $(options.table).bootstrapTable('refresh');
@@ -1599,7 +1599,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                 bom_item: row.pk,
                 output: outputId == 'untracked' ? null : outputId,
                 table: table,
-                onSuccess: function(response, opts) {
+                success: function(response, opts) {
                     reloadAllocationData();
                 }
             });
@@ -1727,7 +1727,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                         quantity: {},
                     },
                     title: '{% trans "Edit Allocation" %}',
-                    onSuccess: reloadAllocationData,
+                    success: reloadAllocationData,
                 });
             });
 
@@ -1737,7 +1737,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                 constructForm(`/api/build/item/${pk}/`, {
                     method: 'DELETE',
                     title: '{% trans "Remove Allocation" %}',
-                    onSuccess: reloadAllocationData,
+                    success: reloadAllocationData,
                 });
             });
         },
@@ -2305,9 +2305,9 @@ function autoAllocateStockToBuild(build_id, bom_items=[], options={}) {
         title: '{% trans "Allocate Stock Items" %}',
         confirm: true,
         preFormContent: html,
-        onSuccess: function(response) {
-            if (options.onSuccess) {
-                options.onSuccess(response);
+        success: function(response) {
+            if (options.success) {
+                options.success(response);
             }
         }
     });

--- a/InvenTree/templates/js/translated/company.js
+++ b/InvenTree/templates/js/translated/company.js
@@ -76,7 +76,7 @@ function createManufacturerPart(options={}) {
         fields: fields,
         method: 'POST',
         title: '{% trans "Add Manufacturer Part" %}',
-        onSuccess: options.onSuccess
+        success: options.success
     });
 }
 
@@ -97,7 +97,7 @@ function editManufacturerPart(part, options={}) {
     constructForm(url, {
         fields: fields,
         title: '{% trans "Edit Manufacturer Part" %}',
-        onSuccess: options.onSuccess
+        success: options.success
     });
 }
 
@@ -182,7 +182,7 @@ function createSupplierPart(options={}) {
         fields: fields,
         method: 'POST',
         title: '{% trans "Add Supplier Part" %}',
-        onSuccess: options.onSuccess,
+        success: options.success,
     });
 }
 
@@ -199,7 +199,7 @@ function editSupplierPart(part, options={}) {
     constructForm(`/api/company/part/${part}/`, {
         fields: fields,
         title: options.title || '{% trans "Edit Supplier Part" %}',
-        onSuccess: options.onSuccess
+        success: options.success
     });
 }
 
@@ -268,7 +268,7 @@ function deleteSupplierParts(parts, options={}) {
         form_data: {
             items: ids,
         },
-        onSuccess: options.success,
+        success: options.success,
     });
 }
 
@@ -496,7 +496,7 @@ function deleteManufacturerParts(selections, options={}) {
         form_data: {
             items: ids,
         },
-        onSuccess: options.success,
+        success: options.success,
     });
 }
 
@@ -543,7 +543,7 @@ function deleteManufacturerPartParameters(selections, options={}) {
         form_data: {
             items: ids,
         },
-        onSuccess: options.success,
+        success: options.success,
     });
 
 }
@@ -681,7 +681,7 @@ function loadManufacturerPartTable(table, url, options) {
                 editManufacturerPart(
                     pk,
                     {
-                        onSuccess: function() {
+                        success: function() {
                             $(table).bootstrapTable('refresh');
                         }
                     }
@@ -789,7 +789,7 @@ function loadManufacturerPartParameterTable(table, url, options) {
                         units: {},
                     },
                     title: '{% trans "Edit Parameter" %}',
-                    onSuccess: function() {
+                    success: function() {
                         $(table).bootstrapTable('refresh');
                     }
                 });
@@ -800,7 +800,7 @@ function loadManufacturerPartParameterTable(table, url, options) {
                 constructForm(`/api/company/part/manufacturer/parameter/${pk}/`, {
                     method: 'DELETE',
                     title: '{% trans "Delete Parameter" %}',
-                    onSuccess: function() {
+                    success: function() {
                         $(table).bootstrapTable('refresh');
                     }
                 });
@@ -996,7 +996,7 @@ function loadSupplierPartTable(table, url, options) {
                 editSupplierPart(
                     pk,
                     {
-                        onSuccess: function() {
+                        success: function() {
                             $(table).bootstrapTable('refresh');
                         }
                     }

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -299,7 +299,7 @@ function constructDeleteForm(fields, options) {
  * - data: map of data to fill out field values with
  * - focus: Name of field to focus on when modal is displayed
  * - preventClose: Set to true to prevent form from closing on success
- * - onSuccess: callback function when form action is successful
+ * - success: callback function when form action is successful
  * - follow: If a 'url' is provided by the API on success, redirect to it
  * - redirect: A URL to redirect to after form success
  * - reload: Set to true to reload the current page after form success
@@ -1078,9 +1078,9 @@ function handleFormSuccess(response, options) {
             $(options.modal).modal('hide');
         }
 
-        if (options.onSuccess) {
+        if (options.success) {
             // Callback function
-            options.onSuccess(response, options);
+            options.success(response, options);
         }
 
         if (options.follow && response.url) {
@@ -1594,9 +1594,9 @@ function addSecondaryModal(field, fields, options) {
             secondary.fields = secondary.fields(data);
         }
 
-        // If no onSuccess function is defined, provide a default one
-        if (!secondary.onSuccess) {
-            secondary.onSuccess = function(data) {
+        // If no success function is defined, provide a default one
+        if (!secondary.success) {
+            secondary.success = function(data) {
 
                 // Force refresh from the API, to get full detail
                 inventreeGet(`${url}${data.pk}/`, {}, {

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -155,14 +155,14 @@ function completeShipment(shipment_id, options={}) {
                 confirm: true,
                 confirmMessage: '{% trans "Confirm Shipment" %}',
                 buttons: options.buttons,
-                onSuccess: function(data) {
+                success: function(data) {
                     // Reload tables
                     $('#so-lines-table').bootstrapTable('refresh');
                     $('#pending-shipments-table').bootstrapTable('refresh');
                     $('#completed-shipments-table').bootstrapTable('refresh');
 
-                    if (options.onSuccess instanceof Function) {
-                        options.onSuccess(data);
+                    if (options.success instanceof Function) {
+                        options.success(data);
                     }
                 },
                 reload: options.reload
@@ -255,7 +255,7 @@ function completePendingShipmentsHelper(shipments, shipment_idx, options={}) {
                         }
                     }
                 ],
-                onSuccess: function(data) {
+                success: function(data) {
                     completePendingShipmentsHelper(shipments, shipment_idx + 1, options);
                 },
             }
@@ -299,7 +299,7 @@ function completePurchaseOrder(order_id, options={}) {
 
                 return html;
             },
-            onSuccess: function(response) {
+            success: function(response) {
                 handleFormSuccess(response, options);
             }
         }
@@ -333,7 +333,7 @@ function cancelPurchaseOrder(order_id, options={}) {
 
                 return html;
             },
-            onSuccess: function(response) {
+            success: function(response) {
                 handleFormSuccess(response, options);
             }
         }
@@ -360,7 +360,7 @@ function issuePurchaseOrder(order_id, options={}) {
 
                 return html;
             },
-            onSuccess: function(response) {
+            success: function(response) {
                 handleFormSuccess(response, options);
             }
         }
@@ -387,7 +387,7 @@ function cancelSalesOrder(order_id, options={}) {
 
                 return html;
             },
-            onSuccess: function(response) {
+            success: function(response) {
                 handleFormSuccess(response, options);
             }
         }
@@ -437,9 +437,9 @@ function createSalesOrderShipment(options={}) {
                     method: 'POST',
                     fields: fields,
                     title: '{% trans "Create New Shipment" %}',
-                    onSuccess: function(data) {
-                        if (options.onSuccess) {
-                            options.onSuccess(data);
+                    success: function(data) {
+                        if (options.success) {
+                            options.success(data);
                         }
                     }
                 });
@@ -483,7 +483,7 @@ function createSalesOrder(options={}) {
                 icon: 'fa-user',
             }
         },
-        onSuccess: function(data) {
+        success: function(data) {
             location.href = `/order/sales-order/${data.pk}/`;
         },
         title: '{% trans "Create Sales Order" %}',
@@ -525,10 +525,10 @@ function createPurchaseOrder(options={}) {
                 icon: 'fa-user',
             }
         },
-        onSuccess: function(data) {
+        success: function(data) {
 
-            if (options.onSuccess) {
-                options.onSuccess(data);
+            if (options.success) {
+                options.success(data);
             } else {
                 // Default action is to redirect browser to the new PurchaseOrder
                 location.href = `/order/purchase-order/${data.pk}/`;
@@ -651,7 +651,7 @@ function newSupplierPartFromOrderWizard(e) {
 
     createSupplierPart({
         part: part,
-        onSuccess: function(data) {
+        success: function(data) {
 
             // TODO: 2021-08-23 - This whole form wizard needs to be refactored.
             // In the future, use the API forms functionality to add the new item
@@ -1022,7 +1022,7 @@ function orderParts(parts_list, options={}) {
                 // Launch dialog to create new supplier part
                 createSupplierPart({
                     part: pk,
-                    onSuccess: function(response) {
+                    success: function(response) {
                         setRelatedFieldData(
                             `part_${pk}`,
                             response,
@@ -1038,7 +1038,7 @@ function orderParts(parts_list, options={}) {
 
                 // Launch dialog to create new purchase order
                 createPurchaseOrder({
-                    onSuccess: function(response) {
+                    success: function(response) {
                         setRelatedFieldData(
                             `order_${pk}`,
                             response,
@@ -1066,7 +1066,7 @@ function newPurchaseOrderFromOrderWizard(e) {
 
     createPurchaseOrder({
         supplier: supplier,
-        onSuccess: function(data) {
+        success: function(data) {
 
             // TODO: 2021-08-23 - The whole form wizard needs to be refactored
             // In the future, the drop-down should be using a dynamic AJAX request
@@ -1781,7 +1781,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                             fields: fields,
                             data: data,
                             title: '{% trans "Duplicate Line Item" %}',
-                            onSuccess: function(response) {
+                            success: function(response) {
                                 $(table).bootstrapTable('refresh');
                             }
                         });
@@ -1798,7 +1798,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                 constructForm(`/api/order/po-line/${pk}/`, {
                     fields: fields,
                     title: '{% trans "Edit Line Item" %}',
-                    onSuccess: function() {
+                    success: function() {
                         $(table).bootstrapTable('refresh');
                     }
                 });
@@ -1811,7 +1811,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                 constructForm(`/api/order/po-line/${pk}/`, {
                     method: 'DELETE',
                     title: '{% trans "Delete Line Item" %}',
-                    onSuccess: function() {
+                    success: function() {
                         $(table).bootstrapTable('refresh');
                     }
                 });
@@ -2234,7 +2234,7 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
                         fields: fields,
                         data: data,
                         title: '{% trans "Duplicate Line" %}',
-                        onSuccess: function(response) {
+                        success: function(response) {
                             $(table).bootstrapTable('refresh');
                         }
                     });
@@ -2255,7 +2255,7 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
                     notes: {},
                 },
                 title: '{% trans "Edit Line" %}',
-                onSuccess: reloadTable,
+                success: reloadTable,
             });
         });
 
@@ -2266,7 +2266,7 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
             constructForm(`/api/order/po-extra-line/${pk}/`, {
                 method: 'DELETE',
                 title: '{% trans "Delete Line" %}',
-                onSuccess: reloadTable,
+                success: reloadTable,
             });
         });
     }
@@ -2575,7 +2575,7 @@ function loadSalesOrderShipmentTable(table, options={}) {
             constructForm(`/api/order/so/shipment/${pk}/`, {
                 fields: fields,
                 title: '{% trans "Edit Shipment" %}',
-                onSuccess: function() {
+                success: function() {
                     $(table).bootstrapTable('refresh');
                 }
             });
@@ -2593,7 +2593,7 @@ function loadSalesOrderShipmentTable(table, options={}) {
             constructForm(`/api/order/so/shipment/${pk}/`, {
                 title: '{% trans "Delete Shipment" %}',
                 method: 'DELETE',
-                onSuccess: function() {
+                success: function() {
                     $(table).bootstrapTable('refresh');
                 }
             });
@@ -3180,7 +3180,7 @@ function showAllocationSubTable(index, row, element, options) {
                         quantity: {},
                     },
                     title: '{% trans "Edit Stock Allocation" %}',
-                    onSuccess: function() {
+                    success: function() {
                         // Refresh the parent table
                         $(options.table).bootstrapTable('refresh');
                     },
@@ -3198,7 +3198,7 @@ function showAllocationSubTable(index, row, element, options) {
                     method: 'DELETE',
                     confirmMessage: '{% trans "Confirm Delete Operation" %}',
                     title: '{% trans "Delete Stock Allocation" %}',
-                    onSuccess: function() {
+                    success: function() {
                         // Refresh the parent table
                         $(options.table).bootstrapTable('refresh');
                     }
@@ -3709,7 +3709,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                         fields: fields,
                         data: data,
                         title: '{% trans "Duplicate Line Item" %}',
-                        onSuccess: function(response) {
+                        success: function(response) {
                             $(table).bootstrapTable('refresh');
                         }
                     });
@@ -3731,7 +3731,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                     notes: {},
                 },
                 title: '{% trans "Edit Line Item" %}',
-                onSuccess: reloadTable,
+                success: reloadTable,
             });
         });
 
@@ -3742,7 +3742,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
             constructForm(`/api/order/so-line/${pk}/`, {
                 method: 'DELETE',
                 title: '{% trans "Delete Line Item" %}',
-                onSuccess: reloadTable,
+                success: reloadTable,
             });
         });
 
@@ -3772,7 +3772,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                                     auto_fill: true,
                                 }
                             },
-                            onSuccess: function() {
+                            success: function() {
                                 $(table).bootstrapTable('refresh');
                             }
                         });
@@ -4073,7 +4073,7 @@ function loadSalesOrderExtraLineTable(table, options={}) {
                         fields: fields,
                         data: data,
                         title: '{% trans "Duplicate Line" %}',
-                        onSuccess: function(response) {
+                        success: function(response) {
                             $(table).bootstrapTable('refresh');
                         }
                     });
@@ -4094,7 +4094,7 @@ function loadSalesOrderExtraLineTable(table, options={}) {
                     notes: {},
                 },
                 title: '{% trans "Edit Line" %}',
-                onSuccess: reloadTable,
+                success: reloadTable,
             });
         });
 
@@ -4105,7 +4105,7 @@ function loadSalesOrderExtraLineTable(table, options={}) {
             constructForm(`/api/order/so-extra-line/${pk}/`, {
                 method: 'DELETE',
                 title: '{% trans "Delete Line" %}',
-                onSuccess: reloadTable,
+                success: reloadTable,
             });
         });
     }

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -339,7 +339,7 @@ function deletePartCategory(pk, options={}) {
         title: '{% trans "Delete Part Category" %}',
         method: 'DELETE',
         preFormContent: html,
-        onSuccess: function(response) {
+        success: function(response) {
             handleFormSuccess(response, options);
         }
     });
@@ -410,7 +410,7 @@ function duplicatePart(pk, options={}) {
                 groups: partGroups(),
                 title: title,
                 data: data,
-                onSuccess: function(data) {
+                success: function(data) {
                     // Follow the new part
                     location.href = `/part/${data.pk}/`;
                 }
@@ -455,7 +455,7 @@ function deletePart(pk, options={}) {
                     method: 'DELETE',
                     title: '{% trans "Delete Part" %}',
                     preFormContent: html,
-                    onSuccess: function(response) {
+                    success: function(response) {
                         handleFormSuccess(response, options);
                     }
                 }
@@ -527,7 +527,7 @@ function validateBom(part_id, options={}) {
         preFormContent: html,
         title: '{% trans "Validate Bill of Materials" %}',
         reload: options.reload,
-        onSuccess: function(response) {
+        success: function(response) {
             showMessage('{% trans "Validated Bill of Materials" %}');
         }
     });
@@ -554,7 +554,7 @@ function duplicateBom(part_id, options={}) {
         },
         confirm: true,
         title: '{% trans "Copy Bill of Materials" %}',
-        onSuccess: function(response) {
+        success: function(response) {
             if (options.success) {
                 options.success(response);
             }
@@ -884,7 +884,7 @@ function loadPartParameterTable(table, url, options) {
                         data: {},
                     },
                     title: '{% trans "Edit Parameter" %}',
-                    onSuccess: function() {
+                    success: function() {
                         $(table).bootstrapTable('refresh');
                     }
                 });
@@ -896,7 +896,7 @@ function loadPartParameterTable(table, url, options) {
                 constructForm(`/api/part/parameter/${pk}/`, {
                     method: 'DELETE',
                     title: '{% trans "Delete Parameter" %}',
-                    onSuccess: function() {
+                    success: function() {
                         $(table).bootstrapTable('refresh');
                     }
                 });
@@ -1186,7 +1186,7 @@ function loadRelatedPartsTable(table, part_id, options={}) {
                 constructForm(`/api/part/related/${pk}/`, {
                     method: 'DELETE',
                     title: '{% trans "Delete Part Relationship" %}',
-                    onSuccess: function() {
+                    success: function() {
                         $(table).bootstrapTable('refresh');
                     }
                 });
@@ -2004,7 +2004,7 @@ function loadPartTestTemplateTable(table, options) {
                         requires_attachment: {},
                     },
                     title: '{% trans "Edit Test Result Template" %}',
-                    onSuccess: function() {
+                    success: function() {
                         table.bootstrapTable('refresh');
                     },
                 });
@@ -2018,7 +2018,7 @@ function loadPartTestTemplateTable(table, options) {
                 constructForm(url, {
                     method: 'DELETE',
                     title: '{% trans "Delete Test Result Template" %}',
-                    onSuccess: function() {
+                    success: function() {
                         table.bootstrapTable('refresh');
                     },
                 });
@@ -2165,7 +2165,7 @@ function initPriceBreakSet(table, options) {
             },
             method: 'POST',
             title: '{% trans "Add Price Break" %}',
-            onSuccess: reloadPriceBreakTable,
+            success: reloadPriceBreakTable,
         });
     });
 
@@ -2175,7 +2175,7 @@ function initPriceBreakSet(table, options) {
         constructForm(`${pb_url}${pk}/`, {
             method: 'DELETE',
             title: '{% trans "Delete Price Break" %}',
-            onSuccess: reloadPriceBreakTable,
+            success: reloadPriceBreakTable,
         });
     });
 
@@ -2189,7 +2189,7 @@ function initPriceBreakSet(table, options) {
                 price_currency: {},
             },
             title: '{% trans "Edit Price Break" %}',
-            onSuccess: reloadPriceBreakTable,
+            success: reloadPriceBreakTable,
         });
     });
 }

--- a/InvenTree/templates/js/translated/plugin.js
+++ b/InvenTree/templates/js/translated/plugin.js
@@ -19,7 +19,7 @@ function installPlugin() {
             url: {},
             confirm: {},
         },
-        onSuccess: function(data) {
+        success: function(data) {
             msg = '{% trans "The Plugin was installed" %}';
             showMessage(msg, {style: 'success', details: data.result, timeout: 30000});
         }

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -178,7 +178,7 @@ function deleteStockLocation(pk, options={}) {
         title: '{% trans "Delete Stock Location" %}',
         method: 'DELETE',
         preFormContent: html,
-        onSuccess: function(response) {
+        success: function(response) {
             handleFormSuccess(response, options);
         }
     });
@@ -327,8 +327,8 @@ function stockItemGroups(options={}) {
 function duplicateStockItem(pk, options) {
 
     // If no "success" function provided, add a default
-    if (!options.onSuccess) {
-        options.onSuccess = function(response) {
+    if (!options.success) {
+        options.success = function(response) {
 
             showAlertOrCache('{% trans "Stock item duplicated" %}', true, {style: 'success'});
 
@@ -373,7 +373,7 @@ function deleteStockItem(pk, options={}) {
         method: 'DELETE',
         title: '{% trans "Delete Stock Item" %}',
         preFormContent: html,
-        onSuccess: function(response) {
+        success: function(response) {
             handleFormSuccess(response, options);
         }
     });
@@ -436,8 +436,8 @@ function createNewStockItem(options={}) {
     options.fields = stockItemFields(options);
     options.groups = stockItemGroups(options);
 
-    if (!options.onSuccess) {
-        options.onSuccess = function(response) {
+    if (!options.success) {
+        options.success = function(response) {
             // If a single stock item has been created, follow it!
             if (response.pk) {
                 var url = `/stock/item/${response.pk}/`;
@@ -1515,7 +1515,7 @@ function loadStockTestResultsTable(table, options) {
                 }
             },
             title: '{% trans "Add Test Result" %}',
-            onSuccess: reloadTestTable,
+            success: reloadTestTable,
         });
     });
 
@@ -1536,7 +1536,7 @@ function loadStockTestResultsTable(table, options) {
                 notes: {},
             },
             title: '{% trans "Edit Test Result" %}',
-            onSuccess: reloadTestTable,
+            success: reloadTestTable,
         });
     });
 
@@ -1558,7 +1558,7 @@ function loadStockTestResultsTable(table, options) {
         constructForm(url, {
             method: 'DELETE',
             title: '{% trans "Delete Test Result" %}',
-            onSuccess: reloadTestTable,
+            success: reloadTestTable,
             preFormContent: html,
         });
     });
@@ -2691,7 +2691,7 @@ function loadInstalledInTable(table, options) {
                 uninstallStockItem(
                     pk,
                     {
-                        onSuccess: function(response) {
+                        success: function(response) {
                             table.bootstrapTable('refresh');
                         }
                     }
@@ -2731,7 +2731,7 @@ function uninstallStockItem(installed_item_id, options={}) {
 
                 return html;
             },
-            onSuccess: function(response) {
+            success: function(response) {
                 handleFormSuccess(response, options);
             }
         }
@@ -2794,9 +2794,9 @@ function installStockItem(stock_item_id, part_id, options={}) {
             confirm: true,
             title: '{% trans "Install Stock Item" %}',
             preFormContent: html,
-            onSuccess: function(response) {
-                if (options.onSuccess) {
-                    options.onSuccess(response);
+            success: function(response) {
+                if (options.Success) {
+                    options.Success(response);
                 }
             }
         }


### PR DESCRIPTION
Replaced all instanced for 'OnSuccess' with 'success' for JS code. 

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3189"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

Closes https://github.com/inventree/InvenTree/issues/3007