### PR TITLE
Sanitize data before displaying in markdown editor

### DIFF
--- a/InvenTree/InvenTree/mixins.py
+++ b/InvenTree/InvenTree/mixins.py
@@ -35,7 +35,7 @@ class CleanMixin():
         return Response(serializer.data)
 
     def clean_data(self, data: dict) -> dict:
-        """Clean / snatize data.
+        """Clean / sanitize data.
 
         This uses mozillas bleach under the hood to disable certain html tags by
         encoding them - this leads to script tags etc. to not work.

--- a/InvenTree/templates/js/translated/helpers.js
+++ b/InvenTree/templates/js/translated/helpers.js
@@ -248,9 +248,6 @@ function setupNotesField(element, url, options={}) {
         },
     });
 
-    // Ensure markdown data is sanitized against XSS attacks
-    initial = sanitizeData(initial);
-
     var toolbar_icons = [
         'preview', '|',
     ];
@@ -277,6 +274,11 @@ function setupNotesField(element, url, options={}) {
         initialValue: initial,
         toolbar: toolbar_icons,
         shortcuts: [],
+        renderingConfig: {
+            markedOptions: {
+                sanitize: true,
+            }
+        }
     });
 
 

--- a/InvenTree/templates/js/translated/helpers.js
+++ b/InvenTree/templates/js/translated/helpers.js
@@ -248,6 +248,9 @@ function setupNotesField(element, url, options={}) {
         },
     });
 
+    // Ensure markdown data is sanitized against XSS attacks
+    initial = sanitizeData(initial);
+
     var toolbar_icons = [
         'preview', '|',
     ];


### PR DESCRIPTION
Ensure data loaded via the API is sanitized before displaying in EasyMDE

Provides front-end sanitization in parallel with the fixes in https://github.com/inventree/InvenTree/pull/3204

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3205"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

