### PR TITLE
fix docs link for "email settings not configured" warning

### DIFF
--- a/InvenTree/templates/stats.html
+++ b/InvenTree/templates/stats.html
@@ -74,7 +74,7 @@
         <td><span class='fas fa-envelope'></span></td>
         <td>{% trans "Email Settings" %}</td>
         <td>
-            <a href='{% inventree_docs_url %}/admin/email'>
+            <a href='{% inventree_docs_url %}/settings/email'>
                 <span class='badge rounded-pill bg-warning'>{% trans "Email settings not configured" %}</span>
             </a>
         </td>


### PR DESCRIPTION
the "System Information" dialog contains a link to the nonexistent docs page https://inventree.readthedocs.io/en/0.7.3/admin/email, i think the proper link should be https://inventree.readthedocs.io/en/0.7.3/settings/email/


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3209"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

