### PR TITLE
Fix API endpoint permission for the "AttachmentMixin" class

### DIFF
--- a/InvenTree/InvenTree/api.py
+++ b/InvenTree/InvenTree/api.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
 from InvenTree.mixins import ListCreateAPI
+from InvenTree.permissions import RolePermission
 
 from .status import is_worker_running
 from .version import (inventreeApiVersion, inventreeInstanceName,
@@ -182,7 +183,10 @@ class APIDownloadMixin:
 class AttachmentMixin:
     """Mixin for creating attachment objects, and ensuring the user information is saved correctly."""
 
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [
+        permissions.IsAuthenticated,
+        RolePermission,
+    ]
 
     filter_backends = [
         DjangoFilterBackend,

--- a/InvenTree/templates/attachment_table.html
+++ b/InvenTree/templates/attachment_table.html
@@ -2,7 +2,7 @@
 
 <div id='attachment-buttons'>
     <div class='btn-group' role='group'>
-        <div class='btn-group'>
+        <div class='btn-group' id='multi-attachment-actions'>
             <button class='btn btn-primary dropdown-toggle' type='button' data-bs-toggle='dropdown' title='{% trans "Actions" %}'>
                 <span class='fas fa-tools'></span> <span class='caret'></span>
             </button>

--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -222,6 +222,11 @@ class RuleSet(models.Model):
     @classmethod
     def check_table_permission(cls, user, table, permission):
         """Check if the provided user has the specified permission against the table."""
+
+        # Superuser knows no bounds
+        if user.is_superuser:
+            return True
+
         # If the table does *not* require permissions
         if table in cls.RULESET_IGNORE:
             return True


### PR DESCRIPTION
- Any authenticated user could perform CREATE and UPDATE operations on attachments
- Could be performed via the browsable DRF API
- Could also be performed via the front-end (with some advanced jiggering of OPTIONS code)

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3218"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

