### PR TITLE
Prevent calculation of 'allocation_count' before model is saved

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1318,6 +1318,11 @@ class Part(MetadataMixin, MPTTModel):
 
     def allocation_count(self, **kwargs):
         """Return the total quantity of stock allocated for this part, against both build orders and sales orders."""
+
+        if self.id is None:
+            # If this instance has not been saved, foreign-key lookups will fail
+            return 0
+
         return sum(
             [
                 self.build_order_allocation_count(**kwargs),


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/3234

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3235"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

