### PR TITLE
Adds a template for handling 403 errors due to CSRF issues

### DIFF
--- a/InvenTree/templates/403_csrf.html
+++ b/InvenTree/templates/403_csrf.html
@@ -1,0 +1,23 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load inventree_extras %}
+
+{% block page_title %}
+{% inventree_title %} | {% trans "Permission Denied" %}
+{% endblock %}
+
+{% block content %}
+<h3>{% trans "Authentication Failure" %}</h3>
+
+<div class='alert alert-danger alert-block'>
+    {% trans "You have been logged out from InvenTree." %}
+</div>
+<hr>
+<div class='btn-group float-right' role='group'>
+    <a type='button' class='btn btn-primary' href='{% url "account_login" %}'>
+        <span class='fas fa-sign-in-alt'></span> {% trans "Login" %}
+    </a>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
e.g. when switching between users but leaving tabs open, CSRF / session issues can cause errors.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3260"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

