### PR TITLE
[BUG] Duplication of "base URL" setting

### DIFF
--- a/InvenTree/InvenTree/tests.py
+++ b/InvenTree/InvenTree/tests.py
@@ -23,6 +23,7 @@ from stock.models import StockLocation
 
 from . import config, helpers, ready, status, version
 from .validators import validate_overage, validate_part_name
+from django.contrib.sites.models import Site
 
 
 class ValidatorTest(TestCase):
@@ -604,3 +605,16 @@ class TestInstanceName(helpers.InvenTreeTestCase):
         InvenTreeSetting.set_setting("INVENTREE_INSTANCE", "Testing title", self.user)
 
         self.assertEqual(version.inventreeInstanceTitle(), 'Testing title')
+
+        # The site should also be changed
+        site_obj = Site.objects.all().order_by('id').first()
+        self.assertEqual(site_obj.name, 'Testing title')
+
+    def test_instance_url(self):
+        """Test instance url settings."""
+        # Set up required setting
+        InvenTreeSetting.set_setting("INVENTREE_BASE_URL", "http://127.1.2.3", self.user)
+
+        # The site should also be changed
+        site_obj = Site.objects.all().order_by('id').first()
+        self.assertEqual(site_obj.domain, 'http://127.1.2.3')

--- a/InvenTree/InvenTree/tests.py
+++ b/InvenTree/InvenTree/tests.py
@@ -9,6 +9,7 @@ from unittest import mock
 import django.core.exceptions as django_exceptions
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 
@@ -23,7 +24,6 @@ from stock.models import StockLocation
 
 from . import config, helpers, ready, status, version
 from .validators import validate_overage, validate_part_name
-from django.contrib.sites.models import Site
 
 
 class ValidatorTest(TestCase):

--- a/InvenTree/common/tests.py
+++ b/InvenTree/common/tests.py
@@ -133,6 +133,7 @@ class SettingsTest(InvenTreeTestCase):
             'choices',
             'units',
             'requires_restart',
+            'after_save',
         ]
 
         for k in setting.keys():


### PR DESCRIPTION
Fixes #3196

Adds after_safe key to settings: This provided callable is executed after the setting is saved.
The current (=>new) setting object is supplied to the function as the first argument.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3263"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

