### PR TITLE
Docker requirements update

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,9 +39,11 @@ jobs:
           python3 ci/version_check.py
           echo "git_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "git_commit_date=$(git show -s --format=%ci)" >> $GITHUB_ENV
-      - name: Run Unit Tests
+      - name: Build Docker Image
         run: |
           docker-compose build
+      - name: Run Unit Tests
+        run: |
           docker-compose run inventree-dev-server invoke update
           docker-compose up -d
           docker-compose run inventree-dev-server invoke wait

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ invoke>=1.4.0                   # Invoke build tool
 psycopg2>=2.9.1
 mysqlclient>=2.0.3
 pgcli>=3.1.0
-mariadb>=1.0.7,<=1.1.0
+mariadb>=1.0.7,<1.1.0
 
 # gunicorn web server
 gunicorn>=20.1.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ invoke>=1.4.0                   # Invoke build tool
 psycopg2>=2.9.1
 mysqlclient>=2.0.3
 pgcli>=3.1.0
-mariadb>=1.0.7
+mariadb>=1.0.7,<=1.1.0
 
 # gunicorn web server
 gunicorn>=20.1.0


### PR DESCRIPTION
A recent update to [mariadb](https://pypi.org/project/mariadb/#history) breaks the docker build.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3266"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

