### PR TITLE
Change the default serialization level for postgresql DB

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -532,7 +532,7 @@ if "postgres" in db_engine:  # pragma: no cover
     # https://docs.djangoproject.com/en/3.2/ref/databases/#isolation-level
     if "isolation_level" not in db_options:
         serializable = _is_true(
-            os.getenv("INVENTREE_DB_ISOLATION_SERIALIZABLE", "true")
+            os.getenv("INVENTREE_DB_ISOLATION_SERIALIZABLE", "false")
         )
         db_options["isolation_level"] = (
             ISOLATION_LEVEL_SERIALIZABLE


### PR DESCRIPTION
- Previously defaulted to SERIALIZABLE
- Now defaults to READ_COMMITTED

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3268"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

