### PR TITLE
Part API Filter Fix

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -866,7 +866,8 @@ class PartFilter(rest_filters.FilterSet):
     def filter_in_bom(self, queryset, name, part):
         """Limit queryset to parts in the BOM for the specified part"""
 
-        queryset = queryset.filter(id__in=part.get_parts_in_bom())
+        bom_parts = part.get_parts_in_bom()
+        queryset = queryset.filter(id__in=[p.pk for p in bom_parts])
         return queryset
 
     is_template = rest_filters.BooleanFilter()

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -400,6 +400,21 @@ class PartAPITest(InvenTreeAPITestCase):
         for part in response.data:
             self.assertEqual(part['category'], 2)
 
+    def test_filter_by_in_bom(self):
+        """Test that we can filter part list by the 'in_bom_for' parameter"""
+
+        url = reverse('api-part-list')
+
+        response = self.get(
+            url,
+            {
+                'in_bom_for': 100,
+            },
+            expected_code=200,
+        )
+
+        self.assertEqual(len(response.data), 4)
+
     def test_filter_by_related(self):
         """Test that we can filter by the 'related' status"""
         url = reverse('api-part-list')


### PR DESCRIPTION
Fixes bug in part API, the `in_bom_for` filter was not functioning correctly.

This PR fixes the issue and adds a new unit test

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3271"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

