### PR TITLE
BREAKING: Remove old classes

### DIFF
--- a/InvenTree/plugin/__init__.py
+++ b/InvenTree/plugin/__init__.py
@@ -1,14 +1,13 @@
 """Utility file to enable simper imports."""
 
 from .helpers import MixinImplementationError, MixinNotImplementedError
-from .plugin import IntegrationPluginBase, InvenTreePlugin
+from .plugin import InvenTreePlugin
 from .registry import registry
 
 __all__ = [
     'registry',
 
     'InvenTreePlugin',
-    'IntegrationPluginBase',
     'MixinNotImplementedError',
     'MixinImplementationError',
 ]

--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -298,16 +298,3 @@ class InvenTreePlugin(MixinBase, MetaBase):
         self.package = package
         self.sign_state = sign_state
     # endregion
-
-
-class IntegrationPluginBase(InvenTreePlugin):
-    """Legacy base class for plugins.
-
-    Do not use!
-    """
-
-    def __init__(self, *args, **kwargs):
-        """Send warning about using this reference."""
-        # TODO remove in 0.8.0
-        warnings.warn("This import is deprecated - use InvenTreePlugin", DeprecationWarning)
-        super().__init__(*args, **kwargs)

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from django.test import TestCase
 
 import plugin.templatetags.plugin_extras as plugin_tags
-from plugin import IntegrationPluginBase, InvenTreePlugin, registry
+from plugin import InvenTreePlugin, registry
 from plugin.samples.integration.another_sample import (NoIntegrationPlugin,
                                                        WrongIntegrationPlugin)
 from plugin.samples.integration.sample import SampleIntegrationPlugin
@@ -162,11 +162,3 @@ class InvenTreePluginTests(TestCase):
             self.assertEqual(self.plugin_old.slug, 'old')
             # check default value is used
             self.assertEqual(self.plugin_old.get_meta_value('ABC', 'ABCD', '123'), '123')
-
-        # check usage of the old class fires
-        class OldPlugin(IntegrationPluginBase):
-            pass
-
-        with self.assertWarns(DeprecationWarning):
-            plg = OldPlugin()
-            self.assertIsInstance(plg, InvenTreePlugin)


### PR DESCRIPTION
Removes the depreciated class IntegrationPluginBase

This should only be included in 0.8.0

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3283"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

