### PR TITLE
Fix spelling error

### DIFF
--- a/InvenTree/templates/InvenTree/settings/plugin.html
+++ b/InvenTree/templates/InvenTree/settings/plugin.html
@@ -13,7 +13,7 @@
 {% block content %}
 
 <div class='alert alert-block alert-danger'>
-    {% trans "Changing the settings below require you to immediatly restart the server. Do not change this while under active usage." %}
+    {% trans "Changing the settings below require you to immediately restart the server. Do not change this while under active usage." %}
 </div>
 
 <div class='table-responsive'>


### PR DESCRIPTION
immediatly -> immediately

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3288"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

