### PR TITLE
Fix table sorting issues

### DIFF
--- a/InvenTree/templates/js/translated/attachment.js
+++ b/InvenTree/templates/js/translated/attachment.js
@@ -196,6 +196,7 @@ function loadAttachmentTable(url, options) {
         search: true,
         queryParams: options.filters || {},
         uniqueId: 'pk',
+        sidePagination: 'server',
         onPostBody: function() {
 
             // Add callback for 'edit' button

--- a/InvenTree/templates/js/translated/tables.js
+++ b/InvenTree/templates/js/translated/tables.js
@@ -375,10 +375,6 @@ $.fn.inventreeTable = function(options) {
         options.totalField = 'count';
         options.dataField = 'results';
 
-        if (options.sidePagination == null) {
-            options.sidePagination = 'server';
-        }
-
     } else {
         options.pagination = false;
     }


### PR DESCRIPTION
- Recent update changed default table pagination to "server"
- This broke at least the BOM table, maybe others
- Revert the behaviour to previous to observe old defaults
- Update pagination mode for attachment tables specifically

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3289"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

