### PR TITLE
Bump django version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -94,9 +94,9 @@ distlib==0.3.4 \
     --hash=sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b \
     --hash=sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579
     # via virtualenv
-django==3.2.13 \
-    --hash=sha256:6d93497a0a9bf6ba0e0b1a29cccdc40efbfc76297255b1309b3a884a688ec4b6 \
-    --hash=sha256:b896ca61edc079eb6bbaa15cf6071eb69d6aac08cce5211583cfb41515644fdf
+django==3.2.14 \
+    --hash=sha256:677182ba8b5b285a4e072f3ac17ceee6aff1b5ce77fd173cc5b6a2d3dc022fcf \
+    --hash=sha256:a8681e098fa60f7c33a4b628d6fcd3fe983a0939ff1301ecacac21d0b38bad56
     # via
     #   -c requirements.txt
     #   django-debug-toolbar

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # Please keep this list sorted - if you pin a version provide a reason
-Django<4                                # Django package
+Django>=3.2.14,<4                       # Django package
 coreapi                                 # API documentation for djangorestframework
 cryptography==3.4.8                     # Core cryptographic functionality
 django-allauth                          # SSO for external providers via OpenID

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ defusedxml==0.7.1
     #   python3-openid
 diff-match-patch==20200713
     # via django-import-export
-django==3.2.13
+django==3.2.14
     # via
     #   -r requirements.in
     #   django-allauth


### PR DESCRIPTION
Updates django based on recent [django security advisory](https://github.com/advisories/GHSA-p64x-8rxx-wf6q)

Closes https://github.com/inventree/InvenTree/pull/3297/

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3299"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

