### PR TITLE
Remove custom 2FA code

### DIFF
--- a/InvenTree/InvenTree/urls.py
+++ b/InvenTree/InvenTree/urls.py
@@ -35,9 +35,9 @@ from .views import (AboutView, AppearanceSelectView, CurrencyRefreshView,
                     CustomConnectionsView, CustomEmailView,
                     CustomPasswordResetFromKeyView,
                     CustomSessionDeleteOtherView, CustomSessionDeleteView,
-                    CustomTwoFactorRemove, DatabaseStatsView, DynamicJsView,
-                    EditUserView, IndexView, NotificationsView, SearchView,
-                    SetPasswordView, SettingsView, auth_request)
+                    DatabaseStatsView, DynamicJsView, EditUserView, IndexView,
+                    NotificationsView, SearchView, SetPasswordView,
+                    SettingsView, auth_request)
 
 admin.site.site_header = "InvenTree Admin"
 
@@ -163,10 +163,6 @@ frontendpatterns = [
     re_path(r'^accounts/email/', CustomEmailView.as_view(), name='account_email'),
     re_path(r'^accounts/social/connections/', CustomConnectionsView.as_view(), name='socialaccount_connections'),
     re_path(r"^accounts/password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$", CustomPasswordResetFromKeyView.as_view(), name="account_reset_password_from_key"),
-
-    # Temporary fix for django-allauth-2fa # TODO remove
-    # See https://github.com/inventree/InvenTree/security/advisories/GHSA-8j76-mm54-52xq
-    re_path(r'^accounts/two_factor/remove/?$', CustomTwoFactorRemove.as_view(), name='two-factor-remove'),
 
     re_path(r'^accounts/', include('allauth_2fa.urls')),    # MFA support
     re_path(r'^accounts/', include('allauth.urls')),        # included urlpatterns

--- a/InvenTree/InvenTree/urls.py
+++ b/InvenTree/InvenTree/urls.py
@@ -35,9 +35,9 @@ from .views import (AboutView, AppearanceSelectView, CurrencyRefreshView,
                     CustomConnectionsView, CustomEmailView,
                     CustomPasswordResetFromKeyView,
                     CustomSessionDeleteOtherView, CustomSessionDeleteView,
-                    DatabaseStatsView, DynamicJsView, EditUserView, IndexView,
-                    NotificationsView, SearchView, SetPasswordView,
-                    SettingsView, auth_request)
+                    CustomTwoFactorRemove, DatabaseStatsView, DynamicJsView,
+                    EditUserView, IndexView, NotificationsView, SearchView,
+                    SetPasswordView, SettingsView, auth_request)
 
 admin.site.site_header = "InvenTree Admin"
 
@@ -163,6 +163,10 @@ frontendpatterns = [
     re_path(r'^accounts/email/', CustomEmailView.as_view(), name='account_email'),
     re_path(r'^accounts/social/connections/', CustomConnectionsView.as_view(), name='socialaccount_connections'),
     re_path(r"^accounts/password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$", CustomPasswordResetFromKeyView.as_view(), name="account_reset_password_from_key"),
+
+    # Temporary fix for django-allauth-2fa # TODO remove
+    # See https://github.com/inventree/InvenTree/security/advisories/GHSA-8j76-mm54-52xq
+    re_path(r'^accounts/two_factor/remove/?$', CustomTwoFactorRemove.as_view(), name='two-factor-remove'),
 
     re_path(r'^accounts/', include('allauth_2fa.urls')),    # MFA support
     re_path(r'^accounts/', include('allauth.urls')),        # included urlpatterns

--- a/InvenTree/InvenTree/views.py
+++ b/InvenTree/InvenTree/views.py
@@ -28,6 +28,7 @@ from allauth.account.models import EmailAddress
 from allauth.account.views import EmailView, PasswordResetFromKeyView
 from allauth.socialaccount.forms import DisconnectForm
 from allauth.socialaccount.views import ConnectionsView
+from allauth_2fa.views import TwoFactorRemove
 from djmoney.contrib.exchange.models import ExchangeBackend, Rate
 from user_sessions.views import SessionDeleteOtherView, SessionDeleteView
 
@@ -761,3 +762,10 @@ class NotificationsView(TemplateView):
     """View for showing notifications."""
 
     template_name = "InvenTree/notifications/notifications.html"
+
+
+# Custom 2FA removal form to allow custom redirect URL
+
+class CustomTwoFactorRemove(TwoFactorRemove):
+    """Specify custom URL redirect."""
+    success_url = reverse_lazy("settings")

--- a/InvenTree/InvenTree/views.py
+++ b/InvenTree/InvenTree/views.py
@@ -28,7 +28,6 @@ from allauth.account.models import EmailAddress
 from allauth.account.views import EmailView, PasswordResetFromKeyView
 from allauth.socialaccount.forms import DisconnectForm
 from allauth.socialaccount.views import ConnectionsView
-from allauth_2fa.views import TwoFactorRemove
 from djmoney.contrib.exchange.models import ExchangeBackend, Rate
 from user_sessions.views import SessionDeleteOtherView, SessionDeleteView
 
@@ -37,7 +36,7 @@ from common.settings import currency_code_default, currency_codes
 from part.models import PartCategory
 from users.models import RuleSet, check_user_role
 
-from .forms import CustomTOTPDeviceRemoveForm, EditUserForm, SetPasswordForm
+from .forms import EditUserForm, SetPasswordForm
 
 
 def auth_request(request):
@@ -762,12 +761,3 @@ class NotificationsView(TemplateView):
     """View for showing notifications."""
 
     template_name = "InvenTree/notifications/notifications.html"
-
-
-# Temporary fix for django-allauth-2fa # TODO remove
-# See https://github.com/inventree/InvenTree/security/advisories/GHSA-8j76-mm54-52xq
-
-class CustomTwoFactorRemove(TwoFactorRemove):
-    """Use custom form."""
-    form_class = CustomTOTPDeviceRemoveForm
-    success_url = reverse_lazy("settings")

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ django-allauth==0.51.0
     # via
     #   -r requirements.in
     #   django-allauth-2fa
-django-allauth-2fa==0.9
+django-allauth-2fa==0.10.0
     # via -r requirements.in
 django-cleanup==6.0.0
     # via -r requirements.in


### PR DESCRIPTION
Recent updates to [django-allauth-2fa](https://github.com/valohai/django-allauth-2fa/) have negated our need for custom code here.

Closes https://github.com/inventree/InvenTree/issues/3294

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3300"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

