### PR TITLE
Allow BOM table to be filtered by "stock available" parameter

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -7,8 +7,12 @@ INVENTREE_API_VERSION = 61
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
 
+v63 -> 2022-07-06 : https://github.com/inventree/InvenTree/pull/3301
+    - Allow BOM List API endpoint to be filtered by "available_stock" paramater
+
 v62 -> 2022-07-05 : https://github.com/inventree/InvenTree/pull/3296
     - Allows search on BOM List API endpoint
+    - Allows ordering on BOM List API endpoint
 
 v61 -> 2022-06-12 : https://github.com/inventree/InvenTree/pull/3183
     - Migrate the "Convert Stock Item" form class to use the API

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1542,7 +1542,7 @@ class BomFilter(rest_filters.FilterSet):
             queryset = queryset.filter(available_stock__gt=0)
         else:
             queryset = queryset.filter(available_stock=0)
-        
+
         return queryset
 
 

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1531,6 +1531,20 @@ class BomFilter(rest_filters.FilterSet):
 
         return queryset
 
+    available_stock = rest_filters.BooleanFilter(label="Has available stock", method="filter_available_stock")
+
+    def filter_available_stock(self, queryset, name, value):
+        """Filter the queryset based on whether each line item has any available stock"""
+
+        value = str2bool(value)
+
+        if value:
+            queryset = queryset.filter(available_stock__gt=0)
+        else:
+            queryset = queryset.filter(available_stock=0)
+        
+        return queryset
+
 
 class BomList(ListCreateDestroyAPIView):
     """API endpoint for accessing a list of BomItem objects.

--- a/InvenTree/templates/js/translated/table_filters.js
+++ b/InvenTree/templates/js/translated/table_filters.js
@@ -59,6 +59,10 @@ function getAvailableTableFilters(tableKey) {
                 type: 'bool',
                 title: '{% trans "Assembled Part" %}',
             },
+            available_stock: {
+                type: 'bool',
+                title: '{% trans "Has Available Stock" %}',
+            },
             validated: {
                 type: 'bool',
                 title: '{% trans "Validated" %}',


### PR DESCRIPTION
- Adds new filter option for BOM list endpoint
- Allows BOM table to be filtered by stock availability

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3301"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

