### PR TITLE
Prevent creation of new settings objects when importing data

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -343,6 +343,10 @@ class BaseInvenTreeSetting(models.Model):
             # Unless otherwise specified, attempt to create the setting
             create = kwargs.get('create', True)
 
+            # Prevent creation of new settings objects when importing data
+            if InvenTree.ready.isImportingData() or not InvenTree.ready.canAppAccessDatabase(allow_test=True):
+                create = False
+
             if create:
                 # Attempt to create a new settings object
                 setting = cls(


### PR DESCRIPTION
Fix issues with duplicating settings during data import

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3319"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

