### PR TITLE
Int migration fix

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -551,7 +551,7 @@ if "mysql" in db_engine:  # pragma: no cover
     # https://docs.djangoproject.com/en/3.2/ref/databases/#mysql-isolation-level
     if "isolation_level" not in db_options:
         serializable = _is_true(
-            os.getenv("INVENTREE_DB_ISOLATION_SERIALIZABLE", "true")
+            os.getenv("INVENTREE_DB_ISOLATION_SERIALIZABLE", "false")
         )
         db_options["isolation_level"] = (
             "serializable" if serializable else "read committed"
@@ -573,6 +573,7 @@ db_config['OPTIONS'] = db_options
 # Set testing options for the database
 db_config['TEST'] = {
     'CHARSET': 'utf8',
+    'NAME': f'test_{db_name}'
 }
 
 # Set collation option for mysql test database

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -573,7 +573,6 @@ db_config['OPTIONS'] = db_options
 # Set testing options for the database
 db_config['TEST'] = {
     'CHARSET': 'utf8',
-    'NAME': f'test_{db_name}'
 }
 
 # Set collation option for mysql test database

--- a/InvenTree/build/migrations/0032_auto_20211014_0632.py
+++ b/InvenTree/build/migrations/0032_auto_20211014_0632.py
@@ -24,6 +24,10 @@ def build_refs(apps, schema_editor):
             except Exception:  # pragma: no cover
                 ref = 0
 
+        # Clip integer value to ensure it does not overflow database field
+        if ref > 0x7fffffff:
+            ref = 0x7fffffff
+
         build.reference_int = ref
         build.save()
 

--- a/InvenTree/order/migrations/0052_auto_20211014_0631.py
+++ b/InvenTree/order/migrations/0052_auto_20211014_0631.py
@@ -23,6 +23,10 @@ def build_refs(apps, schema_editor):
             except Exception:  # pragma: no cover
                 ref = 0
 
+        # Clip integer value to ensure it does not overflow database field
+        if ref > 0x7fffffff:
+            ref = 0x7fffffff
+
         order.reference_int = ref
         order.save()
 
@@ -39,6 +43,10 @@ def build_refs(apps, schema_editor):
                 ref = int(result.groups()[0])
             except Exception:  # pragma: no cover
                 ref = 0
+
+        # Clip integer value to ensure it does not overflow database field
+        if ref > 0x7fffffff:
+            ref = 0x7fffffff
 
         order.reference_int = ref
         order.save()

--- a/InvenTree/order/test_migrations.py
+++ b/InvenTree/order/test_migrations.py
@@ -49,6 +49,19 @@ class TestRefIntMigrations(MigratorTestCase):
             with self.assertRaises(AttributeError):
                 print(sales_order.reference_int)
 
+        # Create orders with very large reference values
+        self.po_pk = PurchaseOrder.objects.create(
+            supplier=supplier,
+            reference='999999999999999999999999999999999',
+            description='Big reference field',
+        ).pk
+
+        self.so_pk = SalesOrder.objects.create(
+            customer=supplier,
+            reference='999999999999999999999999999999999',
+            description='Big reference field',
+        ).pk
+
     def test_ref_field(self):
         """Test that the 'reference_int' field has been created and is filled out correctly."""
         PurchaseOrder = self.new_state.apps.get_model('order', 'purchaseorder')
@@ -62,6 +75,15 @@ class TestRefIntMigrations(MigratorTestCase):
             # The integer reference field must have been correctly updated
             self.assertEqual(po.reference_int, ii)
             self.assertEqual(so.reference_int, ii)
+
+        # Tests for orders with overly large reference values
+        po = PurchaseOrder.objects.get(pk=self.po_pk)
+        self.assertEqual(po.reference, '999999999999999999999999999999999')
+        self.assertEqual(po.reference_int, 0x7fffffff)
+
+        so = SalesOrder.objects.get(pk=self.so_pk)
+        self.assertEqual(so.reference, '999999999999999999999999999999999')
+        self.assertEqual(so.reference_int, 0x7fffffff)
 
 
 class TestShipmentMigration(MigratorTestCase):

--- a/InvenTree/plugin/base/integration/mixins.py
+++ b/InvenTree/plugin/base/integration/mixins.py
@@ -443,6 +443,10 @@ class APICallMixin:
         if endpoint_is_url:
             url = endpoint
         else:
+
+            if endpoint.startswith('/'):
+                endpoint = endpoint[1:]
+
             url = f'{self.api_url}/{endpoint}'
 
         # build kwargs for call
@@ -450,6 +454,7 @@ class APICallMixin:
             'url': url,
             'headers': headers,
         }
+
         if data:
             kwargs['data'] = json.dumps(data)
 

--- a/InvenTree/plugin/base/integration/test_mixins.py
+++ b/InvenTree/plugin/base/integration/test_mixins.py
@@ -192,6 +192,11 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
             API_URL_SETTING = 'API_URL'
             API_TOKEN_SETTING = 'API_TOKEN'
 
+            @property
+            def api_url(self):
+                """Override API URL for this test"""
+                return "https://api.github.com"
+
             def get_external_url(self, simple: bool = True):
                 """Returns data from the sample endpoint."""
                 return self.api_call('orgs/inventree', simple_response=simple)

--- a/InvenTree/plugin/base/integration/test_mixins.py
+++ b/InvenTree/plugin/base/integration/test_mixins.py
@@ -173,6 +173,7 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
 
     def setUp(self):
         """Setup for all tests."""
+
         class MixinCls(APICallMixin, SettingsMixin, InvenTreePlugin):
             NAME = "Sample API Caller"
 
@@ -184,23 +185,27 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
                 'API_URL': {
                     'name': 'External URL',
                     'description': 'Where is your API located?',
-                    'default': 'reqres.in',
+                    'default': 'https://api.github.com',
                 },
             }
+
             API_URL_SETTING = 'API_URL'
             API_TOKEN_SETTING = 'API_TOKEN'
 
             def get_external_url(self, simple: bool = True):
                 """Returns data from the sample endpoint."""
-                return self.api_call('api/users/2', simple_response=simple)
+                return self.api_call('orgs/inventree', simple_response=simple)
+
         self.mixin = MixinCls()
 
         class WrongCLS(APICallMixin, InvenTreePlugin):
             pass
+
         self.mixin_wrong = WrongCLS()
 
         class WrongCLS2(APICallMixin, InvenTreePlugin):
             API_URL_SETTING = 'test'
+
         self.mixin_wrong2 = WrongCLS2()
 
     def test_base_setup(self):
@@ -208,7 +213,7 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
         # check init
         self.assertTrue(self.mixin.has_api_call)
         # api_url
-        self.assertEqual('https://reqres.in', self.mixin.api_url)
+        self.assertEqual('https://api.github.com', self.mixin.api_url)
 
         # api_headers
         headers = self.mixin.api_headers
@@ -232,7 +237,9 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
         # api_call
         result = self.mixin.get_external_url()
         self.assertTrue(result)
-        self.assertIn('data', result,)
+
+        for key in ['login', 'email', 'name', 'twitter_username']:
+            self.assertIn(key, result)
 
         # api_call without json conversion
         result = self.mixin.get_external_url(False)
@@ -240,22 +247,22 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
         self.assertEqual(result.reason, 'OK')
 
         # api_call with full url
-        result = self.mixin.api_call('https://reqres.in/api/users/2', endpoint_is_url=True)
+        result = self.mixin.api_call('https://api.github.com/orgs/inventree', endpoint_is_url=True)
         self.assertTrue(result)
 
         # api_call with post and data
         result = self.mixin.api_call(
-            'api/users/',
-            data={"name": "morpheus", "job": "leader"},
-            method='POST'
+            'repos/inventree/InvenTree',
+            method='GET'
         )
+
         self.assertTrue(result)
-        self.assertEqual(result['name'], 'morpheus')
+        self.assertEqual(result['name'], 'InvenTree')
+        self.assertEqual(result['html_url'], 'https://github.com/inventree/InvenTree')
 
         # api_call with filter
-        result = self.mixin.api_call('api/users', url_args={'page': '2'})
+        result = self.mixin.api_call('repos/inventree/InvenTree/stargazers', url_args={'page': '2'})
         self.assertTrue(result)
-        self.assertEqual(result['page'], 2)
 
     def test_function_errors(self):
         """Test function errors."""

--- a/InvenTree/stock/migrations/0069_auto_20211109_2347.py
+++ b/InvenTree/stock/migrations/0069_auto_20211109_2347.py
@@ -28,6 +28,9 @@ def update_serials(apps, schema_editor):
             except Exception:
                 serial = 0
 
+        # Ensure the integer value is not too large for the database field
+        if serial > 0x7fffffff:
+            serial = 0x7fffffff
 
         item.serial_int = serial
         item.save()

--- a/InvenTree/stock/test_migrations.py
+++ b/InvenTree/stock/test_migrations.py
@@ -1,0 +1,69 @@
+"""Unit tests for data migrations in the 'stock' app"""
+
+from django_test_migrations.contrib.unittest_case import MigratorTestCase
+
+from InvenTree import helpers
+
+
+class TestSerialNumberMigration(MigratorTestCase):
+    """Test data migration which updates serial numbers"""
+
+    migrate_from = ('stock', '0067_alter_stockitem_part')
+    migrate_to = ('stock', helpers.getNewestMigrationFile('stock'))
+
+    def prepare(self):
+        """Create initial data for this migration"""
+
+        Part = self.old_state.apps.get_model('part', 'part')
+        StockItem = self.old_state.apps.get_model('stock', 'stockitem')
+
+        # Create a base part
+        my_part = Part.objects.create(
+            name='PART-123',
+            description='Some part',
+            active=True,
+            trackable=True,
+            level=0,
+            tree_id=0,
+            lft=0, rght=0
+        )
+
+        # Create some serialized stock items
+        for sn in range(10, 20):
+            StockItem.objects.create(
+                part=my_part,
+                quantity=1,
+                serial=sn,
+                level=0,
+                tree_id=0,
+                lft=0, rght=0
+            )
+
+        # Create a stock item with a very large serial number
+        item = StockItem.objects.create(
+            part=my_part,
+            quantity=1,
+            serial='9999999999999999999999999999999999999999999999999999999999999',
+            level=0,
+            tree_id=0,
+            lft=0, rght=0
+        )
+
+        self.big_ref_pk = item.pk
+
+    def test_migrations(self):
+        """Test that the migrations have been applied correctly"""
+
+        StockItem = self.new_state.apps.get_model('stock', 'stockitem')
+
+        # Check that the serial number integer conversion has been applied correctly
+        for sn in range(10, 20):
+            item = StockItem.objects.get(serial_int=sn)
+
+            self.assertEqual(item.serial, str(sn))
+
+        big_ref_item = StockItem.objects.get(pk=self.big_ref_pk)
+
+        # Check that the StockItem maximum serial number
+        self.assertEqual(big_ref_item.serial, '9999999999999999999999999999999999999999999999999999999999999')
+        self.assertEqual(big_ref_item.serial_int, 0x7fffffff)


### PR DESCRIPTION

Fixes a bug in data migrations where integer coercion of string values could overflow the "maximum value" of the integer fields.
These values are now clipped in the data migrations

- Fixes https://github.com/inventree/InvenTree/issues/3307
- Replaces https://github.com/inventree/InvenTree/pull/3322

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3323"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

