### PR TITLE
Update unit tests for API plugin mixin class

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -551,7 +551,7 @@ if "mysql" in db_engine:  # pragma: no cover
     # https://docs.djangoproject.com/en/3.2/ref/databases/#mysql-isolation-level
     if "isolation_level" not in db_options:
         serializable = _is_true(
-            os.getenv("INVENTREE_DB_ISOLATION_SERIALIZABLE", "true")
+            os.getenv("INVENTREE_DB_ISOLATION_SERIALIZABLE", "false")
         )
         db_options["isolation_level"] = (
             "serializable" if serializable else "read committed"
@@ -573,6 +573,7 @@ db_config['OPTIONS'] = db_options
 # Set testing options for the database
 db_config['TEST'] = {
     'CHARSET': 'utf8',
+    'NAME': f'test_{db_name}'
 }
 
 # Set collation option for mysql test database

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -573,7 +573,6 @@ db_config['OPTIONS'] = db_options
 # Set testing options for the database
 db_config['TEST'] = {
     'CHARSET': 'utf8',
-    'NAME': f'test_{db_name}'
 }
 
 # Set collation option for mysql test database

--- a/InvenTree/plugin/base/integration/mixins.py
+++ b/InvenTree/plugin/base/integration/mixins.py
@@ -443,6 +443,10 @@ class APICallMixin:
         if endpoint_is_url:
             url = endpoint
         else:
+
+            if endpoint.startswith('/'):
+                endpoint = endpoint[1:]
+
             url = f'{self.api_url}/{endpoint}'
 
         # build kwargs for call
@@ -450,6 +454,7 @@ class APICallMixin:
             'url': url,
             'headers': headers,
         }
+
         if data:
             kwargs['data'] = json.dumps(data)
 

--- a/InvenTree/plugin/base/integration/test_mixins.py
+++ b/InvenTree/plugin/base/integration/test_mixins.py
@@ -192,6 +192,11 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
             API_URL_SETTING = 'API_URL'
             API_TOKEN_SETTING = 'API_TOKEN'
 
+            @property
+            def api_url(self):
+                """Override API URL for this test"""
+                return "https://api.github.com"
+
             def get_external_url(self, simple: bool = True):
                 """Returns data from the sample endpoint."""
                 return self.api_call('orgs/inventree', simple_response=simple)

--- a/InvenTree/plugin/base/integration/test_mixins.py
+++ b/InvenTree/plugin/base/integration/test_mixins.py
@@ -173,6 +173,7 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
 
     def setUp(self):
         """Setup for all tests."""
+
         class MixinCls(APICallMixin, SettingsMixin, InvenTreePlugin):
             NAME = "Sample API Caller"
 
@@ -184,23 +185,27 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
                 'API_URL': {
                     'name': 'External URL',
                     'description': 'Where is your API located?',
-                    'default': 'reqres.in',
+                    'default': 'https://api.github.com',
                 },
             }
+
             API_URL_SETTING = 'API_URL'
             API_TOKEN_SETTING = 'API_TOKEN'
 
             def get_external_url(self, simple: bool = True):
                 """Returns data from the sample endpoint."""
-                return self.api_call('api/users/2', simple_response=simple)
+                return self.api_call('orgs/inventree', simple_response=simple)
+
         self.mixin = MixinCls()
 
         class WrongCLS(APICallMixin, InvenTreePlugin):
             pass
+
         self.mixin_wrong = WrongCLS()
 
         class WrongCLS2(APICallMixin, InvenTreePlugin):
             API_URL_SETTING = 'test'
+
         self.mixin_wrong2 = WrongCLS2()
 
     def test_base_setup(self):
@@ -208,7 +213,7 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
         # check init
         self.assertTrue(self.mixin.has_api_call)
         # api_url
-        self.assertEqual('https://reqres.in', self.mixin.api_url)
+        self.assertEqual('https://api.github.com', self.mixin.api_url)
 
         # api_headers
         headers = self.mixin.api_headers
@@ -232,7 +237,9 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
         # api_call
         result = self.mixin.get_external_url()
         self.assertTrue(result)
-        self.assertIn('data', result,)
+
+        for key in ['login', 'email', 'name', 'twitter_username']:
+            self.assertIn(key, result)
 
         # api_call without json conversion
         result = self.mixin.get_external_url(False)
@@ -240,22 +247,22 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
         self.assertEqual(result.reason, 'OK')
 
         # api_call with full url
-        result = self.mixin.api_call('https://reqres.in/api/users/2', endpoint_is_url=True)
+        result = self.mixin.api_call('https://api.github.com/orgs/inventree', endpoint_is_url=True)
         self.assertTrue(result)
 
         # api_call with post and data
         result = self.mixin.api_call(
-            'api/users/',
-            data={"name": "morpheus", "job": "leader"},
-            method='POST'
+            'repos/inventree/InvenTree',
+            method='GET'
         )
+
         self.assertTrue(result)
-        self.assertEqual(result['name'], 'morpheus')
+        self.assertEqual(result['name'], 'InvenTree')
+        self.assertEqual(result['html_url'], 'https://github.com/inventree/InvenTree')
 
         # api_call with filter
-        result = self.mixin.api_call('api/users', url_args={'page': '2'})
+        result = self.mixin.api_call('repos/inventree/InvenTree/stargazers', url_args={'page': '2'})
         self.assertTrue(result)
-        self.assertEqual(result['page'], 2)
 
     def test_function_errors(self):
         """Test function errors."""


### PR DESCRIPTION
- API at previous target URL has changed
- Simplier to use the github API as a test case

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3328"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

