### PR TITLE
Add 'refresh' button for part parameter table

### DIFF
--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -206,6 +206,12 @@
         <h4>{% trans "Part Parameters" %}</h4>
     </div>
     <div class='panel-content'>
+        <div id='param-button-toolbar'>
+            <div class='btn-group' role='group'>
+                {% include "filter_list.html" with id="parameters" %}
+            </div>
+        </div>
+
         <table class='table table-striped table-condensed' data-toolbar='#param-button-toolbar' id='parametric-part-table'>
         </table>
     </div>

--- a/InvenTree/plugin/base/integration/test_mixins.py
+++ b/InvenTree/plugin/base/integration/test_mixins.py
@@ -190,6 +190,11 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
             API_URL_SETTING = 'API_URL'
             API_TOKEN_SETTING = 'API_TOKEN'
 
+            @property
+            def api_url(self):
+                """Override API URL for this test"""
+                return "https://api.github.com"
+
             def get_external_url(self, simple: bool = True):
                 """Returns data from the sample endpoint."""
                 return self.api_call('api/users/2', simple_response=simple)

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -1198,6 +1198,8 @@ function loadRelatedPartsTable(table, part_id, options={}) {
  */
 function loadParametricPartTable(table, options={}) {
 
+    setupFilterList('parameters', $(table), '#filter-list-parameters');
+
     var columns = [
         {
             field: 'name',


### PR DESCRIPTION
Allows parameter table to be reloaded without loading entire page

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3329"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

