### PR TITLE
Specify upper bound for mariadb python version

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ invoke>=1.4.0                   # Invoke build tool
 psycopg2>=2.9.1
 mysqlclient>=2.0.3
 pgcli>=3.1.0
-mariadb>=1.0.7
+mariadb>=1.0.7,<1.1.0
 
 # gunicorn web server
 gunicorn>=20.1.0


### PR DESCRIPTION
- 1.1.0 and above causes build process to break

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3333"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

