### PR TITLE
Annotate "in_stock" quantity to SupplierPart API

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 64
+INVENTREE_API_VERSION = 65
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v65 -> 2022-07-15 : https://github.com/inventree/InvenTree/pull/3335
+    - Annotates 'in_stock' quantity to the SupplierPart API
 
 v64 -> 2022-07-08 : https://github.com/inventree/InvenTree/pull/3310
     - Annotate 'on_order' quantity to BOM list API

--- a/InvenTree/company/api.py
+++ b/InvenTree/company/api.py
@@ -263,6 +263,13 @@ class SupplierPartList(ListCreateDestroyAPIView):
 
     queryset = SupplierPart.objects.all()
 
+    def get_queryset(self, *args, **kwargs):
+        """Return annotated queryest object for the SupplierPart list"""
+        queryset = super().get_queryset(*args, **kwargs)
+        queryset = SupplierPartSerializer.annotate_queryset(queryset)
+
+        return queryset
+
     def filter_queryset(self, queryset):
         """Custom filtering for the queryset."""
         queryset = super().filter_queryset(queryset)

--- a/InvenTree/templates/js/translated/company.js
+++ b/InvenTree/templates/js/translated/company.js
@@ -840,6 +840,7 @@ function loadSupplierPartTable(table, url, options) {
         queryParams: filters,
         name: 'supplierparts',
         groupBy: false,
+        sortable: true,
         formatNoMatches: function() {
             return '{% trans "No supplier parts found" %}';
         },
@@ -956,6 +957,11 @@ function loadSupplierPartTable(table, url, options) {
                 field: 'packaging',
                 title: '{% trans "Packaging" %}',
                 sortable: false,
+            },
+            {
+                field: 'in_stock',
+                title: '{% trans "In Stock" %}',
+                sortable: true,
             },
             {
                 field: 'available',


### PR DESCRIPTION
- Adds "in_stock" quantity to SupplierPart data
- Allows "supplier part" table to display current stock quantity for each supplier part

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3335"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

