### PR TITLE
Do not show low/no stock warning for template parts

### DIFF
--- a/InvenTree/part/templates/part/stock_count.html
+++ b/InvenTree/part/templates/part/stock_count.html
@@ -3,8 +3,10 @@
 
 {% decimal total_stock %}
 
+{% if not part.is_template %}
 {% if total_stock == 0 %}
 <span class='badge badge-right rounded-pill bg-danger'>{% trans "No Stock" %}</span>
 {% elif total_stock < part.minimum_stock %}
 <span class='badge badge-right rounded-pill bg-warning'>{% trans "Low Stock" %}</span>
+{% endif %}
 {% endif %}

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -578,7 +578,7 @@ function partStockLabel(part, options={}) {
         // There IS stock available for this part
 
         // Is stock "low" (below the 'minimum_stock' quantity)?
-        if ((part.minimum_stock > 0) && (part.minimum_stock > part.in_stock)) {
+        if ((part.minimum_stock > 0) && (part.minimum_stock > part.in_stock) && !part.is_template) {
             return `<span class='badge rounded-pill bg-warning ${options.classes}'>{% trans "Low stock" %}: ${part.in_stock}${part.units}</span>`;
         } else if (part.unallocated_stock == 0) {
             if (part.ordering) {
@@ -607,7 +607,7 @@ function partStockLabel(part, options={}) {
         } else if (part.building) {
             // There is no stock, but stock is being built
             return `<span class='badge rounded-pill bg-info ${options.classes}'>{% trans "Building" %}: ${part.building}${part.units}</span>`;
-        } else {
+        } else if (!part.is_template) {
             // There is no stock
             return `<span class='badge rounded-pill bg-danger ${options.classes}'>{% trans "No Stock" %}</span>`;
         }
@@ -1286,7 +1286,7 @@ function partGridTile(part) {
 
     var stock = `${part.in_stock}`;
 
-    if (!part.in_stock) {
+    if (!part.in_stock && !part.is_template) {
         stock = `<span class='badge rounded-pill bg-danger'>{% trans "No Stock" %}</span>`;
     } else if (!part.unallocated_stock) {
         stock = `<span class='badge rounded-pill bg-warning'>{% trans "Not available" %}</span>`;
@@ -1462,7 +1462,7 @@ function loadPartTable(table, url, options={}) {
                 // There IS stock available for this part
 
                 // Is stock "low" (below the 'minimum_stock' quantity)?
-                if (row.minimum_stock && row.minimum_stock > row.in_stock) {
+                if (row.minimum_stock && row.minimum_stock > row.in_stock && !row.is_template) {
                     value += `<span class='badge badge-right rounded-pill bg-warning'>{% trans "Low stock" %}</span>`;
                 } else if (value == 0) {
                     if (row.ordering) {
@@ -1489,7 +1489,7 @@ function loadPartTable(table, url, options={}) {
                     // There is no stock, but stock is being built
                     value = `0<span class='badge badge-right rounded-pill bg-info'>{% trans "Building" %}: ${row.building}</span>`;
                     link = '?display=build-orders';
-                } else {
+                } else if (!row.is_template) {
                     // There is no stock
                     value = `0<span class='badge badge-right rounded-pill bg-danger'>{% trans "No Stock" %}</span>`;
                 }


### PR DESCRIPTION
This hides the "No Stock"/"Low Stock" label for parts marked as template.

AIUI, template parts will never exist in stock, so showing the warning makes no sense.

If this is not how template parts are meant to be used then this could depend on `part.active` instead.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3338"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

