### PR TITLE
Use env-variable for image tag on docker-compose deployments

### DIFF
--- a/docker/production/.env
+++ b/docker/production/.env
@@ -42,4 +42,7 @@ INVENTREE_CACHE_PORT=6379
 # Enable plugins?
 INVENTREE_PLUGINS_ENABLED=False
 
+# Image tag that should be used
+INVENTREE_TAG=stable
+
 COMPOSE_PROJECT_NAME=inventree-production

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     inventree-server:
         container_name: inventree-server
         # If you wish to specify a particular InvenTree version, do so here
-        image: inventree/inventree:stable
+        image: inventree/inventree:${INVENTREE_TAG:-stable}
         expose:
             - 8000
         depends_on:
@@ -91,7 +91,7 @@ services:
     inventree-worker:
         container_name: inventree-worker
         # If you wish to specify a particular InvenTree version, do so here
-        image: inventree/inventree:stable
+        image: inventree/inventree:${INVENTREE_TAG:-stable}
         command: invoke worker
         depends_on:
             - inventree-server


### PR DESCRIPTION
This PR adds the option to use an env variable to select the used image tag

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3350"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

