### PR TITLE
Fix API filtering for PurchaseOrderLineItem

### DIFF
--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -495,7 +495,7 @@ class PurchaseOrderLineItemList(APIDownloadMixin, ListCreateAPI):
     search_fields = [
         'part__part__name',
         'part__part__description',
-        'part__MPN',
+        'part__manufacturer_part__MPN',
         'part__SKU',
         'reference',
     ]


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/3352

Incorrect search field meant the API was (silently) throwing an error.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3356"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

