### PR TITLE
Allow plugin loading from external directory

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -15,7 +15,6 @@ import random
 import socket
 import string
 import sys
-from pathlib import Path
 
 import django.conf.locale
 from django.core.files.storage import default_storage
@@ -935,48 +934,6 @@ PLUGINS_ENABLED = _is_true(get_setting(
 ))
 
 PLUGIN_FILE = get_plugin_file()
-
-# Plugin Directories (local plugins will be loaded from these directories)
-PLUGIN_DIRS = ['plugin.builtin', ]
-
-CUSTOM_PLUGIN_DIRS = os.getenv('INVENTREE_PLUGIN_DIR', None)
-
-if not TESTING:
-    # load local plugin directory
-    PLUGIN_DIRS.append('plugins')  # pragma: no cover
-
-    # optionally load custom plugin directory
-    if CUSTOM_PLUGIN_DIRS is not None:
-        # Allow multiple plugin directories to be specified
-        for pd_text in CUSTOM_PLUGIN_DIRS.split(','):
-            pd = Path(pd_text.strip()).absolute()
-
-            # Attempt to create the directory if it does not already exist
-            if not pd.exists():
-                try:
-                    pd.mkdir(exist_ok=True)
-                except Exception:
-                    logger.error(f"Could not create plugin directory '{pd}'")
-                    continue
-
-            # Ensure the directory has an __init__.py file
-            init_filename = pd.joinpath('__init__.py')
-
-            if not init_filename.exists():
-                try:
-                    init_filename.write_text("# InvenTree plugin directory\n")
-                except Exception:
-                    logger.error(f"Could not create file '{init_filename}'")
-                    continue
-
-            if pd.exists() and pd.is_dir():
-                # By this point, we have confirmed that the directory at least exists
-                logger.info(f"Added plugin directory: '{pd}'")
-                PLUGIN_DIRS.append(pd)
-
-if DEBUG or TESTING:
-    # load samples in debug mode
-    PLUGIN_DIRS.append('plugin.samples')
 
 # Plugin test settings
 PLUGIN_TESTING = get_setting('PLUGIN_TESTING', TESTING)  # are plugins beeing tested?

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -941,7 +941,7 @@ PLUGIN_DIRS = ['plugin.builtin', ]
 CUSTOM_PLUGIN_DIRS = os.getenv('INVENTREE_PLUGIN_DIR', None)
 
 if not TESTING:
-    # load local deploy directory in prod
+    # load local plugin directory
     PLUGIN_DIRS.append('plugins')  # pragma: no cover
 
     # optionally load custom plugin directory
@@ -950,7 +950,7 @@ if not TESTING:
         for pd in CUSTOM_PLUGIN_DIRS.split(','):
             pd = pd.strip()
 
-            # Attempt to create the directory if it does not alreadyd exist
+            # Attempt to create the directory if it does not already exist
             if not os.path.exists(pd):
                 try:
                     os.makedirs(pd, exist_ok=True)

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -15,6 +15,7 @@ import random
 import socket
 import string
 import sys
+from pathlib import Path
 
 import django.conf.locale
 from django.core.files.storage import default_storage
@@ -947,32 +948,29 @@ if not TESTING:
     # optionally load custom plugin directory
     if CUSTOM_PLUGIN_DIRS is not None:
         # Allow multiple plugin directories to be specified
-        for pd in CUSTOM_PLUGIN_DIRS.split(','):
-            pd = pd.strip()
+        for pd_text in CUSTOM_PLUGIN_DIRS.split(','):
+            pd = Path(pd_text.strip()).absolute()
 
             # Attempt to create the directory if it does not already exist
-            if not os.path.exists(pd):
+            if not pd.exists():
                 try:
-                    os.makedirs(pd, exist_ok=True)
+                    pd.mkdir(exist_ok=True)
                 except Exception:
                     logger.error(f"Could not create plugin directory '{pd}'")
                     continue
 
             # Ensure the directory has an __init__.py file
-            init_filename = os.path.join(pd, '__init__.py')
+            init_filename = pd.joinpath('__init__.py')
 
-            if not os.path.exists(init_filename):
+            if not init_filename.exists():
                 try:
-                    with open(init_filename, 'w') as init_file:
-                        init_file.write("# InvenTree plugin directory\n")
+                    init_filename.write_text("# InvenTree plugin directory\n")
                 except Exception:
                     logger.error(f"Could not create file '{init_filename}'")
                     continue
 
-            if os.path.exists(pd) and os.path.isdir(pd):
+            if pd.exists() and pd.is_dir():
                 # By this point, we have confirmed that the directory at least exists
-                pd = os.path.abspath(pd)
-
                 logger.info(f"Added plugin directory: '{pd}'")
                 PLUGIN_DIRS.append(pd)
 

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -172,10 +172,16 @@ class GitStatus:
 
 
 # region plugin finders
-def get_modules(pkg):
+def get_modules(pkg, path=None):
     """Get all modules in a package."""
     context = {}
-    for loader, name, _ in pkgutil.walk_packages(pkg.__path__):
+
+    if path is None:
+        path = pkg.__path__
+    elif type(path) is not list:
+        path = [path]
+
+    for loader, name, _ in pkgutil.walk_packages(path):
         try:
             module = loader.find_module(name).load_module(name)
             pkg_names = getattr(module, '__all__', None)
@@ -199,7 +205,7 @@ def get_classes(module):
     return inspect.getmembers(module, inspect.isclass)
 
 
-def get_plugins(pkg, baseclass):
+def get_plugins(pkg, baseclass, path=None):
     """Return a list of all modules under a given package.
 
     - Modules must be a subclass of the provided 'baseclass'
@@ -207,7 +213,7 @@ def get_plugins(pkg, baseclass):
     """
     plugins = []
 
-    modules = get_modules(pkg)
+    modules = get_modules(pkg, path=path)
 
     # Iterate through each module in the package
     for mod in modules:

--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -275,7 +275,11 @@ class InvenTreePlugin(MixinBase, MetaBase):
         """Path to the plugin."""
         if self._is_package:
             return self.__module__  # pragma: no cover
-        return pathlib.Path(self.def_path).relative_to(settings.BASE_DIR)
+
+        try:
+            return pathlib.Path(self.def_path).relative_to(settings.BASE_DIR)
+        except ValueError:
+            return pathlib.Path(self.def_path)
 
     @property
     def settings_url(self):

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -199,18 +199,12 @@ class PluginsRegistry:
         for plugin in settings.PLUGIN_DIRS:
 
             parent_path = None
+            parent_obj = pathlib.Path(plugin)
 
             # If a "path" is provided, some special handling is required
-            if os.path.sep in plugin:
-                path_split = [el for el in plugin.split(os.path.sep)]
-
-                if len(path_split) > 0:
-                    parent_path = os.path.sep.join(path_split[:-1])
-
-                    if not parent_path.endswith(os.path.sep):
-                        parent_path += os.path.sep
-
-                    plugin = path_split[-1]
+            if parent_obj.name is not plugin and len(parent_obj.parts) > 1:
+                parent_path = parent_obj.parent
+                plugin = parent_obj.name
 
             modules = get_plugins(importlib.import_module(plugin), InvenTreePlugin, path=parent_path)
 

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -187,6 +187,53 @@ class PluginsRegistry:
 
         logger.info('Finished reloading plugins')
 
+    def plugin_dirs(self):
+        """Construct a list of directories from where plugins can be loaded"""
+
+        dirs = ['plugin.builtin', ]
+
+        if settings.TESTING or settings.DEBUG:
+            # If in TEST or DEBUG mode, load plugins from the 'samples' directory
+            dirs.append('plugin.samples')
+
+        if settings.TESTING:
+            custom_dirs = os.getenv('INVENTREE_PLUGIN_TEST_DIR', None)
+        else:
+            custom_dirs = os.getenv('INVENTREE_PLUGIN_DIR', None)
+
+            # Load from user specified directories (unless in testing mode)
+            dirs.append('plugins')
+
+        if custom_dirs is not None:
+            # Allow multiple plugin directories to be specified
+            for pd_text in custom_dirs.split(','):
+                pd = pathlib.Path(pd_text.strip()).absolute()
+
+                # Attempt to create the directory if it does not already exist
+                if not pd.exists():
+                    try:
+                        pd.mkdir(exist_ok=True)
+                    except Exception:
+                        logger.error(f"Could not create plugin directory '{pd}'")
+                        continue
+
+                # Ensure the directory has an __init__.py file
+                init_filename = pd.joinpath('__init__.py')
+
+                if not init_filename.exists():
+                    try:
+                        init_filename.write_text("# InvenTree plugin directory\n")
+                    except Exception:
+                        logger.error(f"Could not create file '{init_filename}'")
+                        continue
+
+                if pd.exists() and pd.is_dir():
+                    # By this point, we have confirmed that the directory at least exists
+                    logger.info(f"Added plugin directory: '{pd}'")
+                    dirs.append(pd)
+
+        return dirs
+
     def collect_plugins(self):
         """Collect plugins from all possible ways of loading."""
         if not settings.PLUGINS_ENABLED:
@@ -196,13 +243,16 @@ class PluginsRegistry:
         self.plugin_modules = []  # clear
 
         # Collect plugins from paths
-        for plugin in settings.PLUGIN_DIRS:
+        for plugin in self.plugin_dirs():
+
+            print(f"Loading plugins from directory '{plugin}'")
 
             parent_path = None
             parent_obj = pathlib.Path(plugin)
 
             # If a "path" is provided, some special handling is required
             if parent_obj.name is not plugin and len(parent_obj.parts) > 1:
+                print("loading from a qualified path:", plugin)
                 parent_path = parent_obj.parent
                 plugin = parent_obj.name
 

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -197,7 +197,23 @@ class PluginsRegistry:
 
         # Collect plugins from paths
         for plugin in settings.PLUGIN_DIRS:
-            modules = get_plugins(importlib.import_module(plugin), InvenTreePlugin)
+
+            parent_path = None
+
+            # If a "path" is provided, some special handling is required
+            if os.path.sep in plugin:
+                path_split = [el for el in plugin.split(os.path.sep)]
+
+                if len(path_split) > 0:
+                    parent_path = os.path.sep.join(path_split[:-1])
+
+                    if not parent_path.endswith(os.path.sep):
+                        parent_path += os.path.sep
+
+                    plugin = path_split[-1]
+
+            modules = get_plugins(importlib.import_module(plugin), InvenTreePlugin, path=parent_path)
+
             if modules:
                 [self.plugin_modules.append(item) for item in modules]
 


### PR DESCRIPTION
Ref: https://github.com/inventree/InvenTree/pull/3348

Fixes https://github.com/inventree/InvenTree/issues/3287

This PR allows plugins to be loaded from an external directory, which provides an easier workflow for users, especially when running under docker.

- Looks for the `INVENTREE_PLUGIN_DIR` environment variable
- Loads plugins from that directory (at runtime)

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3364"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

### TODO

- [x] Documentation - update plugin docs with information on external directory - https://github.com/inventree/inventree-docs/pull/322
- [ ] Unit testing for new features