### PR TITLE
Handle exception when path is not relative to base path

### DIFF
--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -307,7 +307,11 @@ class InvenTreePlugin(MixinBase, MetaBase):
         """
         if self._is_package:
             return self.__module__  # pragma: no cover
-        return pathlib.Path(self.def_path).relative_to(settings.BASE_DIR)
+
+        try:
+            return pathlib.Path(self.def_path).relative_to(settings.BASE_DIR)
+        except ValueError:
+            return pathlib.Path(self.def_path)
 
     @property
     def settings_url(self):


### PR DESCRIPTION
(cherry picked from commit 2bdba081b5a867825501c62a005aeeb0fd5f8828)

Fixes issue when plugin directory is not relative to base source code directory

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3378"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

