### PR TITLE
Fix LabelPrintingMixin label_instance contains now specific data

### DIFF
--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -95,6 +95,7 @@ class LabelPrintMixin:
         label_name = "label.pdf"
 
         label_names = []
+        label_instances = []
 
         # Merge one or more PDF files into a single download
         for item in items_to_print:
@@ -104,6 +105,7 @@ class LabelPrintMixin:
             label_name = label.generate_filename(request)
 
             label_names.append(label_name)
+            label_instances.append(label)
 
             if debug_mode:
                 outputs.append(label.render_as_string(request))
@@ -123,9 +125,6 @@ class LabelPrintMixin:
             - Return a JSON response indicating that the printing has been offloaded
             """
 
-            # Label instance
-            label_instance = self.get_object()
-
             for idx, output in enumerate(outputs):
                 """For each output, we generate a temporary image file, which will then get sent to the printer."""
 
@@ -138,7 +137,7 @@ class LabelPrintMixin:
                     plugin.plugin_slug(),
                     pdf,
                     filename=label_names[idx],
-                    label_instance=label_instance,
+                    label_instance=label_instances[idx],
                     user=request.user,
                 )
 


### PR DESCRIPTION
This PR patches the `LabelPrintMixin`to always invoke the plugin with the specific `label_instance` which contains the `object_to_print` attribute with the specific `PartItem`. See https://github.com/inventree/InvenTree/discussions/3368#discussioncomment-3215201 for reference.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3394"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

