### PR TITLE
Remove references to "plugins" volume in production docker-compose file

### DIFF
--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -85,7 +85,6 @@ services:
         volumes:
             # Data volume must map to /home/inventree/data
             - inventree_data:/home/inventree/data
-            - inventree_plugins:/home/inventree/InvenTree/plugins
         restart: unless-stopped
 
     # Background worker process handles long-running or periodic tasks
@@ -101,7 +100,6 @@ services:
         volumes:
             # Data volume must map to /home/inventree/data
             - inventree_data:/home/inventree/data
-            - inventree_plugins:/home/inventree/InvenTree/plugins
         restart: unless-stopped
 
     # nginx acts as a reverse proxy
@@ -136,10 +134,3 @@ volumes:
             o: bind
             # This directory specified where InvenTree data are stored "outside" the docker containers
             device: ${INVENTREE_EXT_VOLUME:?You must specify the 'INVENTREE_EXT_VOLUME' variable in the .env file!}
-    inventree_plugins:
-        driver: local
-        driver_opts:
-          type: none
-          o: bind
-          # This directory specified where the optional local plugin directory is stored "outside" the docker containers
-          device: ${INVENTREE_EXT_PLUGINS:-./}


### PR DESCRIPTION
This is going to be handled by passing an environment variable through: https://github.com/inventree/InvenTree/pull/3364


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3406"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

