### PR TITLE
Docker compose relative path

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -51,6 +51,17 @@ jobs:
           docker-compose run inventree-dev-server invoke wait
           docker-compose run inventree-dev-server invoke test
           docker-compose down
+      - name: Check Data Directory
+        # The following file structure should have been created by the docker image
+        run: |
+          test -d data
+          test -d data/env
+          test -d data/media
+          test -d data/static
+          test -d data/plugins
+          test -f data/config.yaml
+          test -f data/plugins.txt
+          test -f data/secret_key.txt
       - name: Set up QEMU
         if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,10 +21,6 @@ on:
     branches:
       - 'master'
 
-  pull_request:
-    branches:
-      - 'master'
-
 jobs:
 
   # Build the docker image

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,6 +56,7 @@ jobs:
         run: |
           test -d data
           test -d data/env
+          test -d data/pgdb
           test -d data/media
           test -d data/static
           test -d data/plugins

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,6 +21,10 @@ on:
     branches:
       - 'master'
 
+  pull_request:
+    branches:
+      - 'master'
+
 jobs:
 
   # Build the docker image
@@ -41,6 +45,7 @@ jobs:
           echo "git_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "git_commit_date=$(git show -s --format=%ci)" >> $GITHUB_ENV
       - name: Build Docker Image
+        # Build the development docker image (using docker-compose.yml)
         run: |
           docker-compose build
       - name: Run Unit Tests
@@ -70,6 +75,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/setup-buildx-action@v1
       - name: Set up cosign
+        if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@48866aa521d8bf870604709cd43ec2f602d03ff2
       - name: Login to Dockerhub
         if: github.event_name != 'pull_request'
@@ -78,6 +84,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Extract Docker metadata
+        if: github.event_name != 'pull_request'
         id: meta
         uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
         with:
@@ -97,12 +104,13 @@ jobs:
             commit_hash=${{ env.git_commit_hash }}
             commit_date=${{ env.git_commit_date }}
       - name: Sign the published image
+        if: github.event_name != 'pull_request'
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: cosign sign ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}
       - name: Push to Stable Branch
         uses: ad-m/github-push-action@master
-        if: env.stable_release == 'true'
+        if: env.stable_release == 'true' && github.event_name != 'pull_request'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: stable

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -245,14 +245,13 @@ class PluginsRegistry:
         # Collect plugins from paths
         for plugin in self.plugin_dirs():
 
-            print(f"Loading plugins from directory '{plugin}'")
+            logger.info(f"Loading plugins from directory '{plugin}'")
 
             parent_path = None
             parent_obj = pathlib.Path(plugin)
 
             # If a "path" is provided, some special handling is required
             if parent_obj.name is not plugin and len(parent_obj.parts) > 1:
-                print("loading from a qualified path:", plugin)
                 parent_path = parent_obj.parent
                 plugin = parent_obj.name
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,10 +48,6 @@ services:
         ports:
             # Expose web server on port 8000
             - 8000:8000
-        # Note: If using the inventree-dev-proxy container (see below),
-        # comment out the "ports" directive (above) and uncomment the "expose" directive
-        #expose:
-        #    - 8000
         volumes:
             # Mount local source directory to /home/inventree
             - ./:/home/inventree

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,17 +25,17 @@ services:
         expose:
             - ${INVENTREE_DB_PORT:-5432}/tcp
         environment:
-            - PGDATA=/var/lib/postgresql/data/dev/pgdb
+            - PGDATA=/var/lib/postgresql/data/pgdb
             - POSTGRES_USER=${INVENTREE_DB_USER:?You must provide the 'INVENTREE_DB_USER' variable in the .env file}
             - POSTGRES_PASSWORD=${INVENTREE_DB_PASSWORD:?You must provide the 'INVENTREE_DB_PASSWORD' variable in the .env file}
             - POSTGRES_DB=${INVENTREE_DB_NAME:?You must provide the 'INVENTREE_DB_NAME' variable in the .env file}
         volumes:
           # Map 'data' volume such that postgres database is stored externally
-          - inventree_src:/var/lib/postgresql/data
+          - ./data:/var/lib/postgresql/data
         restart: unless-stopped
 
-    # InvenTree web server services
-    # Uses gunicorn as the web server
+    # InvenTree web server service
+    # Runs the django built-in webserver application
     inventree-dev-server:
         container_name: inventree-dev-server
         depends_on:
@@ -53,8 +53,8 @@ services:
         #expose:
         #    - 8000
         volumes:
-            # Ensure you specify the location of the 'src' directory at the end of this file
-            - inventree_src:/home/inventree
+            # Mount local source directory to /home/inventree
+            - ./:/home/inventree
         env_file:
             - .env
         restart: unless-stopped
@@ -67,38 +67,8 @@ services:
         depends_on:
             - inventree-dev-server
         volumes:
-            # Ensure you specify the location of the 'src' directory at the end of this file
-            - inventree_src:/home/inventree
+            # Mount local source directory to /home/inventree
+            - ./:/home/inventree
         env_file:
             - .env
         restart: unless-stopped
-
-    ### Optional: Serve static and media files using nginx
-    ### Uncomment the following lines to enable nginx proxy for testing
-    ### Note: If enabling the proxy, change "ports" to "expose" for the inventree-dev-server container (above)
-    #inventree-dev-proxy:
-    #    container_name: inventree-dev-proxy
-    #    image: nginx:stable
-    #    depends_on:
-    #        - inventree-dev-server
-    #    ports:
-    #        # Change "8000" to the port that you want InvenTree web server to be available on
-    #        - 8000:80
-    #    volumes:
-    #        # Provide ./nginx.dev.conf file to the container
-    #        # Refer to the provided example file as a starting point
-    #        - ./nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
-    #        # nginx proxy needs access to static and media files
-    #        - inventree_src:/var/www
-    #    restart: unless-stopped
-
-volumes:
-    # Persistent data, stored external to the container(s)
-    inventree_src:
-        driver: local
-        driver_opts:
-            type: none
-            o: bind
-            # This directory specified where InvenTree source code is stored "outside" the docker containers
-            # By default, this directory is one level above the "docker" directory
-            device: ${INVENTREE_EXT_VOLUME:-./}

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -69,7 +69,7 @@ services:
             - ${INVENTREE_CACHE_PORT:-6379}
         restart: always
 
-    # InvenTree web server services
+    # InvenTree web server service
     # Uses gunicorn as the web server
     inventree-server:
         container_name: inventree-server


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/2143

This PR adjusts the default (development) docker-compose script to allow usage with docker-compose v2

@matmair I have added some checks to the docker CI build - in theory this should fail if the required files and directories are not created in the expected locations.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3410"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

