### PR TITLE
[BUG] Extra url schemes not working.

### DIFF
--- a/InvenTree/InvenTree/fields.py
+++ b/InvenTree/InvenTree/fields.py
@@ -20,11 +20,12 @@ import InvenTree.helpers
 from .validators import allowable_url_schemes
 
 
-class InvenTreeURLRest(RestURLField):
+class InvenTreeRestURLField(RestURLField):
     """Custom field for DRF with custom scheme vaildators."""
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.validators[-1].schemes = allowable_url_schemes()
+
 
 class InvenTreeURLFormField(FormURLField):
     """Custom URL form field with custom scheme validators."""

--- a/InvenTree/InvenTree/fields.py
+++ b/InvenTree/InvenTree/fields.py
@@ -13,10 +13,18 @@ from djmoney.forms.fields import MoneyField
 from djmoney.models.fields import MoneyField as ModelMoneyField
 from djmoney.models.validators import MinMoneyValidator
 
+from rest_framework.fields import URLField as RestURLField
+
 import InvenTree.helpers
 
 from .validators import allowable_url_schemes
 
+
+class InvenTreeURLRest(RestURLField):
+    """Custom field for DRF with custom scheme vaildators."""
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.validators[-1].schemes = allowable_url_schemes()
 
 class InvenTreeURLFormField(FormURLField):
     """Custom URL form field with custom scheme validators."""
@@ -27,7 +35,7 @@ class InvenTreeURLFormField(FormURLField):
 class InvenTreeURLField(models.URLField):
     """Custom URL field which has custom scheme validators."""
 
-    default_validators = [validators.URLValidator(schemes=allowable_url_schemes())]
+    validators = [validators.URLValidator(schemes=allowable_url_schemes())]
 
     def formfield(self, **kwargs):
         """Return a Field instance for this field."""

--- a/InvenTree/InvenTree/fields.py
+++ b/InvenTree/InvenTree/fields.py
@@ -12,7 +12,6 @@ from django.utils.translation import gettext_lazy as _
 from djmoney.forms.fields import MoneyField
 from djmoney.models.fields import MoneyField as ModelMoneyField
 from djmoney.models.validators import MinMoneyValidator
-
 from rest_framework.fields import URLField as RestURLField
 
 import InvenTree.helpers

--- a/InvenTree/InvenTree/fields.py
+++ b/InvenTree/InvenTree/fields.py
@@ -22,6 +22,7 @@ from .validators import allowable_url_schemes
 class InvenTreeRestURLField(RestURLField):
     """Custom field for DRF with custom scheme vaildators."""
     def __init__(self, **kwargs):
+        """Update schemes."""
         super().__init__(**kwargs)
         self.validators[-1].schemes = allowable_url_schemes()
 

--- a/InvenTree/InvenTree/serializers.py
+++ b/InvenTree/InvenTree/serializers.py
@@ -5,9 +5,9 @@ from collections import OrderedDict
 from decimal import Decimal
 
 from django.conf import settings
-from django.db import models
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 import tablib
@@ -19,9 +19,9 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import empty
 from rest_framework.serializers import DecimalField
 from rest_framework.utils import model_meta
-from InvenTree.fields import InvenTreeRestURLField
 
 from common.models import InvenTreeSetting
+from InvenTree.fields import InvenTreeRestURLField
 from InvenTree.helpers import download_image_from_url
 
 

--- a/InvenTree/InvenTree/serializers.py
+++ b/InvenTree/InvenTree/serializers.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from decimal import Decimal
 
 from django.conf import settings
+from django.db import models
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils.translation import gettext_lazy as _
@@ -18,6 +19,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import empty
 from rest_framework.serializers import DecimalField
 from rest_framework.utils import model_meta
+from InvenTree.fields import InvenTreeURLFormField, InvenTreeURLRest
 
 from common.models import InvenTreeSetting
 from InvenTree.helpers import download_image_from_url
@@ -63,6 +65,12 @@ class InvenTreeMoneySerializer(MoneyField):
 
 class InvenTreeModelSerializer(serializers.ModelSerializer):
     """Inherits the standard Django ModelSerializer class, but also ensures that the underlying model class data are checked on validation."""
+
+    # Switch out URLField mapping
+    serializer_field_mapping = {
+        **serializers.ModelSerializer.serializer_field_mapping,
+        models.URLField: InvenTreeURLRest,
+    }
 
     def __init__(self, instance=None, data=empty, **kwargs):
         """Custom __init__ routine to ensure that *default* values (as specified in the ORM) are used by the DRF serializers, *if* the values are not provided by the user."""

--- a/InvenTree/InvenTree/serializers.py
+++ b/InvenTree/InvenTree/serializers.py
@@ -19,7 +19,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import empty
 from rest_framework.serializers import DecimalField
 from rest_framework.utils import model_meta
-from InvenTree.fields import InvenTreeURLFormField, InvenTreeURLRest
+from InvenTree.fields import InvenTreeRestURLField
 
 from common.models import InvenTreeSetting
 from InvenTree.helpers import download_image_from_url
@@ -69,7 +69,7 @@ class InvenTreeModelSerializer(serializers.ModelSerializer):
     # Switch out URLField mapping
     serializer_field_mapping = {
         **serializers.ModelSerializer.serializer_field_mapping,
-        models.URLField: InvenTreeURLRest,
+        models.URLField: InvenTreeRestURLField,
     }
 
     def __init__(self, instance=None, data=empty, **kwargs):


### PR DESCRIPTION
This PR patches the DRF ModelSerializer to use a Custom URLField that allows a custom set of protocols in links. This was probably overseen in the switch to the API rendered form. With the way it is patched now every URLField will become a InvenTreeRestURLField.

Fixes #3411

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>