### PR TITLE
docker: disable redis image by default

### DIFF
--- a/docker/production/.env
+++ b/docker/production/.env
@@ -34,10 +34,12 @@ INVENTREE_DB_PORT=5432
 #INVENTREE_DB_USER=pguser
 #INVENTREE_DB_PASSWORD=pgpassword
 
-# Redis cache setup
+# Redis cache setup (disabled by default)
+# Un-comment the following lines to enable Redis cache
+# Note that you will also have to run docker-compose with the --profile redis command
 # Refer to settings.py for other cache options
-INVENTREE_CACHE_HOST=inventree-cache
-INVENTREE_CACHE_PORT=6379
+#INVENTREE_CACHE_HOST=inventree-cache
+#INVENTREE_CACHE_PORT=6379
 
 # Enable plugins?
 INVENTREE_PLUGINS_ENABLED=False

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.8"
 
-# Docker compose recipe for InvenTree production server, with the following containerized processes
+# Docker compose recipe for a production-ready InvenTree setup, with the following containers:
 # - PostgreSQL as the database backend
 # - gunicorn as the InvenTree web server
 # - django-q as the InvenTree background worker process
 # - nginx as a reverse proxy
-# - redis as the cache manager
+# - redis as the cache manager (optional, disabled by default)
 
 # ---------------------
 # READ BEFORE STARTING!
@@ -18,10 +18,8 @@ version: "3.8"
 # Changes made to this file are reflected across all containers!
 #
 # IMPORTANT NOTE:
-# You should not have to change *anything* within the docker-compose.yml file!
+# You should not have to change *anything* within this docker-compose.yml file!
 # Instead, make any changes in the .env file!
-# The only *mandatory* change is to set the INVENTREE_EXT_VOLUME variable,
-# which defines the directory (on your local machine) where persistent data are stored.
 
 # ------------------------
 # InvenTree Image Versions
@@ -29,15 +27,12 @@ version: "3.8"
 # By default, this docker-compose script targets the STABLE version of InvenTree,
 # image: inventree/inventree:stable
 #
-# To run the LATEST (development) version of InvenTree, change the target image to:
-# image: inventree/inventree:latest
+# To run the LATEST (development) version of InvenTree,
+# change the INVENTREE_TAG variable (in the .env file) to "latest"
 #
 # Alternatively, you could target a specific tagged release version with (for example):
-# image: inventree/inventree:0.5.3
+# INVENTREE_TAG=0.7.5
 #
-# NOTE: If you change the target image, ensure it is the same for the following containers:
-# - inventree-server
-# - inventree-worker
 
 services:
     # Database service
@@ -58,11 +53,14 @@ services:
         restart: unless-stopped
 
     # redis acts as database cache manager
+    # only runs under the "redis" profile : https://docs.docker.com/compose/profiles/
     inventree-cache:
         container_name: inventree-cache
         image: redis:7.0
         depends_on:
             - inventree-db
+        profiles:
+            - redis
         env_file:
             - .env
         expose:
@@ -79,7 +77,6 @@ services:
             - 8000
         depends_on:
             - inventree-db
-            - inventree-cache
         env_file:
             - .env
         volumes:


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/3292

This PR adjusts the sample production docker-compose file, disabling the redis container by default.

By making use of the [docker profiles](https://docs.docker.com/compose/profiles/) feature the service is still defined but will not be started by default.

This allows us to move forward and "ignore" (for now) the redis issues outlined in #3292 

Updated docs: https://github.com/inventree/inventree-docs/pull/334

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3416"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
