### PR TITLE
Fixes bug introduced by moving to pathlib

### DIFF
--- a/InvenTree/InvenTree/test_views.py
+++ b/InvenTree/InvenTree/test_views.py
@@ -2,6 +2,7 @@
 
 import os
 
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from InvenTree.helpers import InvenTreeTestCase
@@ -41,3 +42,80 @@ class ViewTests(InvenTreeTestCase):
         self.assertIn("<div id='detail-panels'>", content)
 
         # TODO: In future, run the javascript and ensure that the panels get created!
+
+    def test_settings_page(self):
+        """Test that the 'settings' page loads correctly"""
+
+        # Settings page loads
+        url = reverse('settings')
+
+        # Attempt without login
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+        # Login with default client
+        self.client.login(username=self.username, password=self.password)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+
+        user_panels = [
+            'account',
+            'user-display',
+            'user-home',
+            'user-reports',
+        ]
+
+        staff_panels = [
+            'server',
+            'login',
+            'barcodes',
+            'currencies',
+            'parts',
+            'stock',
+        ]
+
+        plugin_panels = [
+            'plugin',
+        ]
+
+        # Default user has staff access, so all panels will be present
+        for panel in user_panels + staff_panels + plugin_panels:
+            self.assertIn(f"select-{panel}", content)
+            self.assertIn(f"panel-{panel}", content)
+
+        # Now create a user who does not have staff access
+        pleb_user = get_user_model().objects.create_user(
+            username='pleb',
+            password='notstaff',
+        )
+
+        pleb_user.groups.add(self.group)
+        pleb_user.is_superuser = False
+        pleb_user.is_staff = False
+        pleb_user.save()
+
+        self.client.logout()
+
+        result = self.client.login(
+            username='pleb',
+            password='notstaff',
+        )
+
+        self.assertTrue(result)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+
+        # Normal user still has access to user-specific panels
+        for panel in user_panels:
+            self.assertIn(f"select-{panel}", content)
+            self.assertIn(f"panel-{panel}", content)
+
+        # Normal user does NOT have access to global or plugin settings
+        for panel in staff_panels + plugin_panels:
+            self.assertNotIn(f"select-{panel}", content)
+            self.assertNotIn(f"panel-{panel}", content)

--- a/InvenTree/InvenTree/views.py
+++ b/InvenTree/InvenTree/views.py
@@ -637,7 +637,8 @@ class SettingsView(TemplateView):
             ctx["rates_updated"] = None
 
         # load locale stats
-        STAT_FILE = settings.BASE_DIR.joinpath('InvenTree/locale_stats.json').abolute()
+        STAT_FILE = settings.BASE_DIR.joinpath('InvenTree/locale_stats.json').absolute()
+
         try:
             ctx["locale_stats"] = json.load(open(STAT_FILE, 'r'))
         except Exception:

--- a/InvenTree/templates/InvenTree/settings/user.html
+++ b/InvenTree/templates/InvenTree/settings/user.html
@@ -248,7 +248,11 @@
         {% for object in session_list %}
             <tr {% if object.session_key == session_key %}class="active"{% endif %}>
             <td>{{ object.ip }}</td>
+            {% if object.user_agent or object.device %}
             <td>{{ object.user_agent|device|default_if_none:unknown_on_unknown|safe }}</td>
+            {% else %}
+            <td>{{ unknown_on_unknown }}</td>
+            {% endif %}
             <td>
                 {% if object.session_key == session_key %}
                 {% blocktrans with time=object.last_activity|timesince %}{{ time }} ago (this session){% endblocktrans %}


### PR DESCRIPTION
Ref: https://github.com/inventree/InvenTree/pull/3392

A simple typo broke rendering on the "settings" page. This PR fixes that, and also introduces some unit testing to ensure that the settings page gets rendered correctly.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3419"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

