### PR TITLE
Fix "part" column sorting in BOM table

### DIFF
--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -798,7 +798,7 @@ function loadBomTable(table, options={}) {
     // Part column
     cols.push(
         {
-            field: 'sub_part',
+            field: 'sub_part_detail.full_name',
             title: '{% trans "Part" %}',
             sortable: true,
             switchable: false,


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/3330

In the BOM table, the "part" column was sorted by part ID, not part name! Very simple fix.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3422"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

