### PR TITLE
Fix version-copy button according to #3373

### DIFF
--- a/InvenTree/InvenTree/static/script/inventree/inventree.js
+++ b/InvenTree/InvenTree/static/script/inventree/inventree.js
@@ -110,7 +110,7 @@ function inventreeDocReady() {
         launchModalForm(`/about/`, {
             no_post: true,
             after_render: function() {
-                attachClipboard('.clip-btn', 'modal-form');
+                attachClipboard('.clip-btn', 'modal-form', 'about-copy-text');
             }
         });
     });
@@ -121,9 +121,6 @@ function inventreeDocReady() {
             no_post: true,
         });
     });
-
-    // Initialize clipboard-buttons
-    attachClipboard('.clip-btn');
 
     // Generate brand-icons
     $('.brand-icon').each(function(i, obj) {


### PR DESCRIPTION
See issue #3373 

This behaviour was introduced recently, the change seems to fix it again.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3425"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

