### PR TITLE
Add links to all notifications that do not have a link

### DIFF
--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -650,13 +650,15 @@ def after_error_logged(sender, instance: Error, created: bool, **kwargs):
 
             users = get_user_model().objects.filter(is_staff=True)
 
+            link = InvenTree.helpers.construct_absolute_url(
+                reverse('admin:error_report_error_change', kwargs={'object_id': instance.pk})
+            )
+
             context = {
                 'error': instance,
                 'name': _('Server Error'),
                 'message': _('An error has been logged by the server.'),
-                'link': InvenTree.helpers.construct_absolute_url(
-                    reverse('admin:error_report_error_change', kwargs={'object_id': instance.pk})
-                )
+                'link': link
             }
 
             common.notifications.trigger_notification(

--- a/InvenTree/common/serializers.py
+++ b/InvenTree/common/serializers.py
@@ -1,10 +1,12 @@
 """JSON serializers for common components."""
 
+from django.urls import reverse
+
 from rest_framework import serializers
 
 from common.models import (InvenTreeSetting, InvenTreeUserSetting,
                            NotificationMessage)
-from InvenTree.helpers import get_objectreference
+from InvenTree.helpers import construct_absolute_url, get_objectreference
 from InvenTree.serializers import InvenTreeModelSerializer
 
 
@@ -157,7 +159,22 @@ class NotificationMessageSerializer(InvenTreeModelSerializer):
 
     def get_target(self, obj):
         """Function to resolve generic object reference to target."""
-        return get_objectreference(obj, 'target_content_type', 'target_object_id')
+        target = get_objectreference(obj, 'target_content_type', 'target_object_id')
+
+        if 'link' not in target:
+            # Check if objekt has an absolute_url function
+            if hasattr(obj.target_object, 'get_absolute_url'):
+                target['link'] = obj.target_object.get_absolute_url()
+            else:
+                # check if user is staff - link to admin
+                request = self.context['request']
+                if request.user and request.user.is_staff:
+                    meta = obj.target_object._meta
+                    target['link'] = construct_absolute_url(reverse(
+                        f'admin:{meta.db_table}_change',
+                        kwargs={'object_id': obj.target_object_id}
+                    ))
+        return target
 
     def get_source(self, obj):
         """Function to resolve generic object reference to source."""


### PR DESCRIPTION
This PR checks if there is an get_absolute_url function or just provides a link to the admin page it the user is staff.
@SchrodingersGat should this be controlled by a setting?

Todo:
- [x] Testing
- [ ] Possibly setting

Closes #3367

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3431"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

