### PR TITLE
Fix for docker-compose v1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
 version: "3.8"
 
-name: "inventree-development"
-
 # Docker compose recipe for InvenTree development server
 # - Runs PostgreSQL as the database backend
 # - Uses built-in django webserver

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -1,7 +1,5 @@
 version: "3.8"
 
-name: "inventree-production"
-
 # Docker compose recipe for a production-ready InvenTree setup, with the following containers:
 # - PostgreSQL as the database backend
 # - gunicorn as the InvenTree web server


### PR DESCRIPTION
v1 does not support the name attribute

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3434"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

