### PR TITLE
Check that notification target is not null

### DIFF
--- a/InvenTree/common/serializers.py
+++ b/InvenTree/common/serializers.py
@@ -162,7 +162,7 @@ class NotificationMessageSerializer(InvenTreeModelSerializer):
         target = get_objectreference(obj, 'target_content_type', 'target_object_id')
 
         if target and 'link' not in target:
-            # Check if objekt has an absolute_url function
+            # Check if object has an absolute_url function
             if hasattr(obj.target_object, 'get_absolute_url'):
                 target['link'] = obj.target_object.get_absolute_url()
             else:

--- a/InvenTree/common/serializers.py
+++ b/InvenTree/common/serializers.py
@@ -161,7 +161,7 @@ class NotificationMessageSerializer(InvenTreeModelSerializer):
         """Function to resolve generic object reference to target."""
         target = get_objectreference(obj, 'target_content_type', 'target_object_id')
 
-        if 'link' not in target:
+        if target and 'link' not in target:
             # Check if objekt has an absolute_url function
             if hasattr(obj.target_object, 'get_absolute_url'):
                 target['link'] = obj.target_object.get_absolute_url()
@@ -174,6 +174,7 @@ class NotificationMessageSerializer(InvenTreeModelSerializer):
                         f'admin:{meta.db_table}_change',
                         kwargs={'object_id': obj.target_object_id}
                     ))
+
         return target
 
     def get_source(self, obj):

--- a/InvenTree/templates/js/translated/notification.js
+++ b/InvenTree/templates/js/translated/notification.js
@@ -174,6 +174,12 @@ function updateNotificationReadState(btn, panel_caller=false) {
             } else {
                 count = count + 1;
             }
+
+            // Prevent negative notification count
+            if (count < 0) {
+                count = 0;
+            }
+
             // update notification indicator now
             updateNotificationIndicator(count);
 


### PR DESCRIPTION
Recent update for notification serializer could throw an error if the 'target' was None.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3449"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

