### PR TITLE
Fix: Treegrid is loading an eternity for huge amounts of data

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,14 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 69
+INVENTREE_API_VERSION = 70
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v70 -> 2022-08-02 : https://github.com/inventree/InvenTree/pull/3451
+    - Adds a 'depth' parameter to the PartCategory list API
+    - Adds a 'depth' parameter to the StockLocation list API
 
 v69 -> 2022-08-01 : https://github.com/inventree/InvenTree/pull/3443
     - Updates the PartCategory list API:

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -283,6 +283,22 @@ def str2bool(text, test=True):
         return str(text).lower() in ['0', 'n', 'no', 'none', 'f', 'false', 'off', ]
 
 
+def str2int(text, default=None):
+    """Convert a string to int if possible
+
+    Args:
+        text: Int like string
+        default: Return value if str is no int like
+
+    Returns:
+        Converted int value
+    """
+    try:
+        return int(text)
+    except Exception:
+        return default
+
+
 def is_bool(text):
     """Determine if a string value 'looks' like a boolean."""
     if str2bool(text, True):

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -877,6 +877,16 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'default': True,
         },
 
+        'INVENTREE_TREE_DEPTH': {
+            'name': _('Tree Depth'),
+            'description': _('Default tree depth for treeview. Deeper levels can be lazy loaded as they are needed.'),
+            'default': 1,
+            'validator': [
+                int,
+                MinValueValidator(0),
+            ]
+        },
+
         'BARCODE_ENABLE': {
             'name': _('Barcode Support'),
             'description': _('Enable barcode scanner support'),

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -85,6 +85,8 @@ class CategoryList(ListCreateAPI):
 
         cascade = str2bool(params.get('cascade', False))
 
+        depth = params.get("depth", None)
+
         # Do not filter by category
         if cat_id is None:
             pass
@@ -94,12 +96,18 @@ class CategoryList(ListCreateAPI):
             if not cascade:
                 queryset = queryset.filter(parent=None)
 
+            if depth is not None:
+                queryset = queryset.filter(level__lte=int(depth))
+
         else:
             try:
                 category = PartCategory.objects.get(pk=cat_id)
 
                 if cascade:
                     parents = category.get_descendants(include_self=True)
+                    if depth is not None:
+                        parents = parents.filter(level__lte=category.level + int(depth))
+
                     parent_ids = [p.id for p in parents]
 
                     queryset = queryset.filter(parent__in=parent_ids)

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -97,7 +97,7 @@ class CategoryList(ListCreateAPI):
             if not cascade:
                 queryset = queryset.filter(parent=None)
 
-            if depth is not None:
+            if cascade and depth is not None:
                 queryset = queryset.filter(level__lte=depth)
 
         else:

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -25,7 +25,8 @@ from company.models import Company, ManufacturerPart, SupplierPart
 from InvenTree.api import (APIDownloadMixin, AttachmentMixin,
                            ListCreateDestroyAPIView)
 from InvenTree.filters import InvenTreeOrderingFilter
-from InvenTree.helpers import DownloadFile, increment, isNull, str2bool
+from InvenTree.helpers import (DownloadFile, increment, isNull, str2bool,
+                               str2int)
 from InvenTree.mixins import (CreateAPI, ListAPI, ListCreateAPI, RetrieveAPI,
                               RetrieveUpdateAPI, RetrieveUpdateDestroyAPI,
                               UpdateAPI)
@@ -85,7 +86,7 @@ class CategoryList(ListCreateAPI):
 
         cascade = str2bool(params.get('cascade', False))
 
-        depth = params.get("depth", None)
+        depth = str2int(params.get('depth', None))
 
         # Do not filter by category
         if cat_id is None:
@@ -97,7 +98,7 @@ class CategoryList(ListCreateAPI):
                 queryset = queryset.filter(parent=None)
 
             if depth is not None:
-                queryset = queryset.filter(level__lte=int(depth))
+                queryset = queryset.filter(level__lte=depth)
 
         else:
             try:
@@ -106,7 +107,7 @@ class CategoryList(ListCreateAPI):
                 if cascade:
                     parents = category.get_descendants(include_self=True)
                     if depth is not None:
-                        parents = parents.filter(level__lte=category.level + int(depth))
+                        parents = parents.filter(level__lte=category.level + depth)
 
                     parent_ids = [p.id for p in parents]
 

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -252,8 +252,8 @@ class StockLocationList(ListCreateAPI):
             # If we allow "cascade" at the top-level, this essentially means *all* locations
             if not cascade:
                 queryset = queryset.filter(parent=None)
-                
-            if depth != None:
+
+            if depth is not None:
                 queryset = queryset.filter(level__lte=int(depth))
 
         else:
@@ -264,9 +264,9 @@ class StockLocationList(ListCreateAPI):
                 # All sub-locations to be returned too?
                 if cascade:
                     parents = location.get_descendants(include_self=True)
-                    if depth != None:
+                    if depth is not None:
                         parents = parents.filter(level__lte=location.level + int(depth))
-                        
+
                     parent_ids = [p.id for p in parents]
                     queryset = queryset.filter(parent__in=parent_ids)
 

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -253,7 +253,7 @@ class StockLocationList(ListCreateAPI):
             if not cascade:
                 queryset = queryset.filter(parent=None)
 
-            if depth is not None:
+            if cascade and depth is not None:
                 queryset = queryset.filter(level__lte=depth)
 
         else:

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -26,7 +26,7 @@ from InvenTree.api import (APIDownloadMixin, AttachmentMixin,
                            ListCreateDestroyAPIView)
 from InvenTree.filters import InvenTreeOrderingFilter
 from InvenTree.helpers import (DownloadFile, extract_serial_numbers, isNull,
-                               str2bool)
+                               str2bool, str2int)
 from InvenTree.mixins import (CreateAPI, ListAPI, ListCreateAPI, RetrieveAPI,
                               RetrieveUpdateAPI, RetrieveUpdateDestroyAPI)
 from order.models import PurchaseOrder, SalesOrder, SalesOrderAllocation
@@ -241,7 +241,7 @@ class StockLocationList(ListCreateAPI):
 
         cascade = str2bool(params.get('cascade', False))
 
-        depth = params.get("depth", None)
+        depth = str2int(params.get('depth', None))
 
         # Do not filter by location
         if loc_id is None:
@@ -254,7 +254,7 @@ class StockLocationList(ListCreateAPI):
                 queryset = queryset.filter(parent=None)
 
             if depth is not None:
-                queryset = queryset.filter(level__lte=int(depth))
+                queryset = queryset.filter(level__lte=depth)
 
         else:
 
@@ -265,7 +265,7 @@ class StockLocationList(ListCreateAPI):
                 if cascade:
                     parents = location.get_descendants(include_self=True)
                     if depth is not None:
-                        parents = parents.filter(level__lte=location.level + int(depth))
+                        parents = parents.filter(level__lte=location.level + depth)
 
                     parent_ids = [p.id for p in parents]
                     queryset = queryset.filter(parent__in=parent_ids)

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -241,6 +241,8 @@ class StockLocationList(ListCreateAPI):
 
         cascade = str2bool(params.get('cascade', False))
 
+        depth = params.get("depth", None)
+
         # Do not filter by location
         if loc_id is None:
             pass
@@ -250,6 +252,9 @@ class StockLocationList(ListCreateAPI):
             # If we allow "cascade" at the top-level, this essentially means *all* locations
             if not cascade:
                 queryset = queryset.filter(parent=None)
+                
+            if depth != None:
+                queryset = queryset.filter(level__lte=int(depth))
 
         else:
 
@@ -259,6 +264,9 @@ class StockLocationList(ListCreateAPI):
                 # All sub-locations to be returned too?
                 if cascade:
                     parents = location.get_descendants(include_self=True)
+                    if depth != None:
+                        parents = parents.filter(level__lte=location.level + int(depth))
+                        
                     parent_ids = [p.id for p in parents]
                     queryset = queryset.filter(parent__in=parent_ids)
 

--- a/InvenTree/stock/test_api.py
+++ b/InvenTree/stock/test_api.py
@@ -54,11 +54,44 @@ class StockLocationTest(StockAPITestCase):
         StockLocation.objects.create(name='top', description='top category')
 
     def test_list(self):
-        """Test StockLocation list."""
-        # Check that we can request the StockLocation list
-        response = self.client.get(self.list_url, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreaterEqual(len(response.data), 1)
+        """Test the StockLocationList API endpoint"""
+        test_cases = [
+            ({}, 8, 'no parameters'),
+            ({'parent': 1, 'cascade': False}, 2, 'Filter by parent, no cascading'),
+            ({'parent': 1, 'cascade': True}, 2, 'Filter by parent, cascading'),
+            ({'cascade': True, 'depth': 0}, 8, 'Cascade with no parent, depth=0'),
+            ({'cascade': False, 'depth': 10}, 8, 'Cascade with no parent, depth=0'),
+            ({'parent': 'null', 'cascade': True, 'depth': 0}, 7, 'Cascade with null parent, depth=0'),
+            ({'parent': 'null', 'cascade': True, 'depth': 10}, 8, 'Cascade with null parent and bigger depth'),
+            ({'parent': 'null', 'cascade': False, 'depth': 10}, 3, 'No cascade even with depth specified with null parent'),
+            ({'parent': 1, 'cascade': False, 'depth': 0}, 2, 'Dont cascade with depth=0 and parent'),
+            ({'parent': 1, 'cascade': True, 'depth': 0}, 2, 'Cascade with depth=0 and parent'),
+            ({'parent': 1, 'cascade': False, 'depth': 1}, 2, 'Dont cascade even with depth=1 specified with parent'),
+            ({'parent': 1, 'cascade': True, 'depth': 1}, 2, 'Cascade with depth=1 with parent'),
+            ({'parent': 1, 'cascade': True, 'depth': 'abcdefg'}, 2, 'Cascade with invalid depth and parent'),
+        ]
+
+        for params, res_len, description in test_cases:
+            response = self.get(self.list_url, params, expected_code=200)
+            self.assertEqual(len(response.data), res_len, description)
+
+        # Check that the required fields are present
+        fields = [
+            'pk',
+            'name',
+            'description',
+            'level',
+            'parent',
+            'items',
+            'pathstring',
+            'owner',
+            'url'
+        ]
+
+        response = self.get(self.list_url, expected_code=200)
+        for result in response.data:
+            for f in fields:
+                self.assertIn(f, result)
 
     def test_add(self):
         """Test adding StockLocation."""

--- a/InvenTree/templates/InvenTree/settings/global.html
+++ b/InvenTree/templates/InvenTree/settings/global.html
@@ -22,6 +22,7 @@
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DOWNLOAD_FROM_URL" icon="fa-cloud-download-alt" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DOWNLOAD_IMAGE_MAX_SIZE" icon="fa-server" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_REQUIRE_CONFIRM" icon="fa-check" %}
+        {% include "InvenTree/settings/setting.html" with key="INVENTREE_TREE_DEPTH" icon="fa-sitemap" %}
     </tbody>
 </table>
 

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -1903,19 +1903,19 @@ function loadPartCategoryTable(table, options) {
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
-                    let html = "";
+                    let html = '';
 
-                    if(row._level >= MAX_DEPTH && !row.subReceived) {
-                        if(row.subRequested) {
+                    if (row._level >= MAX_DEPTH && !row.subReceived) {
+                        if (row.subRequested) {
                             html += `<a href='#'><span class='fas fa-sync fa-spin'></span></a>`;
                         } else {
                             html += `
-                                <a href='#' pk='${row.pk}' class="load-sub-category">
+                                <a href='#' pk='${row.pk}' class='load-sub-category'>
                                     <span class='fas fa-sync-alt' title='{% trans "Load Subcategories" %}'></span>
                                 </a> `;
                         }
                     }
-                    
+
                     html += renderLink(
                         value,
                         `/part/category/${row.pk}/`

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -1732,7 +1732,7 @@ function loadPartTable(table, url, options={}) {
  * Display a table of part categories
  */
 function loadPartCategoryTable(table, options) {
-    const MAX_DEPTH = 1;
+
     var params = options.params || {};
 
     var filterListElement = options.filterList || '#filter-list-category';
@@ -1750,7 +1750,7 @@ function loadPartCategoryTable(table, options) {
 
     if (tree_view) {
         params.cascade = true;
-        params.depth = MAX_DEPTH;
+        params.depth = global_settings.INVENTREE_TREE_DEPTH;
     }
 
     var original = {};
@@ -1905,7 +1905,7 @@ function loadPartCategoryTable(table, options) {
                 formatter: function(value, row) {
                     let html = '';
 
-                    if (row._level >= MAX_DEPTH && !row.subReceived) {
+                    if (row._level >= global_settings.INVENTREE_TREE_DEPTH && !row.subReceived) {
                         if (row.subRequested) {
                             html += `<a href='#'><span class='fas fa-sync fa-spin'></span></a>`;
                         } else {

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -2389,14 +2389,14 @@ function loadStockLocationTable(table, options) {
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
-                    let html = "";
+                    let html = '';
 
-                    if(row._level >= MAX_DEPTH && !row.subReceived) {
-                        if(row.subRequested) {
+                    if (row._level >= MAX_DEPTH && !row.subReceived) {
+                        if (row.subRequested) {
                             html += `<a href='#'><span class='fas fa-sync fa-spin'></span></a>`;
                         } else {
                             html += `
-                                <a href='#' pk='${row.pk}' class="load-sub-location">
+                                <a href='#' pk='${row.pk}' class='load-sub-location'>
                                     <span class='fas fa-sync-alt' title='{% trans "Load Subloactions" %}'></span>
                                 </a> `;
                         }

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -2217,7 +2217,7 @@ function loadStockTable(table, options) {
  * Display a table of stock locations
  */
 function loadStockLocationTable(table, options) {
-
+    const MAX_DEPTH = 1;
     var params = options.params || {};
 
     var filterListElement = options.filterList || '#filter-list-location';
@@ -2226,6 +2226,7 @@ function loadStockLocationTable(table, options) {
 
     if (tree_view) {
         params.cascade = true;
+        params.depth = MAX_DEPTH;
     }
 
     var filters = {};
@@ -2246,6 +2247,35 @@ function loadStockLocationTable(table, options) {
 
     for (var key in params) {
         filters[key] = params[key];
+    }
+
+    // Function to request sub-location items
+    function requestSubItems(parent_pk) {
+        inventreeGet(
+            options.url || '{% url "api-location-list" %}',
+            {
+                parent: parent_pk,
+            },
+            {
+                success: function(response) {
+                    // Add the returned sub-items to the table
+                    for (var idx = 0; idx < response.length; idx++) {
+                        response[idx].parent = parent_pk;
+                    }
+
+                    const row = $(table).bootstrapTable('getRowByUniqueId', parent_pk);
+                    row.subReceived = true;
+
+                    $(table).bootstrapTable('updateByUniqueId', parent_pk, row, true);
+
+                    table.bootstrapTable('append', response);
+                },
+                error: function(xhr) {
+                    console.error('Error requesting sub-locations for location=' + parent_pk);
+                    showApiError(xhr);
+                }
+            }
+        );
     }
 
     table.inventreeTable({
@@ -2285,6 +2315,20 @@ function loadStockLocationTable(table, options) {
                         onExpand: function() {
 
                         }
+                    });
+
+                    // Callback for 'load sub location' button
+                    $(table).find('.load-sub-location').click(function(event) {
+                        event.preventDefault();
+
+                        const pk = $(this).attr('pk');
+                        const row = $(table).bootstrapTable('getRowByUniqueId', pk);
+
+                        // Request BOM data for this subassembly
+                        requestSubItems(row.pk);
+
+                        row.subRequested = true;
+                        $(table).bootstrapTable('updateByUniqueId', pk, row, true);
                     });
                 } else {
                     $('#view-location-tree').removeClass('btn-secondary').addClass('btn-outline-secondary');
@@ -2345,10 +2389,25 @@ function loadStockLocationTable(table, options) {
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
-                    return renderLink(
+                    let html = "";
+
+                    if(row._level >= MAX_DEPTH && !row.subReceived) {
+                        if(row.subRequested) {
+                            html += `<a href='#'><span class='fas fa-sync fa-spin'></span></a>`;
+                        } else {
+                            html += `
+                                <a href='#' pk='${row.pk}' class="load-sub-location">
+                                    <span class='fas fa-sync-alt' title='{% trans "Load Subloactions" %}'></span>
+                                </a> `;
+                        }
+                    }
+
+                    html += renderLink(
                         value,
                         `/stock/location/${row.pk}/`
                     );
+
+                    return html;
                 },
             },
             {

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -2217,7 +2217,7 @@ function loadStockTable(table, options) {
  * Display a table of stock locations
  */
 function loadStockLocationTable(table, options) {
-    const MAX_DEPTH = 1;
+
     var params = options.params || {};
 
     var filterListElement = options.filterList || '#filter-list-location';
@@ -2226,7 +2226,7 @@ function loadStockLocationTable(table, options) {
 
     if (tree_view) {
         params.cascade = true;
-        params.depth = MAX_DEPTH;
+        params.depth = global_settings.INVENTREE_TREE_DEPTH;
     }
 
     var filters = {};
@@ -2391,7 +2391,7 @@ function loadStockLocationTable(table, options) {
                 formatter: function(value, row) {
                     let html = '';
 
-                    if (row._level >= MAX_DEPTH && !row.subReceived) {
+                    if (row._level >= global_settings.INVENTREE_TREE_DEPTH && !row.subReceived) {
                         if (row.subRequested) {
                             html += `<a href='#'><span class='fas fa-sync fa-spin'></span></a>`;
                         } else {

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -2324,7 +2324,7 @@ function loadStockLocationTable(table, options) {
                         const pk = $(this).attr('pk');
                         const row = $(table).bootstrapTable('getRowByUniqueId', pk);
 
-                        // Request BOM data for this subassembly
+                        // Request sub-location for this location
                         requestSubItems(row.pk);
 
                         row.subRequested = true;


### PR DESCRIPTION
Loading the tree grid with huge amounts of data can take more than 5 minutes as described in #3438. I tried to add a max depth in this PR and lazy load the rest as its requested by the user.

### Screenshots

https://user-images.githubusercontent.com/60048565/182368321-cf4b4193-67a2-4c5b-9636-997ccec277a5.mov

![image](https://user-images.githubusercontent.com/60048565/182605830-57ae5187-be0f-4036-b2aa-8f5731723e9f.png)


### Remaining Issues

#### 1. Tree does not keep the collapsed items collapsed after new items are added to the tree

This seems like an upstream issue. I opened an issue on their side: wenzhixin/bootstrap-table#6304

#### 2. The spinning animations is not shown correctly

I think this is caused by the browser, because if more data is loading and processed by the browser the thread is blocked and nothing else can happen, so the animation would start after loading, but then the loading state is removed, so we don't see any spinning animation.
--> Seems like this is working if they are very few items in the table

Let me know what you think of this solution and if there is another tree grid which should be handled similar. The categories?

fixes #3438

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3451"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

