### PR TITLE
Fix bug introduced in #3459

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1782,7 +1782,7 @@ class ColorTheme(models.Model):
         files_list = []
 
         for file in settings.STATIC_COLOR_THEMES_DIR.iterdir():
-            files_list.append(file.stem)
+            files_list.append([file.stem, file.suffix])
 
         # Get color themes choices (CSS sheets)
         choices = [(file_name.lower(), _(file_name.replace('-', ' ').title()))


### PR DESCRIPTION
Ref: https://github.com/inventree/InvenTree/pull/3459

Updating to Pathlib introduced a bug which broke the color themes directory parsing.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3462"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

