### PR TITLE
load admin first

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -135,6 +135,8 @@ MEDIA_URL = '/media/'
 # Application definition
 
 INSTALLED_APPS = [
+    # Admin site integration
+    'django.contrib.admin',
 
     # InvenTree apps
     'build.apps.BuildConfig',
@@ -150,7 +152,6 @@ INSTALLED_APPS = [
     'InvenTree.apps.InvenTreeConfig',       # InvenTree app runs last
 
     # Core django modules
-    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'user_sessions',                # db user sessions


### PR DESCRIPTION
- Fixes https://github.com/inventree/InvenTree/issues/3355
- Fixes https://github.com/inventree/InvenTree/issues/3483

Placing 'django.contrib.admin' at the start of `INSTALLED_APPS` seems to address this issue, although it is a very unsatisfying result. Still no idea why the simpleactionplugin causes the admin page to error out.

@matmair any thoughts as to negative consequences of putting 'django.contrib.admin' at the start of the list?

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3484"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

