### PR TITLE
[FR] Add plugin keys, state and version  to version info

### DIFF
--- a/InvenTree/InvenTree/api.py
+++ b/InvenTree/InvenTree/api.py
@@ -12,6 +12,7 @@ from rest_framework.serializers import ValidationError
 
 from InvenTree.mixins import ListCreateAPI
 from InvenTree.permissions import RolePermission
+from part.templatetags.inventree_extras import plugins_info
 
 from .status import is_worker_running
 from .version import (inventreeApiVersion, inventreeInstanceName,
@@ -36,6 +37,7 @@ class InfoView(AjaxView):
             'apiVersion': inventreeApiVersion(),
             'worker_running': is_worker_running(),
             'plugins_enabled': settings.PLUGINS_ENABLED,
+            'active_plugins': plugins_info(),
         }
 
         return JsonResponse(data)

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -17,6 +17,7 @@ import InvenTree.helpers
 from common.models import ColorTheme, InvenTreeSetting, InvenTreeUserSetting
 from common.settings import currency_code_default
 from InvenTree import settings, version
+from plugin import registry
 from plugin.models import NotificationUserSetting, PluginSetting
 
 register = template.Library()
@@ -147,6 +148,25 @@ def inventree_docker_mode(*args, **kwargs):
 def plugins_enabled(*args, **kwargs):
     """Return True if plugins are enabled for the server instance."""
     return djangosettings.PLUGINS_ENABLED
+
+
+@register.simple_tag()
+def plugins_info(*args, **kwargs):
+    """Return information about activated plugins."""
+    # Check if plugins are even enabled
+    if not djangosettings.PLUGINS_ENABLED:
+        return False
+
+    # Fetch plugins
+    plug_list = [plg for plg in registry.plugins.values() if plg.plugin_config().active]
+    # Format list
+    return [
+        {
+            'name': plg.name,
+            'slug': plg.slug,
+            'version': plg.version
+        } for plg in plug_list
+    ]
 
 
 @register.simple_tag()

--- a/InvenTree/templates/version.html
+++ b/InvenTree/templates/version.html
@@ -6,3 +6,4 @@ Django Version: {% django_version %}
 Database: {% inventree_db_engine %}
 Debug-Mode: {% inventree_in_debug_mode %}
 Deployed using Docker: {% inventree_docker_mode %}
+Active plugins: {% plugins_info %}


### PR DESCRIPTION
This PR adds additional information to the version info endpoint.

Fixes #3477

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3496"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

