### PR TITLE
Update translation function name to new default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Any user-facing strings *must* be passed through the translation engine.
 For strings exposed via Python code, use the following format:
 
 ```python
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 user_facing_string = _('This string will be exposed to the translation engine!')
 ```

--- a/InvenTree/plugin/builtin/integration/core_notifications.py
+++ b/InvenTree/plugin/builtin/integration/core_notifications.py
@@ -1,7 +1,7 @@
 """Core set of Notifications as a Plugin."""
 
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from allauth.account.models import EmailAddress
 


### PR DESCRIPTION
Needed for Django 4.0

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3497"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

