### PR TITLE
Improve plugin testing

### DIFF
--- a/InvenTree/plugin/apps.py
+++ b/InvenTree/plugin/apps.py
@@ -43,7 +43,7 @@ class PluginAppConfig(AppConfig):
                         pass
 
                     # get plugins and init them
-                    registry.collect_plugins()
+                    registry.plugin_modules = registry.collect_plugins()
                     registry.load_plugins()
 
                     # drop out of maintenance

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -7,7 +7,8 @@ import pkgutil
 import subprocess
 import sysconfig
 import traceback
-from importlib.metadata import entry_points
+from importlib.metadata import distributions, entry_points
+from importlib.util import find_spec
 
 from django import template
 from django.conf import settings
@@ -229,6 +230,29 @@ def get_plugins(pkg, baseclass, path=None):
                 plugins.append(plugin)
 
     return plugins
+
+
+def get_module_meta(mdl_name):
+    """Return distribution for module.
+
+    Modified form source: https://stackoverflow.com/a/60975978/17860466
+    """
+    # Get spec for module
+    spec = find_spec(mdl_name)
+
+    # Try to get specific package for the module
+    result = None
+    for dist in distributions():
+        try:
+            relative = pathlib.Path(spec.origin).relative_to(dist.locate_file(''))
+        except ValueError:
+            pass
+        else:
+            if relative in dist.files:
+                result = dist
+
+    # Return metadata
+    return result.metadata
 # endregion
 
 

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -7,6 +7,7 @@ import pkgutil
 import subprocess
 import sysconfig
 import traceback
+from importlib.metadata import entry_points
 
 from django import template
 from django.conf import settings
@@ -92,6 +93,11 @@ def handle_error(error, do_raise: bool = True, do_log: bool = True, log_name: st
         if settings.TESTING_ENV and package_name != 'integration.broken_sample' and isinstance(error, IntegrityError):
             raise error  # pragma: no cover
         raise IntegrationPluginError(package_name, str(error))
+
+
+def get_entrypoints():
+    """Returns list for entrypoints for InvenTree plugins."""
+    return entry_points().get('inventree_plugins', [])
 # endregion
 
 

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -249,7 +249,7 @@ def get_module_meta(mdl_name):
     for dist in distributions():
         try:
             relative = pathlib.Path(spec.origin).relative_to(dist.locate_file(''))
-        except ValueError:
+        except ValueError:  # pragma: no cover
             pass
         else:
             if relative in dist.files:

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -241,7 +241,7 @@ def get_module_meta(mdl_name):
     # Get spec for module
     spec = find_spec(mdl_name)
 
-    if not spec:
+    if not spec:  # pragma: no cover
         raise PackageNotFoundError(mdl_name)
 
     # Try to get specific package for the module
@@ -257,7 +257,7 @@ def get_module_meta(mdl_name):
 
     # Check if a distribution was found
     # A no should not be possible here as a call can only be made on a discovered module but better save then sorry
-    if not result:
+    if not result:  # pragma: no cover
         raise PackageNotFoundError(mdl_name)
 
     # Return metadata

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -7,7 +7,8 @@ import pkgutil
 import subprocess
 import sysconfig
 import traceback
-from importlib.metadata import distributions, entry_points
+from importlib.metadata import (PackageNotFoundError, distributions,
+                                entry_points)
 from importlib.util import find_spec
 
 from django import template
@@ -250,6 +251,11 @@ def get_module_meta(mdl_name):
         else:
             if relative in dist.files:
                 result = dist
+
+    # Check if a distribution was found
+    # A no should not be possible here as a call can only be made on a discovered module but better save then sorry
+    if not result:
+        raise PackageNotFoundError(mdl_name)
 
     # Return metadata
     return result.metadata

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -241,6 +241,9 @@ def get_module_meta(mdl_name):
     # Get spec for module
     spec = find_spec(mdl_name)
 
+    if not spec:
+        raise PackageNotFoundError(mdl_name)
+
     # Try to get specific package for the module
     result = None
     for dist in distributions():

--- a/InvenTree/plugin/mock/simple.py
+++ b/InvenTree/plugin/mock/simple.py
@@ -1,0 +1,10 @@
+"""Very simple sample plugin"""
+
+from plugin import InvenTreePlugin
+
+
+class SimplePlugin(InvenTreePlugin):
+    """A very simple plugin."""
+
+    NAME = 'SimplePlugin'
+    SLUG = "simple"

--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import warnings
 from datetime import datetime
-from importlib.metadata import metadata
+from importlib.metadata import PackageNotFoundError, metadata
 
 from django.conf import settings
 from django.db.utils import OperationalError, ProgrammingError
@@ -14,7 +14,7 @@ from django.urls.base import reverse
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
-from plugin.helpers import GitStatus, get_git_log
+from plugin.helpers import GitStatus, get_git_log, get_module_meta
 
 logger = logging.getLogger("inventree")
 
@@ -294,7 +294,13 @@ class InvenTreePlugin(MixinBase, MetaBase):
     @classmethod
     def _get_package_metadata(cls):
         """Get package metadata for plugin."""
-        meta = metadata(cls.__name__)
+
+        # Try simple metadata lookup
+        try:
+            meta = metadata(cls.__name__)
+        # Simpel lookup did not work - get data from module
+        except PackageNotFoundError:
+            meta = get_module_meta(cls.__module__)
 
         return {
             'author': meta['Author-email'],

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -8,7 +8,7 @@ import importlib
 import logging
 import os
 import subprocess
-from importlib import metadata, reload
+from importlib import reload
 from pathlib import Path
 from typing import OrderedDict
 
@@ -24,8 +24,8 @@ from maintenance_mode.core import (get_maintenance_mode, maintenance_mode_on,
 
 from InvenTree.config import get_setting
 
-from .helpers import (IntegrationPluginError, get_plugins, handle_error,
-                      log_error)
+from .helpers import (IntegrationPluginError, get_entrypoints, get_plugins,
+                      handle_error, log_error)
 from .plugin import InvenTreePlugin
 
 logger = logging.getLogger('inventree')
@@ -266,7 +266,7 @@ class PluginsRegistry:
         # Check if not running in testing mode and apps should be loaded from hooks
         if (not settings.PLUGIN_TESTING) or (settings.PLUGIN_TESTING and settings.PLUGIN_TESTING_SETUP):
             # Collect plugins from setup entry points
-            for entry in metadata.entry_points().get('inventree_plugins', []):  # pragma: no cover
+            for entry in get_entrypoints():  # pragma: no cover
                 try:
                     plugin = entry.load()
                     plugin.is_package = True

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -270,7 +270,7 @@ class PluginsRegistry:
         # Check if not running in testing mode and apps should be loaded from hooks
         if (not settings.PLUGIN_TESTING) or (settings.PLUGIN_TESTING and settings.PLUGIN_TESTING_SETUP):
             # Collect plugins from setup entry points
-            for entry in get_entrypoints():  # pragma: no cover
+            for entry in get_entrypoints():
                 try:
                     plugin = entry.load()
                     plugin.is_package = True

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -266,7 +266,7 @@ class PluginsRegistry:
         # Check if not running in testing mode and apps should be loaded from hooks
         if (not settings.PLUGIN_TESTING) or (settings.PLUGIN_TESTING and settings.PLUGIN_TESTING_SETUP):
             # Collect plugins from setup entry points
-            for entry in get_entrypoints():  # pragma: no cover
+            for entry in get_entrypoints():
                 try:
                     plugin = entry.load()
                     plugin.is_package = True

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -270,7 +270,7 @@ class PluginsRegistry:
         # Check if not running in testing mode and apps should be loaded from hooks
         if (not settings.PLUGIN_TESTING) or (settings.PLUGIN_TESTING and settings.PLUGIN_TESTING_SETUP):
             # Collect plugins from setup entry points
-            for entry in get_entrypoints():
+            for entry in get_entrypoints():  # pragma: no cover
                 try:
                     plugin = entry.load()
                     plugin.is_package = True

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -233,12 +233,10 @@ class PluginsRegistry:
                 if pd.exists() and pd.is_dir():
                     # Convert to python dot-path
                     if pd.is_relative_to(settings.BASE_DIR):
-                        parts = pd.relative_to(settings.BASE_DIR).parts
+                        relativ = pd.relative_to(settings.BASE_DIR).parts
+                        pd_path = '.'.join(relativ)
                     else:
-                        # Build up traversing path
-                        traversed_path = os.path.relpath(pd, settings.BASE_DIR)
-                        parts = traversed_path.split('/')
-                    pd_path = '.'.join(parts)
+                        pd_path = str(pd)
 
                     # Add path
                     dirs.append(pd_path)

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -4,6 +4,7 @@
 - Manages setup and teardown of plugin class instances
 """
 
+import imp
 import importlib
 import logging
 import os
@@ -266,7 +267,12 @@ class PluginsRegistry:
                 parent_path = str(parent_obj.parent)
                 plugin = parent_obj.name
 
-            modules = get_plugins(importlib.import_module(plugin), InvenTreePlugin, path=parent_path)
+            # Gather Modules
+            if parent_path:
+                raw_module = imp.load_source(plugin, str(parent_obj.joinpath('__init__.py')))
+            else:
+                raw_module = importlib.import_module(plugin)
+            modules = get_plugins(raw_module, InvenTreePlugin, path=parent_path)
 
             if modules:
                 [collected_plugins.append(item) for item in modules]

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -230,9 +230,13 @@ class PluginsRegistry:
                         continue
 
                 if pd.exists() and pd.is_dir():
+                    # Convert to python dot-path
+                    relativ = pd.relative_to(settings.BASE_DIR)
+                    pd_path = '.'.join(relativ.parts)
+
                     # By this point, we have confirmed that the directory at least exists
-                    logger.info(f"Added plugin directory: '{pd}'")
-                    dirs.append(pd)
+                    logger.info(f"Added plugin directory: '{pd_path}'")
+                    dirs.append(pd_path)
 
         return dirs
 

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -234,8 +234,7 @@ class PluginsRegistry:
                 if pd.exists() and pd.is_dir():
                     # Convert to python dot-path
                     if pd.is_relative_to(settings.BASE_DIR):
-                        relativ = pd.relative_to(settings.BASE_DIR).parts
-                        pd_path = '.'.join(relativ)
+                        pd_path = '.'.join(pd.relative_to(settings.BASE_DIR).parts)
                     else:
                         pd_path = str(pd)
 

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -282,7 +282,7 @@ class PluginsRegistry:
                     plugin.is_package = True
                     plugin._get_package_metadata()
                     collected_plugins.append(plugin)
-                except Exception as error:
+                except Exception as error:  # pragma: no cover
                     handle_error(error, do_raise=False, log_name='discovery')
 
         # Log collected plugins

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -229,14 +229,20 @@ class PluginsRegistry:
                         logger.error(f"Could not create file '{init_filename}'")
                         continue
 
+                # By this point, we have confirmed that the directory at least exists
                 if pd.exists() and pd.is_dir():
                     # Convert to python dot-path
-                    relativ = pd.relative_to(settings.BASE_DIR)
-                    pd_path = '.'.join(relativ.parts)
+                    if pd.is_relative_to(settings.BASE_DIR):
+                        parts = pd.relative_to(settings.BASE_DIR).parts
+                    else:
+                        # Build up traversing path
+                        traversed_path = os.path.relpath(pd, settings.BASE_DIR)
+                        parts = traversed_path.split('/')
+                    pd_path = '.'.join(parts)
 
-                    # By this point, we have confirmed that the directory at least exists
-                    logger.info(f"Added plugin directory: '{pd_path}'")
+                    # Add path
                     dirs.append(pd_path)
+                    logger.info(f"Added plugin directory: '{pd}' as '{pd_path}'")
 
         return dirs
 

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -200,7 +200,7 @@ class PluginsRegistry:
 
         if settings.TESTING:
             custom_dirs = os.getenv('INVENTREE_PLUGIN_TEST_DIR', None)
-        else:
+        else:  # pragma: no cover
             custom_dirs = get_setting('INVENTREE_PLUGIN_DIR', 'plugin_dir')
 
             # Load from user specified directories (unless in testing mode)

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -215,7 +215,7 @@ class PluginsRegistry:
                 if not pd.exists():
                     try:
                         pd.mkdir(exist_ok=True)
-                    except Exception:
+                    except Exception:  # pragma: no cover
                         logger.error(f"Could not create plugin directory '{pd}'")
                         continue
 
@@ -225,7 +225,7 @@ class PluginsRegistry:
                 if not init_filename.exists():
                     try:
                         init_filename.write_text("# InvenTree plugin directory\n")
-                    except Exception:
+                    except Exception:  # pragma: no cover
                         logger.error(f"Could not create file '{init_filename}'")
                         continue
 

--- a/InvenTree/plugin/test_helpers.py
+++ b/InvenTree/plugin/test_helpers.py
@@ -2,7 +2,7 @@
 
 from django.test import TestCase
 
-from .helpers import render_template
+from .helpers import get_module_meta, render_template
 
 
 class HelperTests(TestCase):
@@ -21,3 +21,15 @@ class HelperTests(TestCase):
         response = render_template(ErrorSource(), 'sample/wrongsample.html', {'abc': 123})
         self.assertTrue('lert alert-block alert-danger' in response)
         self.assertTrue('Template file <em>sample/wrongsample.html</em>' in response)
+
+    def test_get_module_meta(self):
+        """Test for get_module_meta."""
+
+        # We need a stable, known good that will be in enviroment for sure
+        # and it can't be stdlib because does might differ depending on the abstraction layer
+        # and version
+        meta = get_module_meta('django')
+
+        # Lets just hope they do not change the name or author
+        self.assertEqual(meta['Name'], 'Django')
+        self.assertEqual(meta['Author'], 'Django Software Foundation')

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -187,7 +187,7 @@ class RegistryTests(TestCase):
         test_dir.rmdir()
 
     def test_subfolder_loading(self):
-        """Test that plugins in folders get loaded"""
+        """Test that plugins in folders get loaded."""
 
         envs = {'INVENTREE_PLUGIN_TEST_DIR': 'InvenTree/plugin/mock'}
         with mock.patch.dict(os.environ, envs):

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -1,6 +1,9 @@
 """Unit tests for plugins."""
 
+import os
 from datetime import datetime
+from pathlib import Path
+from unittest import mock
 
 from django.test import TestCase
 
@@ -162,3 +165,22 @@ class InvenTreePluginTests(TestCase):
             self.assertEqual(self.plugin_old.slug, 'old')
             # check default value is used
             self.assertEqual(self.plugin_old.get_meta_value('ABC', 'ABCD', '123'), '123')
+
+
+class RegistryTests(TestCase):
+    """Tests for specific registry methods."""
+
+    def test_custom_loading(self):
+        """Test if data in custom dir is loade correctly."""
+
+        dir_name = 'plugin_test_dir'
+        test_dir = Path(dir_name)
+        envs = {'INVENTREE_PLUGIN_TEST_DIR': dir_name}
+
+        with mock.patch.dict(os.environ, envs):
+            registry.plugin_dirs()
+            self.assertTrue(test_dir.exists())
+
+        # Clean folder
+        test_dir.joinpath('__init__.py').unlink(missing_ok=True)
+        test_dir.rmdir()

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -3,7 +3,7 @@
 import os
 import subprocess
 from datetime import datetime
-# from pathlib import Path
+from pathlib import Path
 from unittest import mock
 
 from django.test import TestCase, override_settings
@@ -171,9 +171,8 @@ class InvenTreePluginTests(TestCase):
 class RegistryTests(TestCase):
     """Tests for specific registry methods."""
 
-    """
     def test_custom_loading(self):
-        ""Test if data in custom dir is loade correctly.""
+        """Test if data in custom dir is loade correctly."""
 
         dir_name = 'plugin_test_dir'
         test_dir = Path(dir_name)
@@ -186,7 +185,6 @@ class RegistryTests(TestCase):
         # Clean folder
         test_dir.joinpath('__init__.py').unlink(missing_ok=True)
         test_dir.rmdir()
-    """
 
     def test_subfolder_loading(self):
         """Test that plugins in folders get loaded."""

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -3,7 +3,7 @@
 import os
 import subprocess
 from datetime import datetime
-from pathlib import Path
+# from pathlib import Path
 from unittest import mock
 
 from django.test import TestCase, override_settings
@@ -171,8 +171,9 @@ class InvenTreePluginTests(TestCase):
 class RegistryTests(TestCase):
     """Tests for specific registry methods."""
 
+    """
     def test_custom_loading(self):
-        """Test if data in custom dir is loade correctly."""
+        ""Test if data in custom dir is loade correctly.""
 
         dir_name = 'plugin_test_dir'
         test_dir = Path(dir_name)
@@ -185,6 +186,7 @@ class RegistryTests(TestCase):
         # Clean folder
         test_dir.joinpath('__init__.py').unlink(missing_ok=True)
         test_dir.rmdir()
+    """
 
     def test_subfolder_loading(self):
         """Test that plugins in folders get loaded."""

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -184,3 +184,15 @@ class RegistryTests(TestCase):
         # Clean folder
         test_dir.joinpath('__init__.py').unlink(missing_ok=True)
         test_dir.rmdir()
+
+    def test_folder_loading(self):
+        """Test that plugins in folders get loaded"""
+
+        envs = {'INVENTREE_PLUGIN_TEST_DIR': 'InvenTree/plugin/mock'}
+        with mock.patch.dict(os.environ, envs):
+            registry.reload_plugins(full_reload=True)
+
+            plg = registry.get_plugin('simple')
+            self.assertTrue(plg)
+            self.assertEqual(plg.slug, 'simple')
+            self.assertEqual(plg.human_name, 'SimplePlugin')

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -185,7 +185,7 @@ class RegistryTests(TestCase):
         test_dir.joinpath('__init__.py').unlink(missing_ok=True)
         test_dir.rmdir()
 
-    def test_folder_loading(self):
+    def test_subfolder_loading(self):
         """Test that plugins in folders get loaded"""
 
         envs = {'INVENTREE_PLUGIN_TEST_DIR': 'InvenTree/plugin/mock'}

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -1,11 +1,12 @@
 """Unit tests for plugins."""
 
 import os
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 import plugin.templatetags.plugin_extras as plugin_tags
 from plugin import InvenTreePlugin, registry
@@ -196,3 +197,18 @@ class RegistryTests(TestCase):
             self.assertTrue(plg)
             self.assertEqual(plg.slug, 'simple')
             self.assertEqual(plg.human_name, 'SimplePlugin')
+
+    @override_settings(PLUGIN_TESTING_SETUP=True)
+    def test_package_loading(self):
+        """Test that pypi installed plugins work."""
+        # Install package
+        subprocess.check_output('pip install inventree-zapier'.split())
+
+        # Reload
+        registry.reload_plugins(full_reload=True)
+
+        # Test
+        plg = registry.get_plugin('zapier')
+        self.assertTrue(plg)
+        self.assertEqual(plg.slug, 'zapier')
+        self.assertEqual(plg.name, 'inventree_zapier')


### PR DESCRIPTION
Adds testing for #3516 
This PR:
- Refactors `collect_plugins` to foley collect plugins (needed for simpler testing)
- Makes `get_module_meta` more resilient in changing env
- Removes several safety catches from coverage
- Fixes several issues with custom plugin dirs
- Adds tests for helpers and registry functions

Closes #3408

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3517"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

