### PR TITLE
[FR] Tie github actions to specific commit hashes

### DIFF
--- a/.github/workflows/check_translations.yaml
+++ b/.github/workflows/check_translations.yaml
@@ -21,10 +21,9 @@ jobs:
       INVENTREE_MEDIA_ROOT: ./media
       INVENTREE_STATIC_ROOT: ./static
 
-
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Install Dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ name: Docker
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
   push:
     branches:
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Version Check
         run: |
           pip install requests
@@ -66,30 +66,30 @@ jobs:
           test -f data/secret_key.txt
       - name: Set up QEMU
         if: github.event_name != 'pull_request'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # pin@v1
       - name: Set up Docker Buildx
         if: github.event_name != 'pull_request'
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # pin@v1
       - name: Set up cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@48866aa521d8bf870604709cd43ec2f602d03ff2
+        uses: sigstore/cosign-installer@48866aa521d8bf870604709cd43ec2f602d03ff2 # pin@48866aa521d8bf870604709cd43ec2f602d03ff2
       - name: Login to Dockerhub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # pin@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Extract Docker metadata
         if: github.event_name != 'pull_request'
         id: meta
-        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a # pin@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
         with:
           images: |
             inventree/inventree
       - name: Build and Push
         id: build-and-push
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # pin@v2
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
@@ -103,9 +103,10 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}
+        run: cosign sign ${{ steps.meta.outputs.tags }}@${{
+          steps.build-and-push.outputs.digest }}
       - name: Push to Stable Branch
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@9a46ba8d86d3171233e861a4351b1278a2805c83 # pin@master
         if: env.stable_release == 'true' && github.event_name != 'pull_request'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # pin@v1
       - name: Set up cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@48866aa521d8bf870604709cd43ec2f602d03ff2 # pin@48866aa521d8bf870604709cd43ec2f602d03ff2
+        uses: sigstore/cosign-installer@09a077b27eb1310dcfb21981bee195b30ce09de0 # pin@v2.5.0
       - name: Login to Dockerhub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # pin@v1
@@ -82,7 +82,7 @@ jobs:
       - name: Extract Docker metadata
         if: github.event_name != 'pull_request'
         id: meta
-        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a # pin@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a # pin@v4.0.1
         with:
           images: |
             inventree/inventree

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -15,7 +15,6 @@ env:
   python_version: 3.9
   node_version: 16
   # The OS version must be set per job
-
   server_start_sleep: 60
 
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # pin@v1
       - name: Enviroment Setup
         uses: ./.github/actions/setup
         with:
@@ -45,7 +44,7 @@ jobs:
     needs: pep_style
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # pin@v1
       - name: Enviroment Setup
         uses: ./.github/actions/setup
         with:
@@ -67,7 +66,7 @@ jobs:
     needs: pep_style
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # pin@v1
       - name: Enviroment Setup
         uses: ./.github/actions/setup
         with:
@@ -83,18 +82,18 @@ jobs:
     needs: pep_style
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ env.python_version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.python_version }}
-        cache: 'pip'
-    - name: Run pre-commit Checks
-      uses: pre-commit/action@v2.0.3
-    - name: Check Version
-      run: |
-        pip install requests
-        python3 ci/version_check.py
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - name: Set up Python ${{ env.python_version }}
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
+        with:
+          python-version: ${{ env.python_version }}
+          cache: 'pip'
+      - name: Run pre-commit Checks
+        uses: pre-commit/action@9b88afc9cd57fd75b655d5c71bd38146d07135fe # pin@v2.0.3
+      - name: Check Version
+        run: |
+          pip install requests
+          python3 ci/version_check.py
 
   python:
     name: Tests - inventree-python
@@ -114,7 +113,7 @@ jobs:
       INVENTREE_PYTHON_TEST_PASSWORD: testpassword
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # pin@v1
       - name: Enviroment Setup
         uses: ./.github/actions/setup
         with:
@@ -122,7 +121,8 @@ jobs:
           dev-install: true
           update: true
       - name: Download Python Code For `${{ env.wrapper_name }}`
-        run: git clone --depth 1 https://github.com/inventree/${{ env.wrapper_name }} ./${{ env.wrapper_name }}
+        run: git clone --depth 1 https://github.com/inventree/${{ env.wrapper_name }}
+          ./${{ env.wrapper_name }}
       - name: Start InvenTree Server
         run: |
           invoke delete-data -f
@@ -143,7 +143,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # pin@v1
       - name: Enviroment Setup
         uses: ./.github/actions/setup
         with:
@@ -155,8 +155,8 @@ jobs:
     name: Tests - DB [SQLite] + Coverage
     runs-on: ubuntu-20.04
 
-    needs: ['javascript', 'html', 'pre-commit']
-    continue-on-error: true   # continue if a step fails so that coverage gets pushed
+    needs: [ 'javascript', 'html', 'pre-commit' ]
+    continue-on-error: true # continue if a step fails so that coverage gets pushed
 
     env:
       INVENTREE_DB_NAME: ./inventree.sqlite
@@ -164,7 +164,7 @@ jobs:
       INVENTREE_PLUGINS_ENABLED: true
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # pin@v1
       - name: Enviroment Setup
         uses: ./.github/actions/setup
         with:
@@ -186,7 +186,7 @@ jobs:
     name: Tests - DB [PostgreSQL]
     runs-on: ubuntu-20.04
 
-    needs: ['javascript', 'html', 'pre-commit']
+    needs: [ 'javascript', 'html', 'pre-commit' ]
     if: github.event_name == 'push'
 
     env:
@@ -214,7 +214,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # pin@v1
       - name: Enviroment Setup
         uses: ./.github/actions/setup
         with:
@@ -231,7 +231,7 @@ jobs:
     name: Tests - DB [MySQL]
     runs-on: ubuntu-20.04
 
-    needs: ['javascript', 'html', 'pre-commit']
+    needs: [ 'javascript', 'html', 'pre-commit' ]
     if: github.event_name == 'push'
 
     env:
@@ -253,12 +253,13 @@ jobs:
           MYSQL_USER: inventree
           MYSQL_PASSWORD: password
           MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s
+          --health-retries=3
         ports:
           - 3306:3306
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # pin@v1
       - name: Enviroment Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,17 @@
 name: Publish release notes
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   tweet:
     runs-on: ubuntu-latest
     steps:
-      - uses: Eomm/why-don-t-you-tweet@v1
+      - uses: Eomm/why-don-t-you-tweet@f61f2a86c30c46528c1398a1abb1f64aa0988f69 # pin@v1
         with:
-          tweet-message: "InvenTree release ${{ github.event.release.tag_name }} is out now! Release notes: ${{ github.event.release.html_url }} #opensource #inventree"
+          tweet-message: "InvenTree release ${{ github.event.release.tag_name }} is out
+            now! Release notes: ${{ github.event.release.html_url }} #opensource
+            #inventree"
         env:
           TWITTER_CONSUMER_API_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
           TWITTER_CONSUMER_API_SECRET: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
@@ -19,14 +21,14 @@ jobs:
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
 
   reddit:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: bluwy/release-for-reddit-action@v1
-          with:
-            username: ${{ secrets.REDDIT_USERNAME }}
-            password: ${{ secrets.REDDIT_PASSWORD }}
-            app-id: ${{ secrets.REDDIT_APP_ID }}
-            app-secret: ${{ secrets.REDDIT_APP_SECRET }}
-            subreddit: InvenTree
-            title: "InvenTree version ${{ github.event.release.tag_name }} released"
-            comment: "${{ github.event.release.body }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bluwy/release-for-reddit-action@4d948192aff856da22f19f9806b00b46ca384547 # pin@v1
+        with:
+          username: ${{ secrets.REDDIT_USERNAME }}
+          password: ${{ secrets.REDDIT_PASSWORD }}
+          app-id: ${{ secrets.REDDIT_APP_ID }}
+          app-secret: ${{ secrets.REDDIT_APP_SECRET }}
+          subreddit: InvenTree
+          title: "InvenTree version ${{ github.event.release.tag_name }} released"
+          comment: "${{ github.event.release.body }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,7 +3,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '24 11 * * *'
+    - cron: '24 11 * * *'
 
 jobs:
   stale:
@@ -14,12 +14,13 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue seems stale. Please react to show this is still important.'
-        stale-pr-message: 'This PR seems stale. Please react to show this is still important.'
-        stale-issue-label: 'inactive'
-        stale-pr-label: 'inactive'
-        start-date: '2022-01-01'
-        exempt-all-milestones: true
+      - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # pin@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue seems stale. Please react to show this is still
+            important.'
+          stale-pr-message: 'This PR seems stale. Please react to show this is still important.'
+          stale-issue-label: 'inactive'
+          stale-pr-label: 'inactive'
+          start-date: '2022-01-01'
+          exempt-all-milestones: true

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -20,17 +20,17 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20 # pin@v1
         with:
           python-version: 3.9
       - name: Install Dependencies
         run: |
-            sudo apt-get update
-            sudo apt-get install -y gettext
-            pip3 install invoke
-            invoke install
+          sudo apt-get update
+          sudo apt-get install -y gettext
+          pip3 install invoke
+          invoke install
       - name: Make Translations
         run: |
           invoke translate
@@ -42,7 +42,7 @@ jobs:
           git add "*.po"
           git commit -m "updated translation base"
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@9a46ba8d86d3171233e861a4351b1278a2805c83 # pin@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: l10

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,7 @@
 name: Update dependency files regularly
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   schedule:
     - cron: "0 0 * * *"
 
@@ -9,14 +9,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Setup
         run: pip install -r requirements-dev.txt
       - name: Update requirements.txt
         run: pip-compile --output-file=requirements.txt requirements.in -U
       - name: Update requirements-dev.txt
-        run: pip-compile --generate-hashes --output-file=requirements-dev.txt requirements-dev.in -U
-      - uses: stefanzweifel/git-auto-commit-action@v4
+        run: pip-compile --generate-hashes --output-file=requirements-dev.txt
+          requirements-dev.in -U
+      - uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80 # pin@v4
         with:
           commit_message: "[Bot] Updated dependency"
           branch: dep-update

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -2,9 +2,9 @@
 name: Welcome
 on:
   pull_request:
-    types: [opened]
+    types: [ opened ]
   issues:
-    types: [opened]
+    types: [ opened ]
 
 jobs:
   run:
@@ -13,13 +13,13 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/first-interaction@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: |
-          Welcome to InvenTree! Please check the [contributing docs](https://inventree.readthedocs.io/en/latest/contribute/) on how to help.
-          If you experience setup / install issues please read all [install docs]( https://inventree.readthedocs.io/en/latest/start/intro/).
-        pr-message: |
-          This is your first PR, welcome!
-          Please check [Contributing](https://github.com/inventree/InvenTree/blob/master/CONTRIBUTING.md) to make sure your submission fits our general code-style and workflow.
-          Make sure to document why this PR is needed and to link connected issues so we can review it faster.
+      - uses: actions/first-interaction@bd33205aa5c96838e10fd65df0d01efd613677c1 # pin@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            Welcome to InvenTree! Please check the [contributing docs](https://inventree.readthedocs.io/en/latest/contribute/) on how to help.
+            If you experience setup / install issues please read all [install docs]( https://inventree.readthedocs.io/en/latest/start/intro/).
+          pr-message: |
+            This is your first PR, welcome!
+            Please check [Contributing](https://github.com/inventree/InvenTree/blob/master/CONTRIBUTING.md) to make sure your submission fits our general code-style and workflow.
+            Make sure to document why this PR is needed and to link connected issues so we can review it faster.


### PR DESCRIPTION
This PR pins all github actions.
It also updates:
- [cosign-installer](https://github.com/sigstore/cosign-installer) to v2.5.0

Fixes #3530

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3532"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

