### PR TITLE
WIP: a solution for multi label printing

### DIFF
--- a/InvenTree/label/templates/label/labels.html
+++ b/InvenTree/label/templates/label/labels.html
@@ -1,0 +1,41 @@
+{% load report %}
+{% load barcode %}
+
+<head>
+    <style>
+        @page {
+            size: {{ width }}mm {{ height }}mm;
+            {% block margin %}
+            margin: 0mm;
+            {% endblock %}
+        }
+
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+            margin: 0mm;
+            color: #000;
+            background-color: #FFF;
+        }
+
+        img {
+            display: inline-block;
+            image-rendering: pixelated;
+        }
+
+        .thelabel {
+            break-after: always;
+        }
+
+        {% block style %}
+        {% endblock %}
+
+    </style>
+</head>
+
+<body>
+    {% for output in outputs %}
+    <div class="thelabel">
+        {{ output }}
+    </div>
+    {% endfor %}
+</body>


### PR DESCRIPTION
A hack and slash solution to multi-label printing (note that this is against stable not master, though it looks like it will auto merge against master as well).

A proposed fix for #3528 

TODO:
- [ ] Determine how this affects the plugin system.  Will require understanding what the plugin system is accomplishing in the first place.
- [ ] Template debug mode is ignored.  Labels are always rendered as pdf.
- [ ] PDF inline is ignored.  File is always downloaded.

A, likely breaking, refactor of the label templates would probably be required to clean this up.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3537"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

