### PR TITLE
Fix weasyprint version (#3539)

### DIFF
--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -158,16 +158,12 @@ class LabelPrintMixin:
 
             pages = []
 
-            if len(outputs) > 1:
-                # If more than one output is generated, merge them into a single file
-                for output in outputs:
-                    doc = output.get_document()
-                    for page in doc.pages:
-                        pages.append(page)
+            for output in outputs:
+                doc = output.get_document()
+                for page in doc.pages:
+                    pages.append(page)
 
-                pdf = outputs[0].get_document().copy(pages).write_pdf()
-            else:
-                pdf = outputs[0].get_document().write_pdf()
+            pdf = outputs[0].get_document().copy(pages).write_pdf()
 
             inline = common.models.InvenTreeUserSetting.get_setting('LABEL_INLINE', user=request.user)
 

--- a/InvenTree/label/templates/label/label_base.html
+++ b/InvenTree/label/templates/label/label_base.html
@@ -15,6 +15,8 @@
             margin: 0mm;
             color: #000;
             background-color: #FFF;
+            page-break-before: always;
+            page-break-after: always;
         }
 
         img {
@@ -22,14 +24,23 @@
             image-rendering: pixelated;
         }
 
+        .content {
+            width: 100%;
+            break-after: always;
+            position: relative;
+        }
+
         {% block style %}
+        /* User-defined styles can go here */
         {% endblock %}
 
     </style>
 </head>
 
 <body>
-    {% block content %}
-    <!-- Label data rendered here! -->
-    {% endblock %}
+    <div class='content'>
+        {% block content %}
+        <!-- Label data rendered here! -->
+        {% endblock %}
+    </div>
 </body>

--- a/InvenTree/report/api.py
+++ b/InvenTree/report/api.py
@@ -233,17 +233,12 @@ class ReportPrintMixin:
             pages = []
 
             try:
+                for output in outputs:
+                    doc = output.get_document()
+                    for page in doc.pages:
+                        pages.append(page)
 
-                if len(outputs) > 1:
-                    # If more than one output is generated, merge them into a single file
-                    for output in outputs:
-                        doc = output.get_document()
-                        for page in doc.pages:
-                            pages.append(page)
-
-                    pdf = outputs[0].get_document().copy(pages).write_pdf()
-                else:
-                    pdf = outputs[0].get_document().write_pdf()
+                pdf = outputs[0].get_document().copy(pages).write_pdf()
 
             except TemplateDoesNotExist as e:
 

--- a/requirements.in
+++ b/requirements.in
@@ -33,6 +33,7 @@ rapidfuzz==0.7.6                        # Fuzzy string matching
 sentry-sdk                              # Error reporting (optional)
 setuptools                              # Standard depenedency
 tablib[xls,xlsx,yaml]                   # Support for XLS and XLSX formats
+weasyprint==54.3                        # PDF generation
 
 # Fixed sub-dependencies
 py-moneyed<2.0                          # For django-money # FIXED 2022-06-18 as we need `moneyed.localization`

--- a/requirements.txt
+++ b/requirements.txt
@@ -230,8 +230,10 @@ urllib3==1.26.11
     #   sentry-sdk
 wcwidth==0.2.5
     # via blessed
-weasyprint==56.1
-    # via django-weasyprint
+weasyprint==54.3
+    # via
+    #   -r requirements.in
+    #   django-weasyprint
 webencodings==0.5.1
     # via
     #   bleach


### PR DESCRIPTION
* Pin weasyprint version

- Revert to 54.3
- Fixes https://github.com/inventree/InvenTree/issues/3528

* Simplify label printing for multiple pages

* Simplify PDF generation for multiple report outputs

* Add content wrapper div for base label template

- Allows more extensibility

(cherry picked from commit 87e7112326357ea8dbe3d31eb461d0ba1ea9f991)

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3540"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

