### PR TITLE
fix typo in variable name (#3541)

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -678,7 +678,7 @@ EMAIL_SUBJECT_PREFIX = get_setting('INVENTREE_EMAIL_PREFIX', 'email.prefix', '[I
 EMAIL_USE_TLS = get_boolean_setting('INVENTREE_EMAIL_TLS', 'email.tls', False)
 EMAIL_USE_SSL = get_boolean_setting('INVENTREE_EMAIL_SSL', 'email.ssl', False)
 
-DEFUALT_FROM_EMAIL = get_setting('INVENTREE_EMAIL_SENDER', 'email.sender', '')
+DEFAULT_FROM_EMAIL = get_setting('INVENTREE_EMAIL_SENDER', 'email.sender', '')
 
 EMAIL_USE_LOCALTIME = False
 EMAIL_TIMEOUT = 60


### PR DESCRIPTION
this fixes broken e-mail from configuration.

(cherry picked from commit d102a87effe0fa010251b440f68b2ced16bb4ffb)

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3543"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

