### PR TITLE
Fix: Broken subfolder tests in postgres/docker CI in master

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -185,9 +185,7 @@ jobs:
   postgres:
     name: Tests - DB [PostgreSQL]
     runs-on: ubuntu-20.04
-
     needs: [ 'javascript', 'html', 'pre-commit' ]
-    if: github.event_name == 'push'
 
     env:
       INVENTREE_DB_ENGINE: django.db.backends.postgresql

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -191,6 +191,10 @@ class InvenTreePluginTests(TestCase):
 class RegistryTests(TestCase):
     """Tests for registry loading methods."""
 
+    def mockDir(self) -> None:
+        """Returns path to mock dir"""
+        return str(Path(__file__).parent.joinpath('mock').absolute())
+
     def run_package_test(self, directory):
         """General runner for testing package based installs."""
 
@@ -223,7 +227,7 @@ class RegistryTests(TestCase):
 
     def test_subfolder_loading(self):
         """Test that plugins in subfolders get loaded."""
-        self.run_package_test(str(Path(__file__).parent.joinpath('mock').absolute()))
+        self.run_package_test(self.mockDir())
 
     def test_folder_loading(self):
         """Test that plugins in folders outside of BASE_DIR get loaded."""
@@ -232,7 +236,7 @@ class RegistryTests(TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             # Fill directory with sample data
             new_dir = Path(tmp).joinpath('mock')
-            shutil.copytree(Path(__file__).parent.joinpath('mock').absolute(), new_dir)
+            shutil.copytree(self.mockDir(), new_dir)
 
             # Run tests
             self.run_package_test(str(new_dir))

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -3,7 +3,7 @@
 import os
 import shutil
 import subprocess
-import tempfile
+# import tempfile
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
@@ -221,21 +221,21 @@ class RegistryTests(TestCase):
         # Clean folder up
         shutil.rmtree(test_dir, ignore_errors=True)
 
-    def test_subfolder_loading(self):
-        """Test that plugins in subfolders get loaded."""
-        self.run_package_test('InvenTree/plugin/mock')
+    # def test_subfolder_loading(self):
+    #     """Test that plugins in subfolders get loaded."""
+    #     self.run_package_test('InvenTree/plugin/mock')
 
-    def test_folder_loading(self):
-        """Test that plugins in folders outside of BASE_DIR get loaded."""
+    # def test_folder_loading(self):
+    #     """Test that plugins in folders outside of BASE_DIR get loaded."""
 
-        # Run in temporary directory -> always a new random name
-        with tempfile.TemporaryDirectory() as tmp:
-            # Fill directory with sample data
-            new_dir = Path(tmp).joinpath('mock')
-            shutil.copytree(Path('InvenTree/plugin/mock').absolute(), new_dir)
+    #     # Run in temporary directory -> always a new random name
+    #     with tempfile.TemporaryDirectory() as tmp:
+    #         # Fill directory with sample data
+    #         new_dir = Path(tmp).joinpath('mock')
+    #         shutil.copytree(Path('InvenTree/plugin/mock').absolute(), new_dir)
 
-            # Run tests
-            self.run_package_test(str(new_dir))
+    #         # Run tests
+    #         self.run_package_test(str(new_dir))
 
     @override_settings(PLUGIN_TESTING_SETUP=True)
     def test_package_loading(self):

--- a/InvenTree/plugin/test_plugin.py
+++ b/InvenTree/plugin/test_plugin.py
@@ -3,7 +3,7 @@
 import os
 import shutil
 import subprocess
-# import tempfile
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
@@ -221,21 +221,21 @@ class RegistryTests(TestCase):
         # Clean folder up
         shutil.rmtree(test_dir, ignore_errors=True)
 
-    # def test_subfolder_loading(self):
-    #     """Test that plugins in subfolders get loaded."""
-    #     self.run_package_test('InvenTree/plugin/mock')
+    def test_subfolder_loading(self):
+        """Test that plugins in subfolders get loaded."""
+        self.run_package_test(str(Path(__file__).parent.joinpath('mock').absolute()))
 
-    # def test_folder_loading(self):
-    #     """Test that plugins in folders outside of BASE_DIR get loaded."""
+    def test_folder_loading(self):
+        """Test that plugins in folders outside of BASE_DIR get loaded."""
 
-    #     # Run in temporary directory -> always a new random name
-    #     with tempfile.TemporaryDirectory() as tmp:
-    #         # Fill directory with sample data
-    #         new_dir = Path(tmp).joinpath('mock')
-    #         shutil.copytree(Path('InvenTree/plugin/mock').absolute(), new_dir)
+        # Run in temporary directory -> always a new random name
+        with tempfile.TemporaryDirectory() as tmp:
+            # Fill directory with sample data
+            new_dir = Path(tmp).joinpath('mock')
+            shutil.copytree(Path(__file__).parent.joinpath('mock').absolute(), new_dir)
 
-    #         # Run tests
-    #         self.run_package_test(str(new_dir))
+            # Run tests
+            self.run_package_test(str(new_dir))
 
     @override_settings(PLUGIN_TESTING_SETUP=True)
     def test_package_loading(self):

--- a/tasks.py
+++ b/tasks.py
@@ -519,7 +519,7 @@ def test(c, database=None):
     manage(c, 'check')
 
     # Run coverage tests
-    manage(c, 'test', pty=True)
+    manage(c, 'test plugin.test_plugin', pty=True)
 
 
 @task(help={'dev': 'Set up development enviroment at the end'})

--- a/tasks.py
+++ b/tasks.py
@@ -519,7 +519,7 @@ def test(c, database=None):
     manage(c, 'check')
 
     # Run coverage tests
-    manage(c, 'test plugin.test_plugin', pty=True)
+    manage(c, 'test', pty=True)
 
 
 @task(help={'dev': 'Set up development enviroment at the end'})


### PR DESCRIPTION
This PR:
- reintroduces postgres tests on each run
- fixes the tests introduced in #3517

Fixes #3558 

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3559"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

