### PR TITLE
Scheduling improvements

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 70
+INVENTREE_API_VERSION = 71
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v71 -> 2022-08-18 : https://github.com/inventree/InvenTree/pull/3564
+    - Updates to the "part scheduling" API endpoint
 
 v70 -> 2022-08-02 : https://github.com/inventree/InvenTree/pull/3451
     - Adds a 'depth' parameter to the PartCategory list API

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1,6 +1,6 @@
 """Provides a JSON API for the Part app."""
 
-import datetime
+import functools
 from decimal import Decimal, InvalidOperation
 
 from django.db import transaction
@@ -474,27 +474,27 @@ class PartScheduling(RetrieveAPI):
 
     def retrieve(self, request, *args, **kwargs):
         """Return scheduling information for the referenced Part instance"""
-        today = datetime.datetime.now().date()
 
         part = self.get_object()
 
         schedule = []
 
-        def add_schedule_entry(date, quantity, title, label, url):
+        def add_schedule_entry(date, quantity, title, label, url, speculative_quantity=0):
             """Check if a scheduled entry should be added:
 
             - date must be non-null
             - date cannot be in the "past"
             - quantity must not be zero
             """
-            if date and date >= today and quantity != 0:
-                schedule.append({
-                    'date': date,
-                    'quantity': quantity,
-                    'title': title,
-                    'label': label,
-                    'url': url,
-                })
+
+            schedule.append({
+                'date': date,
+                'quantity': quantity,
+                'speculative_quantity': speculative_quantity,
+                'title': title,
+                'label': label,
+                'url': url,
+            })
 
         # Add purchase order (incoming stock) information
         po_lines = order.models.PurchaseOrderLineItem.objects.filter(
@@ -571,23 +571,77 @@ class PartScheduling(RetrieveAPI):
         and just looking at what stock items the user has actually allocated against the Build.
         """
 
-        build_allocations = BuildItem.objects.filter(
-            stock_item__part=part,
-            build__status__in=BuildStatus.ACTIVE_CODES,
-        ).prefetch_related('build')
+        # Grab a list of BomItem objects that this part might be used in
+        bom_items = BomItem.objects.filter(part.get_used_in_bom_item_filter())
 
-        for allocation in build_allocations:
+        for bom_item in bom_items:
+            # Find a list of active builds for this BomItem
 
-            add_schedule_entry(
-                allocation.build.target_date,
-                -allocation.quantity,
-                _('Stock required for Build Order'),
-                str(allocation.build),
-                allocation.build.get_absolute_url(),
+            builds = Build.objects.filter(
+                status__in=BuildStatus.ACTIVE_CODES,
+                part=bom_item.part,
             )
 
+            for build in builds:
+
+                if bom_item.sub_part.trackable:
+                    # Trackable parts are allocated against the outputs
+                    required_quantity = build.remaining * bom_item.quantity
+                else:
+                    # Non-trackable parts are allocated against the build itself
+                    required_quantity = build.quantity * bom_item.quantity
+
+                # Grab all allocations against the spefied BomItem
+                allocations = BuildItem.objects.filter(
+                    bom_item=bom_item,
+                    build=build,
+                )
+
+                # Total allocated for *this* part
+                part_allocated_quantity = 0
+
+                # Total allocated for *any* part
+                total_allocated_quantity = 0
+
+                for allocation in allocations:
+                    total_allocated_quantity += allocation.quantity
+
+                    if allocation.stock_item.part == part:
+                        part_allocated_quantity += allocation.quantity
+
+                speculative_quantity = 0
+
+                # Consider the case where the build order is *not* fully allocated
+                if required_quantity > total_allocated_quantity:
+                    speculative_quantity = -1 * (required_quantity - total_allocated_quantity)
+
+                add_schedule_entry(
+                    build.target_date,
+                    -part_allocated_quantity,
+                    _('Stock required for Build Order'),
+                    str(build),
+                    build.get_absolute_url(),
+                    speculative_quantity=speculative_quantity
+                )
+
+        def compare(entry_1, entry_2):
+            """Comparison function for sorting entries by date.
+
+            Account for the fact that either date might be None
+            """
+
+            date_1 = entry_1['date']
+            date_2 = entry_2['date']
+
+            if date_1 is None:
+                return -1
+            elif date_2 is None:
+                return 1
+
+            return -1 if date_1 < date_2 else 1
+
         # Sort by incrementing date values
-        schedule = sorted(schedule, key=lambda entry: entry['date'])
+        schedule = sorted(schedule, key=functools.cmp_to_key(compare))
 
         return Response(schedule)
 

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -432,9 +432,10 @@
 
     // Load the "scheduling" tab
     onPanelLoad('scheduling', function() {
-        loadPartSchedulingChart('part-schedule-chart', {{ part.pk }});
+        var chart = loadPartSchedulingChart('part-schedule-chart', {{ part.pk }});
 
         $('#btn-schedule-reload').click(function() {
+            chart.destroy();
             loadPartSchedulingChart('part-schedule-chart', {{ part.pk }});
         });
     });

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -40,6 +40,11 @@
         <div class='d-flex flex-wrap'>
             <h4>{% trans "Part Scheduling" %}</h4>
             {% include "spacer.html" %}
+            <div class='btn-group' role='group'>
+                <button class='btn btn-primary' type='button' id='btn-schedule-reload' title='{% trans "Refresh scheduling data" %}'>
+                    <span class='fas fa-redo-alt'></span> {% trans "Refresh" %}
+                </button>
+            </div>
         </div>
     </div>
     <div class='panel-content'>
@@ -428,6 +433,10 @@
     // Load the "scheduling" tab
     onPanelLoad('scheduling', function() {
         loadPartSchedulingChart('part-schedule-chart', {{ part.pk }});
+
+        $('#btn-schedule-reload').click(function() {
+            loadPartSchedulingChart('part-schedule-chart', {{ part.pk }});
+        });
     });
 
     // Load the "suppliers" tab

--- a/InvenTree/part/templates/part/part_scheduling.html
+++ b/InvenTree/part/templates/part/part_scheduling.html
@@ -4,3 +4,15 @@
 <div id='part-schedule' style='max-height: 300px;'>
     <canvas id='part-schedule-chart' width='100%' style='max-height: 300px;'></canvas>
 </div>
+
+<table class='table table-striped table-condensed' id='part-schedule-table'>
+    <thead>
+        <tr>
+            <th>{% trans "Link" %}</th>
+            <th>{% trans "Description" %}</th>
+            <th>{% trans "Scheduled Quantity" %}</th>
+            <th>{% trans "Date" %}</th>
+        </tr>
+    </thead>
+    <tbody></tbody>
+</table>

--- a/InvenTree/part/templates/part/part_scheduling.html
+++ b/InvenTree/part/templates/part/part_scheduling.html
@@ -10,8 +10,8 @@
         <tr>
             <th>{% trans "Link" %}</th>
             <th>{% trans "Description" %}</th>
-            <th>{% trans "Scheduled Quantity" %}</th>
             <th>{% trans "Date" %}</th>
+            <th>{% trans "Scheduled Quantity" %}</th>
         </tr>
     </thead>
     <tbody></tbody>

--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -519,7 +519,6 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
                 </a>
             </td>
             <td id='description-${pk}'><em>${part.description}</em></td>
-            <td id='stock-${pk}'><em>${part.stock}</em></td>
             <td>${buttons}</td>
         </tr>
         `;
@@ -552,7 +551,6 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
             <tr>
                 <th>{% trans "Part" %}</th>
                 <th>{% trans "Description" %}</th>
-                <th>{% trans "Stock" %}</th>
                 <th><!-- Actions --></th>
             </tr>
         </thead>

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -2326,14 +2326,15 @@ function loadPartSchedulingChart(canvas_id, part_id) {
 
                     if (date == null) {
                         date_string = '<em>{% trans "No date specified" %}</em>';
+                        date_string += `<span class='fas fa-exclamation-circle icon-red float-right' title='{% trans "No date specified" %}'></span>`;
                     } else if (date < today) {
-                        date_string += ' <em>({% trans "In the past" %})</em>';
+                        date_string += `<span class='fas fa-exclamation-circle icon-yellow float-right' title='{% trans "Specified date is in the past" %}'></span>`;
                     }
 
-                    var quantity_string = entry.quantity;
+                    var quantity_string = entry.quantity + entry.speculative_quantity;
 
-                    if (entry.speculative_quantity != null && entry.speculative_quantity != 0) {
-                        quantity_string += ` <em><small> (${entry.speculative_quantity})</small></em>`;
+                    if (entry.speculative_quantity != 0) {
+                        quantity_string += `<span class='fas fa-info-circle icon-blue float-right' title='{% trans "Speculative" %}'></span>`;
                     }
 
                     // Add an entry to the scheduling table
@@ -2464,9 +2465,9 @@ function loadPartSchedulingChart(canvas_id, part_id) {
             {
                 label: '{% trans "Scheduled Stock Quantities" %}',
                 data: quantity_scheduled,
-                backgroundColor: 'rgba(160, 220, 80, 0.75)',
+                backgroundColor: 'rgba(160, 80, 220, 0.75)',
                 borderWidth: 3,
-                borderColor: 'rgb(160, 220, 80)'
+                borderColor: 'rgb(160, 80, 220)'
             },
             {
                 label: '{% trans "Minimum Quantity" %}',
@@ -2516,19 +2517,6 @@ function loadPartSchedulingChart(canvas_id, part_id) {
         });
     }
 
-    // Ensure that the vertical scale is "expanded" to show all data
-    var y_scale = y_max - y_min;
-
-    if (y_scale > 0) {
-        if (y_min < 0) {
-            y_min -= 0.1 * y_scale;
-        }
-
-        if (y_max > 0) {
-            y_max += 0.1 * y_scale;
-        }
-    }
-
     // Update the table
     $("#part-schedule-table").find('tbody').html(table_html);
 
@@ -2549,7 +2537,7 @@ function loadPartSchedulingChart(canvas_id, part_id) {
                 },
                 y: {
                     min: 0,
-                    max: y_max,
+                    max: 1.1 * y_max,
                 }
             },
             plugins: {

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -2316,6 +2316,9 @@ function loadPartSchedulingChart(canvas_id, part_id) {
                         url: entry.url,
                     });
                 });
+            },
+            error: function(response) {
+                console.error(`Error retrieving scheduling information for part ${part_id}`);
             }
         }
     );

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -2261,6 +2261,14 @@ function initPriceBreakSet(table, options) {
 }
 
 
+/*
+ * Load a chart which displays projected scheduling information for a particular part.
+ * This takes into account:
+ * - Current stock levels / availability
+ * - Upcoming / scheduled build orders
+ * - Upcoming / scheduled sales orders
+ * - Upcoming / scheduled purchase orders
+ */
 function loadPartSchedulingChart(canvas_id, part_id) {
 
     var part_info = null;
@@ -2272,6 +2280,11 @@ function loadPartSchedulingChart(canvas_id, part_id) {
             part_info = response;
         }
     });
+
+    if (!part_info) {
+        console.error(`Error loading part information for part ${part_id}`);
+        return;
+    }
 
     var today = moment();
 

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -2515,7 +2515,7 @@ function loadPartSchedulingChart(canvas_id, part_id) {
     }
 
     // Update the table
-    $("#part-schedule-table").find('tbody').html(table_html);
+    $('#part-schedule-table').find('tbody').html(table_html);
 
     var y_range = y_max - y_min;
 

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -2453,9 +2453,6 @@ function loadPartSchedulingChart(canvas_id, part_id) {
         // Update min / max values
         if (quantity < y_min) y_min = quantity;
         if (quantity > y_max) y_max = quantity;
-
-        if (speculative_min < y_min) y_min = speculative_min;
-        if (speculative_max > y_max) y_max = speculative_max;
     }
 
     var context = document.getElementById(canvas_id);
@@ -2520,6 +2517,11 @@ function loadPartSchedulingChart(canvas_id, part_id) {
     // Update the table
     $("#part-schedule-table").find('tbody').html(table_html);
 
+    var y_range = y_max - y_min;
+
+    y_max += 0.1 * y_range;
+    y_min -= 0.1 * y_range;
+
     return new Chart(context, {
         type: 'scatter',
         data: data,
@@ -2536,8 +2538,8 @@ function loadPartSchedulingChart(canvas_id, part_id) {
                     },
                 },
                 y: {
-                    min: 0,
-                    max: 1.1 * y_max,
+                    min: y_min,
+                    max: y_max,
                 }
             },
             plugins: {

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -2432,7 +2432,7 @@ function loadPartSchedulingChart(canvas_id, part_id) {
 
         if (speculative < 0) {
             speculative_min += speculative;
-        } if (speculative > 0) {
+        } else if (speculative > 0) {
             speculative_max += speculative;
         }
 


### PR DESCRIPTION
This PR provides a significant enhancement to the "scheduling" display for parts.

It attempts to quantify some of the uncertainty around part scheduling:

1. What if the order does not have a target date
2. What if the order is scheduled "in the past"
3. What if a build order is scheduled but stock has not been assigned?

With particular regard to point 3: A build order refers to a BOM, and as BOM items can have variants or substitutes, we cannot know which parts will be used until they are actually allocated to the build. Thus, this is represented as "uncertainty".

The PR also adds a data table to the scheduling view.

![image](https://user-images.githubusercontent.com/10080325/185266031-905e4a8a-6b8a-42ff-ae82-13c9d5737be2.png)


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3564"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

