### PR TITLE
Add ability to quickly duplicate build orders

### DIFF
--- a/InvenTree/build/templates/build/build_base.html
+++ b/InvenTree/build/templates/build/build_base.html
@@ -55,6 +55,9 @@ src="{% static 'img/blank_image.png' %}"
         {% if build.is_active %}
         <li><a class='dropdown-item' href='#' id='build-cancel'><span class='fas fa-times-circle icon-red'></span> {% trans "Cancel Build" %}</a></li>
         {% endif %}
+        {% if roles.build.add %}
+        <li><a class='dropdown-item' href='#' id='build-duplicate'><span class='fas fa-clone'></span> {% trans "Duplicate Build" %}</a></li>
+        {% endif %}
         {% if build.status == BuildStatus.CANCELLED and roles.build.delete %}
         <li><a class='dropdown-item' href='#' id='build-delete'><span class='fas fa-trash-alt icon-red'></span> {% trans "Delete Build" %}</a>
         {% endif %}
@@ -209,6 +212,7 @@ src="{% static 'img/blank_image.png' %}"
 
 {% block js_ready %}
 
+    {% if roles.build.change %}
     $("#build-edit").click(function () {
         editBuildOrder({{ build.pk }});
     });
@@ -230,6 +234,13 @@ src="{% static 'img/blank_image.png' %}"
             completed: {% if build.remaining == 0 %}true{% else %}false{% endif %},
         });
     });
+    {% endif %}
+
+    {% if roles.build.add %}
+    $('#build-duplicate').click(function() {
+        duplicateBuildOrder({{ build.pk }});
+    });
+    {% endif %}
 
     {% if report_enabled %}
     $('#print-build-report').click(function() {

--- a/InvenTree/order/templates/order/order_base.html
+++ b/InvenTree/order/templates/order/order_base.html
@@ -219,28 +219,10 @@ $('#print-order-report').click(function() {
 
 $("#edit-order").click(function() {
 
-    constructForm('{% url "api-po-detail" order.pk %}', {
-        fields: {
-            reference: {
-                icon: 'fa-hashtag',
-            },
-            {% if order.lines.count == 0 and order.status == PurchaseOrderStatus.PENDING %}
-            supplier: {
-            },
-            {% endif %}
-            supplier_reference: {},
-            description: {},
-            target_date: {
-                icon: 'fa-calendar-alt',
-            },
-            link: {
-                icon: 'fa-link',
-            },
-            responsible: {
-                icon: 'fa-user',
-            },
-        },
-        title: '{% trans "Edit Purchase Order" %}',
+    editPurchaseOrder({{ order.pk }}, {
+        {% if order.lines.count > 0 or order.status != PurchaseOrderStatus.PENDING %}
+        hide_supplier: true,
+        {% endif %}
         reload: true,
     });
 });

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -23,6 +23,7 @@
     cancelBuildOrder,
     completeBuildOrder,
     createBuildOutput,
+    duplicateBuildOrder,
     editBuildOrder,
     loadAllocationTable,
     loadBuildOrderAllocationTable,
@@ -75,7 +76,9 @@ function buildFormFields() {
     };
 }
 
-
+/*
+ * Edit an existing BuildOrder via the API
+ */
 function editBuildOrder(pk) {
 
     var fields = buildFormFields();
@@ -87,6 +90,10 @@ function editBuildOrder(pk) {
     });
 }
 
+
+/*
+ * Create a new build order via an API form
+ */
 function newBuildOrder(options={}) {
     /* Launch modal form to create a new BuildOrder.
      */
@@ -113,14 +120,39 @@ function newBuildOrder(options={}) {
         fields.sales_order.value = options.sales_order;
     }
 
+    if (options.data) {
+        delete options.data.pk;
+    }
+
     constructForm(`/api/build/`, {
         fields: fields,
+        data: options.data,
         follow: true,
         method: 'POST',
         title: '{% trans "Create Build Order" %}',
         onSuccess: options.onSuccess,
     });
 }
+
+
+/*
+ * Duplicate an existing build order.
+ */
+function duplicateBuildOrder(build_id, options={}) {
+
+    inventreeGet(`/api/build/${build_id}/`, {}, {
+        success: function(data) {
+            // Clear out data we do not want to be duplicated
+            delete data['pk'];
+            delete data['issued_by'];
+            delete data['reference'];
+
+            options.data = data;
+            newBuildOrder(options);
+        }
+    });
+}
+
 
 
 /* Construct a form to cancel a build order */

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -30,6 +30,7 @@
     createPurchaseOrderLineItem,
     createSalesOrder,
     createSalesOrderShipment,
+    editPurchaseOrder,
     editPurchaseOrderLineItem,
     exportOrder,
     issuePurchaseOrder,
@@ -493,41 +494,79 @@ function createSalesOrder(options={}) {
     });
 }
 
+
+/*
+ * Construct a set of fields for a purchase order form
+ */
+function purchaseOrderFields(options={}) {
+
+    var fields = {
+        reference: {
+            icon: 'fa-hashtag',
+        },
+        supplier: {
+            icon: 'fa-building',
+            secondary: {
+                title: '{% trans "Add Supplier" %}',
+                fields: function() {
+                    var fields = companyFormFields();
+
+                    fields.is_supplier.value = true;
+
+                    return fields;
+                }
+            }
+        },
+        description: {},
+        supplier_reference: {},
+        target_date: {
+            icon: 'fa-calendar-alt',
+        },
+        link: {
+            icon: 'fa-link',
+        },
+        responsible: {
+            icon: 'fa-user',
+        },
+    };
+
+    if (options.supplier) {
+        fields.supplier.value = options.supplier;
+    }
+
+    if (options.hide_supplier) {
+        fields.supplier.hidden = true;
+    }
+
+    return fields;
+}
+
+
+/*
+ * Edit an existing PurchaseOrder
+ */
+function editPurchaseOrder(pk, options={}) {
+
+    var fields = purchaseOrderFields(options);
+
+    constructForm(`/api/order/po/${pk}/`, {
+        fields: fields,
+        title: '{% trans "Edit Purchase Order" %}',
+        onSuccess: function(response) {
+            handleFormSuccess(response, options);
+        }
+    });
+}
+
+
 // Create a new PurchaseOrder
 function createPurchaseOrder(options={}) {
 
+    var fields = purchaseOrderFields(options);
+
     constructForm('{% url "api-po-list" %}', {
         method: 'POST',
-        fields: {
-            reference: {
-                icon: 'fa-hashtag',
-            },
-            supplier: {
-                icon: 'fa-building',
-                value: options.supplier,
-                secondary: {
-                    title: '{% trans "Add Supplier" %}',
-                    fields: function() {
-                        var fields = companyFormFields();
-
-                        fields.is_supplier.value = true;
-
-                        return fields;
-                    }
-                }
-            },
-            description: {},
-            supplier_reference: {},
-            target_date: {
-                icon: 'fa-calendar-alt',
-            },
-            link: {
-                icon: 'fa-link',
-            },
-            responsible: {
-                icon: 'fa-user',
-            }
-        },
+        fields: fields,
         onSuccess: function(data) {
 
             if (options.onSuccess) {


### PR DESCRIPTION
Adds a button to the build order detail page to quickly duplicate the build order.

![image](https://user-images.githubusercontent.com/10080325/185277002-bbd0b83a-110f-4bed-be2e-10efca22037d.png)
![image](https://user-images.githubusercontent.com/10080325/185277174-65b3f6f2-5770-4660-9951-9b14ff31c32b.png)


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3565"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

