### PR TITLE
fix: invalid chars in cache key

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -131,7 +131,7 @@ class BaseInvenTreeSetting(models.Model):
         for k, v in kwargs.items():
             key += f"_{k}:{v}"
 
-        return key
+        return key.replace(" ", "")
 
     @classmethod
     def allValues(cls, user=None, exclude_hidden=False):


### PR DESCRIPTION
This PR fixes invalid cache keys errors.

```log
/workspaces/InvenTree/dev/venv/lib/python3.10/site-packages/django/core/cache/backends/base.py:250: CacheKeyWarning: Cache key contains characters that will cause errors if used with memcached: ':1:PluginSetting:SERVER_plugin:CupsLabels - cups'
  warnings.warn(warning, CacheKeyWarning)
/workspaces/InvenTree/dev/venv/lib/python3.10/site-packages/django/core/cache/backends/base.py:250: CacheKeyWarning: Cache key contains characters that will cause errors if used with memcached: ':1:PluginSetting:PORT_plugin:CupsLabels - cups'
  warnings.warn(warning, CacheKeyWarning)
/workspaces/InvenTree/dev/venv/lib/python3.10/site-packages/django/core/cache/backends/base.py:250: CacheKeyWarning: Cache key contains characters that will cause errors if used with memcached: ':1:PluginSetting:USER_plugin:CupsLabels - cups'
  warnings.warn(warning, CacheKeyWarning)
/workspaces/InvenTree/dev/venv/lib/python3.10/site-packages/django/core/cache/backends/base.py:250: CacheKeyWarning: Cache key contains characters that will cause errors if used with memcached: ':1:PluginSetting:PASSWORD_plugin:CupsLabels - cups'
  warnings.warn(warning, CacheKeyWarning)
/workspaces/InvenTree/dev/venv/lib/python3.10/site-packages/django/core/cache/backends/base.py:250: CacheKeyWarning: Cache key contains characters that will cause errors if used with memcached: ':1:PluginSetting:PRINTER_plugin:CupsLabels - cups'
  warnings.warn(warning, CacheKeyWarning)
/workspaces/InvenTree/dev/venv/lib/python3.10/site-packages/django/core/cache/backends/base.py:250: CacheKeyWarning: Cache key contains characters that will cause errors if used with memcached: ':1:PluginSetting:ROTATION_plugin:CupsLabels - cups'
  warnings.warn(warning, CacheKeyWarning)
```

which are caused by https://github.com/inventree/InvenTree/blob/1b76828305ec9f3160bf01fcac460ad5dcc58540/InvenTree/plugin/models.py#L106

one other solution I can think if is using a `__repr__` which outputs a string without spaces and then use `{v!r}`.

The erros come from a Django function in `django/core/cache/backends/base.py:250`:
```py
def memcache_key_warnings(key):
    if len(key) > MEMCACHE_MAX_KEY_LENGTH:
        yield (
            'Cache key will cause errors if used with memcached: %r '
            '(longer than %s)' % (key, MEMCACHE_MAX_KEY_LENGTH)
        )
    for char in key:
        if ord(char) < 33 or ord(char) == 127:
            yield (
                'Cache key contains characters that will cause errors if '
                'used with memcached: %r' % key
            )
            break
```

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3574"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

