### PR TITLE
Add a 'zero stock' threshold line to the part scheduling tab

### DIFF
--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -2525,15 +2525,34 @@ function loadPartSchedulingChart(canvas_id, part_id) {
         ],
     };
 
+    var t_min = quantity_scheduled[0].x;
+    var t_max = quantity_scheduled[quantity_scheduled.length - 1].x;
+
+    // Construct a 'zero stock' threshold line
+    data.datasets.push({
+        data: [
+            {
+                x: t_min,
+                y: 0,
+            },
+            {
+                x: t_max,
+                y: 0,
+            }
+        ],
+        borderColor: 'rgba(250, 50, 50, 0.75)',
+        label: 'zero-stock-level',
+    });
+
+    // Construct a 'minimum stock' threshold line
     if (part_info.minimum_stock) {
-        // Construct a 'minimum stock' threshold line
         var minimum_stock_curve = [
             {
-                x: quantity_scheduled[0].x,
+                x: t_min,
                 y: part_info.minimum_stock,
             },
             {
-                x: quantity_scheduled[quantity_scheduled.length - 1].x,
+                x: t_max,
                 y: part_info.minimum_stock,
             }
         ];
@@ -2612,7 +2631,14 @@ function loadPartSchedulingChart(canvas_id, part_id) {
                             return `{% trans "Quantity" %}: ${item.raw.y}${delta}`;
                         }
                     }
-                }
+                },
+                legend: {
+                    labels: {
+                        filter: function(item, chart) {
+                            return !item.text.includes('zero-stock-level');
+                        }
+                    }
+                },
             },
         }
     });


### PR DESCRIPTION
Better visibility of when projected stock will dip below zero

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3587"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

