### PR TITLE
Sanitize search input

### DIFF
--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -1007,6 +1007,11 @@ function getFormFieldValue(name, field={}, options={}) {
             value = null;
         }
         break;
+    case 'string':
+    case 'url':
+    case 'email':
+        value = sanitizeInputString(el.val());
+        break;
     default:
         value = el.val();
         break;

--- a/InvenTree/templates/js/translated/helpers.js
+++ b/InvenTree/templates/js/translated/helpers.js
@@ -341,10 +341,10 @@ function sanitizeInputString(s, options={}) {
     s = s.trim();
 
     // Remove ASCII control characters
-    s = s.replace(/[^\x20-\x7E]+/g, "");
+    s = s.replace(/[^\x20-\x7E]+/g, '');
 
     // Remove type-setting charactrs
-    s = s.replace(/[\u200E\u200F\u202A\u202B\u202C\u202D\u202E]/g, "");
+    s = s.replace(/[\u200E\u200F\u202A\u202B\u202C\u202D\u202E]/g, '');
 
     return s;
 }

--- a/InvenTree/templates/js/translated/helpers.js
+++ b/InvenTree/templates/js/translated/helpers.js
@@ -10,6 +10,7 @@
     makeIconButton,
     makeProgressBar,
     renderLink,
+    sanitizeInputString,
     select2Thumbnail,
     setupNotesField,
     thumbnailImage
@@ -325,4 +326,25 @@ function setupNotesField(element, url, options={}) {
             });
         });
     }
+}
+
+
+/*
+ * Sanitize a string provided by the user from an input field,
+ * e.g. data form or search box
+ *
+ * - Remove leading / trailing whitespace
+ * - Remove hidden control characters
+ */
+function sanitizeInputString(s, options={}) {
+
+    s = s.trim();
+
+    // Remove ASCII control characters
+    s = s.replace(/[^\x20-\x7E]+/g, "");
+
+    // Remove type-setting charactrs
+    s = s.replace(/[\u200E\u200F\u202A\u202B\u202C\u202D\u202E]/g, "");
+
+    return s;
 }

--- a/InvenTree/templates/js/translated/helpers.js
+++ b/InvenTree/templates/js/translated/helpers.js
@@ -338,13 +338,13 @@ function setupNotesField(element, url, options={}) {
  */
 function sanitizeInputString(s, options={}) {
 
-    s = s.trim();
-
     // Remove ASCII control characters
-    s = s.replace(/[^\x20-\x7E]+/g, '');
+    s = s.replace(/[\x01-\x1F]+/g, '');
 
-    // Remove type-setting charactrs
-    s = s.replace(/[\u200E\u200F\u202A\u202B\u202C\u202D\u202E]/g, '');
+    // Remove non-printable characters
+    s = s.replace(/[^ -~]+/g, '');
+
+    s = s.trim();
 
     return s;
 }

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -98,7 +98,9 @@ var searchQueries = [];
 
 function searchTextChanged(event) {
 
-    searchText = $('#offcanvas-search').find('#search-input').val();
+    var text = $('#offcanvas-search').find('#search-input').val();
+
+    searchText = sanitizeInputString(text);
 
     clearTimeout(searchInputTimer);
     searchInputTimer = setTimeout(updateSearch, 250);


### PR DESCRIPTION
Remove ASCII and unicode control characters from search input text.

Copying and pasting text to search with may include hidden control characters which can either:

- Cause incorrect / unexpected search results
- Throw errors if the database collation does not allow extended unicode characters

A simple fix here is to strip such characters out from the search text

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3591"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

