### PR TITLE
Bug fix for loading asset files in reports

### DIFF
--- a/InvenTree/report/templatetags/report.py
+++ b/InvenTree/report/templatetags/report.py
@@ -5,7 +5,7 @@ import os
 
 from django import template
 from django.conf import settings
-from django.utils.safestring import mark_safe
+from django.utils.safestring import SafeString, mark_safe
 
 import InvenTree.helpers
 from common.models import InvenTreeSetting
@@ -28,11 +28,15 @@ def asset(filename):
     Raises:
         FileNotFoundError if file does not exist
     """
+    if type(filename) is SafeString:
+        # Prepend an empty string to enforce 'stringiness'
+        filename = '' + filename
+
     # If in debug mode, return URL to the image, not a local file
     debug_mode = InvenTreeSetting.get_setting('REPORT_DEBUG_MODE')
 
     # Test if the file actually exists
-    full_path = settings.MEDIA_ROOT.joinpath('report', 'assets', filename)
+    full_path = settings.MEDIA_ROOT.joinpath('report', 'assets', filename).resolve()
 
     if not full_path.exists() or not full_path.is_file():
         raise FileNotFoundError(f"Asset file '{filename}' does not exist")
@@ -54,6 +58,10 @@ def uploaded_image(filename, replace_missing=True, replacement_file='blank_image
     Returns:
         A fully qualified path to the image
     """
+
+    if type(filename) is SafeString:
+        # Prepend an empty string to enforce 'stringiness'
+        filename = '' + filename
 
     # If in debug mode, return URL to the image, not a local file
     debug_mode = InvenTreeSetting.get_setting('REPORT_DEBUG_MODE')

--- a/InvenTree/report/tests.py
+++ b/InvenTree/report/tests.py
@@ -9,6 +9,7 @@ from django.core.cache import cache
 from django.http.response import StreamingHttpResponse
 from django.test import TestCase
 from django.urls import reverse
+from django.utils.safestring import SafeString
 
 from PIL import Image
 
@@ -49,6 +50,10 @@ class ReportTagTest(TestCase):
         asset = report_tags.asset('test.txt')
         self.assertEqual(asset, '/media/report/assets/test.txt')
 
+        # Ensure that a 'safe string' also works
+        asset = report_tags.asset(SafeString('test.txt'))
+        self.assertEqual(asset, '/media/report/assets/test.txt')
+
         self.debug_mode(False)
         asset = report_tags.asset('test.txt')
         self.assertEqual(asset, f'file://{asset_dir}/test.txt')
@@ -87,8 +92,15 @@ class ReportTagTest(TestCase):
         img = report_tags.uploaded_image('part/images/test.jpg')
         self.assertEqual(img, '/media/part/images/test.jpg')
 
+        # Ensure that a 'safe string' also works
+        img = report_tags.uploaded_image(SafeString('part/images/test.jpg'))
+        self.assertEqual(img, '/media/part/images/test.jpg')
+
         self.debug_mode(False)
         img = report_tags.uploaded_image('part/images/test.jpg')
+        self.assertEqual(img, f'file://{img_path.joinpath("test.jpg")}')
+
+        img = report_tags.uploaded_image(SafeString('part/images/test.jpg'))
         self.assertEqual(img, f'file://{img_path.joinpath("test.jpg")}')
 
     def test_part_image(self):


### PR DESCRIPTION
- Pathlib does not play well with SafeString
- Enforce string type' when loading an asset file
- Add unit tests

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3596"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

