### PR TITLE
Sanitize search text in bootstrap table

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -896,11 +896,13 @@ def strip_html_tags(value: str, raise_error=True, field_name=None):
 def remove_non_printable_characters(value: str, remove_ascii=True, remove_unicode=True):
     """Remove non-printable / control characters from the provided string"""
 
-    # Remove ASCII control characters
-    cleaned = regex.sub(u'[\x01-\x1F]+', '', value)
+    if remove_ascii:
+        # Remove ASCII control characters
+        cleaned = regex.sub(u'[\x01-\x1F]+', '', value)
 
-    # Remove Unicode control characters
-    cleaned = regex.sub(u'[^\P{C}]+', '', value)
+    if remove_unicode:
+        # Remove Unicode control characters
+        cleaned = regex.sub(u'[^\P{C}]+', '', value)
 
     return cleaned
 

--- a/InvenTree/InvenTree/mixins.py
+++ b/InvenTree/InvenTree/mixins.py
@@ -1,12 +1,9 @@
 """Mixins for (API) views in the whole project."""
 
-from django.utils.translation import gettext_lazy as _
-
-import regex
-from bleach import clean
 from rest_framework import generics, status
-from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
+
+from InvenTree.helpers import remove_non_printable_characters, strip_html_tags
 
 
 class CleanMixin():
@@ -49,34 +46,8 @@ class CleanMixin():
         Ref: https://github.com/mozilla/bleach/issues/192
         """
 
-        cleaned = clean(
-            data,
-            strip=True,
-            tags=[],
-            attributes=[],
-        )
-
-        # Add escaped characters back in
-        replacements = {
-            '&gt;': '>',
-            '&lt;': '<',
-            '&amp;': '&',
-        }
-
-        for o, r in replacements.items():
-            cleaned = cleaned.replace(o, r)
-
-        # If the length changed, it means that HTML tags were removed!
-        if len(cleaned) != len(data):
-            raise ValidationError({
-                field: [_("Remove HTML tags from this value")]
-            })
-
-        # Remove ASCII control characters
-        cleaned = regex.sub(u'[\x01-\x1F]+', '', cleaned)
-
-        # Remove Unicode control characters
-        cleaned = regex.sub(u'[^\P{C}]+', '', cleaned)
+        cleaned = strip_html_tags(data, field_name=field)
+        cleaned = remove_non_printable_characters(cleaned)
 
         return cleaned
 

--- a/InvenTree/InvenTree/views.py
+++ b/InvenTree/InvenTree/views.py
@@ -38,6 +38,7 @@ from part.models import PartCategory
 from users.models import RuleSet, check_user_role
 
 from .forms import EditUserForm, SetPasswordForm
+from .helpers import remove_non_printable_characters, strip_html_tags
 
 
 def auth_request(request):
@@ -599,6 +600,9 @@ class SearchView(TemplateView):
         context = self.get_context_data()
 
         query = request.POST.get('search', '')
+
+        query = strip_html_tags(query, raise_error=False)
+        query = remove_non_printable_characters(query)
 
         context['query'] = query
 

--- a/InvenTree/templates/InvenTree/search.html
+++ b/InvenTree/templates/InvenTree/search.html
@@ -33,6 +33,8 @@
         });
     }
 
+    var search_text = sanitizeInputString("{{ query|escapejs }}");
+
     function addItem(label, title, icon, options) {
 
         // Construct a "badge" to add to the sidebar item
@@ -85,7 +87,7 @@
         "{% url 'api-part-list' %}",
         {
             params: {
-                original_search: "{{ query }}",
+                original_search: search_text,
             },
             checkbox: false,
             disableFilters: true,
@@ -96,7 +98,7 @@
 
     loadPartCategoryTable($("#table-category"), {
         params: {
-            original_search: "{{ query }}",
+            original_search: search_text,
         }
     });
 
@@ -107,7 +109,7 @@
         "{% url 'api-manufacturer-part-list' %}",
         {
             params: {
-                original_search: "{{ query }}",
+                original_search: search_text,
                 part_detail: true,
                 supplier_detail: true,
                 manufacturer_detail: true
@@ -122,7 +124,7 @@
         "{% url 'api-supplier-part-list' %}",
         {
             params: {
-                original_search: "{{ query }}",
+                original_search: search_text,
                 part_detail: true,
                 supplier_detail: true,
                 manufacturer_detail: true
@@ -141,7 +143,7 @@
     loadBuildTable('#table-build-order', {
         locale: '{{ request.LANGUAGE_CODE }}',
         params: {
-            original_search: '{{ query }}',
+            original_search: search_text,
         }
     });
 
@@ -156,7 +158,7 @@
         filterKey: 'stocksearch',
         url: "{% url 'api-stock-list' %}",
         params: {
-            original_search: "{{ query }}",
+            original_search: search_text,
             part_detail: true,
             location_detail: true
         }
@@ -167,7 +169,7 @@
     loadStockLocationTable($("#table-location"), {
         filterKey: 'locationsearch',
         params: {
-            original_search: "{{ query }}",
+            original_search: search_text,
         },
     });
 
@@ -180,8 +182,8 @@
 
     loadCompanyTable('#table-manufacturer', "{% url 'api-company-list' %}", {
         params: {
-            original_search: "{{ query }}",
-            is_manufacturer: "true",
+            original_search: search_text,
+            is_manufacturer: true,
         }
     });
 
@@ -190,8 +192,8 @@
 
     loadCompanyTable('#table-supplier', "{% url 'api-company-list' %}", {
         params: {
-            original_search: "{{ query }}",
-            is_supplier: "true",
+            original_search: search_text,
+            is_supplier: true,
         }
     });
 
@@ -199,7 +201,7 @@
 
     loadPurchaseOrderTable('#table-purchase-order', {
         params: {
-            original_search: '{{ query }}',
+            original_search: search_text,
         }
     });
 
@@ -210,8 +212,8 @@
 
     loadCompanyTable('#table-customer', "{% url 'api-company-list' %}", {
         params: {
-            original_search: "{{ query }}",
-            is_customer: "true",
+            original_search: search_text,
+            is_customer: true,
         }
     });
 
@@ -219,7 +221,7 @@
 
     loadSalesOrderTable('#table-sales-orders', {
         params: {
-            original_search: '{{ query }}',
+            original_search: search_text,
         }
     });
 
@@ -230,7 +232,7 @@
     enableSidebar(
         'search',
         {
-            hide_toggle: 'true',
+            hide_toggle: true,
         }
     );
 

--- a/InvenTree/templates/js/translated/tables.js
+++ b/InvenTree/templates/js/translated/tables.js
@@ -346,7 +346,9 @@ function convertQueryParameters(params, filters) {
     if ('original_search' in params) {
         var search = params['search'] || '';
 
-        params['search'] = search + ' ' + params['original_search'];
+        var clean_search = sanitizeInputString(search + ' ' + params['original_search']);
+
+        params['search'] = clean_search;
 
         delete params['original_search'];
     }


### PR DESCRIPTION
Follow up to https://github.com/inventree/InvenTree/pull/3591

- Sanitize search input text in bootstrap table
- Sanitize search input text for stand-along "search" page

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3609"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

