### PR TITLE
Add confirmation field for incomplete purchase orders

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,14 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 73
+INVENTREE_API_VERSION = 74
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v74 -> 2022-08-28 : https://github.com/inventree/InvenTree/pull/3615
+    - Add confirmation field for completing PurchaseOrder if the order has incomplete lines
+    - Add confirmation field for completing SalesOrder if the order has incomplete lines
 
 v73 -> 2022-08-24 : https://github.com/inventree/InvenTree/pull/3605
     - Add 'description' field to PartParameterTemplate model

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -204,6 +204,21 @@ class PurchaseOrderCancelSerializer(serializers.Serializer):
 class PurchaseOrderCompleteSerializer(serializers.Serializer):
     """Serializer for completing a purchase order."""
 
+    accept_incomplete = serializers.BooleanField(
+        label=_('Accept Incomplete'),
+        help_text=_('Allow order to be closed with incoimplete line items'),
+        required=False,
+        default=False,
+    )
+
+    def validate_accept_incomplete(self, value):
+        """Check if the 'accept_incomplete' field is required"""
+
+        order = self.context['order']
+
+        if not value and not order.is_complete:
+            raise ValidationError(_("Order has incomplete line items"))
+
     class Meta:
         """Metaclass options."""
 

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -19,7 +19,7 @@ import stock.models
 import stock.serializers
 from common.settings import currency_code_mappings
 from company.serializers import CompanyBriefSerializer, SupplierPartSerializer
-from InvenTree.helpers import extract_serial_numbers, normalize
+from InvenTree.helpers import extract_serial_numbers, normalize, str2bool
 from InvenTree.serializers import (InvenTreeAttachmentSerializer,
                                    InvenTreeDecimalField,
                                    InvenTreeModelSerializer,
@@ -206,7 +206,7 @@ class PurchaseOrderCompleteSerializer(serializers.Serializer):
 
     accept_incomplete = serializers.BooleanField(
         label=_('Accept Incomplete'),
-        help_text=_('Allow order to be closed with incoimplete line items'),
+        help_text=_('Allow order to be closed with incomplete line items'),
         required=False,
         default=False,
     )
@@ -218,6 +218,8 @@ class PurchaseOrderCompleteSerializer(serializers.Serializer):
 
         if not value and not order.is_complete:
             raise ValidationError(_("Order has incomplete line items"))
+
+        return value
 
     class Meta:
         """Metaclass options."""
@@ -1094,13 +1096,43 @@ class SalesOrderShipmentAllocationItemSerializer(serializers.Serializer):
 class SalesOrderCompleteSerializer(serializers.Serializer):
     """DRF serializer for manually marking a sales order as complete."""
 
+    accept_incomplete = serializers.BooleanField(
+        label=_('Accept Incomplete'),
+        help_text=_('Allow order to be closed with incomplete line items'),
+        required=False,
+        default=False,
+    )
+
+    def validate_accept_incomplete(self, value):
+        """Check if the 'accept_incomplete' field is required"""
+
+        order = self.context['order']
+
+        if not value and not order.is_completed():
+            raise ValidationError(_("Order has incomplete line items"))
+
+        return value
+
+    def get_context_data(self):
+        """Custom context data for this serializer"""
+
+        order = self.context['order']
+
+        return {
+            'is_complete': order.is_completed(),
+            'pending_shipments': order.pending_shipment_count,
+        }
+
     def validate(self, data):
         """Custom validation for the serializer"""
         data = super().validate(data)
 
         order = self.context['order']
 
-        order.can_complete(raise_error=True)
+        order.can_complete(
+            raise_error=True,
+            allow_incomplete_lines=str2bool(data.get('accept_incomplete', False)),
+        )
 
         return data
 
@@ -1108,10 +1140,14 @@ class SalesOrderCompleteSerializer(serializers.Serializer):
         """Save the serializer to complete the SalesOrder"""
         request = self.context['request']
         order = self.context['order']
+        data = self.validated_data
 
         user = getattr(request, 'user', None)
 
-        order.complete_order(user)
+        order.complete_order(
+            user,
+            allow_incomplete_lines=str2bool(data.get('accept_incomplete', False)),
+        )
 
 
 class SalesOrderCancelSerializer(serializers.Serializer):

--- a/InvenTree/order/templates/order/sales_order_base.html
+++ b/InvenTree/order/templates/order/sales_order_base.html
@@ -64,7 +64,7 @@ src="{% static 'img/blank_image.png' %}"
 
 </div>
 {% if order.status == SalesOrderStatus.PENDING %}
-<button type='button' class='btn btn-success' id='complete-order' title='{% trans "Complete Sales Order" %}'{% if not order.is_completed %} disabled{% endif %}>
+<button type='button' class='btn btn-success' id='complete-order' title='{% trans "Complete Sales Order" %}'>
     <span class='fas fa-check-circle'></span> {% trans "Complete Order" %}
 </button>
 {% endif %}
@@ -253,12 +253,12 @@ $("#cancel-order").click(function() {
 });
 
 $("#complete-order").click(function() {
-    constructForm('{% url "api-so-complete" order.id %}', {
-        method: 'POST',
-        title: '{% trans "Complete Sales Order" %}',
-        confirm: true,
-        reload: true,
-    });
+    completeSalesOrder(
+        {{ order.pk }},
+        {
+            reload: true,
+        }
+    );
 });
 
 {% if report_enabled %}

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -322,7 +322,19 @@ class PurchaseOrderTest(OrderTest):
 
         self.assignRole('purchase_order.add')
 
-        self.post(url, {}, expected_code=201)
+        # Should fail due to incomplete lines
+        response = self.post(url, {}, expected_code=400)
+
+        self.assertIn('Order has incomplete line items', str(response.data['accept_incomplete']))
+
+        # Post again, accepting incomplete line items
+        self.post(
+            url,
+            {
+                'accept_incomplete': True,
+            },
+            expected_code=201
+        )
 
         po.refresh_from_db()
 

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -328,8 +328,6 @@ function constructForm(url, options) {
         constructFormBody({}, options);
     }
 
-    options.fields = options.fields || {};
-
     // Save the URL
     options.url = url;
 
@@ -350,6 +348,13 @@ function constructForm(url, options) {
 
         // Extract any custom 'context' information from the OPTIONS data
         options.context = OPTIONS.context || {};
+
+        // Construct fields (can be a static parameter or a function)
+        if (options.fieldsFunction) {
+            options.fields = options.fieldsFunction(options);
+        } else {
+            options.fields = options.fields || {};
+        }
 
         /*
          * Determine what "type" of form we want to construct,

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -24,6 +24,7 @@
     cancelPurchaseOrder,
     cancelSalesOrder,
     completePurchaseOrder,
+    completeSalesOrder,
     completeShipment,
     completePendingShipments,
     createPurchaseOrder,
@@ -381,6 +382,60 @@ function issuePurchaseOrder(order_id, options={}) {
             }
         }
     );
+}
+
+
+/*
+ * Launches a modal form to mark a SalesOrder as "complete"
+ */
+function completeSalesOrder(order_id, options={}) {
+
+    constructForm(
+        `/api/order/so/${order_id}/complete/`,
+        {
+            method: 'POST',
+            title: '{% trans "Complete Sales Order" %}',
+            confirm: true,
+            fieldsFunction: function(opts) {
+                var fields = {
+                    accept_incomplete: {},
+                };
+
+                if (opts.context.is_complete) {
+                    delete fields['accept_incomplete'];
+                }
+
+                return fields;
+            },
+            preFormContent: function(opts) {
+                var html = `
+                <div class='alert alert-block alert-info'>
+                    {% trans "Mark this order as complete?" %}
+                </div>`;
+
+                if (opts.context.pending_shipments) {
+                    html += `
+                    <div class='alert alert-block alert-danger'>
+                    {% trans "Order cannot be completed as there are incomplete shipments" %}<br>
+                    </div>`;
+                }
+
+                if (!opts.context.is_complete) {
+                    html += `
+                    <div class='alert alert-block alert-warning'>
+                    {% trans "This order has line items which have not been completed." %}<br>
+                    {% trans "Completing this order means that the order and line items will no longer be editable." %}
+                    </div>`;
+                }
+
+                return html;
+            },
+            onSuccess: function(response) {
+                handleFormSuccess(response, options);
+            }
+        }
+    )
+
 }
 
 

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -434,8 +434,7 @@ function completeSalesOrder(order_id, options={}) {
                 handleFormSuccess(response, options);
             }
         }
-    )
-
+    );
 }
 
 

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -282,6 +282,17 @@ function completePurchaseOrder(order_id, options={}) {
             method: 'POST',
             title: '{% trans "Complete Purchase Order" %}',
             confirm: true,
+            fieldsFunction: function(opts) {
+                var fields = {
+                    accept_incomplete: {},
+                };
+
+                if (opts.context.is_complete) {
+                    delete fields['accept_incomplete'];
+                }
+
+                return fields;
+            },
             preFormContent: function(opts) {
 
                 var html = `


### PR DESCRIPTION
Allow PurchaseOrder and SalesOrder objects to be completed with incomplete lines. Adds boolean field for user confirmation.

Closes https://github.com/inventree/InvenTree/issues/3400

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3615"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

