### PR TITLE
Fix for stable branch push

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -105,10 +105,3 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         run: cosign sign ${{ steps.meta.outputs.tags }}@${{
           steps.build-and-push.outputs.digest }}
-      - name: Push to Stable Branch
-        uses: ad-m/github-push-action@9a46ba8d86d3171233e861a4351b1278a2805c83 # pin@master
-        if: env.stable_release == 'true' && github.event_name != 'pull_request'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: stable
-          force: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,13 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - name: Version Check
+        run: |
+          pip install requests
+          python3 ci/version_check.py
       - name: Push to Stable Branch
         uses: ad-m/github-push-action@9a46ba8d86d3171233e861a4351b1278a2805c83 # pin@master
+        if: env.stable_release == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,19 @@ on:
     types: [ published ]
 
 jobs:
+
+  stable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - name: Push to Stable Branch
+        uses: ad-m/github-push-action@9a46ba8d86d3171233e861a4351b1278a2805c83 # pin@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: stable
+          force: true
+
   tweet:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fix the workflow for pushing to the stable branch on a tagged release.

Move into the "release" workflow rather than pinning to the end of the docker workflow

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3619"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

