### PR TITLE
Remove broken URL

### DIFF
--- a/InvenTree/part/urls.py
+++ b/InvenTree/part/urls.py
@@ -28,9 +28,6 @@ part_detail_urls = [
 
 category_urls = [
 
-    # Top level subcategory display
-    re_path(r'^subcategory/', views.PartIndex.as_view(template_name='part/subcategory.html'), name='category-index-subcategory'),
-
     # Category detail views
     re_path(r'(?P<pk>\d+)/', views.CategoryDetail.as_view(), name='category-detail'),
 ]


### PR DESCRIPTION
- subcategories template was removed a long time ago

Fixes https://github.com/inventree/InvenTree/issues/3621

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3623"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

