### PR TITLE
Fix default ordering for build orders

### DIFF
--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -100,6 +100,8 @@ class BuildList(APIDownloadMixin, ListCreateAPI):
         'reference': ['reference_int', 'reference'],
     }
 
+    ordering = '-reference'
+
     search_fields = [
         'reference',
         'title',

--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -292,7 +292,7 @@ class PurchaseOrderList(APIDownloadMixin, ListCreateAPI):
         'status',
     ]
 
-    ordering = '-creation_date'
+    ordering = '-reference'
 
 
 class PurchaseOrderDetail(RetrieveUpdateDestroyAPI):
@@ -733,7 +733,7 @@ class SalesOrderList(APIDownloadMixin, ListCreateAPI):
         'customer_reference',
     ]
 
-    ordering = '-creation_date'
+    ordering = '-reference'
 
 
 class SalesOrderDetail(RetrieveUpdateDestroyAPI):


### PR DESCRIPTION
- Order by reference
- Show "newer" references first

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3626"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

