### PR TITLE
Fix sales order table refresh

### DIFF
--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2571,7 +2571,7 @@ function loadSalesOrderTable(table, options) {
             return `<div id='purchase-order-calendar'></div>`;
         },
         onRefresh: function() {
-            loadPurchaseOrderTable(table, options);
+            loadSalesOrderTable(table, options);
         },
         onLoadSuccess: function() {
 


### PR DESCRIPTION
- Refreshing the SalesOrder table would actually reload the PurchaseOrder table

Fixes https://github.com/inventree/InvenTree/issues/3625

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3627"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

