### PR TITLE
Fix sales order table refresh (#3627)

### DIFF
--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2465,7 +2465,7 @@ function loadSalesOrderTable(table, options) {
             return `<div id='purchase-order-calendar'></div>`;
         },
         onRefresh: function() {
-            loadPurchaseOrderTable(table, options);
+            loadSalesOrderTable(table, options);
         },
         onLoadSuccess: function() {
 


### PR DESCRIPTION
- Refreshing the SalesOrder table would actually reload the PurchaseOrder table

(cherry picked from commit 23edd794312b5eea2e00878d2216150048747a4e)

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3628"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

