### PR TITLE
Update settings value lookup to include typ

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1329,6 +1329,8 @@ class InvenTreeSetting(BaseInvenTreeSetting):
         },
     }
 
+    typ = 'inventree'
+
     class Meta:
         """Meta options for InvenTreeSetting."""
 
@@ -1641,6 +1643,8 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
             'validator': bool,
         },
     }
+
+    typ = 'user'
 
     class Meta:
         """Meta options for InvenTreeUserSetting."""

--- a/InvenTree/common/serializers.py
+++ b/InvenTree/common/serializers.py
@@ -70,6 +70,7 @@ class GlobalSettingsSerializer(SettingsSerializer):
             'choices',
             'model_name',
             'api_url',
+            'typ',
         ]
 
 
@@ -93,6 +94,7 @@ class UserSettingsSerializer(SettingsSerializer):
             'choices',
             'model_name',
             'api_url',
+            'typ',
         ]
 
 
@@ -122,6 +124,7 @@ class GenericReferencedSettingSerializer(SettingsSerializer):
                 'choices',
                 'model_name',
                 'api_url',
+                'typ',
             ]
 
         # set Meta class

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -173,6 +173,8 @@ class PluginConfig(models.Model):
 class PluginSetting(common.models.BaseInvenTreeSetting):
     """This model represents settings for individual plugins."""
 
+    typ = 'plugin'
+
     class Meta:
         """Meta for PluginSetting."""
         unique_together = [
@@ -221,6 +223,8 @@ class PluginSetting(common.models.BaseInvenTreeSetting):
 
 class NotificationUserSetting(common.models.BaseInvenTreeSetting):
     """This model represents notification settings for a user."""
+
+    typ = 'notification'
 
     class Meta:
         """Meta for NotificationUserSetting."""

--- a/InvenTree/templates/InvenTree/settings/setting.html
+++ b/InvenTree/templates/InvenTree/settings/setting.html
@@ -24,11 +24,11 @@
     <td>
         {% if setting.is_bool %}
         <div class='form-check form-switch'>
-            <input class='form-check-input boolean-setting' fieldname='{{ setting.key.upper }}' pk='{{ setting.pk }}' setting='{{ setting.key.upper }}' id='setting-value-{{ setting.key.upper }}' type='checkbox' {% if setting.as_bool %}checked=''{% endif %} {% if plugin %}plugin='{{ plugin.slug }}'{% endif %}{% if user_setting %}user='{{request.user.id}}'{% endif %}{% if notification_setting %}notification='{{request.user.id}}'{% endif %}>
+            <input class='form-check-input boolean-setting' fieldname='{{ setting.key.upper }}' pk='{{ setting.pk }}' setting='{{ setting.key.upper }}' id='setting-value-{{ setting.pk }}-{{ setting.typ }}' type='checkbox' {% if setting.as_bool %}checked=''{% endif %}{{reference}}>
         </div>
         {% else %}
         <div id='setting-{{ setting.pk }}'>
-            <span id='setting-value-{{ setting.key.upper }}' fieldname='{{ setting.key.upper }}'>
+            <span id='setting-value-{{ setting.pk }}-{{ setting.typ }}' fieldname='{{ setting.key.upper }}'>
                 {% if setting.value %}
                 {% if setting.is_choice %}
                 <strong>{{ setting.as_choice }}</strong>

--- a/InvenTree/templates/js/dynamic/settings.js
+++ b/InvenTree/templates/js/dynamic/settings.js
@@ -118,15 +118,16 @@ function editSetting(key, options={}) {
                 },
                 onSuccess: function(response) {
 
-                    var setting = response.key;
+                    var setting_pk = response.pk;
+                    var setting_typ = response.typ;
 
                     if (reload_required) {
                         location.reload();
                     } else if (response.type == 'boolean') {
                         var enabled = response.value.toString().toLowerCase() == 'true';
-                        $(`#setting-value-${setting}`).prop('checked', enabled);
+                        $(`#setting-value-${setting_pk}-${setting_typ}`).prop('checked', enabled);
                     } else {
-                        $(`#setting-value-${setting}`).html(response.value);
+                        $(`#setting-value-${setting_pk}-${setting_typ}`).html(response.value);
                     }
                 }
             });


### PR DESCRIPTION
This PR fixes a bug that caused UI problems with settings with the same key. If a setting was changed all settings with the key were changed - regardless of the settings type.
Especially important for plugins.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3636"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

