### PR TITLE
Add extra information callout to stock item display

### DIFF
--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -149,6 +149,9 @@
             {% if roles.part.view %}
             </a>
             {% endif %}
+            {% if item.part.description %}
+            <span class='fas fa-info-circle icon-blue float-right' title='{{ item.part.description }}'></span>
+            {% endif %}
         </td>
     </tr>
 


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/3650

Adds an information icon containing the part description to the stock item page.

Provides a non intrusive method of providing some extra information about the base part.

![image](https://user-images.githubusercontent.com/10080325/189000618-679982b1-b085-443b-991d-5ca2ae9ff28a.png)


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3658"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

