### PR TITLE
Update config_template.yaml

### DIFF
--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -126,10 +126,10 @@ cors:
   # - https://sub.example.com
 
 # MEDIA_ROOT is the local filesystem location for storing uploaded files
-# media_root: '/home/inventree/data/media'
+#media_root: '/home/inventree/data/media'
 
 # STATIC_ROOT is the local filesystem location for storing static files
-# static_root: '/home/inventree/data/static'
+#static_root: '/home/inventree/data/static'
 
 # Background worker options
 background:


### PR DESCRIPTION
I removed the space characters preceding 'static_root:' in line 132 and 'media_root:' in line 129 as they cause a YAML parsing error if not removed when uncommenting these options.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3689"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

