### PR TITLE
Only limit length of link if specified

### DIFF
--- a/InvenTree/templates/js/translated/helpers.js
+++ b/InvenTree/templates/js/translated/helpers.js
@@ -258,7 +258,7 @@ function renderLink(text, url, options={}) {
         return text;
     }
 
-    var max_length = options.max_length || 100;
+    var max_length = options.max_length || 0;
 
     if (max_length > 0) {
         text = shortenString(text, {


### PR DESCRIPTION
Default behaviour meant that some table links were being shorted erroneously, producing unexpected / incorrect output.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3700"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

