### PR TITLE
Show placeholder for null IPN values in "stock" table

### DIFF
--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -1729,7 +1729,11 @@ function loadStockTable(table, options) {
         switchable: params['part_detail'],
         formatter: function(value, row) {
             var ipn = row.part_detail.IPN;
-            return withTitle(shortenString(ipn), ipn);
+            if (ipn) {
+                return withTitle(shortenString(ipn), ipn);
+            } else {
+                return '-';
+            }
         },
     };
 


### PR DESCRIPTION
- Otherwise can display the text "null"

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3737"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

