### PR TITLE
Last Connection date for user in admin panel

### DIFF
--- a/InvenTree/users/admin.py
+++ b/InvenTree/users/admin.py
@@ -208,7 +208,7 @@ class InvenTreeUserAdmin(UserAdmin):
 
     (And it's confusing!)
     """
-    list_display = ('username', 'email', 'first_name', 'last_name', 'is_staff', 'last_login') # display last connection for each user in user admin panel.
+    list_display = ('username', 'email', 'first_name', 'last_name', 'is_staff', 'last_login')  # display last connection for each user in user admin panel.
     fieldsets = (
         (None, {'fields': ('username', 'password')}),
         (_('Personal info'), {'fields': ('first_name', 'last_name', 'email')}),

--- a/InvenTree/users/admin.py
+++ b/InvenTree/users/admin.py
@@ -209,7 +209,6 @@ class InvenTreeUserAdmin(UserAdmin):
     (And it's confusing!)
     """
     list_display = ('username', 'email', 'first_name', 'last_name', 'is_staff', 'last_login') # display last connection for each user in user admin panel.
-    
     fieldsets = (
         (None, {'fields': ('username', 'password')}),
         (_('Personal info'), {'fields': ('first_name', 'last_name', 'email')}),

--- a/InvenTree/users/admin.py
+++ b/InvenTree/users/admin.py
@@ -208,7 +208,8 @@ class InvenTreeUserAdmin(UserAdmin):
 
     (And it's confusing!)
     """
-
+    list_display = ('username', 'email', 'first_name', 'last_name', 'is_staff', 'last_login') # display last connection for each user in user admin panel.
+    
     fieldsets = (
         (None, {'fields': ('username', 'password')}),
         (_('Personal info'), {'fields': ('first_name', 'last_name', 'email')}),


### PR DESCRIPTION
Hi, there, 
I'm not sure on which branch to pr this tiny modif, let me know.
That's my first step in django workflow.

It's not really usefull, even not from a FR, but that's something I was looking for, and find a way in my django readings.


This simple addition to display last connection for each user in user admin panel.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3747"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

