### PR TITLE
Bug fix for boolean settings

### DIFF
--- a/InvenTree/templates/InvenTree/settings/setting.html
+++ b/InvenTree/templates/InvenTree/settings/setting.html
@@ -39,7 +39,18 @@
             </span>
             {{ setting.units }}
             <div class='btn-group float-right'>
-                <button class='btn btn-outline-secondary btn-small btn-edit-setting' pk='{{ setting.pk }}' setting='{{ setting.key.upper }}' title='{% trans "Edit setting" %}' {% if plugin %}plugin='{{ plugin.slug }}'{% endif %}{% if user_setting %}user='{{request.user.id}}'{% endif %}>
+                <button
+                    class='btn btn-outline-secondary btn-small btn-edit-setting'
+                    title='{% trans "Edit setting" %}'
+                    pk='{{ setting.pk }}'
+                    setting='{{ setting.key.upper }}'
+                    {% if plugin %}plugin='{{ plugin.slug }}'{% endif %}
+                    {% if user_setting or notification_setting %}user='{{request.user.id}}'{% endif %}
+                    {% if notification_setting %}
+                    notification=true
+                    method='{{ setting.method }}'
+                    {% endif %}
+                >
                     <span class='fas fa-edit icon-green'></span>
                 </button>
             </div>

--- a/InvenTree/templates/InvenTree/settings/setting.html
+++ b/InvenTree/templates/InvenTree/settings/setting.html
@@ -24,7 +24,7 @@
     <td>
         {% if setting.is_bool %}
         <div class='form-check form-switch'>
-            <input class='form-check-input boolean-setting' fieldname='{{ setting.key.upper }}' pk='{{ setting.pk }}' setting='{{ setting.key.upper }}' id='setting-value-{{ setting.pk }}-{{ setting.typ }}' type='checkbox' {% if setting.as_bool %}checked=''{% endif %}{{reference}}>
+            <input class='form-check-input boolean-setting' fieldname='{{ setting.key.upper }}' pk='{{ setting.pk }}' setting='{{ setting.key.upper }}' id='setting-value-{{ setting.pk }}-{{ setting.typ }}' type='checkbox' {% if setting.as_bool %}checked=''{% endif %}{{reference}} {% if user_setting %}user='{{request.user.id}}'{% endif %}>
         </div>
         {% else %}
         <div id='setting-{{ setting.pk }}'>

--- a/InvenTree/templates/InvenTree/settings/setting.html
+++ b/InvenTree/templates/InvenTree/settings/setting.html
@@ -23,9 +23,7 @@
     </td>
     <td>
         {% if setting.is_bool %}
-        <div class='form-check form-switch'>
-            <input class='form-check-input boolean-setting' fieldname='{{ setting.key.upper }}' pk='{{ setting.pk }}' setting='{{ setting.key.upper }}' id='setting-value-{{ setting.pk }}-{{ setting.typ }}' type='checkbox' {% if setting.as_bool %}checked=''{% endif %}{{reference}} {% if user_setting %}user='{{request.user.id}}'{% endif %}>
-        </div>
+        {% include "InvenTree/settings/setting_boolean.html" %}
         {% else %}
         <div id='setting-{{ setting.pk }}'>
             <span id='setting-value-{{ setting.pk }}-{{ setting.typ }}' fieldname='{{ setting.key.upper }}'>

--- a/InvenTree/templates/InvenTree/settings/setting_boolean.html
+++ b/InvenTree/templates/InvenTree/settings/setting_boolean.html
@@ -8,6 +8,7 @@
         type='checkbox'
         {% if setting.as_bool %}checked=''{% endif %}
         {{ reference }}
+        {% if plugin %}plugin='{{ plugin.slug }}'{% endif %}
         {% if user_setting or notification_setting %}user='{{ request.user.pk }}'{% endif %}
         {% if notification_setting %}
         notification=true

--- a/InvenTree/templates/InvenTree/settings/setting_boolean.html
+++ b/InvenTree/templates/InvenTree/settings/setting_boolean.html
@@ -1,0 +1,17 @@
+<div class='form-check form-switch'>
+    <input
+        class='form-check-input boolean-setting'
+        fieldname='{{ setting.key.upper }}'
+        pk='{{ setting.pk }}'
+        setting='{{ setting.key.upper }}'
+        id='setting-value-{{setting.pk }}-{{ setting.typ }}'
+        type='checkbox'
+        {% if setting.as_bool %}checked=''{% endif %}
+        {{ reference }}
+        {% if user_setting or notification_setting %}user='{{ request.user.pk }}'{% endif %}
+        {% if notification_setting %}
+        notification=true
+        method='{{ setting.method }}'
+        {% endif %}
+    >
+</div>

--- a/InvenTree/templates/InvenTree/settings/settings.html
+++ b/InvenTree/templates/InvenTree/settings/settings.html
@@ -78,12 +78,12 @@ $('table').find('.boolean-setting').change(function() {
     // Global setting by default
     var url = `/api/settings/global/${setting}/`;
 
-    if (plugin) {
+    if (notification) {
+        url = `/api/settings/notification/${pk}/`;
+    } else if (plugin) {
         url = `/api/plugin/settings/${plugin}/${setting}/`;
     } else if (user) {
         url = `/api/settings/user/${setting}/`;
-    } else if (notification) {
-        url = `/api/settings/notification/${pk}/`;
     }
 
     inventreePut(


### PR DESCRIPTION
Boolean user settings are currently completely borked in the settings page.

Ref: https://github.com/inventree/InvenTree/issues/3654

- Ensure "user" attribute is provided
- Fix for *all* boolean user settings

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3760"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

