### PR TITLE
Fix for allowing plugins without explicit metadata

### DIFF
--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -64,6 +64,7 @@ def handle_error(error, do_raise: bool = True, do_log: bool = True, log_name: st
     """Handles an error and casts it as an IntegrationPluginError."""
     package_path = traceback.extract_tb(error.__traceback__)[-1].filename
     install_path = sysconfig.get_paths()["purelib"]
+
     try:
         package_name = pathlib.Path(package_path).relative_to(install_path).parts[0]
     except ValueError:
@@ -88,9 +89,10 @@ def handle_error(error, do_raise: bool = True, do_log: bool = True, log_name: st
         log_error({package_name: str(error)}, **log_kwargs)
 
     if do_raise:
-        # do a straight raise if we are playing with enviroment variables at execution time, ignore the broken sample
+        # do a straight raise if we are playing with environment variables at execution time, ignore the broken sample
         if settings.TESTING_ENV and package_name != 'integration.broken_sample' and isinstance(error, IntegrityError):
             raise error  # pragma: no cover
+
         raise IntegrationPluginError(package_name, str(error))
 # endregion
 

--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import warnings
 from datetime import datetime
-from importlib.metadata import metadata
+from importlib.metadata import PackageNotFoundError, metadata
 
 from django.conf import settings
 from django.db.utils import OperationalError, ProgrammingError
@@ -294,7 +294,18 @@ class InvenTreePlugin(MixinBase, MetaBase):
     @classmethod
     def _get_package_metadata(cls):
         """Get package metadata for plugin."""
-        meta = metadata(cls.__name__)
+
+        # Try simple metadata lookup
+        try:
+            meta = metadata(cls.__name__)
+        # Simple lookup did not work - get data from module
+        except PackageNotFoundError:
+
+            try:
+                meta = metadata(cls.__module__.split('.')[0])
+            except PackageNotFoundError:
+                # Not much information we can extract at this point
+                return {}
 
         return {
             'author': meta['Author-email'],

--- a/InvenTree/templates/InvenTree/settings/plugin_settings.html
+++ b/InvenTree/templates/InvenTree/settings/plugin_settings.html
@@ -7,7 +7,7 @@
 
 
 {% block heading %}
-{% blocktrans with name=plugin.human_name %}Plugin details for {{name}}{% endblocktrans %}
+{% trans "Plugin" %}: <em>{{ plugin.human_name }}</em>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Cherry picked from https://github.com/inventree/InvenTree/pull/3768