### PR TITLE
Save language settings for 30 days

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -607,6 +607,8 @@ if type(EXTRA_URL_SCHEMES) not in [list]:  # pragma: no cover
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 LANGUAGE_CODE = get_setting('INVENTREE_LANGUAGE', 'language', 'en-us')
+# Store language settings for 30 days
+LANGUAGE_COOKIE_AGE = 2592000
 
 # If a new language translation is supported, it must be added here
 LANGUAGES = [


### PR DESCRIPTION
This PR sets the cookie for language settings to 2592000 seconds -> 30 days.

Closes #3722

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3779"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

