### PR TITLE
Reduce duplication in plugin testing

### DIFF
--- a/InvenTree/InvenTree/api_tester.py
+++ b/InvenTree/InvenTree/api_tester.py
@@ -10,6 +10,9 @@ from django.http.response import StreamingHttpResponse
 
 from rest_framework.test import APITestCase
 
+from plugin import registry
+from plugin.models import PluginConfig
+
 
 class UserMixin:
     """Mixin to setup a user and login for tests.
@@ -85,6 +88,21 @@ class UserMixin:
 
                 ruleset.save()
                 break
+
+
+class PluginMixin:
+    """Mixin to ensure that all plugins are loaded for tests."""
+
+    def setUp(self):
+        """Setup for plugin tests."""
+        super().setUp()
+
+        # Load plugin configs
+        self.plugin_confs = PluginConfig.objects.all()
+        # Reload if not present
+        if not self.plugin_confs:
+            registry.reload_plugins()
+            self.plugin_confs = PluginConfig.objects.all()
 
 
 class InvenTreeAPITestCase(UserMixin, APITestCase):

--- a/InvenTree/InvenTree/apps.py
+++ b/InvenTree/InvenTree/apps.py
@@ -65,12 +65,6 @@ class InvenTreeConfig(AppConfig):
             )
         logger.info("Started background tasks...")
 
-        # Make regular backups
-        InvenTree.tasks.schedule_task(
-            'InvenTree.tasks.run_backup',
-            schedule_type=Schedule.DAILY,
-        )
-
     def update_exchange_rates(self):  # pragma: no cover
         """Update exchange rates each time the server is started.
 

--- a/InvenTree/common/tests.py
+++ b/InvenTree/common/tests.py
@@ -9,10 +9,9 @@ from django.core.cache import cache
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from InvenTree.api_tester import InvenTreeAPITestCase
+from InvenTree.api_tester import InvenTreeAPITestCase, PluginMixin
 from InvenTree.helpers import InvenTreeTestCase, str2bool
-from plugin import registry
-from plugin.models import NotificationUserSetting, PluginConfig
+from plugin.models import NotificationUserSetting
 
 from .api import WebhookView
 from .models import (ColorTheme, InvenTreeSetting, InvenTreeUserSetting,
@@ -540,7 +539,7 @@ class NotificationUserSettingsApiTest(InvenTreeAPITestCase):
         self.assertEqual(str(test_setting), 'NOTIFICATION_METHOD_MAIL (for testuser): True')
 
 
-class PluginSettingsApiTest(InvenTreeAPITestCase):
+class PluginSettingsApiTest(PluginMixin, InvenTreeAPITestCase):
     """Tests for the plugin settings API."""
 
     def test_plugin_list(self):
@@ -561,12 +560,6 @@ class PluginSettingsApiTest(InvenTreeAPITestCase):
 
     def test_valid_plugin_slug(self):
         """Test that an valid plugin slug runs through."""
-        # load plugin configs
-        fixtures = PluginConfig.objects.all()
-        if not fixtures:
-            registry.reload_plugins()
-            fixtures = PluginConfig.objects.all()
-
         # get data
         url = reverse('api-plugin-setting-detail', kwargs={'plugin': 'sample', 'key': 'API_KEY'})
         response = self.get(url, expected_code=200)

--- a/InvenTree/plugin/test_api.py
+++ b/InvenTree/plugin/test_api.py
@@ -99,14 +99,6 @@ class PluginDetailAPITest(PluginMixin, InvenTreeAPITestCase):
         }, follow=True)
         self.assertEqual(response.status_code, 200)
 
-        # activate everything
-        response = self.client.post(url, {
-            'action': 'plugin_activate',
-            'index': 0,
-            '_selected_action': [f.pk for f in self.plugin_confs],
-        }, follow=True)
-        self.assertEqual(response.status_code, 200)
-
         # save to deactivate a plugin
         response = self.client.post(reverse('admin:plugin_pluginconfig_change', args=(test_plg.pk, )), {
             '_save': 'Save',


### PR DESCRIPTION
This PR:
- reduces the code duplication for plugins
- makes a few tests a bit easier

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3800"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

