### PR TITLE
Add postgresql-client to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get install -y  --no-install-recommends \
     # SQLite support
     sqlite3 \
     # PostgreSQL support
-    libpq-dev \
+    libpq-dev postgresql-client \
     # MySQL / MariaDB support
     default-libmysqlclient-dev mariadb-client && \
     apt-get autoclean && apt-get autoremove


### PR DESCRIPTION
Required for `pg_dump` and `pg_restore` support.

Ref: https://github.com/inventree/InvenTree/pull/3783

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3802"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

