### PR TITLE
Revert "Switch to registry for tasks"

### DIFF
--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -4,9 +4,7 @@ import json
 import logging
 import re
 import warnings
-from dataclasses import dataclass
 from datetime import timedelta
-from typing import Callable
 
 from django.conf import settings
 from django.core import mail as django_mail
@@ -128,69 +126,6 @@ def offload_task(taskname, *args, force_async=False, force_sync=False, **kwargs)
         _func(*args, **kwargs)
 
 
-@dataclass()
-class ScheduledTask:
-    """A scheduled task.
-
-    - interval: The interval at which the task should be run
-    - minutes: The number of minutes between task runs
-    - func: The function to be run
-    """
-
-    func: Callable
-    interval: str
-    minutes: int = None
-
-    MINUTES = "I"
-    HOURLY = "H"
-    DAILY = "D"
-    WEEKLY = "W"
-    MONTHLY = "M"
-    QUARTERLY = "Q"
-    YEARLY = "Y"
-    TYPE = [MINUTES, HOURLY, DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY]
-
-
-class TaskRegister:
-    """Registery for periodicall tasks."""
-    task_list: list[ScheduledTask] = []
-
-    def register(self, task, schedule, minutes: int = None):
-        """Register a task with the que."""
-        self.task_list.append(ScheduledTask(task, schedule, minutes))
-
-
-tasks = TaskRegister()
-
-
-def scheduled_task(interval: str, minutes: int = None):
-    """Register the given task as a scheduled task.
-
-    - interval: The interval at which the task should be run
-    - minutes: The number of minutes between task runs
-
-    Example:
-    ```python
-    @register(ScheduledTask.DAILY)
-    def my_custom_funciton():
-        ...
-    ```
-    """
-
-    def _task_wrapper(admin_class):
-        if not isinstance(admin_class, Callable):
-            raise ValueError('Wrapped object must be a function')
-
-        if interval not in ScheduledTask.TYPE:
-            raise ValueError(f'Invalid interval. Must be one of {ScheduledTask.TYPE}')
-
-        tasks.register(admin_class, interval, minutes=minutes)
-
-        return admin_class
-    return _task_wrapper
-
-
-@scheduled_task(ScheduledTask.MINUTES, 15)
 def heartbeat():
     """Simple task which runs at 5 minute intervals, so we can determine that the background worker is actually running.
 
@@ -214,7 +149,6 @@ def heartbeat():
     heartbeats.delete()
 
 
-@scheduled_task(ScheduledTask.DAILY)
 def delete_successful_tasks():
     """Delete successful task logs which are more than a month old."""
     try:
@@ -234,7 +168,6 @@ def delete_successful_tasks():
         results.delete()
 
 
-@scheduled_task(ScheduledTask.DAILY)
 def delete_old_error_logs():
     """Delete old error logs from the server."""
     try:
@@ -257,7 +190,6 @@ def delete_old_error_logs():
         return
 
 
-@scheduled_task(ScheduledTask.DAILY)
 def check_for_updates():
     """Check if there is an update for InvenTree."""
     try:
@@ -300,7 +232,6 @@ def check_for_updates():
     )
 
 
-@scheduled_task(ScheduledTask.DAILY)
 def update_exchange_rates():
     """Update currency exchange rates."""
     try:

--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -273,7 +273,6 @@ def update_exchange_rates():
         logger.error(f"Error updating exchange rates: {e}")
 
 
-@scheduled_task(ScheduledTask.DAILY)
 def run_backup():
     """Run the backup command."""
     call_command("dbbackup", noinput=True, clean=True, compress=True, interactive=False)

--- a/InvenTree/build/tasks.py
+++ b/InvenTree/build/tasks.py
@@ -144,7 +144,6 @@ def notify_overdue_build_order(bo: build.models.Build):
     trigger_event(event_name, build_order=bo.pk)
 
 
-@InvenTree.tasks.scheduled_task(InvenTree.tasks.ScheduledTask.DAILY)
 def check_overdue_build_orders():
     """Check if any outstanding BuildOrders have just become overdue
 

--- a/InvenTree/common/tasks.py
+++ b/InvenTree/common/tasks.py
@@ -5,12 +5,9 @@ from datetime import datetime, timedelta
 
 from django.core.exceptions import AppRegistryNotReady
 
-from InvenTree.tasks import ScheduledTask, scheduled_task
-
 logger = logging.getLogger('inventree')
 
 
-@scheduled_task(ScheduledTask.DAILY)
 def delete_old_notifications():
     """Remove old notifications from the database.
 

--- a/InvenTree/order/tasks.py
+++ b/InvenTree/order/tasks.py
@@ -6,13 +6,12 @@ from django.utils.translation import gettext_lazy as _
 
 import common.notifications
 import InvenTree.helpers
+import InvenTree.tasks
 import order.models
 from InvenTree.status_codes import PurchaseOrderStatus, SalesOrderStatus
-from InvenTree.tasks import ScheduledTask, scheduled_task
 from plugin.events import trigger_event
 
 
-@scheduled_task(ScheduledTask.DAILY)
 def notify_overdue_purchase_order(po: order.models.PurchaseOrder):
     """Notify users that a PurchaseOrder has just become 'overdue'"""
 
@@ -56,7 +55,6 @@ def notify_overdue_purchase_order(po: order.models.PurchaseOrder):
     )
 
 
-@scheduled_task(ScheduledTask.DAILY)
 def check_overdue_purchase_orders():
     """Check if any outstanding PurchaseOrders have just become overdue:
 


### PR DESCRIPTION
Reverts inventree/InvenTree#3790

Reason: scheduled tasks cannot be registered using the function reference - only using 'dotted string' notation:

![image](https://user-images.githubusercontent.com/10080325/196156277-6db754ff-3464-48aa-88fb-342bb2e643a4.png)
