### PR TITLE
Bom table load fix

### DIFF
--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -1308,14 +1308,19 @@ function loadBomTable(table, options={}) {
 
             var data = table.bootstrapTable('getData');
 
+            var update_required = false;
+
             for (var idx = 0; idx < data.length; idx++) {
-                var row = data[idx];
 
-                if (!row.parentId) {
-                    row.parentId = parent_id;
-
-                    table.bootstrapTable('updateByUniqueId', row.pk, row, true);
+                if (!data[idx].parentId) {
+                    data[idx].parentId = parent_id;
+                    update_required = true;
                 }
+            }
+
+            // Re-load the table back data
+            if (update_required) {
+                table.bootstrapTable('load', data);
             }
         },
         onLoadSuccess: function(data) {

--- a/InvenTree/templates/js/translated/filters.js
+++ b/InvenTree/templates/js/translated/filters.js
@@ -324,7 +324,7 @@ function setupFilterList(tableKey, table, target, options={}) {
 
     // Callback for reloading the table
     element.find(`#reload-${tableKey}`).click(function() {
-        $(table).bootstrapTable('refresh');
+        reloadTableFilters(table);
     });
 
     // Add a callback for downloading table data

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -1308,8 +1308,11 @@ function loadParametricPartTable(table, options={}) {
                     row[`parameter_${parameter.template}`] = parameter.data;
                 });
 
-                $(table).bootstrapTable('updateByUniqueId', pk, row);
+                data[idx] = row;
             }
+
+            // Update the table
+            $(table).bootstrapTable('load', data);
         }
     });
 }

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -1301,7 +1301,6 @@ function loadParametricPartTable(table, options={}) {
 
             for (var idx = 0; idx < data.length; idx++) {
                 var row = data[idx];
-                var pk = row.pk;
 
                 // Make each parameter accessible, based on the "template" columns
                 row.parameters.forEach(function(parameter) {

--- a/InvenTree/templates/js/translated/tables.js
+++ b/InvenTree/templates/js/translated/tables.js
@@ -543,7 +543,7 @@ function customGroupSorter(sortName, sortOrder, sortData) {
     // Allows us to escape any nasty HTML tags which are rendered to the DOM
     $.fn.bootstrapTable.utils._calculateObjectValue = $.fn.bootstrapTable.utils.calculateObjectValue;
 
-    $.fn.bootstrapTable.utils.calculateObjectValue2 = function escapeCellValue(self, name, args, defaultValue) {
+    $.fn.bootstrapTable.utils.calculateObjectValue = function escapeCellValue(self, name, args, defaultValue) {
 
         var args_list = [];
 

--- a/InvenTree/templates/js/translated/tables.js
+++ b/InvenTree/templates/js/translated/tables.js
@@ -543,7 +543,7 @@ function customGroupSorter(sortName, sortOrder, sortData) {
     // Allows us to escape any nasty HTML tags which are rendered to the DOM
     $.fn.bootstrapTable.utils._calculateObjectValue = $.fn.bootstrapTable.utils.calculateObjectValue;
 
-    $.fn.bootstrapTable.utils.calculateObjectValue = function escapeCellValue(self, name, args, defaultValue) {
+    $.fn.bootstrapTable.utils.calculateObjectValue2 = function escapeCellValue(self, name, args, defaultValue) {
 
         var args_list = [];
 


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/3810

Multiple calls to update single table rows are extremely inefficient. Instead, process the data for the entire table, then re-draw the table in a single hit.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3826"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

