### PR TITLE
Improve redraw speed of build allocation table

### DIFF
--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1471,13 +1471,16 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
         // How many rows are fully allocated?
         var allocated_rows = 0;
 
-        bom_items.forEach(function(row) {
-            $(table).bootstrapTable('updateByUniqueId', row.pk, row, true);
+        for (var idx = 0; idx < bom_items.length; idx++) {
+            var row = bom_items[idx];
 
             if (isRowFullyAllocated(row)) {
-                allocated_rows += 1;
+                allocated_rows++;
             }
-        });
+        }
+
+        // Reload table data
+        $(table).bootstrapTable('load', bom_items);
 
         // Find the top-level progess bar for this build output
         var output_progress_bar = $(`#output-progress-${outputId}`);


### PR DESCRIPTION
- Reload table data in one go, rather than one row at a time
- Reduces redraw time (in one example) from ~4s to ~0.05s

Fixes https://github.com/inventree/InvenTree/issues/3512

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3831"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

