### PR TITLE
Prevent assigning of empty barcode data

### DIFF
--- a/InvenTree/plugin/base/barcodes/api.py
+++ b/InvenTree/plugin/base/barcodes/api.py
@@ -48,7 +48,9 @@ class BarcodeScan(APIView):
         """
         data = request.data
 
-        if 'barcode' not in data:
+        barcode_data = data.get('barcode', None)
+
+        if not barcode_data:
             raise ValidationError({'barcode': _('Must provide barcode_data parameter')})
 
         # Ensure that the default barcode handlers are run first
@@ -57,7 +59,6 @@ class BarcodeScan(APIView):
             InvenTreeExternalBarcodePlugin(),
         ] + registry.with_mixin('barcode')
 
-        barcode_data = data.get('barcode')
         barcode_hash = hash_barcode(barcode_data)
 
         # Look for a barcode plugin which knows how to deal with this barcode

--- a/InvenTree/plugin/base/barcodes/api.py
+++ b/InvenTree/plugin/base/barcodes/api.py
@@ -106,10 +106,10 @@ class BarcodeAssign(APIView):
 
         data = request.data
 
-        if 'barcode' not in data:
-            raise ValidationError({'barcode': _('Must provide barcode_data parameter')})
+        barcode_data = data.get('barcode', None)
 
-        barcode_data = data['barcode']
+        if not barcode_data:
+            raise ValidationError({'barcode': _('Must provide barcode_data parameter')})
 
         # Here we only check against 'InvenTree' plugins
         plugins = [

--- a/InvenTree/plugin/base/barcodes/api.py
+++ b/InvenTree/plugin/base/barcodes/api.py
@@ -51,7 +51,7 @@ class BarcodeScan(APIView):
         barcode_data = data.get('barcode', None)
 
         if not barcode_data:
-            raise ValidationError({'barcode': _('Must provide barcode_data parameter')})
+            raise ValidationError({'barcode': _('Missing barcode data')})
 
         # Ensure that the default barcode handlers are run first
         plugins = [
@@ -110,7 +110,7 @@ class BarcodeAssign(APIView):
         barcode_data = data.get('barcode', None)
 
         if not barcode_data:
-            raise ValidationError({'barcode': _('Must provide barcode_data parameter')})
+            raise ValidationError({'barcode': _('Missing barcode data')})
 
         # Here we only check against 'InvenTree' plugins
         plugins = [

--- a/InvenTree/plugin/base/barcodes/test_barcode.py
+++ b/InvenTree/plugin/base/barcodes/test_barcode.py
@@ -55,7 +55,8 @@ class BarcodeAPITest(InvenTreeAPITestCase):
         self.assertEqual(response.status_code, 400)
 
         data = response.data
-        self.assertIn('error', data)
+        self.assertIn('barcode', data)
+        self.assertIn('Missing barcode data', str(response.data['barcode']))
 
     def test_find_part(self):
         """Test that we can lookup a part based on ID."""


### PR DESCRIPTION
Prevents empty barcodes from being assigned via the API

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3851"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

