### PR TITLE
Make PartCategories to be filterable by name and description

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 77
+INVENTREE_API_VERSION = 78
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v78 -> 2022-10-25 : https://github.com/inventree/InvenTree/pull/3854
+    - Make PartCategory to be filtered by name and description
 
 v77 -> 2022-10-12 : https://github.com/inventree/InvenTree/pull/3772
     - Adds model permission checks for barcode assignment actions

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -153,6 +153,8 @@ class CategoryList(ListCreateAPI):
     ]
 
     filterset_fields = [
+        'name',
+        'description'
     ]
 
     ordering_fields = [


### PR DESCRIPTION
As we discussed here:
https://github.com/inventree/inventree-python/issues/143

There are cases when an user would like to make an exact search to category by name or description.
This PR adds these two fields to the filterable fields.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3854"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

