### PR TITLE
Enable build order search in quick-search window

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1612,6 +1612,13 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
             'validator': bool,
         },
 
+        'SEARCH_PREVIEW_SHOW_BUILD_ORDERS': {
+            'name': _('Search Build Orders'),
+            'description': _('Display build orders in search preview window'),
+            'default': True,
+            'validator': bool,
+        },
+
         'SEARCH_PREVIEW_SHOW_PURCHASE_ORDERS': {
             'name': _('Search Purchase Orders'),
             'description': _('Display purchase orders in search preview window'),

--- a/InvenTree/templates/InvenTree/settings/user_search.html
+++ b/InvenTree/templates/InvenTree/settings/user_search.html
@@ -23,6 +23,7 @@
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_HIDE_UNAVAILABLE_STOCK" user_setting=True icon='fa-eye-slash' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_LOCATIONS" user_setting=True icon='fa-sitemap' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_COMPANIES" user_setting=True icon='fa-building' %}
+            {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_BUILD_ORDERS" user_setting=True icon='fa-tools' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_PURCHASE_ORDERS" user_setting=True icon='fa-shopping-cart' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_EXCLUDE_INACTIVE_PURCHASE_ORDERS" user_setting=True icon='fa-eye-slash' %}
             {% include "InvenTree/settings/setting.html" with key="SEARCH_PREVIEW_SHOW_SALES_ORDERS" user_setting=True icon='fa-truck' %}

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -247,6 +247,22 @@ function updateSearch() {
         );
     }
 
+    if (checkPermission('build') && user_settings.SEARCH_PREVIEW_SHOW_BUILD_ORDERS) {
+        // Search for matching build orders
+        addSearchQuery(
+            'build',
+            '{% trans "Build Orders" %}',
+            '{% url "api-build-list" %}',
+            {
+                part_detail: true,
+            },
+            renderBuild,
+            {
+                url: '/build',
+            }
+        );
+    }
+
     if ((checkPermission('sales_order') || checkPermission('purchase_order')) && user_settings.SEARCH_PREVIEW_SHOW_COMPANIES) {
         // Search for matching companies
         addSearchQuery(


### PR DESCRIPTION
Add user setting to enable search preview for build orders

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3856"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

