### PR TITLE
Allow PartCategories to be filtered by parent_id

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 78
+INVENTREE_API_VERSION = 79
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v79 -> 2022-10-28 : https://github.com/inventree/InvenTree/pull/3876
+    - Make PartCategory to be filtered by parent_id
 
 v78 -> 2022-10-25 : https://github.com/inventree/InvenTree/pull/3854
     - Make PartCategory to be filtered by name and description

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -154,7 +154,8 @@ class CategoryList(ListCreateAPI):
 
     filterset_fields = [
         'name',
-        'description'
+        'description',
+        'parent_id'
     ]
 
     ordering_fields = [


### PR DESCRIPTION
I apologize for not including this field in #3854, but now I worked on pimping Kin-Tree, and there would be a need for querying child categories.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3876"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

