### PR TITLE
Order editing updates

### DIFF
--- a/InvenTree/InvenTree/tests.py
+++ b/InvenTree/InvenTree/tests.py
@@ -275,8 +275,10 @@ class TestHelpers(TestCase):
             we will simply try multiple times
             """
 
+            tries = 0
+
             with self.assertRaises(expected_error):
-                while retries > 0:
+                while tries < retries:
 
                     try:
                         helpers.download_image_from_url(url, timeout=timeout)
@@ -285,18 +287,17 @@ class TestHelpers(TestCase):
                         if type(exc) is expected_error:
                             # Re-throw this error
                             raise exc
+                        else:
+                            print("Unexpected error:", type(exc), exc)
 
-                    time.sleep(30)
-                    retries -= 1
+                    tries += 1
+                    time.sleep(10 * tries)
 
         # Attempt to download an image which throws a 404
         dl_helper("https://httpstat.us/404", requests.exceptions.HTTPError, timeout=10)
 
         # Attempt to download, but timeout
         dl_helper("https://httpstat.us/200?sleep=5000", requests.exceptions.ReadTimeout, timeout=1)
-
-        # Attempt to download, but not a valid image
-        dl_helper("https://httpstat.us/200", TypeError, timeout=10)
 
         large_img = "https://github.com/inventree/InvenTree/raw/master/InvenTree/InvenTree/static/img/paper_splash_large.jpg"
 

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1259,6 +1259,13 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'validator': bool,
         },
 
+        'SALESORDER_EDIT_COMPLETED_ORDERS': {
+            'name': _('Edit Completed Sales Orders'),
+            'description': _('Allow editing of sales orders after they have been shipped or completed'),
+            'default': False,
+            'validator': bool,
+        },
+
         'PURCHASEORDER_REFERENCE_PATTERN': {
             'name': _('Purchase Order Reference Pattern'),
             'description': _('Required pattern for generating Purchase Order reference field'),

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1266,6 +1266,13 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'validator': order.validators.validate_purchase_order_reference_pattern,
         },
 
+        'PURCHASEORDER_EDIT_COMPLETED_ORDERS': {
+            'name': _('Edit Completed Purchase Orders'),
+            'description': _('Allow editing of purchase orders after they have been shipped or completed'),
+            'default': False,
+            'validator': bool,
+        },
+
         # login / SSO
         'LOGIN_ENABLE_PWD_FORGOT': {
             'name': _('Enable password forgot'),

--- a/InvenTree/order/templates/order/purchase_order_detail.html
+++ b/InvenTree/order/templates/order/purchase_order_detail.html
@@ -248,6 +248,14 @@ loadPurchaseOrderExtraLineTable(
     {
         order: {{ order.pk }},
         status: {{ order.status }},
+        {% if order.is_pending %}
+        pending: true,
+        {% endif %}
+        {% if roles.purchase_order.change %}
+        allow_edit: true,
+        {% else %},
+        allow_edit: false,
+        {% endif %}
     }
 );
 

--- a/InvenTree/order/templates/order/purchase_order_detail.html
+++ b/InvenTree/order/templates/order/purchase_order_detail.html
@@ -253,8 +253,6 @@ loadPurchaseOrderExtraLineTable(
         {% endif %}
         {% if roles.purchase_order.change %}
         allow_edit: true,
-        {% else %},
-        allow_edit: false,
         {% endif %}
     }
 );

--- a/InvenTree/order/templates/order/purchase_order_detail.html
+++ b/InvenTree/order/templates/order/purchase_order_detail.html
@@ -5,11 +5,13 @@
 {% load i18n %}
 {% load static %}
 
+
 {% block sidebar %}
 {% include 'order/po_sidebar.html' %}
 {% endblock %}
 
 {% block page_content %}
+{% settings_value "PURCHASEORDER_EDIT_COMPLETED_ORDERS" as allow_extra_editing %}
 
 <div class='panel panel-hidden' id='panel-order-items'>
     <div class='panel-heading'>
@@ -18,7 +20,7 @@
             {% include "spacer.html" %}
             <div class='btn-group' role='group'>
                 {% if roles.purchase_order.change %}
-                {% if order.status == PurchaseOrderStatus.PENDING %}
+                {% if order.is_pending or allow_extra_editing %}
                 <a class='btn btn-primary' href='{% url "po-upload" order.id %}' role='button'>
                     <span class='fas fa-file-upload side-icon'></span> {% trans "Upload File" %}
                 </a>
@@ -48,10 +50,12 @@
             <h4>{% trans "Extra Lines" %}</h4>
             {% include "spacer.html" %}
             <div class='btn-group' role='group'>
-                {% if roles.purchase_order.change  %}
+                {% if roles.purchase_order.change %}
+                {% if order.is_pending or allow_extra_editing %}
                 <button type='button' class='btn btn-success' id='new-po-extra-line'>
                     <span class='fas fa-plus-circle'></span> {% trans "Add Extra Line" %}
                 </button>
+                {% endif %}
                 {% endif %}
             </div>
         </div>
@@ -208,6 +212,9 @@ loadPurchaseOrderLineItemTable('#po-line-table', {
     allow_edit: true,
     {% else %}
     allow_edit: false,
+    {% endif %}
+    {% if order.status == PurchaseOrderStatus.PENDING %}
+    pending: true,
     {% endif %}
     {% if order.status == PurchaseOrderStatus.PLACED and roles.purchase_order.change %}
     allow_receive: true,

--- a/InvenTree/order/templates/order/sales_order_detail.html
+++ b/InvenTree/order/templates/order/sales_order_detail.html
@@ -10,6 +10,7 @@
 {% endblock %}
 
 {% block page_content %}
+{% settings_value "SALESORDER_EDIT_COMPLETED_ORDERS" as allow_extra_editing %}
 
 <div class='panel panel-hidden' id='panel-order-items'>
     <div class='panel-heading'>
@@ -17,10 +18,12 @@
             <h4>{% trans "Sales Order Items" %}</h4>
             {% include "spacer.html" %}
             <div class='btn-group' role='group'>
-                {% if roles.sales_order.change and order.is_pending %}
+                {% if roles.sales_order.change %}
+                {% if order.is_pending or allow_extra_editing %}
                 <button type='button' class='btn btn-success' id='new-so-line'>
                     <span class='fas fa-plus-circle'></span> {% trans "Add Line Item" %}
                 </button>
+                {% endif %}
                 {% endif %}
             </div>
         </div>
@@ -43,9 +46,11 @@
             {% include "spacer.html" %}
             <div class='btn-group' role='group'>
                 {% if roles.sales_order.change %}
+                {% if order.is_pending or allow_extra_editing %}
                 <button type='button' class='btn btn-success' id='new-so-extra-line'>
                     <span class='fas fa-plus-circle'></span> {% trans "Add Extra Line" %}
                 </button>
+                {% endif %}
                 {% endif %}
             </div>
         </div>
@@ -265,6 +270,12 @@
             order: {{ order.pk }},
             reference: '{{ order.reference }}',
             status: {{ order.status }},
+            {% if roles.sales_order.change %}
+            allow_edit: true,
+            {% endif %}
+            {% if order.is_pending %}
+            pending: true,
+            {% endif %}
         }
     );
 
@@ -289,6 +300,8 @@
         {
             order: {{ order.pk }},
             status: {{ order.status }},
+            {% if roles.sales_order.change %}allow_edit: true,{% endif %}
+            {% if order.is_pending %}pending: true,{% endif %}
         }
     );
 

--- a/InvenTree/templates/InvenTree/settings/po.html
+++ b/InvenTree/templates/InvenTree/settings/po.html
@@ -11,6 +11,7 @@
 <table class='table table-striped table-condensed'>
     <tbody>
         {% include "InvenTree/settings/setting.html" with key="PURCHASEORDER_REFERENCE_PATTERN" %}
+        {% include "InvenTree/settings/setting.html" with key="PURCHASEORDER_EDIT_COMPLETED_ORDERS" icon='fa-edit' %}
     </tbody>
 </table>
 {% endblock %}

--- a/InvenTree/templates/InvenTree/settings/so.html
+++ b/InvenTree/templates/InvenTree/settings/so.html
@@ -13,6 +13,7 @@
     <tbody>
         {% include "InvenTree/settings/setting.html" with key="SALESORDER_REFERENCE_PATTERN" %}
         {% include "InvenTree/settings/setting.html" with key="SALESORDER_DEFAULT_SHIPMENT" icon="fa-truck-loading" %}
+        {% include "InvenTree/settings/setting.html" with key="SALESORDER_EDIT_COMPLETED_ORDERS" icon='fa-edit' %}
     </tbody>
 </table>
 

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2084,6 +2084,11 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
     options.params['order'] = options.order;
     options.params['part_detail'] = true;
 
+    // Override 'editing' if order is not pending
+    if (!options.pending && !global_settings.PURCHASEORDER_EDIT_COMPLETED_ORDERS) {
+        options.allow_edit = false;
+    }
+
     var filters = loadTableFilters('purchaseorderlineitem');
 
     for (var key in options.params) {

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2450,6 +2450,10 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
 
     options.table = table;
 
+    if (!options.pending && !global_settings.PURCHASEORDER_EDIT_COMPLETED_ORDERS) {
+        options.allow_edit = false;
+    }
+
     options.params = options.params || {};
 
     if (!options.order) {
@@ -2566,9 +2570,11 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
 
             var pk = row.pk;
 
-            html += makeIconButton('fa-clone', 'button-duplicate', pk, '{% trans "Duplicate line" %}');
-            html += makeIconButton('fa-edit icon-blue', 'button-edit', pk, '{% trans "Edit line" %}');
-            html += makeIconButton('fa-trash-alt icon-red', 'button-delete', pk, '{% trans "Delete line" %}', );
+            if (options.allow_edit) {
+                html += makeIconButton('fa-clone', 'button-duplicate', pk, '{% trans "Duplicate line" %}');
+                html += makeIconButton('fa-edit icon-blue', 'button-edit', pk, '{% trans "Edit line" %}');
+                html += makeIconButton('fa-trash-alt icon-red', 'button-delete', pk, '{% trans "Delete line" %}', );
+            }
 
             html += `</div>`;
 

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -3751,6 +3751,10 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
     options.table = table;
 
+    if (!options.pending && !global_settings.SALESORDER_EDIT_COMPLETED_ORDERS) {
+        options.allow_edit = false;
+    }
+
     options.params = options.params || {};
 
     if (!options.order) {
@@ -3780,7 +3784,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
     setupFilterList('salesorderlineitem', $(table), filter_target);
 
     // Is the order pending?
-    var pending = options.status == {{ SalesOrderStatus.PENDING }};
+    var pending = options.pending;
 
     // Has the order shipped?
     var shipped = options.status == {{ SalesOrderStatus.SHIPPED }};
@@ -4298,6 +4302,10 @@ function loadSalesOrderExtraLineTable(table, options={}) {
 
     options.table = table;
 
+    if (!options.pending && !global_settings.SALESORDER_EDIT_COMPLETED_ORDERS) {
+        options.allow_edit = false;
+    }
+
     options.params = options.params || {};
 
     if (!options.order) {
@@ -4412,14 +4420,14 @@ function loadSalesOrderExtraLineTable(table, options={}) {
 
             var html = `<div class='btn-group float-right' role='group'>`;
 
-            var pk = row.pk;
-
-            html += makeIconButton('fa-clone', 'button-duplicate', pk, '{% trans "Duplicate line" %}');
-            html += makeIconButton('fa-edit icon-blue', 'button-edit', pk, '{% trans "Edit line" %}');
-            html += makeIconButton('fa-trash-alt icon-red', 'button-delete', pk, '{% trans "Delete line" %}', );
+            if (options.allow_edit) {
+                var pk = row.pk;
+                html += makeIconButton('fa-clone', 'button-duplicate', pk, '{% trans "Duplicate line" %}');
+                html += makeIconButton('fa-edit icon-blue', 'button-edit', pk, '{% trans "Edit line" %}');
+                html += makeIconButton('fa-trash-alt icon-red', 'button-delete', pk, '{% trans "Delete line" %}', );
+            }
 
             html += `</div>`;
-
             return html;
         }
     });


### PR DESCRIPTION
Ref: https://github.com/inventree/InvenTree/pull/3888

Prevent editing of "completed" orders unless a specific user configuration option is enabled

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3902"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

