### PR TITLE
Adds a report template tag for dict access

### DIFF
--- a/InvenTree/report/templatetags/report.py
+++ b/InvenTree/report/templatetags/report.py
@@ -19,6 +19,20 @@ logger = logging.getLogger('inventree')
 
 
 @register.simple_tag()
+def getkey(value: dict, arg):
+    """Perform key lookup in the provided dict object.
+
+    This function is provided to get around template rendering limitations.
+    Ref: https://stackoverflow.com/questions/1906129/dict-keys-with-spaces-in-django-templates
+
+    Arguments:
+        value: A python dict object
+        arg: The 'key' to be found within the dict
+    """
+    return value[arg]
+
+
+@register.simple_tag()
 def asset(filename):
     """Return fully-qualified path for an upload report asset file.
 

--- a/InvenTree/report/tests.py
+++ b/InvenTree/report/tests.py
@@ -29,6 +29,19 @@ class ReportTagTest(TestCase):
         """Enable or disable debug mode for reports"""
         InvenTreeSetting.set_setting('REPORT_DEBUG_MODE', value, change_user=None)
 
+    def test_getkey(self):
+        """Tests for the 'getkey' template tag"""
+
+        data = {
+            'hello': 'world',
+            'foo': 'bar',
+            'with spaces': 'withoutspaces',
+            1: 2,
+        }
+
+        for k, v in data.items():
+            self.assertEqual(report_tags.getkey(data, k), v)
+
     def test_asset(self):
         """Tests for asset files"""
 


### PR DESCRIPTION
(cherry picked from commit 7df2f0f878e312a6f94a2c24304643cde91012de)

Fixes https://github.com/inventree/InvenTree/issues/3891

Provides a template tag which can be used for dict lookup in a template

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3905"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

