### PR TITLE
Add 'barcode_hash' data to more API serializers:

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,15 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 79
+INVENTREE_API_VERSION = 80
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v80 -> 2022-11-07 : https://github.com/inventree/InvenTree/pull/3906
+    - Adds 'barcode_hash' to Part API serializer
+    - Adds 'barcode_hash' to StockLocation API serializer
+    - Adds 'barcode_hash' to SupplierPart API serializer
 
 v79 -> 2022-11-03 : https://github.com/inventree/InvenTree/pull/3895
     - Add metadata to Company

--- a/InvenTree/company/serializers.py
+++ b/InvenTree/company/serializers.py
@@ -308,6 +308,7 @@ class SupplierPartSerializer(InvenTreeModelSerializer):
 
         read_only_fields = [
             'availability_updated',
+            'barcode_hash',
         ]
 
     @staticmethod

--- a/InvenTree/company/serializers.py
+++ b/InvenTree/company/serializers.py
@@ -294,6 +294,7 @@ class SupplierPartSerializer(InvenTreeModelSerializer):
             'MPN',
             'note',
             'pk',
+            'barcode_hash',
             'packaging',
             'pack_size',
             'part',

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -285,6 +285,7 @@ class PartBriefSerializer(InvenTreeModelSerializer):
         fields = [
             'pk',
             'IPN',
+            'barcode_hash',
             'default_location',
             'name',
             'revision',
@@ -430,6 +431,7 @@ class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
             'allocated_to_build_orders',
             'allocated_to_sales_orders',
             'assembly',
+            'barcode_hash',
             'category',
             'category_detail',
             'component',

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -302,6 +302,10 @@ class PartBriefSerializer(InvenTreeModelSerializer):
             'units',
         ]
 
+        read_only_fields = [
+            'barcode_hash',
+        ]
+
 
 class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
     """Serializer for complete detail information of a part.
@@ -468,6 +472,10 @@ class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
             'variant_of',
             'virtual',
         ]
+
+    read_only_fields = [
+        'barcode_hash',
+    ]
 
     def save(self):
         """Save the Part instance"""

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -473,9 +473,9 @@ class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
             'virtual',
         ]
 
-    read_only_fields = [
-        'barcode_hash',
-    ]
+        read_only_fields = [
+            'barcode_hash',
+        ]
 
     def save(self):
         """Save the Part instance"""

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -602,6 +602,7 @@ class LocationSerializer(InvenTree.serializers.InvenTreeModelSerializer):
         model = StockLocation
         fields = [
             'pk',
+            'barcode_hash',
             'url',
             'name',
             'level',

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -65,6 +65,10 @@ class StockItemSerializerBrief(InvenTree.serializers.InvenTreeModelSerializer):
             'barcode_hash',
         ]
 
+        read_only_fields = [
+            'barcode_hash',
+        ]
+
     def validate_serial(self, value):
         """Make sure serial is not to big."""
         if abs(extract_int(value)) > 0x7fffffff:
@@ -258,6 +262,7 @@ class StockItemSerializer(InvenTree.serializers.InvenTreeModelSerializer):
         """
         read_only_fields = [
             'allocated',
+            'barcode_hash',
             'stocktake_date',
             'stocktake_user',
             'updated',
@@ -612,6 +617,10 @@ class LocationSerializer(InvenTree.serializers.InvenTreeModelSerializer):
             'items',
             'owner',
             'icon',
+        ]
+
+        read_only_fields = [
+            'barcode_hash',
         ]
 
 


### PR DESCRIPTION
Adds 'barcode_hash' data to API, so that external applications can determine which items have custom barcode data assigned.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3906"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

