### PR TITLE
Bug fix for PurchaseOrder template

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -381,6 +381,11 @@ class PurchaseOrder(Order):
             trigger_event('purchaseorder.completed', id=self.pk)
 
     @property
+    def is_pending(self):
+        """Return True if the PurchaseOrder is 'pending'"""
+        return self.status == PurchaseOrderStatus.PENDING
+
+    @property
     def is_overdue(self):
         """Returns True if this PurchaseOrder is "overdue".
 

--- a/InvenTree/order/templates/order/order_base.html
+++ b/InvenTree/order/templates/order/order_base.html
@@ -58,8 +58,8 @@
     </ul>
 </div>
 {% if order.status == PurchaseOrderStatus.PENDING %}
-<button type='button' class='btn btn-outline-secondary' id='place-order' title='{% trans "Place order" %}'>
-    <span class='fas fa-paper-plane icon-blue'></span>
+<button type='button' class='btn btn-primary' id='place-order' title='{% trans "Submit Order" %}'>
+    <span class='fas fa-paper-plane'></span> {% trans "Submit Order" %}
 </button>
 {% elif order.status == PurchaseOrderStatus.PLACED %}
 <button type='button' class='btn btn-primary' id='receive-order' title='{% trans "Receive items" %}'>


### PR DESCRIPTION
Fixes bug introduced in https://github.com/inventree/InvenTree/pull/3902

The various "add line item" buttons were not being displayed.

- PurchaseOrder.is_pending method did not exist
- Thus was evaluating to "false" in the template

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3913"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

