### PR TITLE
Fixes for background worker process

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -564,12 +564,16 @@ else:
 # django-q background worker configuration
 Q_CLUSTER = {
     'name': 'InvenTree',
+    'label': 'Background Tasks',
     'workers': int(get_setting('INVENTREE_BACKGROUND_WORKERS', 'background.workers', 4)),
     'timeout': int(get_setting('INVENTREE_BACKGROUND_TIMEOUT', 'background.timeout', 90)),
     'retry': 120,
+    'max_attempts': 5,
     'queue_limit': 50,
+    'catch_up': False,
     'bulk': 10,
     'orm': 'default',
+    'cache': 'default',
     'sync': False,
 }
 

--- a/InvenTree/InvenTree/status.py
+++ b/InvenTree/InvenTree/status.py
@@ -26,15 +26,14 @@ def is_worker_running(**kwargs):
 
     """
     Sometimes Stat.get_all() returns [].
-    In this case we have the 'heartbeat' task running every 15 minutes.
-    Check to see if we have a result within the last 20 minutes
+    In this case we have the 'heartbeat' task running every 5 minutes.
+    Check to see if we have any successful result within the last 10 minutes
     """
 
     now = timezone.now()
-    past = now - timedelta(minutes=20)
+    past = now - timedelta(minutes=10)
 
     results = Success.objects.filter(
-        func='InvenTree.tasks.heartbeat',
         started__gte=past
     )
 

--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -200,7 +200,7 @@ def scheduled_task(interval: str, minutes: int = None, tasklist: TaskRegister = 
     return _task_wrapper
 
 
-@scheduled_task(ScheduledTask.MINUTES, 15)
+@scheduled_task(ScheduledTask.MINUTES, 5)
 def heartbeat():
     """Simple task which runs at 5 minute intervals, so we can determine that the background worker is actually running.
 


### PR DESCRIPTION
- To determine if worker is running, look for *any* successful task, not just heartbeat
- Heartbeat rate increased to 5 minute intervals
- Small adjustments to django_q settings

Closes https://github.com/inventree/InvenTree/issues/3921

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3922"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

