### PR TITLE
Add setting to determine if supplier price breaks are used in pricing

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1093,6 +1093,13 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             ]
         },
 
+        'PRICING_USE_SUPPLIER_PRICING': {
+            'name': _('Use Supplier Pricing'),
+            'description': _('Include supplier price breaks in overall pricing calculations'),
+            'default': True,
+            'validator': bool,
+        },
+
         'PRICING_UPDATE_DAYS': {
             'name': _('Pricing Rebuild Time'),
             'description': _('Number of days before part pricing is automatically updated'),

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2575,14 +2575,26 @@ class PartPricing(models.Model):
         overall_min = None
         overall_max = None
 
-        # Calculate overall minimum cost
-        for cost in [
+        min_costs = [
             self.bom_cost_min,
             self.purchase_cost_min,
             self.internal_cost_min,
-            self.supplier_price_min,
-            self.variant_cost_min,
-        ]:
+            self.variant_cost_min
+        ]
+
+        max_costs = [
+            self.bom_cost_max,
+            self.purchase_cost_max,
+            self.internal_cost_max,
+            self.variant_cost_max
+        ]
+
+        if InvenTreeSetting.get_setting('PRICING_USE_SUPPLIER_PRICING', True):
+            min_costs.append(self.supplier_price_min)
+            max_costs.append(self.supplier_price_max)
+
+        # Calculate overall minimum cost
+        for cost in min_costs:
             if cost is None:
                 continue
 
@@ -2593,13 +2605,7 @@ class PartPricing(models.Model):
                 overall_min = cost
 
         # Calculate overall maximum cost
-        for cost in [
-            self.bom_cost_max,
-            self.purchase_cost_max,
-            self.internal_cost_max,
-            self.supplier_price_max,
-            self.variant_cost_max,
-        ]:
+        for cost in max_costs:
             if cost is None:
                 continue
 

--- a/InvenTree/templates/InvenTree/settings/pricing.html
+++ b/InvenTree/templates/InvenTree/settings/pricing.html
@@ -15,6 +15,7 @@
             {% include "InvenTree/settings/setting.html" with key="PART_BOM_USE_INTERNAL_PRICE" %}
             {% include "InvenTree/settings/setting.html" with key="PRICING_DECIMAL_PLACES" %}
             {% include "InvenTree/settings/setting.html" with key="PRICING_UPDATE_DAYS" icon='fa-calendar-alt' %}
+            {% include "InvenTree/settings/setting.html" with key="PRICING_USE_SUPPLIER_PRICING" icon='fa-check-circle' %}
         </tbody>
     </table>
 </div>


### PR DESCRIPTION
Allow user to enable / disable inclusion of supplier price breaks in overall pricing calculations

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3943"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

