### PR TITLE
Remove DO for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ There are several options to deploy InvenTree.
 <div align="center"><h4>
     <a href="https://inventree.readthedocs.io/en/latest/start/docker/">Docker</a>
     <span> · </span>
-    <a href="https://marketplace.digitalocean.com/apps/inventree?refcode=d6172576d014"><img src="https://www.deploytodo.com/do-btn-blue-ghost.svg" alt="Deploy to DO" width="auto" height="40" /></a>
-    <span> · </span>
     <a href="https://inventree.readthedocs.io/en/latest/start/install/">Bare Metal</a>
 </h4></div>
 


### PR DESCRIPTION
Until we release there will not be a DO package, the old install method is a PITA to package securely so removing it from the readme for now to remove confusion.

Closes #3956

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3957"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

