### PR TITLE
Extend installer issue option

### DIFF
--- a/.github/ISSUE_TEMPLATE/install.yaml
+++ b/.github/ISSUE_TEMPLATE/install.yaml
@@ -4,6 +4,8 @@ labels: ["question", "triage:not-checked", "setup"]
 body:
   - type: checkboxes
     id: deployment
+    validations:
+      required: true
     attributes:
       label: "Deployment Method"
       options:

--- a/.github/ISSUE_TEMPLATE/install.yaml
+++ b/.github/ISSUE_TEMPLATE/install.yaml
@@ -12,6 +12,8 @@ body:
         - label: "Docker Production"
         - label: "Bare metal Development"
         - label: "Bare metal Production"
+        - label: "Digital Ocean image"
+        - label: "Other (please provide a link `Steps to Reproduce`"
   - type: textarea
     id: description
     validations:


### PR DESCRIPTION
This adds 2 more installer selection options to better represent the options in issues.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3961"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

