### PR TITLE
Fix typing

### DIFF
--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -6,7 +6,7 @@ import re
 import warnings
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Callable
+from typing import Callable, List
 
 from django.conf import settings
 from django.core import mail as django_mail
@@ -153,7 +153,7 @@ class ScheduledTask:
 
 class TaskRegister:
     """Registery for periodicall tasks."""
-    task_list: list[ScheduledTask] = []
+    task_list: List[ScheduledTask] = []
 
     def register(self, task, schedule, minutes: int = None):
         """Register a task with the que."""


### PR DESCRIPTION
This PR adds a small typing fix that makes installs with python 3.8 easier

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3966"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

