### PR TITLE
Supplier pricing override

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1105,6 +1105,13 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'validator': bool,
         },
 
+        'PRICING_PURCHASE_HISTORY_OVERRIDES_SUPPLIER': {
+            'name': _('Purchase History Override'),
+            'description': _('Historical purchase order pricing overrides supplier price breaks'),
+            'default': False,
+            'validator': bool,
+        },
+
         'PRICING_USE_VARIANT_PRICING': {
             'name': _('Use Variant Pricing'),
             'description': _('Include variant pricing in overall pricing calculations'),

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2620,9 +2620,9 @@ class PartPricing(models.Model):
             self.internal_cost_max,
         ]
 
-        purchase_history_override = InvenTreeSetting.get_setting('PRICING_PURCHASE_HISTORY_OVERRIDES_SUPPLIER', False)
+        purchase_history_override = InvenTreeSetting.get_setting('PRICING_PURCHASE_HISTORY_OVERRIDES_SUPPLIER', False, cache=False)
 
-        if InvenTreeSetting.get_setting('PRICING_USE_SUPPLIER_PRICING', True):
+        if InvenTreeSetting.get_setting('PRICING_USE_SUPPLIER_PRICING', True, cache=False):
             # Add supplier pricing data, *unless* historical pricing information should override
             if self.purchase_cost_min is None or not purchase_history_override:
                 min_costs.append(self.supplier_price_min)
@@ -2630,7 +2630,7 @@ class PartPricing(models.Model):
             if self.purchase_cost_max is None or not purchase_history_override:
                 max_costs.append(self.supplier_price_max)
 
-        if InvenTreeSetting.get_setting('PRICING_USE_VARIANT_PRICING', True):
+        if InvenTreeSetting.get_setting('PRICING_USE_VARIANT_PRICING', True, cache=False):
             min_costs.append(self.variant_cost_min)
             max_costs.append(self.variant_cost_max)
 

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2620,9 +2620,15 @@ class PartPricing(models.Model):
             self.internal_cost_max,
         ]
 
+        purchase_history_override = InvenTreeSetting.get_setting('PRICING_PURCHASE_HISTORY_OVERRIDES_SUPPLIER', False)
+
         if InvenTreeSetting.get_setting('PRICING_USE_SUPPLIER_PRICING', True):
-            min_costs.append(self.supplier_price_min)
-            max_costs.append(self.supplier_price_max)
+            # Add supplier pricing data, *unless* historical pricing information should override
+            if self.purchase_cost_min is None or not purchase_history_override:
+                min_costs.append(self.supplier_price_min)
+
+            if self.purchase_cost_max is None or not purchase_history_override:
+                max_costs.append(self.supplier_price_max)
 
         if InvenTreeSetting.get_setting('PRICING_USE_VARIANT_PRICING', True):
             min_costs.append(self.variant_cost_min)

--- a/InvenTree/templates/InvenTree/settings/pricing.html
+++ b/InvenTree/templates/InvenTree/settings/pricing.html
@@ -16,6 +16,7 @@
             {% include "InvenTree/settings/setting.html" with key="PRICING_DECIMAL_PLACES" %}
             {% include "InvenTree/settings/setting.html" with key="PRICING_UPDATE_DAYS" icon='fa-calendar-alt' %}
             {% include "InvenTree/settings/setting.html" with key="PRICING_USE_SUPPLIER_PRICING" icon='fa-check-circle' %}
+            {% include "InvenTree/settings/setting.html" with key="PRICING_PURCHASE_HISTORY_OVERRIDES_SUPPLIER" icon='fa-shopping-cart' %}
             {% include "InvenTree/settings/setting.html" with key="PRICING_USE_VARIANT_PRICING" icon='fa-check-circle' %}
             {% include "InvenTree/settings/setting.html" with key="PRICING_ACTIVE_VARIANTS" %}
 


### PR DESCRIPTION
Adds setting to optionally override supplier price breaks if historical pricing is available

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3988"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

