### PR TITLE
Added config setting for logout redirect url

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -584,7 +584,7 @@ if cache_host:  # pragma: no cover
 
 # database user sessions
 SESSION_ENGINE = 'user_sessions.backends.db'
-LOGOUT_REDIRECT_URL = 'index'
+LOGOUT_REDIRECT_URL = get_setting('INVENTREE_LOGOUT_REDIRECT_URL', 'logout_redirect_url', 'index')
 SILENCED_SYSTEM_CHECKS = [
     'admin.E410',
 ]

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -171,6 +171,12 @@ login_default_protocol: http
 remote_login_enabled: False
 remote_login_header: HTTP_REMOTE_USER
 
+# Logout redirect configuration
+# This setting may be required if using remote / proxy login to redirect requests
+# during the logout process (default is 'index'). Please read the docs for more details
+# https://docs.djangoproject.com/en/stable/ref/settings/#logout-redirect-url
+#logout_redirect_url: 'index'
+
 # Permit custom authentication backends
 #authentication_backends:
 #  - 'django.contrib.auth.backends.ModelBackend'


### PR DESCRIPTION
This PR adds the ability to modify the LOGOUT_REDIRECT_URL setting using `INVENTREE_LOGOUT_REDIRECT_URL` and the `config.yaml` file.

Fixes #3994

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/3995"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

