### PR TITLE
Fix for stable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+# Runs on releases
+
+name: Publish release notes
+on:
+  release:
+    types: [ published ]
+
+jobs:
+
+  stable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - name: Version Check
+        run: |
+          pip install requests
+          python3 ci/version_check.py
+      - name: Push to Stable Branch
+        uses: ad-m/github-push-action@4dcce6dea3e3c8187237fc86b7dfdc93e5aaae58 # pin@master
+        if: env.stable_release == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: stable
+          force: true

--- a/.github/workflows/social.yml.disabled
+++ b/.github/workflows/social.yml.disabled
@@ -7,23 +7,6 @@ on:
 
 jobs:
 
-  stable:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - name: Version Check
-        run: |
-          pip install requests
-          python3 ci/version_check.py
-      - name: Push to Stable Branch
-        uses: ad-m/github-push-action@4dcce6dea3e3c8187237fc86b7dfdc93e5aaae58 # pin@master
-        if: env.stable_release == 'true'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: stable
-          force: true
-
   tweet:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Was disabled, as it was bundled in with the social media workflows
- Splits out into separate workflow

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4006"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

