### PR TITLE
Fix for plugin setting not working:

### DIFF
--- a/InvenTree/plugin/api.py
+++ b/InvenTree/plugin/api.py
@@ -1,6 +1,5 @@
-"""JSON API for the plugin app."""
+"""API for the plugin app."""
 
-from django.conf import settings
 from django.urls import include, re_path
 
 from django_filters.rest_framework import DjangoFilterBackend
@@ -238,7 +237,6 @@ general_plugin_api_urls = [
     re_path(r'^.*$', PluginList.as_view(), name='api-plugin-list'),
 ]
 
-if settings.PLUGINS_ENABLED:
-    plugin_api_urls.append(
-        re_path(r'^plugin/', include(general_plugin_api_urls))
-    )
+plugin_api_urls.append(
+    re_path(r'^plugin/', include(general_plugin_api_urls))
+)


### PR DESCRIPTION
Now that "builtin" plugins are always enabled, we need to be able to access the plugin API to configure settings for these plugins - even if plugin support is disabled for the instance.

Fixes https://github.com/inventree/InvenTree/issues/4026

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4032"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

