### PR TITLE
gunicorn: revert support for gevent

### DIFF
--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -12,7 +12,8 @@ loglevel = os.environ.get('INVENTREE_LOG_LEVEL', 'warning').lower()
 capture_output = True
 
 # Worker configuration
-worker_class = 'gevent'  # Allow multi-threading support
+#  TODO: Implement support for gevent
+# worker_class = 'gevent'  # Allow multi-threading support
 worker_tmp_dir = '/dev/shm'  # Write temp file to RAM (faster)
 threads = 4
 

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -14,4 +14,3 @@ mariadb>=1.0.7,<1.1.0
 
 # gunicorn web server
 gunicorn>=20.1.0
-gevent>=22.10.2


### PR DESCRIPTION
- For some reason this causes production docker image to fail to build
- but only in GitHub CI ??

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4035"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

