### PR TITLE
update INVENTREE_LOG_LEVEL param

### DIFF
--- a/docker.dev.env
+++ b/docker.dev.env
@@ -3,7 +3,7 @@
 
 # Set DEBUG to True for a development setup
 INVENTREE_DEBUG=True
-INVENTREE_DEBUG_LEVEL=INFO
+INVENTREE_LOG_LEVEL=INFO
 
 # Database configuration options
 # Note: The example setup is for a PostgreSQL database (change as required)


### PR DESCRIPTION
Turn INVENTREE_DEBUG_LEVEL => INVENTREE_LOG_LEVEL into docker.dev.env

Don't know whether it's a typo or not. I haven't found reference of INVENTREE_DEBUG_LEVEL  param, and I wasn't able to change log level from .env. 



<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4058"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

