### PR TITLE
Load plugins for collectstatic

### DIFF
--- a/InvenTree/InvenTree/ready.py
+++ b/InvenTree/InvenTree/ready.py
@@ -32,7 +32,6 @@ def canAppAccessDatabase(allow_test: bool = False, allow_plugins: bool = False):
         'prerender',
         'rebuild_models',
         'rebuild_thumbnails',
-        'collectstatic',
         'makemessages',
         'compilemessages',
         'backup',
@@ -51,6 +50,7 @@ def canAppAccessDatabase(allow_test: bool = False, allow_plugins: bool = False):
         excluded_commands.extend([
             'makemigrations',
             'migrate',
+            'collectstatic',
         ])
 
     for cmd in excluded_commands:


### PR DESCRIPTION
Hello,

this PR changes the loading mechanism of the plugins so that they are loaded if they are activated and `collectstatic` is executed. Otherwise plugins are not able to expose static files. This was already added for database migrations in #3762 .

Ref: #4020 


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4077"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

