### PR TITLE
Enable rendering of table in Notes markdown into reports

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -789,7 +789,9 @@ MARKDOWNIFY = {
             'src',
             'alt',
         ],
-        'MARKDOWN_EXTENSIONS' : ['markdown.extensions.extra', ],
+        'MARKDOWN_EXTENSIONS': [
+            'markdown.extensions.extra'
+        ],
         'WHITELIST_TAGS': [
             'a',
             'abbr',

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -789,6 +789,7 @@ MARKDOWNIFY = {
             'src',
             'alt',
         ],
+        'MARKDOWN_EXTENSIONS' : ['markdown.extensions.extra', ],
         'WHITELIST_TAGS': [
             'a',
             'abbr',
@@ -802,7 +803,13 @@ MARKDOWNIFY = {
             'ol',
             'p',
             'strong',
-            'ul'
+            'ul',
+            'table',
+            'thead',
+            'tbody',
+            'th',
+            'tr',
+            'td'
         ],
     }
 }


### PR DESCRIPTION
This will allow to render tables in markdown language in the Notes field of build orders correctly into build order reports. Please have a look.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4081"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

