### PR TITLE
List PO/SO/BO by reference in API

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -7,6 +7,9 @@ INVENTREE_API_VERSION = 84
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
 
+v84 -> 2022-12-21: https://github.com/inventree/InvenTree/pull/4083
+    - Add support for listing PO, BO, SO by their reference
+
 v83 -> 2022-11-19 : https://github.com/inventree/InvenTree/pull/3949
     - Add support for structural Stock locations
 

--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,7 +2,7 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 83
+INVENTREE_API_VERSION = 84
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about

--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -65,6 +65,13 @@ class BuildFilter(rest_filters.FilterSet):
 
         return queryset
 
+    # Exact match for reference
+    reference = rest_filters.CharFilter(
+        label='Filter by exact reference',
+        field_name='reference',
+        lookup_expr="iexact"
+    )
+
 
 class BuildList(APIDownloadMixin, ListCreateAPI):
     """API endpoint for accessing a list of Build objects.

--- a/InvenTree/build/test_api.py
+++ b/InvenTree/build/test_api.py
@@ -63,6 +63,14 @@ class TestBuildAPI(InvenTreeAPITestCase):
         response = self.client.get(url, {'part': 99999}, format='json')
         self.assertEqual(len(response.data), 0)
 
+        # Get a certain reference
+        response = self.client.get(url, {'reference': 'BO-0001'}, format='json')
+        self.assertEqual(len(response.data), 1)
+
+        # Get a certain reference
+        response = self.client.get(url, {'reference': 'BO-9999XX'}, format='json')
+        self.assertEqual(len(response.data), 0)
+
     def test_get_build_item_list(self):
         """Test that we can retrieve list of BuildItem objects."""
         url = reverse('api-build-item-list')

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1372,7 +1372,7 @@ class InvenTreeSetting(BaseInvenTreeSetting):
         'PLUGIN_ON_STARTUP': {
             'name': _('Check plugins on startup'),
             'description': _('Check that all plugins are installed on startup - enable in container environments'),
-            'default': os.getenv('INVENTREE_DOCKER', False),
+            'default': str(os.getenv('INVENTREE_DOCKER', False)).lower() in ['1', 'true'],
             'validator': bool,
             'requires_restart': True,
         },

--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -78,8 +78,15 @@ class GeneralExtraLineList:
     ]
 
 
-class PurchaseOrderFilter(rest_filters.FilterSet):
-    """Custom API filters for the PurchaseOrderList endpoint."""
+class OrderFilter(rest_filters.FilterSet):
+    """Base class for custom API filters for the OrderList endpoint."""
+
+    # Exact match for reference
+    reference = rest_filters.CharFilter(
+        label='Filter by exact reference',
+        field_name='reference',
+        lookup_expr="iexact"
+    )
 
     assigned_to_me = rest_filters.BooleanFilter(label='assigned_to_me', method='filter_assigned_to_me')
 
@@ -97,12 +104,26 @@ class PurchaseOrderFilter(rest_filters.FilterSet):
 
         return queryset
 
+
+class PurchaseOrderFilter(OrderFilter):
+    """Custom API filters for the PurchaseOrderList endpoint."""
     class Meta:
         """Metaclass options."""
 
         model = models.PurchaseOrder
         fields = [
             'supplier',
+        ]
+
+
+class SalesOrderFilter(OrderFilter):
+    """Custom API filters for the SalesOrderList endpoint."""
+    class Meta:
+        """Metaclass options."""
+
+        model = models.SalesOrder
+        fields = [
+            'customer',
         ]
 
 
@@ -613,6 +634,7 @@ class SalesOrderList(APIDownloadMixin, ListCreateAPI):
 
     queryset = models.SalesOrder.objects.all()
     serializer_class = serializers.SalesOrderSerializer
+    filterset_class = SalesOrderFilter
 
     def create(self, request, *args, **kwargs):
         """Save user information on create."""

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -68,6 +68,14 @@ class PurchaseOrderTest(OrderTest):
         self.filter({'status': 10}, 3)
         self.filter({'status': 40}, 1)
 
+        # Filter by "reference"
+        self.filter({'reference': 'PO-0001'}, 1)
+        self.filter({'reference': 'PO-9999'}, 0)
+
+        # Filter by "assigned_to_me"
+        self.filter({'assigned_to_me': 1}, 0)
+        self.filter({'assigned_to_me': 0}, 7)
+
     def test_overdue(self):
         """Test "overdue" status."""
         self.filter({'overdue': True}, 0)
@@ -827,6 +835,14 @@ class SalesOrderTest(OrderTest):
         self.filter({'status': 10}, 3)  # PENDING
         self.filter({'status': 20}, 1)  # SHIPPED
         self.filter({'status': 99}, 0)  # Invalid
+
+        # Filter by "reference"
+        self.filter({'reference': 'ABC123'}, 1)
+        self.filter({'reference': 'XXX999'}, 0)
+
+        # Filter by "assigned_to_me"
+        self.filter({'assigned_to_me': 1}, 0)
+        self.filter({'assigned_to_me': 0}, 5)
 
     def test_overdue(self):
         """Test "overdue" status."""


### PR DESCRIPTION
Fixes #3671:

Allows searching for a single PO/BO/SO in the API using a link such as:
```
https://demo.inventree.org/api/order/po/?reference=PO0006
https://demo.inventree.org/api/order/so/?reference=SO0001
https://demo.inventree.org/api/build/?reference=BO0001
```

Also adds a filter for customer to SO list:
```
https://demo.inventree.org/api/order/so/?customer=32
```

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4083"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

