### PR TITLE
Add more tests for order API

### DIFF
--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -401,6 +401,27 @@ class PurchaseOrderTest(OrderTest):
         self.assertEqual(order.get_metadata('yam'), 'yum')
 
 
+class PurchaseOrderLineTest(OrderTest):
+    """Unit tests for PurchaseOrderLineItems."""
+
+    def test_po_line_list(self):
+        """Test the PurchaseOrderLine list API endpoint"""
+        # List *ALL* PurchaseOrderLine items
+        self.filter({}, 7)
+
+        # Filter by pending status
+        self.filter({'pending': 1}, 0)
+        self.filter({'pending': 0}, 0)
+
+        # Filter by received status
+        self.filter({'received': 1}, 0)
+        self.filter({'received': 0}, 0)
+
+        # Filter by has_pricing status
+        self.filter({'has_pricing': 1}, 0)
+        self.filter({'has_pricing': 0}, 0)
+
+
 class PurchaseOrderDownloadTest(OrderTest):
     """Unit tests for downloading PurchaseOrder data via the API endpoint."""
 

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -398,7 +398,7 @@ class PurchaseOrderTest(OrderTest):
         self.assertEqual(order.get_metadata('yam'), 'yum')
 
 
-class PurchaseOrderLineTest(OrderTest):
+class PurchaseOrderLineItemTest(OrderTest):
     """Unit tests for PurchaseOrderLineItems."""
 
     LIST_URL = reverse('api-po-line-list')

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -68,6 +68,18 @@ class PurchaseOrderTest(OrderTest):
         self.filter({'status': 10}, 3)
         self.filter({'status': 40}, 1)
 
+        # Filter by "part"
+        self.filter({'part': 1}, 2)
+        self.filter({'part': 2}, 0)  # Part not assigned to any PO
+        self.assertRaises(ValueError):
+            self.filter({'part': 9999}, 0)  # Non-existant part
+
+        # Filter by "supplier_part"
+        self.filter({'supplier_part': 1}, 2)
+        self.filter({'supplier_part': 2}, 0)  # Part not assigned to any PO
+        self.assertRaises(ValueError):
+            self.filter({'part': 9999}, 0)  # Non-existant part
+        
     def test_overdue(self):
         """Test "overdue" status."""
         self.filter({'overdue': True}, 0)

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -409,16 +409,16 @@ class PurchaseOrderLineTest(OrderTest):
         self.filter({}, 5)
 
         # Filter by pending status
-        self.filter({'pending': 1}, 0)
+        self.filter({'pending': 1}, 5)
         self.filter({'pending': 0}, 0)
 
         # Filter by received status
         self.filter({'received': 1}, 0)
-        self.filter({'received': 0}, 0)
+        self.filter({'received': 0}, 5)
 
         # Filter by has_pricing status
         self.filter({'has_pricing': 1}, 0)
-        self.filter({'has_pricing': 0}, 0)
+        self.filter({'has_pricing': 0}, 5)
 
 
 class PurchaseOrderDownloadTest(OrderTest):

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -74,7 +74,8 @@ class PurchaseOrderTest(OrderTest):
 
         # Filter by "supplier_part"
         self.filter({'supplier_part': 1}, 1)
-        self.filter({'supplier_part': 2}, 0)  # Part not assigned to any PO
+        self.filter({'supplier_part': 3}, 2)
+        self.filter({'supplier_part': 4}, 0)
 
     def test_overdue(self):
         """Test "overdue" status."""
@@ -405,7 +406,7 @@ class PurchaseOrderLineTest(OrderTest):
     def test_po_line_list(self):
         """Test the PurchaseOrderLine list API endpoint"""
         # List *ALL* PurchaseOrderLine items
-        self.filter({}, 7)
+        self.filter({}, 5)
 
         # Filter by pending status
         self.filter({'pending': 1}, 0)

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -1061,6 +1061,8 @@ class SalesOrderTest(OrderTest):
 class SalesOrderLineItemTest(OrderTest):
     """Tests for the SalesOrderLineItem API."""
 
+    LIST_URL = reverse('api-so-line-list')
+
     def setUp(self):
         """Init routine for this unit test class"""
         super().setUp()
@@ -1132,6 +1134,14 @@ class SalesOrderLineItemTest(OrderTest):
             )
 
             self.assertEqual(response.data['count'], n_parts)
+
+        # Filter by has_pricing status
+        self.filter({'has_pricing': 1}, 0)
+        self.filter({'has_pricing': 0}, 25)
+
+        # Filter by has_pricing status
+        self.filter({'completed': 1}, 0)
+        self.filter({'completed': 0}, 25)
 
 
 class SalesOrderDownloadTest(OrderTest):

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -247,6 +247,20 @@ class PurchaseOrderTest(OrderTest):
         del data['pk']
         del data['reference']
 
+        # Duplicate with non-existent PK to provoke error
+        data['duplicate_order'] = 10000001
+        data['duplicate_line_items'] = True
+        data['duplicate_extra_lines'] = False
+
+        data['reference'] = 'PO-9999'
+
+        # Duplicate via the API
+        response = self.post(
+            reverse('api-po-list'),
+            data,
+            expected_code=400
+        )
+
         data['duplicate_order'] = 1
         data['duplicate_line_items'] = True
         data['duplicate_extra_lines'] = False

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -56,6 +56,10 @@ class PurchaseOrderTest(OrderTest):
         # List *ALL* PurchaseOrder items
         self.filter({}, 7)
 
+        # Filter by assigned-to-me
+        self.filter({'assigned_to_me': 1}, 0)
+        self.filter({'assigned_to_me': 0}, 7)
+
         # Filter by supplier
         self.filter({'supplier': 1}, 1)
         self.filter({'supplier': 3}, 5)

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -71,13 +71,13 @@ class PurchaseOrderTest(OrderTest):
         # Filter by "part"
         self.filter({'part': 1}, 2)
         self.filter({'part': 2}, 0)  # Part not assigned to any PO
-        self.assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             self.filter({'part': 9999}, 0)  # Non-existant part
 
         # Filter by "supplier_part"
         self.filter({'supplier_part': 1}, 2)
         self.filter({'supplier_part': 2}, 0)  # Part not assigned to any PO
-        self.assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             self.filter({'part': 9999}, 0)  # Non-existant part
         
     def test_overdue(self):

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -1137,11 +1137,11 @@ class SalesOrderLineItemTest(OrderTest):
 
         # Filter by has_pricing status
         self.filter({'has_pricing': 1}, 0)
-        self.filter({'has_pricing': 0}, 25)
+        self.filter({'has_pricing': 0}, n)
 
         # Filter by has_pricing status
         self.filter({'completed': 1}, 0)
-        self.filter({'completed': 0}, 25)
+        self.filter({'completed': 0}, n)
 
 
 class SalesOrderDownloadTest(OrderTest):

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -71,15 +71,11 @@ class PurchaseOrderTest(OrderTest):
         # Filter by "part"
         self.filter({'part': 1}, 2)
         self.filter({'part': 2}, 0)  # Part not assigned to any PO
-        with self.assertRaises(ValueError):
-            self.filter({'part': 9999}, 0)  # Non-existant part
 
         # Filter by "supplier_part"
         self.filter({'supplier_part': 1}, 2)
         self.filter({'supplier_part': 2}, 0)  # Part not assigned to any PO
-        with self.assertRaises(ValueError):
-            self.filter({'part': 9999}, 0)  # Non-existant part
-        
+
     def test_overdue(self):
         """Test "overdue" status."""
         self.filter({'overdue': True}, 0)

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -73,7 +73,7 @@ class PurchaseOrderTest(OrderTest):
         self.filter({'part': 2}, 0)  # Part not assigned to any PO
 
         # Filter by "supplier_part"
-        self.filter({'supplier_part': 1}, 2)
+        self.filter({'supplier_part': 1}, 1)
         self.filter({'supplier_part': 2}, 0)  # Part not assigned to any PO
 
     def test_overdue(self):
@@ -399,6 +399,8 @@ class PurchaseOrderTest(OrderTest):
 
 class PurchaseOrderLineTest(OrderTest):
     """Unit tests for PurchaseOrderLineItems."""
+
+    LIST_URL = reverse('api-po-line-list')
 
     def test_po_line_list(self):
         """Test the PurchaseOrderLine list API endpoint"""


### PR DESCRIPTION
This adds a few tests to cover lines which are not covered yet according to coveralls.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4088"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

