### PR TITLE
Fix stock location structural check (#4089)

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -148,7 +148,7 @@ class PartCategory(MetadataMixin, InvenTreeTree):
 
         - Ensure that the structural parameter cannot get set if products already assigned to the category
         """
-        if self.pk and self.structural and self.item_count > 0:
+        if self.pk and self.structural and self.partcount(False, False) > 0:
             raise ValidationError(
                 _("You cannot make this part category structural because some parts "
                   "are already assigned to it!"))

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -152,7 +152,7 @@ class StockLocation(InvenTreeBarcodeMixin, MetadataMixin, InvenTreeTree):
 
         - Ensure stock location can't be made structural if stock items already located to them
         """
-        if self.pk and self.structural and self.item_count > 0:
+        if self.pk and self.structural and self.stock_item_count(False) > 0:
             raise ValidationError(
                 _("You cannot make this stock location structural because some stock items "
                   "are already located into it!"))


### PR DESCRIPTION
* Fix stock location structural check

Exclude sub stock location items from preventing that a stock location can be switched to structural.

* Fix structural check on both storage location and parts category

Exclude children of sub- locations/categories in the check to allow this location/category to be structural

(cherry picked from commit 14a2c128a95c79899e4f393a957552824c22a055)

Ref: https://github.com/inventree/InvenTree/pull/4089

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4095"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

