### PR TITLE
Various fixes to the "Download image from URL" functionality

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -151,7 +151,6 @@ def download_image_from_url(remote_url, timeout=2.5):
             timeout=timeout,
             allow_redirects=True,
             stream=True,
-            headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"},
         )
         # Throw an error if anything goes wrong
         response.raise_for_status()

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -151,6 +151,7 @@ def download_image_from_url(remote_url, timeout=2.5):
             timeout=timeout,
             allow_redirects=True,
             stream=True,
+            headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"},
         )
         # Throw an error if anything goes wrong
         response.raise_for_status()

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -145,12 +145,20 @@ def download_image_from_url(remote_url, timeout=2.5):
     # Calculate maximum allowable image size (in bytes)
     max_size = int(InvenTreeSetting.get_setting('INVENTREE_DOWNLOAD_IMAGE_MAX_SIZE')) * 1024 * 1024
 
+    # Add user specified user-agent to request (if specified)
+    user_agent = str(InvenTreeSetting.get_setting('INVENTREE_DOWNLOAD_FROM_URL_USER_AGENT'))
+    if user_agent:
+        headers = {"User-Agent": user_agent}
+    else:
+        headers = None
+
     try:
         response = requests.get(
             remote_url,
             timeout=timeout,
             allow_redirects=True,
             stream=True,
+            headers=headers,
         )
         # Throw an error if anything goes wrong
         response.raise_for_status()

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -146,7 +146,7 @@ def download_image_from_url(remote_url, timeout=2.5):
     max_size = int(InvenTreeSetting.get_setting('INVENTREE_DOWNLOAD_IMAGE_MAX_SIZE')) * 1024 * 1024
 
     # Add user specified user-agent to request (if specified)
-    user_agent = str(InvenTreeSetting.get_setting('INVENTREE_DOWNLOAD_FROM_URL_USER_AGENT'))
+    user_agent = InvenTreeSetting.get_setting('INVENTREE_DOWNLOAD_FROM_URL_USER_AGENT')
     if user_agent:
         headers = {"User-Agent": user_agent}
     else:

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -877,7 +877,7 @@ class InvenTreeSetting(BaseInvenTreeSetting):
 
         'INVENTREE_DOWNLOAD_FROM_URL_USER_AGENT': {
             'name': _('User-agent used to download from URL'),
-            'description': _('Allow to overide the user-agent used to download mages and files from external URL (leave blank for the default)'),
+            'description': _('Allow to override the user-agent used to download mages and files from external URL (leave blank for the default)'),
             'default': '',
         },
 

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -877,7 +877,7 @@ class InvenTreeSetting(BaseInvenTreeSetting):
 
         'INVENTREE_DOWNLOAD_FROM_URL_USER_AGENT': {
             'name': _('User-agent used to download from URL'),
-            'description': _('Allow to override the user-agent used to download mages and files from external URL (leave blank for the default)'),
+            'description': _('Allow to override the user-agent used to download images and files from external URL (leave blank for the default)'),
             'default': '',
         },
 

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -875,6 +875,12 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             ]
         },
 
+        'INVENTREE_DOWNLOAD_FROM_URL_USER_AGENT': {
+            'name': _('User-agent used to download from URL'),
+            'description': _('Allow to overide the user-agent used to download mages and files from external URL (leave blank for the default)'),
+            'default': '',
+        },
+
         'INVENTREE_REQUIRE_CONFIRM': {
             'name': _('Require confirm'),
             'description': _('Require explicit user confirmation for certain action.'),

--- a/InvenTree/company/templates/company/company_base.html
+++ b/InvenTree/company/templates/company/company_base.html
@@ -244,7 +244,7 @@
     });
 
     if (global_settings.INVENTREE_DOWNLOAD_FROM_URL) {
-
+        event.stopPropagation();
         $('#company-image-url').click(function() {
             constructForm(
                 '{% url "api-company-detail" company.pk %}',

--- a/InvenTree/company/templates/company/company_base.html
+++ b/InvenTree/company/templates/company/company_base.html
@@ -58,9 +58,7 @@
             {% if allow_download %}
             <button type='button' class='btn btn-outline-secondary' title="{% trans 'Download image from URL' %}" id='company-image-url'><span class='fas fa-cloud-download-alt'></span></button>
             {% endif %}
-            {% if company.image %}
             <button type='button' class='btn btn-outline-secondary' title='{% trans "Delete image" %}' id='company-image-delete'><span class='fas fa-trash-alt icon-red'></span></button>
-            {% endif %}
         </div>
     </div>
 </div>
@@ -176,6 +174,7 @@
                 showModalImage(data.image);
             });
 
+            $('#company-image-delete').show();
         } else {
             location.reload();
         }
@@ -197,6 +196,9 @@
     $('#company-image').click(function() {
         showModalImage('{{ company.image.url }}');
     });
+    {% else %}
+    $('#company-image-delete').hide();
+    {% endif %}
 
     $('#company-image-delete').click(function(event) {
         event.stopPropagation();
@@ -223,8 +225,6 @@
             }
         );
     });
-
-    {% endif %}
 
     $("#company-image-upload").click(function(event) {
         event.stopPropagation();

--- a/InvenTree/company/templates/company/company_base.html
+++ b/InvenTree/company/templates/company/company_base.html
@@ -244,8 +244,8 @@
     });
 
     if (global_settings.INVENTREE_DOWNLOAD_FROM_URL) {
-        event.stopPropagation();
         $('#company-image-url').click(function() {
+            event.stopPropagation();
             constructForm(
                 '{% url "api-company-detail" company.pk %}',
                 {

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -586,7 +586,7 @@
     {% if roles.part.change %}
 
     if (global_settings.INVENTREE_DOWNLOAD_FROM_URL) {
-
+        event.stopPropagation();
         $("#part-image-url").click(function() {
             constructForm(
                 '{% url "api-part-detail" part.pk %}',
@@ -596,7 +596,9 @@
                     fields: {
                         remote_image: {},
                     },
-                    onSuccess: onSelectImage,
+                    onSuccess: function(data) {
+                        reloadImage(data);
+                    },
                 }
             );
         });

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -586,8 +586,8 @@
     {% if roles.part.change %}
 
     if (global_settings.INVENTREE_DOWNLOAD_FROM_URL) {
-        event.stopPropagation();
         $("#part-image-url").click(function() {
+            event.stopPropagation();
             constructForm(
                 '{% url "api-part-detail" part.pk %}',
                 {

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -391,6 +391,8 @@
     $('#part-thumb').click(function() {
         showModalImage('{{ part.image.url }}');
     });
+    {% else %}
+    $('#part-image-delete').hide();
     {% endif %}
 
     function reloadImage(data) {
@@ -403,6 +405,7 @@
                 showModalImage(data.image);
             });
 
+            $("#part-image-delete").show();
         } else {
             // Otherwise, reload the page
             location.reload();

--- a/InvenTree/part/templates/part/part_thumb.html
+++ b/InvenTree/part/templates/part/part_thumb.html
@@ -13,9 +13,7 @@
             {% if allow_download %}
             <button type='button' class='btn btn-outline-secondary' title="{% trans 'Download image from URL' %}" id='part-image-url'><span class='fas fa-cloud-download-alt'></span></button>
             {% endif %}
-            {% if part.image %}
             <button type='button' class='btn btn-outline-secondary' title='{% trans "Delete image" %}' id='part-image-delete'><span class='fas fa-trash-alt icon-red'></span></button>
-            {% endif %}
         </div>
     </div>
     {% endif %}

--- a/InvenTree/templates/InvenTree/settings/global.html
+++ b/InvenTree/templates/InvenTree/settings/global.html
@@ -21,6 +21,7 @@
         <tr><td colspan='5'></td></tr>
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DOWNLOAD_FROM_URL" icon="fa-cloud-download-alt" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DOWNLOAD_IMAGE_MAX_SIZE" icon="fa-server" %}
+        {% include "InvenTree/settings/setting.html" with key="INVENTREE_DOWNLOAD_FROM_URL_USER_AGENT" icon="fa-server" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_REQUIRE_CONFIRM" icon="fa-check" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_TREE_DEPTH" icon="fa-sitemap" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_BACKUP_ENABLE" icon="fa-hdd" %}


### PR DESCRIPTION
This commit adds an user-agent string to the download request wich prevents some sites from returning a 403 (forbidden) status.
Clicking the download button on the thumbnail, also showed the thumbnail because the event wasn't stopped. The parts thumbnail didn't update after a succesfull download of the image, reloadImage was never called.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4101"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

