### PR TITLE
Change overflow property in order to fix horizontal scrolling (Fix #3569)

### DIFF
--- a/InvenTree/InvenTree/static/css/inventree.css
+++ b/InvenTree/InvenTree/static/css/inventree.css
@@ -18,7 +18,7 @@
 }
 
 main {
-    overflow-x: clip;
+    overflow-x: auto;
 }
 
 .login-screen {


### PR DESCRIPTION
This change seems to fix #3569. I've tried to test it on the browsers available to me (FF, Chrome on Ubuntu; FF, Edge on Windows) but it would be great if someone else could double-check.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4117"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

