### PR TITLE
docker venv fix

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -35,7 +35,7 @@ if [[ -n "$INVENTREE_PY_ENV" ]]; then
         # venv already exists
         echo "Using Python virtual environment: ${INVENTREE_PY_ENV}"
     else
-        # Setup a virtual environment (within the "dev" directory)
+        # Setup a virtual environment (within the "data/env" directory)
         echo "Running first time setup for python environment"
         python3 -m venv ${INVENTREE_PY_ENV} --system-site-packages --upgrade-deps
     fi

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -30,15 +30,18 @@ fi
 # This should be done on the *mounted* filesystem,
 # so that the installed modules persist!
 if [[ -n "$INVENTREE_PY_ENV" ]]; then
-    echo "Using Python virtual environment: ${INVENTREE_PY_ENV}"
-    # Setup a virtual environment (within the "dev" directory)
-    python3 -m venv ${INVENTREE_PY_ENV} --system-site-packages
 
-    # Activate the virtual environment
+    if test -d "$INVENTREE_PY_ENV"; then
+        # venv already exists
+        echo "Using Python virtual environment: ${INVENTREE_PY_ENV}"
+    else
+        # Setup a virtual environment (within the "dev" directory)
+        echo "Running first time setup for python environment"
+        python3 -m venv ${INVENTREE_PY_ENV} --system-site-packages --upgrade-deps
+    fi
+
+    # Now activate the venv
     source ${INVENTREE_PY_ENV}/bin/activate
-
-    # Note: Python packages will have to be installed on first run
-    # e.g docker-compose run inventree-dev-server invoke update
 fi
 
 cd ${INVENTREE_HOME}


### PR DESCRIPTION
- Run once with --upgrade-deps
- Required to ensure that setuptools is automatically upgraded

This change is an addition to recent changes required to get the docker CI build to run. 

Turns out a similar issue prevents docker dev build from running under macOS.

When creating a venv, an older version of setuptools is bundled in (and overrides the hard-coded newer version in system python).

Ref: https://stackoverflow.com/questions/19115391/difference-in-version-of-setuptools-with-virtualenv

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4118"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

