### PR TITLE
Fixes and improvements for the part import wizard

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -121,6 +121,9 @@ CORS_ORIGIN_WHITELIST = get_setting(
     default_value=[]
 )
 
+# Needed for the parts importer, directly impacts the maximum parts that can be uploaded
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
+
 # Web URL endpoint for served static files
 STATIC_URL = '/static/'
 
@@ -376,9 +379,9 @@ for key in db_keys:
         db_config[key] = env_var
 
 # Check that required database configuration options are specified
-reqiured_keys = ['ENGINE', 'NAME']
+required_keys = ['ENGINE', 'NAME']
 
-for key in reqiured_keys:
+for key in required_keys:
     if key not in db_config:  # pragma: no cover
         error_msg = f'Missing required database configuration value {key}'
         logger.error(error_msg)

--- a/InvenTree/part/admin.py
+++ b/InvenTree/part/admin.py
@@ -104,6 +104,24 @@ class PartResource(InvenTreeResource):
         models.Part.objects.rebuild()
 
 
+class PartImportResource(InvenTreeResource):
+    """Class for managing Part data import/export."""
+
+    class Meta(PartResource.Meta):
+        """Metaclass definition"""
+        skip_unchanged = True
+        report_skipped = False
+        clean_model_instances = True
+        exclude = [
+            'id', 'category__name', 'creation_date', 'creation_user',
+            'pricing__overall_min', 'pricing__overall_max',
+            'bom_checksum', 'bom_checked_by', 'bom_checked_date',
+            'lft', 'rght', 'tree_id', 'level',
+            'metadata',
+            'barcode_data', 'barcode_hash',
+        ]
+
+
 class PartAdmin(ImportExportModelAdmin):
     """Admin class for the Part model"""
 

--- a/InvenTree/part/part.py
+++ b/InvenTree/part/part.py
@@ -1,0 +1,37 @@
+"""Functionality for Part import template.
+
+Primarily Part import tools.
+"""
+
+from InvenTree.helpers import DownloadFile, GetExportFormats
+
+from .admin import PartImportResource
+from .models import Part
+
+
+def IsValidPartFormat(fmt):
+    """Test if a file format specifier is in the valid list of part import template file formats."""
+    return fmt.strip().lower() in GetExportFormats()
+
+
+def MakePartTemplate(fmt):
+    """Generate a part import template file (for user download)."""
+    fmt = fmt.strip().lower()
+
+    if not IsValidPartFormat(fmt):
+        fmt = 'csv'
+
+    # Create an "empty" queryset, essentially.
+    # This will then export just the row headers!
+    query = Part.objects.filter(pk=None)
+
+    dataset = PartImportResource().export(
+        queryset=query,
+        importing=True
+    )
+
+    data = dataset.export(fmt)
+
+    filename = 'InvenTree_Part_Template.' + fmt
+
+    return DownloadFile(data, filename)

--- a/InvenTree/part/templates/part/import_wizard/ajax_part_upload.html
+++ b/InvenTree/part/templates/part/import_wizard/ajax_part_upload.html
@@ -26,7 +26,7 @@
 
 {% else %}
     <div class='alert alert-danger alert-block' role='alert'>
-        {% trans "Unsuffitient privileges." %}
+        {% trans "Insufficient privileges." %}
     </div>
 {% endif %}
 </div>

--- a/InvenTree/part/templates/part/import_wizard/match_fields.html
+++ b/InvenTree/part/templates/part/import_wizard/match_fields.html
@@ -1,2 +1,99 @@
 {% extends "part/import_wizard/part_upload.html" %}
-{% include "patterns/wizard/match_fields.html" %}
+{% load inventree_extras %}
+{% load i18n %}
+{% load static %}
+
+{% block form_alert %}
+{% if missing_columns and missing_columns|length > 0 %}
+<div class='alert alert-danger alert-block' style='margin-top:12px;' role='alert'>
+    {% trans "Missing selections for the following required columns" %}:
+    <br>
+    <ul>
+        {% for col in missing_columns %}
+        <li>{{ col }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+{% if duplicates and duplicates|length > 0 %}
+<div class='alert alert-danger alert-block' role='alert'>
+    {% trans "Duplicate selections found, see below. Fix them then retry submitting." %}
+</div>
+{% endif %}
+{% endblock form_alert %}
+
+{% block form_buttons_top %}
+    {% if wizard.steps.prev %}
+    <button name='wizard_goto_step' type='submit' value='{{ wizard.steps.prev }}' class='save btn btn-outline-secondary'>{% trans "Previous Step" %}</button>
+    {% endif %}
+    <button type='submit' class='save btn btn-outline-secondary'>{% trans "Submit Selections" %}</button>
+{% endblock form_buttons_top %}
+
+{% block form_content %}
+    <thead>
+        <tr>
+            <th>{% trans "File Fields" %}</th>
+            <th></th>
+            {% for col in form %}
+            <th>
+                <div>
+                    <input type='hidden' name='col_name_{{ forloop.counter0 }}' value='{{ col.name }}'/>
+                    {{ col.name }}
+                    <button class='btn btn-outline-secondary btn-remove' onClick='removeColFromBomWizard()' id='del_col_{{ forloop.counter0 }}' style='display: inline; float: right;' title='{% trans "Remove column" %}'>
+                        <span col_id='{{ forloop.counter0 }}' class='fas fa-trash-alt icon-red'></span>
+                    </button>
+                </div>
+            </th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{% trans "Match Fields" %}</td>
+            <td></td>
+            {% for col in form %}
+            <td>
+                {{ col }}
+                {% for duplicate in duplicates %}
+                    {% if duplicate == col.value %}
+                    <div class='alert alert-danger alert-block text-center' role='alert' style='padding:2px; margin-top:6px; margin-bottom:2px'>
+                        <strong>{% trans "Duplicate selection" %}</strong>
+                    </div>
+                    {% endif %}
+                {% endfor %}
+            </td>
+            {% endfor %}
+        </tr>
+        {% for row in rows %}
+        {% with forloop.counter as row_index %}
+        <tr>
+            <td style='width: 32px;'>
+                <button class='btn btn-outline-secondary btn-remove' onClick='removeRowFromBomWizard()' id='del_row_{{ row_index }}' style='display: inline; float: left;' title='{% trans "Remove row" %}'>
+                    <span row_id='{{ row_index }}' class='fas fa-trash-alt icon-red'></span>
+                </button>
+            </td>
+            <td style='text-align: left;'>{{ row_index }}</td>
+            {% for item in row.data %}
+            <td>
+                <input type='hidden' name='row_{{ row_index }}_col_{{ forloop.counter0 }}' value='{{ item }}'/>
+                {{ item }}
+            </td>
+            {% endfor %}
+        </tr>
+        {% endwith %}
+        {% endfor %}
+    </tbody>
+{% endblock form_content %}
+
+{% block form_buttons_bottom %}
+{% endblock form_buttons_bottom %}
+
+{% block js_ready %}
+{{ block.super }}
+
+$('.fieldselect').select2({
+    width: '100%',
+    matcher: partialMatcher,
+});
+
+{% endblock %}

--- a/InvenTree/part/templates/part/import_wizard/part_upload.html
+++ b/InvenTree/part/templates/part/import_wizard/part_upload.html
@@ -11,13 +11,106 @@
 
 {% block content %}
     {% trans "Import Parts from File" as header_text %}
-    {% trans "Unsuffitient privileges." as error_text %}
-    {% include "patterns/wizard/upload.html" with header_text=header_text upload_go_ahead=roles.part.change error_text=error_text %}
+    {% trans "Insufficient privileges." as error_text %}
+
+    <div class='panel' id='panel-upload-file'>
+        <div class='panel-heading'>
+            <h4>
+                {{ header_text }}
+                {{ wizard.form.media }}
+            </h4>
+        </div>
+        <div class='panel-content'>
+        {% if roles.part.change %}
+
+            <p>{% blocktrans with step=wizard.steps.step1 count=wizard.steps.count %}Step {{step}} of {{count}}{% endblocktrans %}
+            {% if description %}- {{ description }}{% endif %}</p>
+
+            {% block form_alert %}
+            <div class='alert alert-info alert-block'>
+                <strong>{% trans "Requirements for part import" %}:</strong>
+                <ul>
+                    <li>{% trans "The part import file must contain the required named columns as provided in the " %} <strong><a href='#' id='part-template-download'>{% trans "Part Import Template" %}</a></strong></li>
+                </ul>
+            </div>
+            {% endblock form_alert %}
+
+            <form action='' method='post' class='js-modal-form' enctype='multipart/form-data'>
+            {% csrf_token %}
+            {% load crispy_forms_tags %}
+
+            {% block form_buttons_top %}
+            {% endblock form_buttons_top %}
+
+            <div style='overflow-x:scroll;'>
+                <table class='table table-striped' style='margin-top: 12px; margin-bottom: 0px; table-layout: auto; width: 100%;'>
+                {{ wizard.management_form }}
+                {% block form_content %}
+                {% crispy wizard.form %}
+                {% endblock form_content %}
+                </table>
+            </div>
+
+            {% block form_buttons_bottom %}
+            {% if wizard.steps.prev %}
+            <button name='wizard_goto_step' type='submit' value='{{ wizard.steps.prev }}' class='save btn btn-outline-secondary'>{% trans "Previous Step" %}</button>
+            {% endif %}
+            <button type='submit' class='save btn btn-outline-secondary'>{% trans "Upload File" %}</button>
+            </form>
+            {% endblock form_buttons_bottom %}
+
+        {% else %}
+            <div class='alert alert-danger alert-block' role='alert'>
+                {{ error_text }}
+            </div>
+        {% endif %}
+        </div>
+    </div>
 {% endblock %}
 
 {% block js_ready %}
 {{ block.super }}
 
 enableSidebar('partupload');
+
+$('#part-template-download').click(function() {
+    downloadPartImportTemplate();
+});
+
+function downloadPartImportTemplate(options={}) {
+
+    var format = options.format;
+
+    if (!format) {
+        format = inventreeLoad('part-import-format', 'csv');
+    }
+
+    constructFormBody({}, {
+        title: '{% trans "Download Part Import Template" %}',
+        fields: {
+            format: {
+                label: '{% trans "Format" %}',
+                help_text: '{% trans "Select file format" %}',
+                required: true,
+                type: 'choice',
+                value: format,
+                choices: exportFormatOptions(),
+            }
+        },
+        onSubmit: function(fields, opts) {
+            var format = getFormFieldValue('format', fields['format'], opts);
+
+            // Save the format for next time
+            inventreeSave('part-import-format', format);
+
+            // Hide the modal
+            $(opts.modal).modal('hide');
+
+            // Download the file
+            location.href = `{% url "part-template-download" %}?format=${format}`;
+
+        }
+    });
+}
 
 {% endblock %}

--- a/InvenTree/part/urls.py
+++ b/InvenTree/part/urls.py
@@ -36,7 +36,8 @@ category_urls = [
 part_urls = [
 
     # Upload a part
-    re_path(r'^import/', views.PartImport.as_view(), name='part-import'),
+    re_path(r'^import/$', views.PartImport.as_view(), name='part-import'),
+    re_path(r'^import/?', views.PartImportTemplate.as_view(), name='part-template-download'),
     re_path(r'^import-api/', views.PartImportAjax.as_view(), name='api-part-import'),
 
     # Download a BOM upload template

--- a/InvenTree/report/apps.py
+++ b/InvenTree/report/apps.py
@@ -22,6 +22,9 @@ class ReportConfig(AppConfig):
         if canAppAccessDatabase(allow_test=True):
             self.create_default_test_reports()
             self.create_default_build_reports()
+            self.create_default_bill_of_materials_reports()
+            self.create_default_purchase_order_reports()
+            self.create_default_sales_order_reports()
 
     def create_default_reports(self, model, reports):
         """Copy defualt report files across to the media directory."""
@@ -96,6 +99,25 @@ class ReportConfig(AppConfig):
 
         self.create_default_reports(TestReport, reports)
 
+    def create_default_bill_of_materials_reports(self):
+        """Create database entries for the default Bill of Material templates (if they do not already exist)"""
+        try:
+            from .models import BillOfMaterialsReport
+        except Exception:  # pragma: no cover
+            # Database is not ready yet
+            return
+
+        # List of Build reports to copy across
+        reports = [
+            {
+                'file': 'inventree_bill_of_materials_report.html',
+                'name': 'Bill of Materials',
+                'description': 'Bill of Materials report',
+            }
+        ]
+
+        self.create_default_reports(BillOfMaterialsReport, reports)
+
     def create_default_build_reports(self):
         """Create database entries for the default BuildReport templates (if they do not already exist)"""
         try:
@@ -114,3 +136,41 @@ class ReportConfig(AppConfig):
         ]
 
         self.create_default_reports(BuildReport, reports)
+
+    def create_default_purchase_order_reports(self):
+        """Create database entries for the default SalesOrderReport templates (if they do not already exist)"""
+        try:
+            from .models import PurchaseOrderReport
+        except Exception:  # pragma: no cover
+            # Database is not ready yet
+            return
+
+        # List of Build reports to copy across
+        reports = [
+            {
+                'file': 'inventree_po_report.html',
+                'name': 'InvenTree Purchase Order',
+                'description': 'Purchase Order example report',
+            }
+        ]
+
+        self.create_default_reports(PurchaseOrderReport, reports)
+
+    def create_default_sales_order_reports(self):
+        """Create database entries for the default Sales Order report templates (if they do not already exist)"""
+        try:
+            from .models import SalesOrderReport
+        except Exception:  # pragma: no cover
+            # Database is not ready yet
+            return
+
+        # List of Build reports to copy across
+        reports = [
+            {
+                'file': 'inventree_so_report.html',
+                'name': 'InvenTree Sales Order',
+                'description': 'Sales Order example report',
+            }
+        ]
+
+        self.create_default_reports(SalesOrderReport, reports)

--- a/InvenTree/report/templates/report/inventree_bill_of_materials_report.html
+++ b/InvenTree/report/templates/report/inventree_bill_of_materials_report.html
@@ -1,0 +1,115 @@
+{% extends "report/inventree_report_base.html" %}
+
+{% load i18n %}
+{% load report %}
+{% load barcode %}
+{% load inventree_extras %}
+
+{% block page_margin %}
+margin: 2cm;
+margin-top: 4cm;
+{% endblock %}
+
+{% block bottom_left %}
+content: "v{{report_revision}} - {{ date.isoformat }}";
+{% endblock %}
+
+{% block bottom_center %}
+content: "{% inventree_version shortstring=True %}";
+{% endblock %}
+
+{% block style %}
+
+.header-right {
+    text-align: right;
+    float: right;
+}
+
+.logo {
+    height: 20mm;
+    vertical-align: middle;
+}
+
+.thumb-container {
+    width: 32px;
+    display: inline;
+}
+
+
+.part-thumb {
+    max-width: 32px;
+    max-height: 32px;
+    display: inline;
+}
+
+.part-text {
+    display: inline;
+}
+
+table {
+    border: 1px solid #eee;
+    border-radius: 3px;
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 80%;
+}
+
+table td {
+    border: 1px solid #eee;
+}
+
+table td.shrink {
+    white-space: nowrap
+}
+
+table td.expand {
+    width: 99%
+}
+
+{% endblock %}
+
+{% block header_content %}
+
+    <img class='logo' src='{% company_image supplier %}' alt="{{ supplier }}" width='150'>
+
+    <div class='header-right'>
+        <h3>{% trans "Purchase Order" %} {{ prefix }}{{ reference }}</h3>
+        {% if supplier %}{{ supplier.name }}{% else %}{% trans "Supplier was deleted" %}{% endif %}
+    </div>
+
+{% endblock %}
+
+{% block page_content %}
+
+<h3>{% trans "Line Items" %}</h3>
+
+<table class='table table-striped table-condensed'>
+    <thead>
+        <tr>
+            <th>{% trans "Part" %}</th>
+            <th>{% trans "Quantity" %}</th>
+            <th>{% trans "Reference" %}</th>
+            <th>{% trans "Note" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for line in lines.all %}
+        <tr>
+            <td>
+                <div class='thumb-container'>
+                    <img src='{% part_image line.part.part %}' class='part-thumb'>
+                </div>
+                <div class='part-text'>
+                    {{ line.part.part.full_name }}
+                </div>
+            </td>
+            <td>{% decimal line.quantity %}</td>
+            <td>{{ line.reference }}</td>
+            <td>{{ line.notes }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+
+{% endblock %}


### PR DESCRIPTION
Made changes that resemble PR #4050 to the part import wizard to make the correct form show. 
Added option to download a part import template file. 
Increased the number of allowable form fields because the importer creates a lot of table fields 
when importing multiple parts at once.

@SchrodingersGat Shouldn't there be a check in place to prevent Parts created without Part Categories? 
During testing I forgot filling in the Part Category the import went well, but after that no parts would show up 
in the tables anymore...

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4122"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

