### PR TITLE
Catch potential error when refreshing part pricing

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2374,7 +2374,10 @@ class PartPricing(models.Model):
         """Recalculate all cost data for the referenced Part instance"""
 
         if self.pk is not None:
-            self.refresh_from_db()
+            try:
+                self.refresh_from_db()
+            except PartPricing.DoesNotExist:
+                pass
 
         self.update_bom_cost(save=False)
         self.update_purchase_cost(save=False)


### PR DESCRIPTION
Sentry reported a recurring error on the demo instance, need to catch a DoesNotExist exception

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4154"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

