### PR TITLE
Adds concurrency config for docker CI workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -29,6 +29,9 @@ jobs:
 
   # Build the docker image
   build:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/4155

Prevents docker builds from overwriting each other "out of sequence".

Running a new docker build (for a particular type of event) will cancel any other pending builds, but a "latest" won't interfere with "stable" or "tag" release.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4160"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

