### PR TITLE
[FR] Enable restrictions on allowed domains for signup

### DIFF
--- a/InvenTree/InvenTree/forms.py
+++ b/InvenTree/InvenTree/forms.py
@@ -23,6 +23,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Field, Layout
 
 from common.models import InvenTreeSetting
+from InvenTree.exceptions import log_error
 
 logger = logging.getLogger('inventree')
 
@@ -228,13 +229,13 @@ class RegistratonMixin:
         mailoptions = mail_restriction.split(',')
         for option in mailoptions:
             if not option.startswith('@'):
-                logger.error('LOGIN_SIGNUP_MAIL_RESTRICTION is not configured correctly')
+                log_error('LOGIN_SIGNUP_MAIL_RESTRICTION is not configured correctly')
                 raise forms.ValidationError(_('The provided primary email address is not valid.'))
             else:
                 if split_email[1] == option[1:]:
                     return super().clean_email(email)
 
-        logger.error(f'The provided email domain for {email} is not approved')
+        logger.info(f'The provided email domain for {email} is not approved')
         raise forms.ValidationError(_('The provided email domain is not approved.'))
 
     def save_user(self, request, user, form, commit=True):

--- a/InvenTree/InvenTree/forms.py
+++ b/InvenTree/InvenTree/forms.py
@@ -8,7 +8,6 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth.models import Group, User
 from django.contrib.sites.models import Site
-from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -23,6 +22,7 @@ from crispy_forms.bootstrap import (AppendedText, PrependedAppendedText,
                                     PrependedText)
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Field, Layout
+from rest_framework.exceptions import PermissionDenied
 
 from common.models import InvenTreeSetting
 
@@ -222,12 +222,12 @@ class RegistratonMixin:
         email = form.data.get('email', None)
         if not email:
             logger.error(f'The user {user.username} has no email address')
-            raise ValidationError('The user has no email address')
+            raise PermissionDenied(_('The user has no email address.'))
         mail_restriction = InvenTreeSetting.get_setting('LOGIN_SIGNUP_MAIL_RESTRICTION', None)
         if mail_restriction:
             if not re.match(mail_restriction, user.email):
                 logger.error(f'The user {user.username} has an invalid email address')
-                raise ValidationError('The provided primary email address is not approved.')
+                raise PermissionDenied(_('The provided primary email address is not approved.'))
 
         # Create the user
         user = super().save_user(request, user, form)

--- a/InvenTree/InvenTree/forms.py
+++ b/InvenTree/InvenTree/forms.py
@@ -218,10 +218,6 @@ class RegistratonMixin:
         """Check if the mail is valid to the pattern in LOGIN_SIGNUP_MAIL_RESTRICTION (if enabled in settings)."""
         mail_error = _('The provided primary email address is not valid.')
 
-        if not email:
-            logger.error('The user has no email address')
-            raise forms.ValidationError(_('The user has no email address.'))
-
         mail_restriction = InvenTreeSetting.get_setting('LOGIN_SIGNUP_MAIL_RESTRICTION', None)
         if not mail_restriction:
             return super().clean_email(email)

--- a/InvenTree/InvenTree/forms.py
+++ b/InvenTree/InvenTree/forms.py
@@ -216,8 +216,6 @@ class RegistratonMixin:
 
     def clean_email(self, email):
         """Check if the mail is valid to the pattern in LOGIN_SIGNUP_MAIL_RESTRICTION (if enabled in settings)."""
-        mail_error = _('The provided primary email address is not valid.')
-
         mail_restriction = InvenTreeSetting.get_setting('LOGIN_SIGNUP_MAIL_RESTRICTION', None)
         if not mail_restriction:
             return super().clean_email(email)
@@ -225,13 +223,13 @@ class RegistratonMixin:
         split_email = email.split('@')
         if len(split_email) != 2:
             logger.error(f'The user {email} has an invalid email address')
-            raise forms.ValidationError(mail_error)
+            raise forms.ValidationError(_('The provided primary email address is not valid.'))
 
         mailoptions = mail_restriction.split(',')
         for option in mailoptions:
             if not option.startswith('@'):
                 logger.error('LOGIN_SIGNUP_MAIL_RESTRICTION is not configured correctly')
-                raise forms.ValidationError(mail_error)
+                raise forms.ValidationError(_('The provided primary email address is not valid.'))
             else:
                 if split_email[1] == option[1:]:
                     return super().clean_email(email)

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1375,6 +1375,12 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'validator': bool,
         },
 
+        'LOGIN_SIGNUP_MAIL_RESTRICTION': {
+            'name': _('Allowed domains'),
+            'description': _('Restrict signup to certain domains (comma-separated, strarting with @)'),
+            'default': None,
+        },
+
         'SIGNUP_GROUP': {
             'name': _('Group on signup'),
             'description': _('Group to which new users are assigned on registration'),

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -87,13 +87,24 @@ class BaseInvenTreeSetting(models.Model):
 
         super().save()
 
-        # Get after_save action
+        # Execute after_save action
+        self._call_settings_function('after_save', args, kwargs)
+
+    def _call_settings_function(self, reference: str, args, kwargs):
+        """Call a function associated with a particular setting.
+
+        Args:
+            reference (str): The name of the function to call
+            args: Positional arguments to pass to the function
+            kwargs: Keyword arguments to pass to the function
+        """
+        # Get action
         setting = self.get_setting_definition(self.key, *args, **kwargs)
-        after_save = setting.get('after_save', None)
+        settings_fnc = setting.get(reference, None)
 
         # Execute if callable
-        if callable(after_save):
-            after_save(self)
+        if callable(settings_fnc):
+            settings_fnc(self)
 
     @property
     def cache_key(self):
@@ -1378,7 +1389,7 @@ class InvenTreeSetting(BaseInvenTreeSetting):
         'LOGIN_SIGNUP_MAIL_RESTRICTION': {
             'name': _('Allowed domains'),
             'description': _('Restrict signup to certain domains (comma-separated, strarting with @)'),
-            'default': None,
+            'default': '',
         },
 
         'SIGNUP_GROUP': {

--- a/InvenTree/common/tests.py
+++ b/InvenTree/common/tests.py
@@ -134,6 +134,7 @@ class SettingsTest(InvenTreeTestCase):
             'units',
             'requires_restart',
             'after_save',
+            'before_save',
         ]
 
         for k in setting.keys():

--- a/InvenTree/templates/InvenTree/settings/login.html
+++ b/InvenTree/templates/InvenTree/settings/login.html
@@ -26,6 +26,7 @@
         {% include "InvenTree/settings/setting.html" with key="LOGIN_SIGNUP_PWD_TWICE" icon="fa-user-lock" %}
         {% include "InvenTree/settings/setting.html" with key="LOGIN_SIGNUP_SSO_AUTO" icon="fa-key" %}
         {% include "InvenTree/settings/setting.html" with key="SIGNUP_GROUP" icon="fa-users" %}
+        {% include "InvenTree/settings/setting.html" with key="LOGIN_SIGNUP_MAIL_RESTRICTION" icon="fa-sitemap" %}
     </tbody>
 </table>
 


### PR DESCRIPTION
This PR adds an optional validation step that makes sure only approved email addresses can register new accounts.
This does not prevent users from later changing their email address to a non-approved domain.

Fixes #4168

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4172"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

