### PR TITLE
Change default value for auto-backup setting

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -930,7 +930,7 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'name': _('Automatic Backup'),
             'description': _('Enable automatic backup of database and media files'),
             'validator': bool,
-            'default': True,
+            'default': False,
         },
 
         'INVENTREE_DELETE_TASKS_DAYS': {


### PR DESCRIPTION
This PR changes the "auto backup" scheduled task to be off by default (for new installs or upgrades).

The idea here is to not silently introduce a significant new feature without user interaction. The docs will be updated to reflect this.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4189"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

