### PR TITLE
Configuration options for dbbackup

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -149,7 +149,7 @@ MEDIA_URL = '/media/'
 
 # Database backup options
 # Ref: https://django-dbbackup.readthedocs.io/en/master/configuration.html
-DBBACKUP_SEND_EMAIL = get_boolean_setting('INVENTREE_BACKUP_EMAIL', 'backup_email', False)
+DBBACKUP_SEND_EMAIL = False
 DBBACKUP_STORAGE = get_setting('INVENTREE_BACKUP_STORAGE', 'backup_storage', 'django.core.files.storage.FileSystemStorage')
 DBBACKUP_STORAGE_OPTIONS = get_setting('INVENTREE_BACKUP_OPTIONS', 'backup_options', None)
 

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -150,10 +150,14 @@ MEDIA_URL = '/media/'
 # Database backup options
 # Ref: https://django-dbbackup.readthedocs.io/en/master/configuration.html
 DBBACKUP_SEND_EMAIL = False
-DBBACKUP_STORAGE = get_setting('INVENTREE_BACKUP_STORAGE', 'backup_storage', 'django.core.files.storage.FileSystemStorage')
-DBBACKUP_STORAGE_OPTIONS = get_setting('INVENTREE_BACKUP_OPTIONS', 'backup_options', None)
+DBBACKUP_STORAGE = get_setting(
+    'INVENTREE_BACKUP_STORAGE',
+    'backup_storage',
+    'django.core.files.storage.FileSystemStorage'
+)
 
 # Default backup configuration
+DBBACKUP_STORAGE_OPTIONS = get_setting('INVENTREE_BACKUP_OPTIONS', 'backup_options', None)
 if DBBACKUP_STORAGE_OPTIONS is None:
     DBBACKUP_STORAGE_OPTIONS = {
         'location': config.get_backup_dir(),

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -147,10 +147,17 @@ STATIC_COLOR_THEMES_DIR = STATIC_ROOT.joinpath('css', 'color-themes').resolve()
 # Web URL endpoint for served media files
 MEDIA_URL = '/media/'
 
-# Backup directories
-DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
-DBBACKUP_STORAGE_OPTIONS = {'location': config.get_backup_dir()}
-DBBACKUP_SEND_EMAIL = False
+# Database backup options
+# Ref: https://django-dbbackup.readthedocs.io/en/master/configuration.html
+DBBACKUP_SEND_EMAIL = get_boolean_setting('INVENTREE_BACKUP_EMAIL', 'backup_email', False)
+DBBACKUP_STORAGE = get_setting('INVENTREE_BACKUP_STORAGE', 'backup_storage', 'django.core.files.storage.FileSystemStorage')
+DBBACKUP_STORAGE_OPTIONS = get_setting('INVENTREE_BACKUP_OPTIONS', 'backup_options', None)
+
+# Default backup configuration
+if DBBACKUP_STORAGE_OPTIONS is None:
+    DBBACKUP_STORAGE_OPTIONS = {
+        'location': config.get_backup_dir(),
+    }
 
 # Application definition
 

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -142,8 +142,11 @@ cors:
 # STATIC_ROOT is the local filesystem location for storing static files
 #static_root: '/home/inventree/data/static'
 
-# BACKUP_DIR is the local filesystem location for storing backups
+### Backup configuration options ###
+# INVENTREE_BACKUP_DIR is the local filesystem location for storing backups
+backup_storage: django.core.files.storage.FileSystemStorage
 #backup_dir: '/home/inventree/data/backup'
+#backup_options:
 
 # Background worker options
 background:

--- a/tasks.py
+++ b/tasks.py
@@ -245,10 +245,10 @@ def migrate(c):
 @task(
     post=[static, clean_settings, translate_stats],
     help={
-        'backup_data': 'Perform database backup prior to update operations'
+        'skip_backup': 'Skip database backup step (advanced users)'
     }
 )
-def update(c, backup_data=False):
+def update(c, skip_backup=False):
     """Update InvenTree installation.
 
     This command should be invoked after source code has been updated,
@@ -267,7 +267,7 @@ def update(c, backup_data=False):
     # Ensure required components are installed
     install(c)
 
-    if backup_data:
+    if not skip_backup:
         backup(c)
 
     # Perform database migrations

--- a/tasks.py
+++ b/tasks.py
@@ -180,6 +180,14 @@ def translate_stats(c):
 
     The file generated from this is needed for the UI.
     """
+
+    # Recompile the translation files (.mo)
+    # We do not run 'invoke translate' here, as that will touch the source (.po) files too!
+    try:
+        manage(c, 'compilemessages', pty=True)
+    except Exception:
+        print("WARNING: Translation files could not be compiled:")
+
     path = Path('InvenTree', 'script', 'translation_stats.py')
     c.run(f'python3 {path}')
 
@@ -216,7 +224,7 @@ def restore(c):
     manage(c, "mediarestore --noinput --uncompress")
 
 
-@task(pre=[backup, ], post=[rebuild_models, rebuild_thumbnails])
+@task(post=[rebuild_models, rebuild_thumbnails])
 def migrate(c):
     """Performs database migrations.
 
@@ -234,8 +242,13 @@ def migrate(c):
     print("InvenTree database migrations completed!")
 
 
-@task(pre=[install, migrate, static, clean_settings, translate_stats])
-def update(c):
+@task(
+    post=[static, clean_settings, translate_stats],
+    help={
+        'backup_data': 'Perform database backup prior to update operations'
+    }
+)
+def update(c, backup_data=False):
     """Update InvenTree installation.
 
     This command should be invoked after source code has been updated,
@@ -244,17 +257,21 @@ def update(c):
     The following tasks are performed, in order:
 
     - install
+    - backup (optional)
     - migrate
     - static
     - clean_settings
     - translate_stats
     """
-    # Recompile the translation files (.mo)
-    # We do not run 'invoke translate' here, as that will touch the source (.po) files too!
-    try:
-        manage(c, 'compilemessages', pty=True)
-    except Exception:
-        print("WARNING: Translation files could not be compiled:")
+
+    # Ensure required components are installed
+    install(c)
+
+    if backup_data:
+        backup(c)
+
+    # Perform database migrations
+    migrate(c)
 
 
 # Data tasks


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/4180

This PR adds some setup / configuration options for database backup.

Additionally, backup is no longer "forced" during the "invoke update" step. This allows the update step to be run without backup, in situations where the user might not want this, or where backup is misconfigured.

On some (lower end) systems the "backup" task can stall for a long period of time which can cause worker timeout.

Ref: https://github.com/inventree/InvenTree/discussions/4179

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4190"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

