### PR TITLE
Reload purchase order table after part order

### DIFF
--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -757,7 +757,11 @@
                 success: function(part) {
                     orderParts(
                         [part],
-                        {}
+                        {
+                            onSuccess: function() {
+                                $("#purchase-order-table").bootstrapTable('refresh');
+                            }
+                        }
                     );
                 }
             }

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -1163,8 +1163,9 @@ function orderParts(parts_list, options) {
         if (!($(opts.modal).find('.part-order-row').exists())) {
             closeModal(opts.modal);
             // If there is a onSuccess callback defined, call it
-            if (options && options.onSuccess)
+            if (options && options.onSuccess) {
                 options.onSuccess();
+            }
         }
     }
 

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -1032,7 +1032,7 @@ function exportOrder(redirect_url, options={}) {
 /*
  * Create a new form to order parts based on the list of provided parts.
  */
-function orderParts(parts_list, options={}) {
+function orderParts(parts_list, options) {
 
     var parts = [];
 
@@ -1162,6 +1162,9 @@ function orderParts(parts_list, options={}) {
         // If the modal is now "empty", dismiss it
         if (!($(opts.modal).find('.part-order-row').exists())) {
             closeModal(opts.modal);
+            // If there is a onSuccess callback defined, call it
+            if (options && options.onSuccess)
+                options.onSuccess();
         }
     }
 


### PR DESCRIPTION
When on the part page, going to the "Purchase order" sidebar tab. You can order the part by pressing the "Order Part" button. After a successful order, the form closes but the table on the page is never refreshed.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4219"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

