### PR TITLE
[BUG] Quick Installer: `INVENTREE_DB_PORT` errors

### DIFF
--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -32,7 +32,7 @@ database:
   #USER: sampleuser
   #PASSWORD: samplepassword
   #HOST: samplehost
-  #PORT: sampleport
+  #PORT: 123456
 
   # --- Example Configuration - MySQL ---
   #ENGINE: mysql

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -130,7 +130,7 @@ function detect_envs() {
     export INVENTREE_DB_USER=${INVENTREE_DB_USER:-sampleuser}
     export INVENTREE_DB_PASSWORD=${INVENTREE_DB_PASSWORD:-samplepassword}
     export INVENTREE_DB_HOST=${INVENTREE_DB_HOST:-samplehost}
-    export INVENTREE_DB_PORT=${INVENTREE_DB_PORT:-sampleport}
+    export INVENTREE_DB_PORT=${INVENTREE_DB_PORT:-123456}
 
     export SETUP_CONF_LOADED=true
   fi
@@ -276,7 +276,7 @@ function set_env() {
   # Database host
   sed -i s=#HOST:\ samplehost=HOST:\ ${INVENTREE_DB_HOST}=g ${INVENTREE_CONFIG_FILE}
   # Database port
-  sed -i s=#PORT:\ sampleport=PORT:\ ${INVENTREE_DB_PORT}=g ${INVENTREE_CONFIG_FILE}
+  sed -i s=#PORT:\ 123456=PORT:\ ${INVENTREE_DB_PORT}=g ${INVENTREE_CONFIG_FILE}
 
   # Fixing the permissions
   chown ${APP_USER}:${APP_GROUP} ${DATA_DIR} ${INVENTREE_CONFIG_FILE}


### PR DESCRIPTION
This PR changes the default port to a number so that no issues are raised.

Fixes #4222

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4224"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

