### PR TITLE
Make sure that print label dialog has a submit button.

### DIFF
--- a/InvenTree/templates/js/translated/label.js
+++ b/InvenTree/templates/js/translated/label.js
@@ -321,6 +321,7 @@ function selectLabel(labels, items, options={}) {
     });
 
     modalEnable(modal, true);
+    modalShowSubmitButton(modal, true);
     modalSetTitle(modal, '{% trans "Select Label Template" %}');
     modalSetContent(modal, html);
 


### PR DESCRIPTION
Steps to reproduce problem:
Go to a screen that has a modal without a submit button like "Show QR code" of the Sublocation overview. Close the QR code modal and after that go to the "Print label" option. It will no longer show a submit button.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4240"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

