### PR TITLE
Fix debian 11 detection on installer

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -73,11 +73,11 @@ root_command() {
               SUPPORTED=false
           fi
           ;;
-      "Debian GNU/Linux" | Raspbian)
+      "Debian GNU/Linux" | "debian gnu/linux" | Raspbian)
           if [[ $VER != "11" ]]; then
               SUPPORTED=false
           fi
-          OS=Debian
+          DIST_OS=Debian
           ;;
       *)
           echo "### Distribution not supported"

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -77,7 +77,7 @@ root_command() {
           if [[ $VER != "11" ]]; then
               SUPPORTED=false
           fi
-          DIST_OS=Debian
+          DIST_OS=debian
           ;;
       *)
           echo "### Distribution not supported"

--- a/contrib/installer/src/root_command.sh
+++ b/contrib/installer/src/root_command.sh
@@ -63,11 +63,11 @@ case "$OS" in
             SUPPORTED=false
         fi
         ;;
-    "Debian GNU/Linux" | Raspbian)
+    "Debian GNU/Linux" | "debian gnu/linux" | Raspbian)
         if [[ $VER != "11" ]]; then
             SUPPORTED=false
         fi
-        OS=Debian
+        DIST_OS=Debian
         ;;
     *)
         echo "### Distribution not supported"

--- a/contrib/installer/src/root_command.sh
+++ b/contrib/installer/src/root_command.sh
@@ -67,7 +67,7 @@ case "$OS" in
         if [[ $VER != "11" ]]; then
             SUPPORTED=false
         fi
-        DIST_OS=Debian
+        DIST_OS=debian
         ;;
     *)
         echo "### Distribution not supported"


### PR DESCRIPTION
This PR fixes the debian 11 detection on newer releases.

Fixes https://github.com/inventree/InvenTree/issues/4236

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4241"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

