### PR TITLE
Fix typos/naming

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -64,7 +64,7 @@
   },
 
   "remoteEnv": {
-    // Inventree config
+    // InvenTree config
     "INVENTREE_DEBUG": "True",
     "INVENTREE_DEBUG_LEVEL": "INFO",
     "INVENTREE_DB_ENGINE": "sqlite3",

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -8,7 +8,7 @@ cd /workspaces/InvenTree
 python3 -m venv dev/venv
 . dev/venv/bin/activate
 
-# setup inventree server
+# setup InvenTree server
 pip install invoke
 inv update
 inv setup-dev

--- a/.github/actions/migration/action.yaml
+++ b/.github/actions/migration/action.yaml
@@ -1,6 +1,6 @@
 name: 'Migration test'
 description: 'Run migration test sequenze'
-author: 'inventree'
+author: 'InvenTree'
 
 runs:
     using: 'composite'

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,6 +1,6 @@
 name: 'Setup Enviroment'
 description: 'Setup the enviroment for general InvenTree tests'
-author: 'inventree'
+author: 'InvenTree'
 inputs:
     python:
         required: false

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -692,7 +692,7 @@ class Part(InvenTreeBarcodeMixin, MetadataMixin, MPTTModel):
 
     @property
     def full_name(self):
-        """Format a 'full name' for this Part based on the format PART_NAME_FORMAT defined in Inventree settings.
+        """Format a 'full name' for this Part based on the format PART_NAME_FORMAT defined in InvenTree settings.
 
         As a failsafe option, the following is done:
 

--- a/InvenTree/plugin/builtin/barcodes/inventree_barcode.py
+++ b/InvenTree/plugin/builtin/barcodes/inventree_barcode.py
@@ -23,7 +23,7 @@ class InvenTreeInternalBarcodePlugin(BarcodeMixin, InvenTreePlugin):
     """Builtin BarcodePlugin for matching and generating internal barcodes."""
 
     NAME = "InvenTreeBarcode"
-    TITLE = _("Inventree Barcodes")
+    TITLE = _("InvenTree Barcodes")
     DESCRIPTION = _("Provides native support for barcodes")
     VERSION = "2.0.0"
     AUTHOR = _("InvenTree contributors")

--- a/InvenTree/plugin/builtin/integration/core_notifications.py
+++ b/InvenTree/plugin/builtin/integration/core_notifications.py
@@ -22,13 +22,13 @@ class PlgMixin:
 
     def get_plugin(self):
         """Return plugin reference."""
-        return CoreNotificationsPlugin
+        return InvenTreeCoreNotificationsPlugin
 
 
-class CoreNotificationsPlugin(SettingsContentMixin, SettingsMixin, InvenTreePlugin):
+class InvenTreeCoreNotificationsPlugin(SettingsContentMixin, SettingsMixin, InvenTreePlugin):
     """Core notification methods for InvenTree."""
 
-    NAME = "CoreNotificationsPlugin"
+    NAME = "InvenTreeCoreNotificationsPlugin"
     TITLE = _("InvenTree Notifications")
     AUTHOR = _('InvenTree contributors')
     DESCRIPTION = _('Integrated outgoing notificaton methods')

--- a/InvenTree/plugin/builtin/integration/test_core_notifications.py
+++ b/InvenTree/plugin/builtin/integration/test_core_notifications.py
@@ -5,7 +5,7 @@ from django.core import mail
 from part.test_part import BaseNotificationIntegrationTest
 from plugin import registry
 from plugin.builtin.integration.core_notifications import \
-    CoreNotificationsPlugin
+    InvenTreeCoreNotificationsPlugin
 from plugin.models import NotificationUserSetting
 
 
@@ -18,18 +18,18 @@ class CoreNotificationTestTests(BaseNotificationIntegrationTest):
         self.assertEqual(len(mail.outbox), 0)
 
         # enable plugin and set mail setting to true
-        plugin = registry.plugins.get('corenotificationsplugin')
+        plugin = registry.plugins.get('inventreecorenotificationsplugin')
         plugin.set_setting('ENABLE_NOTIFICATION_EMAILS', True)
         NotificationUserSetting.set_setting(
             key='NOTIFICATION_METHOD_MAIL',
             value=True,
             change_user=self.user,
             user=self.user,
-            method=CoreNotificationsPlugin.EmailNotification.METHOD_NAME
+            method=InvenTreeCoreNotificationsPlugin.EmailNotification.METHOD_NAME
         )
 
         # run through
-        self._notification_run(CoreNotificationsPlugin.EmailNotification)
+        self._notification_run(InvenTreeCoreNotificationsPlugin.EmailNotification)
 
         # Now one mail should be send
         self.assertEqual(len(mail.outbox), 1)

--- a/InvenTree/report/templates/report/inventree_bill_of_materials_report.html
+++ b/InvenTree/report/templates/report/inventree_bill_of_materials_report.html
@@ -94,7 +94,7 @@ table td.expand {
 
 {% block header_content %}
 
-    <img class='logo' src='{% logo_image %}' alt="Inventree logo" width='150'>
+    <img class='logo' src='{% logo_image %}' alt="InvenTree logo" width='150'>
 
     <div class='header-right'>
         <h3>{% trans "Bill of Materials" %}</h3>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,11 +16,11 @@ Merge the crowdin translation updates into master branch
 
 ### Documentation Release
 
-Create new release for the [inventree documentation](https://github.com/inventree/inventree-docs)
+Create new release for the [InvenTree documentation](https://github.com/inventree/inventree-docs)
 
 ### Python Library Release
 
-Create new release for the [inventree python library](https://github.com/inventree/inventree-python)
+Create new release for the [InvenTree python library](https://github.com/inventree/inventree-python)
 
 ## App Release
 

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -191,7 +191,7 @@ function create_initscripts() {
   ${INIT_CMD} start nginx
 
   echo "# (Re)creating init scripts"
-  # This reset scale parameters to a known state
+  # This resets scale parameters to a known state
   inventree scale web="1" worker="1"
 
   echo "# Enabling InvenTree on boot"


### PR DESCRIPTION
This PR:
- fixes some small typos
- makes the usage of the InvenTree name more consistent among exposed strings
- renames the core plugin to include the inventree prefix

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4242"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

