### PR TITLE
Calculate the sub-totals of the po/so in the default currency

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -982,7 +982,7 @@ class OrderExtraLine(OrderLineItem):
         if self.price and self.quantity:
             return convert_money(self.price * self.quantity, self.get_converted_total_price_currency())
         else:
-            return convert_money(0, self.get_converted_total_price_currency())
+            return Money(0, self.get_converted_total_price_currency())
 
     def get_converted_total_price_currency(self):
         """The currency of the total price, for now the InvenTree user default"""
@@ -1081,7 +1081,7 @@ class PurchaseOrderLineItem(OrderLineItem):
         if self.purchase_price and self.quantity:
             return convert_money(self.purchase_price * self.quantity, self.get_converted_total_price_currency())
         else:
-            return convert_money(0, self.get_converted_total_price_currency())
+            return Money(0, self.get_converted_total_price_currency())
 
     def get_converted_total_price_currency(self):
         """The currency of the total price, for now the InvenTree user default"""

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -135,7 +135,7 @@ class Order(MetadataMixin, ReferenceIndexingMixin):
                 # Record the error, try to press on
                 kind, info, data = sys.exc_info()
 
-                log_error('order.get_sub_total_item_price')
+                log_error('order.get_total_price')
                 logger.error(f"Missing exchange rate for '{target_currency}'")
 
                 # Return None to indicate the calculated price is invalid
@@ -152,7 +152,7 @@ class Order(MetadataMixin, ReferenceIndexingMixin):
             except MissingRate:
                 # Record the error, try to press on
 
-                log_error('order.get_sub_total_extra_line_price')
+                log_error('order.get_total_price')
                 logger.error(f"Missing exchange rate for '{target_currency}'")
 
                 # Return None to indicate the calculated price is invalid

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -1230,7 +1230,7 @@ class SalesOrderLineItem(OrderLineItem):
         if self.sale_price and self.quantity:
             return convert_money(self.sale_price * self.quantity, self.get_converted_total_price_currency())
         else:
-            return convert_money(0, self.get_converted_total_price_currency())
+            return Money(0, self.get_converted_total_price_currency())
 
     def get_converted_total_price_currency(self):
         """The currency of the total price, for now the InvenTree user default"""

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -39,18 +39,6 @@ class AbstractOrderSerializer(serializers.Serializer):
         read_only=True,
     )
 
-    sub_total_items_price = InvenTreeMoneySerializer(
-        source='get_sub_total_item_price',
-        allow_null=True,
-        read_only=True,
-    )
-
-    sub_total_extra_line_price = InvenTreeMoneySerializer(
-        source='get_sub_total_extra_line_price',
-        allow_null=True,
-        read_only=True,
-    )
-
 
 class AbstractExtraLineSerializer(serializers.Serializer):
     """Abstract Serializer for a ExtraLine object."""
@@ -75,6 +63,19 @@ class AbstractExtraLineSerializer(serializers.Serializer):
         help_text=_('Price currency'),
     )
 
+    converted_total_price = InvenTreeMoneySerializer(
+        source='get_converted_total_price',
+        allow_null=True,
+        read_only=True,
+    )
+
+    converted_total_price_currency = serializers.ChoiceField(
+        source='get_converted_total_price_currency',
+        allow_null=True,
+        read_only=True,
+        choices=currency_code_mappings(),
+    )
+
 
 class AbstractExtraLineMeta:
     """Abstract Meta for ExtraLine."""
@@ -89,6 +90,8 @@ class AbstractExtraLineMeta:
         'order_detail',
         'price',
         'price_currency',
+        'converted_total_price',
+        'converted_total_price_currency',
     ]
 
 
@@ -171,8 +174,6 @@ class PurchaseOrderSerializer(AbstractOrderSerializer, InvenTreeModelSerializer)
             'target_date',
             'notes',
             'total_price',
-            'sub_total_items_price',
-            'sub_total_extra_line_price',
         ]
 
         read_only_fields = [
@@ -343,6 +344,19 @@ class PurchaseOrderLineItemSerializer(InvenTreeModelSerializer):
 
     order_detail = PurchaseOrderSerializer(source='order', read_only=True, many=False)
 
+    converted_total_price = InvenTreeMoneySerializer(
+        source='get_converted_total_price',
+        allow_null=True,
+        read_only=True,
+    )
+
+    converted_total_price_currency = serializers.ChoiceField(
+        source='get_converted_total_price_currency',
+        allow_null=True,
+        read_only=True,
+        choices=currency_code_mappings(),
+    )
+
     def validate(self, data):
         """Custom validation for the serializer:
 
@@ -397,6 +411,8 @@ class PurchaseOrderLineItemSerializer(InvenTreeModelSerializer):
             'destination_detail',
             'target_date',
             'total_price',
+            'converted_total_price',
+            'converted_total_price_currency',
         ]
 
 
@@ -750,8 +766,6 @@ class SalesOrderSerializer(AbstractOrderSerializer, InvenTreeModelSerializer):
             'shipment_date',
             'target_date',
             'total_price',
-            'sub_total_items_price',
-            'sub_total_extra_line_price',
         ]
 
         read_only_fields = [
@@ -916,6 +930,19 @@ class SalesOrderLineItemSerializer(InvenTreeModelSerializer):
         help_text=_('Sale price currency'),
     )
 
+    converted_total_price = InvenTreeMoneySerializer(
+        source='get_converted_total_price',
+        allow_null=True,
+        read_only=True,
+    )
+
+    converted_total_price_currency = serializers.ChoiceField(
+        source='get_converted_total_price_currency',
+        allow_null=True,
+        read_only=True,
+        choices=currency_code_mappings(),
+    )
+
     class Meta:
         """Metaclass options."""
 
@@ -939,6 +966,8 @@ class SalesOrderLineItemSerializer(InvenTreeModelSerializer):
             'sale_price_currency',
             'shipped',
             'target_date',
+            'converted_total_price',
+            'converted_total_price_currency',
         ]
 
 

--- a/InvenTree/order/serializers.py
+++ b/InvenTree/order/serializers.py
@@ -39,6 +39,18 @@ class AbstractOrderSerializer(serializers.Serializer):
         read_only=True,
     )
 
+    sub_total_items_price = InvenTreeMoneySerializer(
+        source='get_sub_total_item_price',
+        allow_null=True,
+        read_only=True,
+    )
+
+    sub_total_extra_line_price = InvenTreeMoneySerializer(
+        source='get_sub_total_extra_line_price',
+        allow_null=True,
+        read_only=True,
+    )
+
 
 class AbstractExtraLineSerializer(serializers.Serializer):
     """Abstract Serializer for a ExtraLine object."""
@@ -159,6 +171,8 @@ class PurchaseOrderSerializer(AbstractOrderSerializer, InvenTreeModelSerializer)
             'target_date',
             'notes',
             'total_price',
+            'sub_total_items_price',
+            'sub_total_extra_line_price',
         ]
 
         read_only_fields = [
@@ -736,6 +750,8 @@ class SalesOrderSerializer(AbstractOrderSerializer, InvenTreeModelSerializer):
             'shipment_date',
             'target_date',
             'total_price',
+            'sub_total_items_price',
+            'sub_total_extra_line_price',
         ]
 
         read_only_fields = [

--- a/InvenTree/order/templates/order/purchase_order_detail.html
+++ b/InvenTree/order/templates/order/purchase_order_detail.html
@@ -184,6 +184,7 @@ $('#new-po-line').click(function() {
         {% endif %}
         onSuccess: function() {
             $('#po-line-table').bootstrapTable('refresh');
+            reloadTotal();
         }
     });
 });
@@ -199,6 +200,7 @@ $('#new-po-line').click(function() {
             {
                 success: function() {
                     $("#po-line-table").bootstrapTable('refresh');
+                    reloadTotal();
                 }
             }
         );
@@ -242,6 +244,7 @@ $("#new-po-extra-line").click(function() {
         title: '{% trans "Add Order Line" %}',
         onSuccess: function() {
             $("#po-extra-lines-table").bootstrapTable("refresh");
+            reloadTotal();
         },
     });
 });

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2626,10 +2626,7 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
                         fields: fields,
                         data: data,
                         title: '{% trans "Duplicate Line" %}',
-                        onSuccess: function(response) {
-                            $(table).bootstrapTable('refresh');
-                            reloadTotal();
-                        }
+                        onSuccess: reloadTable
                     });
                 }
             });
@@ -2990,7 +2987,6 @@ function loadSalesOrderShipmentTable(table, options={}) {
                 method: 'DELETE',
                 onSuccess: function() {
                     $(table).bootstrapTable('refresh');
-                    reloadTotal();
                 }
             });
         });
@@ -4098,8 +4094,9 @@ function loadSalesOrderLineItemTable(table, options={}) {
                         data: data,
                         title: '{% trans "Duplicate Line Item" %}',
                         onSuccess: function(response) {
-                            $(table).bootstrapTable('refresh');
-                            reloadTotal();
+                            //$(table).bootstrapTable('refresh');
+                            //reloadTotal();
+                            reloadTable();
                         }
                     });
                 }
@@ -4190,8 +4187,6 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
                         // Reload the pending shipment table
                         $('#pending-shipments-table').bootstrapTable('refresh');
-
-                        reloadTotal();
                     }
                 }
             );

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -3890,7 +3890,17 @@ function loadSalesOrderLineItemTable(table, options={}) {
                 });
             },
             footerFormatter: function(data) {
-                return '<div id="sub_total_items_price">';
+                var total = data.map(function(row) {
+                    return +row['converted_total_price'];
+                }).reduce(function(sum, i) {
+                    return sum + i;
+                }, 0);
+
+                var currency = (data.slice(-1)[0] && data.slice(-1)[0].converted_total_price_currency) || 'USD';
+
+                return formatCurrency(total, {
+                    currency: currency,
+                });
             }
         },
         {

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2241,20 +2241,8 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
         }
     }
 
-    function reloadSubTotal() {
-        inventreeGet(`/api/order/po/${options.order}/`,
-            {},
-            {
-                success: function(data) {
-                    $("#sub_total_items_price").html(formatCurrency(data.sub_total_items_price));
-                }
-            }
-        );
-    }
-
     $(table).inventreeTable({
         onPostBody: setupCallbacks,
-        onPostFooter: reloadSubTotal,
         name: 'purchaseorderlines',
         sidePagination: 'server',
         formatNoMatches: function() {
@@ -2388,7 +2376,17 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                     });
                 },
                 footerFormatter: function(data) {
-                    return '<div id="sub_total_items_price">';
+                    var total = data.map(function(row) {
+                        return +row['converted_total_price'];
+                    }).reduce(function(sum, i) {
+                        return sum + i;
+                    }, 0);
+
+                    var currency = (data.slice(-1)[0] && data.slice(-1)[0].converted_total_price_currency) || 'USD';
+
+                    return formatCurrency(total, {
+                        currency: currency,
+                    });
                 }
             },
             {
@@ -2565,7 +2563,17 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
                 });
             },
             footerFormatter: function(data) {
-                return '<div id="sub_total_extra_line_price">';
+                var total = data.map(function(row) {
+                    return +row['converted_total_price'];
+                }).reduce(function(sum, i) {
+                    return sum + i;
+                }, 0);
+
+                var currency = (data.slice(-1)[0] && data.slice(-1)[0].converted_total_price_currency) || 'USD';
+
+                return formatCurrency(total, {
+                    currency: currency,
+                });
             }
         }
     ];
@@ -2599,17 +2607,6 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
     function reloadTable() {
         $(table).bootstrapTable('refresh');
         reloadTotal();
-    }
-
-    function reloadSubTotal() {
-        inventreeGet(`/api/order/po/${options.order}/`,
-            {},
-            {
-                success: function(data) {
-                    $("#sub_total_extra_line_price").html(formatCurrency(data.sub_total_extra_line_price));
-                }
-            }
-        );
     }
 
     // Configure callback functions once the table is loaded
@@ -2669,7 +2666,6 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
 
     $(table).inventreeTable({
         onPostBody: setupCallbacks,
-        onPostFooter: reloadSubTotal,
         name: 'purchaseorderextraline',
         sidePagination: 'client',
         formatNoMatches: function() {
@@ -3760,7 +3756,7 @@ function reloadTotal() {
         {},
         {
             success: function(data) {
-                $(TotalPriceRef).html(formatCurrency(data.price, {currency: data.price_currency}));
+                $(TotalPriceRef).html(formatCurrency(data.total_price, {currency: data.price_currency}));
             }
         }
     );
@@ -4074,17 +4070,6 @@ function loadSalesOrderLineItemTable(table, options={}) {
         reloadTotal();
     }
 
-    function reloadSubTotal() {
-        inventreeGet(`/api/order/so/${options.order}/`,
-            {},
-            {
-                success: function(data) {
-                    $("#sub_total_items_price").html(formatCurrency(data.sub_total_items_price));
-                }
-            }
-        );
-    }
-
     // Configure callback functions once the table is loaded
     function setupCallbacks() {
 
@@ -4272,7 +4257,6 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
     $(table).inventreeTable({
         onPostBody: setupCallbacks,
-        onPostFooter: reloadSubTotal,
         name: 'salesorderlineitems',
         sidePagination: 'client',
         formatNoMatches: function() {
@@ -4390,7 +4374,17 @@ function loadSalesOrderExtraLineTable(table, options={}) {
                 });
             },
             footerFormatter: function(data) {
-                return '<div id="sub_total_extra_line_price">';
+                var total = data.map(function(row) {
+                    return +row['converted_total_price'];
+                }).reduce(function(sum, i) {
+                    return sum + i;
+                }, 0);
+
+                var currency = (data.slice(-1)[0] && data.slice(-1)[0].converted_total_price_currency) || 'USD';
+
+                return formatCurrency(total, {
+                    currency: currency,
+                });
             }
         }
     ];
@@ -4422,17 +4416,6 @@ function loadSalesOrderExtraLineTable(table, options={}) {
     function reloadTable() {
         $(table).bootstrapTable('refresh');
         reloadTotal();
-    }
-
-    function reloadSubTotal() {
-        inventreeGet(`/api/order/so/${options.order}/`,
-            {},
-            {
-                success: function(data) {
-                    $("#sub_total_extra_line_price").html(formatCurrency(data.sub_total_extra_line_price));
-                }
-            }
-        );
     }
 
     // Configure callback functions once the table is loaded
@@ -4492,7 +4475,6 @@ function loadSalesOrderExtraLineTable(table, options={}) {
 
     $(table).inventreeTable({
         onPostBody: setupCallbacks,
-        onPostFooter: reloadSubTotal,
         name: 'salesorderextraline',
         sidePagination: 'client',
         formatNoMatches: function() {

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -4093,11 +4093,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                         fields: fields,
                         data: data,
                         title: '{% trans "Duplicate Line Item" %}',
-                        onSuccess: function(response) {
-                            //$(table).bootstrapTable('refresh');
-                            //reloadTotal();
-                            reloadTable();
-                        }
+                        onSuccess: reloadTable
                     });
                 }
             });

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2236,8 +2236,21 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
         }
     }
 
+    function reloadSubTotal() {
+        inventreeGet(
+            `/api/order/po/${options.order}/`,
+            {},
+            {
+                success: function(data) {
+                    $("#sub_total_items_price").html(formatCurrency(data.sub_total_items_price));
+                }
+            }
+        );
+    }
+
     $(table).inventreeTable({
         onPostBody: setupCallbacks,
+        onPostFooter: reloadSubTotal,
         name: 'purchaseorderlines',
         sidePagination: 'server',
         formatNoMatches: function() {
@@ -2371,17 +2384,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                     });
                 },
                 footerFormatter: function(data) {
-                    var total = data.map(function(row) {
-                        return +row['purchase_price']*row['quantity'];
-                    }).reduce(function(sum, i) {
-                        return sum + i;
-                    }, 0);
-
-                    var currency = (data.slice(-1)[0] && data.slice(-1)[0].purchase_price_currency) || 'USD';
-
-                    return formatCurrency(total, {
-                        currency: currency
-                    });
+                    return '<div id="sub_total_items_price">';
                 }
             },
             {
@@ -2558,17 +2561,7 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
                 });
             },
             footerFormatter: function(data) {
-                var total = data.map(function(row) {
-                    return +row['price'] * row['quantity'];
-                }).reduce(function(sum, i) {
-                    return sum + i;
-                }, 0);
-
-                var currency = (data.slice(-1)[0] && data.slice(-1)[0].price_currency) || 'USD';
-
-                return formatCurrency(total, {
-                    currency: currency,
-                });
+                return '<div id="sub_total_extra_line_price">';
             }
         }
     ];
@@ -2602,6 +2595,18 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
     function reloadTable() {
         $(table).bootstrapTable('refresh');
         reloadTotal();
+    }
+
+    function reloadSubTotal() {
+        inventreeGet(
+            `/api/order/po/${options.order}/`,
+            {},
+            {
+                success: function(data) {
+                    $("#sub_total_extra_line_price").html(formatCurrency(data.sub_total_extra_line_price));
+                }
+            }
+        );
     }
 
     // Configure callback functions once the table is loaded
@@ -2660,6 +2665,7 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
 
     $(table).inventreeTable({
         onPostBody: setupCallbacks,
+        onPostFooter: reloadSubTotal,
         name: 'purchaseorderextraline',
         sidePagination: 'client',
         formatNoMatches: function() {
@@ -3883,17 +3889,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                 });
             },
             footerFormatter: function(data) {
-                var total = data.map(function(row) {
-                    return +row['sale_price'] * row['quantity'];
-                }).reduce(function(sum, i) {
-                    return sum + i;
-                }, 0);
-
-                var currency = (data.slice(-1)[0] && data.slice(-1)[0].sale_price_currency) || 'USD';
-
-                return formatCurrency(total, {
-                    currency: currency,
-                });
+                return '<div id="sub_total_items_price">';
             }
         },
         {
@@ -4071,6 +4067,18 @@ function loadSalesOrderLineItemTable(table, options={}) {
     function reloadTable() {
         $(table).bootstrapTable('refresh');
         reloadTotal();
+    }
+
+    function reloadSubTotal() {
+        inventreeGet(
+            `/api/order/so/${options.order}/`,
+            {},
+            {
+                success: function(data) {
+                    $("#sub_total_items_price").html(formatCurrency(data.sub_total_items_price));
+                }
+            }
+        );
     }
 
     // Configure callback functions once the table is loaded
@@ -4257,6 +4265,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
     $(table).inventreeTable({
         onPostBody: setupCallbacks,
+        onPostFooter: reloadSubTotal,
         name: 'salesorderlineitems',
         sidePagination: 'client',
         formatNoMatches: function() {
@@ -4374,17 +4383,7 @@ function loadSalesOrderExtraLineTable(table, options={}) {
                 });
             },
             footerFormatter: function(data) {
-                var total = data.map(function(row) {
-                    return +row['price'] * row['quantity'];
-                }).reduce(function(sum, i) {
-                    return sum + i;
-                }, 0);
-
-                var currency = (data.slice(-1)[0] && data.slice(-1)[0].price_currency) || 'USD';
-
-                return formatCurrency(total, {
-                    currency: currency,
-                });
+                return '<div id="sub_total_extra_line_price">';
             }
         }
     ];
@@ -4416,6 +4415,18 @@ function loadSalesOrderExtraLineTable(table, options={}) {
     function reloadTable() {
         $(table).bootstrapTable('refresh');
         reloadTotal();
+    }
+
+    function reloadSubTotal() {
+        inventreeGet(
+            `/api/order/so/${options.order}/`,
+            {},
+            {
+                success: function(data) {
+                    $("#sub_total_extra_line_price").html(formatCurrency(data.sub_total_extra_line_price));
+                }
+            }
+        );
     }
 
     // Configure callback functions once the table is loaded
@@ -4474,6 +4485,7 @@ function loadSalesOrderExtraLineTable(table, options={}) {
 
     $(table).inventreeTable({
         onPostBody: setupCallbacks,
+        onPostFooter: reloadSubTotal,
         name: 'salesorderextraline',
         sidePagination: 'client',
         formatNoMatches: function() {

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2171,6 +2171,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                             title: '{% trans "Duplicate Line Item" %}',
                             onSuccess: function(response) {
                                 $(table).bootstrapTable('refresh');
+                                reloadTotal();
                             }
                         });
                     }
@@ -2188,6 +2189,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                     title: '{% trans "Edit Line Item" %}',
                     onSuccess: function() {
                         $(table).bootstrapTable('refresh');
+                        reloadTotal();
                     }
                 });
             });
@@ -2201,6 +2203,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                     title: '{% trans "Delete Line Item" %}',
                     onSuccess: function() {
                         $(table).bootstrapTable('refresh');
+                        reloadTotal();
                     }
                 });
             });
@@ -2229,6 +2232,8 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
 
                             // Reload the "received stock" table
                             $('#stock-table').bootstrapTable('refresh');
+
+                            reloadTotal();
                         }
                     }
                 );
@@ -2237,8 +2242,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
     }
 
     function reloadSubTotal() {
-        inventreeGet(
-            `/api/order/po/${options.order}/`,
+        inventreeGet(`/api/order/po/${options.order}/`,
             {},
             {
                 success: function(data) {
@@ -2598,8 +2602,7 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
     }
 
     function reloadSubTotal() {
-        inventreeGet(
-            `/api/order/po/${options.order}/`,
+        inventreeGet(`/api/order/po/${options.order}/`,
             {},
             {
                 success: function(data) {
@@ -2628,6 +2631,7 @@ function loadPurchaseOrderExtraLineTable(table, options={}) {
                         title: '{% trans "Duplicate Line" %}',
                         onSuccess: function(response) {
                             $(table).bootstrapTable('refresh');
+                            reloadTotal();
                         }
                     });
                 }
@@ -2990,6 +2994,7 @@ function loadSalesOrderShipmentTable(table, options={}) {
                 method: 'DELETE',
                 onSuccess: function() {
                     $(table).bootstrapTable('refresh');
+                    reloadTotal();
                 }
             });
         });
@@ -4070,8 +4075,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
     }
 
     function reloadSubTotal() {
-        inventreeGet(
-            `/api/order/so/${options.order}/`,
+        inventreeGet(`/api/order/so/${options.order}/`,
             {},
             {
                 success: function(data) {
@@ -4100,6 +4104,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                         title: '{% trans "Duplicate Line Item" %}',
                         onSuccess: function(response) {
                             $(table).bootstrapTable('refresh');
+                            reloadTotal();
                         }
                     });
                 }
@@ -4190,6 +4195,8 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
                         // Reload the pending shipment table
                         $('#pending-shipments-table').bootstrapTable('refresh');
+
+                        reloadTotal();
                     }
                 }
             );
@@ -4418,8 +4425,7 @@ function loadSalesOrderExtraLineTable(table, options={}) {
     }
 
     function reloadSubTotal() {
-        inventreeGet(
-            `/api/order/so/${options.order}/`,
+        inventreeGet(`/api/order/so/${options.order}/`,
             {},
             {
                 success: function(data) {
@@ -4448,6 +4454,7 @@ function loadSalesOrderExtraLineTable(table, options={}) {
                         title: '{% trans "Duplicate Line" %}',
                         onSuccess: function(response) {
                             $(table).bootstrapTable('refresh');
+                            reloadTotal();
                         }
                     });
                 }


### PR DESCRIPTION
Instead of summing all prices in the table which could be in different currencies, load them through a callback and the API. See issue #4199


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4245"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

