### PR TITLE
Fix for showing about dialog

### DIFF
--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -166,8 +166,11 @@ def inventree_in_debug_mode(*args, **kwargs):
 @register.simple_tag()
 def inventree_show_about(user, *args, **kwargs):
     """Return True if the about modal should be shown."""
-    if InvenTreeSetting.get_setting('INVENTREE_RESTRICT_ABOUT') and not user.is_superuser:
-        return False
+    if InvenTreeSetting.get_setting('INVENTREE_RESTRICT_ABOUT'):
+        # Return False if the user is not a superuser, or no user information is provided
+        if not user or not user.is_superuser:
+            return False
+
     return True
 
 


### PR DESCRIPTION
Handle case where function is called with empty user