### PR TITLE
Bug fix for creating Part or Company via API

### DIFF
--- a/InvenTree/company/models.py
+++ b/InvenTree/company/models.py
@@ -94,6 +94,17 @@ class Company(MetadataMixin, models.Model):
         ]
         verbose_name_plural = "Companies"
 
+    def __init__(self, *args, **kwargs):
+        """Custom initialization routine for the Company model.
+
+        Ensures that custom serializer fields (without matching model fields) are removed
+        """
+
+        # Remote image specified during creation via API
+        kwargs.pop('remote_image', None)
+
+        super().__init__(*args, **kwargs)
+
     name = models.CharField(max_length=100, blank=False,
                             help_text=_('Company name'),
                             verbose_name=_('Company name'))

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -391,6 +391,17 @@ class Part(InvenTreeBarcodeMixin, MetadataMixin, MPTTModel):
         # For legacy reasons the 'variant_of' field is used to indicate the MPTT parent
         parent_attr = 'variant_of'
 
+    def __init__(self, *args, **kwargs):
+        """Custom initialization routine for the Part model.
+
+        Ensures that custom serializer fields (without matching model fields) are removed
+        """
+
+        # Remote image specified during creation via API
+        kwargs.pop('remote_image', None)
+
+        super().__init__(*args, **kwargs)
+
     @staticmethod
     def get_api_url():
         """Return the list API endpoint URL associated with the Part model"""


### PR DESCRIPTION
- If specified, the "remote_image" field is passed through to the __init__ method
- Throws a 500 error
- Solution is to explicitly ignore the provided field

Closes https://github.com/inventree/inventree-python/issues/162

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4264"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

