### PR TITLE
Add cli to package installs

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -29,6 +29,7 @@ dependencies:
   - gettext
   - nginx
   - jq
+  - libffi7
 targets:
   ubuntu-20.04: true
   debian-11: true

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: env/bin/gunicorn --chdir $APP_HOME/InvenTree -c InvenTree/gunicorn.conf.py InvenTree.wsgi -b 0.0.0.0:$PORT
 worker: env/bin/python InvenTree/manage.py qcluster
+cli: env/bin/python -m invoke


### PR DESCRIPTION
This PR adds an optional call to the command line to run invoke commands easily.
You can now run management commands (invoke tasks) using `sudo inventree run cli` - so eg. `sudo inventree run cli migrate`.

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4274"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

