### PR TITLE
Force builtin plugins to be active

### DIFF
--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -148,6 +148,10 @@ class PluginConfig(models.Model):
 
         ret = super().save(force_insert, force_update, *args, **kwargs)
 
+        if self.is_builtin():
+            # Force active if builtin
+            self.active = True
+
         if not reload:
             if (self.active is False and self.__org_active is True) or \
                (self.active is True and self.__org_active is False):

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -408,6 +408,11 @@ class PluginsRegistry:
             # Check if this is a 'builtin' plugin
             builtin = plg.check_is_builtin()
 
+            # Auto-enable builtin plugins
+            if builtin and plg_db and not plg_db.active:
+                plg_db.active = True
+                plg_db.save()
+
             # Determine if this plugin should be loaded:
             # - If PLUGIN_TESTING is enabled
             # - If this is a 'builtin' plugin

--- a/InvenTree/plugin/test_api.py
+++ b/InvenTree/plugin/test_api.py
@@ -193,8 +193,3 @@ class PluginDetailAPITest(PluginMixin, InvenTreeAPITestCase):
         with self.assertRaises(NotFound) as exc:
             check_plugin(plugin_slug=None, plugin_pk='123')
         self.assertEqual(str(exc.exception.detail), "Plugin '123' not installed")
-
-        # Not active
-        with self.assertRaises(NotFound) as exc:
-            check_plugin(plugin_slug='inventreebarcode', plugin_pk=None)
-        self.assertEqual(str(exc.exception.detail), "Plugin 'inventreebarcode' is not active")


### PR DESCRIPTION
- Not setting the "active" flag can cause ambiguous errors
- e.g. some settings don't work if the plugin is inactive
- By design, builtin plugins are always "active" anyway
- This PR just forces the active field to True

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4276"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

