### PR TITLE
Improvements for part creation API endpoint

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,17 +2,24 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 90
+INVENTREE_API_VERSION = 91
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v91 -> 2023-01-31 : https://github.com/inventree/InvenTree/pull/4281
+    - Improves the API endpoint for creating new Part instances
+
 v90 -> 2023-01-25 : https://github.com/inventree/InvenTree/pull/4186/files
     - Adds a dedicated endpoint to activate a plugin
+
 v89 -> 2023-01-25 : https://github.com/inventree/InvenTree/pull/4214
     - Adds updated field to SupplierPart API
     - Adds API date orddering for supplier part list
+
 v88 -> 2023-01-17: https://github.com/inventree/InvenTree/pull/4225
     - Adds 'priority' field to Build model and api endpoints
+
 v87 -> 2023-01-04 : https://github.com/inventree/InvenTree/pull/4067
     - Add API date filter for stock table on Expiry date
 

--- a/InvenTree/InvenTree/serializers.py
+++ b/InvenTree/InvenTree/serializers.py
@@ -147,6 +147,16 @@ class InvenTreeModelSerializer(serializers.ModelSerializer):
 
         return initials
 
+    def skip_create_fields(self):
+        """Return a list of 'fields' which should be skipped for model creation.
+
+        This is used to 'bypass' a shortcoming of the DRF framework,
+        which does not allow us to have writeable serializer fields which do not exist on the model.
+
+        Default implementation returns an empty list
+        """
+        return []
+
     def save(self, **kwargs):
         """Catch any django ValidationError thrown at the moment `save` is called, and re-throw as a DRF ValidationError."""
         try:
@@ -155,6 +165,17 @@ class InvenTreeModelSerializer(serializers.ModelSerializer):
             raise ValidationError(detail=serializers.as_serializer_error(exc))
 
         return self.instance
+
+    def create(self, validated_data):
+        """Custom create method which supports field adjustment"""
+
+        initial_data = validated_data.copy()
+
+        # Remove any fields which do not exist on the model
+        for field in self.skip_create_fields():
+            initial_data.pop(field, None)
+
+        return super().create(initial_data)
 
     def update(self, instance, validated_data):
         """Catch any django ValidationError, and re-throw as a DRF ValidationError."""
@@ -171,14 +192,20 @@ class InvenTreeModelSerializer(serializers.ModelSerializer):
         In addition to running validators on the serializer fields,
         this class ensures that the underlying model is also validated.
         """
+
         # Run any native validation checks first (may raise a ValidationError)
         data = super().run_validation(data)
 
-        # Now ensure the underlying model is correct
-
         if not hasattr(self, 'instance') or self.instance is None:
             # No instance exists (we are creating a new one)
-            instance = self.Meta.model(**data)
+
+            initial_data = data.copy()
+
+            for field in self.skip_create_fields():
+                # Remove any fields we do not wish to provide to the model
+                initial_data.pop(field, None)
+
+            instance = self.Meta.model._default_manager.create(**initial_data)
         else:
             # Instance already exists (we are updating!)
             instance = self.instance
@@ -598,6 +625,13 @@ class RemoteImageMixin(metaclass=serializers.SerializerMetaclass):
 
     Adds the optional, write-only `remote_image` field to the serializer
     """
+
+    def skip_create_fields(self):
+        """Ensure the 'remote_image' field is skipped when creating a new instance"""
+
+        return [
+            'remote_image',
+        ]
 
     remote_image = serializers.URLField(
         required=False,

--- a/InvenTree/InvenTree/serializers.py
+++ b/InvenTree/InvenTree/serializers.py
@@ -205,7 +205,8 @@ class InvenTreeModelSerializer(serializers.ModelSerializer):
                 # Remove any fields we do not wish to provide to the model
                 initial_data.pop(field, None)
 
-            instance = self.Meta.model._default_manager.create(**initial_data)
+            # Create a (RAM only) instance for extra testing
+            instance = self.Meta.model(**initial_data)
         else:
             # Instance already exists (we are updating!)
             instance = self.instance

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1121,9 +1121,16 @@ class InvenTreeSetting(BaseInvenTreeSetting):
         },
 
         'PART_CREATE_INITIAL': {
-            'name': _('Create initial stock'),
-            'description': _('Create initial stock on part creation'),
+            'name': _('Initial Stock Data'),
+            'description': _('Allow creation of initial stock when adding a new part'),
             'default': False,
+            'validator': bool,
+        },
+
+        'PART_CREATE_SUPPLIER': {
+            'name': _('Initial Supplier Data'),
+            'description': _('Allow creation of initial supplier data when adding a new part'),
+            'default': True,
             'validator': bool,
         },
 

--- a/InvenTree/company/fixtures/company.yaml
+++ b/InvenTree/company/fixtures/company.yaml
@@ -46,3 +46,12 @@
     name: Another manufacturer
     description: They build things and sell it to us
     is_manufacturer: True
+
+- model: company.company
+  pk: 8
+  fields:
+    name: Customer only
+    description: Just a customer
+    is_customer: True
+    is_supplier: False
+    is_manufacturer: False

--- a/InvenTree/company/models.py
+++ b/InvenTree/company/models.py
@@ -94,17 +94,6 @@ class Company(MetadataMixin, models.Model):
         ]
         verbose_name_plural = "Companies"
 
-    def __init__(self, *args, **kwargs):
-        """Custom initialization routine for the Company model.
-
-        Ensures that custom serializer fields (without matching model fields) are removed
-        """
-
-        # Remote image specified during creation via API
-        kwargs.pop('remote_image', None)
-
-        super().__init__(*args, **kwargs)
-
     name = models.CharField(max_length=100, blank=False,
                             help_text=_('Company name'),
                             verbose_name=_('Company name'))

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1096,25 +1096,7 @@ class PartFilter(rest_filters.FilterSet):
 
 
 class PartList(APIDownloadMixin, ListCreateAPI):
-    """API endpoint for accessing a list of Part objects.
-
-    - GET: Return list of objects
-    - POST: Create a new Part object
-
-    The Part object list can be filtered by:
-        - category: Filter by PartCategory reference
-        - cascade: If true, include parts from sub-categories
-        - starred: Is the part "starred" by the current user?
-        - is_template: Is the part a template part?
-        - variant_of: Filter by variant_of Part reference
-        - assembly: Filter by assembly field
-        - component: Filter by component field
-        - trackable: Filter by trackable field
-        - purchaseable: Filter by purcahseable field
-        - salable: Filter by salable field
-        - active: Filter by active field
-        - ancestor: Filter parts by 'ancestor' (template / variant tree)
-    """
+    """API endpoint for accessing a list of Part objects, or creating a new Part instance"""
 
     serializer_class = part_serializers.PartSerializer
     queryset = Part.objects.all()
@@ -1126,6 +1108,9 @@ class PartList(APIDownloadMixin, ListCreateAPI):
         """Return a serializer instance for this endpoint"""
         # Ensure the request context is passed through
         kwargs['context'] = self.get_serializer_context()
+
+        # Indicate that we can create a new Part via this endpoint
+        kwargs['create'] = True
 
         # Pass a list of "starred" parts to the current user to the serializer
         # We do this to reduce the number of database queries required!

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -17,7 +17,6 @@ from rest_framework.response import Response
 
 import order.models
 from build.models import Build, BuildItem
-from company.models import Company, ManufacturerPart, SupplierPart
 from InvenTree.api import (APIDownloadMixin, AttachmentMixin,
                            ListCreateDestroyAPIView)
 from InvenTree.filters import InvenTreeOrderingFilter
@@ -1230,59 +1229,6 @@ class PartList(APIDownloadMixin, ListCreateAPI):
         }
 
         part.save(**{'add_category_templates': copy_templates})
-
-        # Optionally add manufacturer / supplier data to the part
-        if part.purchaseable and str2bool(data.get('add_supplier_info', False)):
-
-            try:
-                manufacturer = Company.objects.get(pk=data.get('manufacturer', None))
-            except Exception:
-                manufacturer = None
-
-            try:
-                supplier = Company.objects.get(pk=data.get('supplier', None))
-            except Exception:
-                supplier = None
-
-            mpn = str(data.get('MPN', '')).strip()
-            sku = str(data.get('SKU', '')).strip()
-
-            # Construct a manufacturer part
-            if manufacturer or mpn:
-                if not manufacturer:
-                    raise ValidationError({
-                        'manufacturer': [_("This field is required")]
-                    })
-                if not mpn:
-                    raise ValidationError({
-                        'MPN': [_("This field is required")]
-                    })
-
-                manufacturer_part = ManufacturerPart.objects.create(
-                    part=part,
-                    manufacturer=manufacturer,
-                    MPN=mpn
-                )
-            else:
-                # No manufacturer part data specified
-                manufacturer_part = None
-
-            if supplier or sku:
-                if not supplier:
-                    raise ValidationError({
-                        'supplier': [_("This field is required")]
-                    })
-                if not sku:
-                    raise ValidationError({
-                        'SKU': [_("This field is required")]
-                    })
-
-                SupplierPart.objects.create(
-                    part=part,
-                    supplier=supplier,
-                    SKU=sku,
-                    manufacturer_part=manufacturer_part,
-                )
 
         headers = self.get_success_headers(serializer.data)
 

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1226,34 +1226,6 @@ class PartList(APIDownloadMixin, ListCreateAPI):
 
         part.save(**{'add_category_templates': copy_templates})
 
-        # Optionally copy data from another part (e.g. when duplicating)
-        copy_from = data.get('copy_from', None)
-
-        if copy_from is not None:
-
-            try:
-                original = Part.objects.get(pk=copy_from)
-
-                copy_bom = str2bool(data.get('copy_bom', False))
-                copy_parameters = str2bool(data.get('copy_parameters', False))
-                copy_image = str2bool(data.get('copy_image', True))
-
-                # Copy image?
-                if copy_image:
-                    part.image = original.image
-                    part.save()
-
-                # Copy BOM?
-                if copy_bom:
-                    part.copy_bom_from(original)
-
-                # Copy parameter data?
-                if copy_parameters:
-                    part.copy_parameters_from(original)
-
-            except (ValueError, Part.DoesNotExist):
-                pass
-
         # Optionally create initial stock item
         initial_stock = str2bool(data.get('initial_stock', False))
 

--- a/InvenTree/part/fixtures/params.yaml
+++ b/InvenTree/part/fixtures/params.yaml
@@ -54,6 +54,20 @@
     template: 3
     data: 12
 
+- model: part.PartParameter
+  pk: 6
+  fields:
+    part: 100
+    template: 3
+    data: 12
+
+- model: part.PartParameter
+  pk: 7
+  fields:
+    part: 100
+    template: 1
+    data: 12
+
 # Add some template parameters to categories (requires category.yaml)
 - model: part.PartCategoryParameterTemplate
   pk: 1

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2023,41 +2023,6 @@ class Part(InvenTreeBarcodeMixin, MetadataMixin, MPTTModel):
 
             parameter.save()
 
-    @transaction.atomic
-    def deep_copy(self, other, **kwargs):
-        """Duplicates non-field data from another part.
-
-        Does not alter the normal fields of this part, but can be used to copy other data linked by ForeignKey refernce.
-
-        Keyword Args:
-            image: If True, copies Part image (default = True)
-            bom: If True, copies BOM data (default = False)
-            parameters: If True, copies Parameters data (default = True)
-        """
-        # Copy the part image
-        if kwargs.get('image', True):
-            if other.image:
-                # Reference the other image from this Part
-                self.image = other.image
-
-        # Copy the BOM data
-        if kwargs.get('bom', False):
-            self.copy_bom_from(other)
-
-        # Copy the parameters data
-        if kwargs.get('parameters', True):
-            self.copy_parameters_from(other)
-
-        # Copy the fields that aren't available in the duplicate form
-        self.salable = other.salable
-        self.assembly = other.assembly
-        self.component = other.component
-        self.purchaseable = other.purchaseable
-        self.trackable = other.trackable
-        self.virtual = other.virtual
-
-        self.save()
-
     def getTestTemplates(self, required=None, include_parent=True):
         """Return a list of all test templates associated with this Part.
 

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -391,17 +391,6 @@ class Part(InvenTreeBarcodeMixin, MetadataMixin, MPTTModel):
         # For legacy reasons the 'variant_of' field is used to indicate the MPTT parent
         parent_attr = 'variant_of'
 
-    def __init__(self, *args, **kwargs):
-        """Custom initialization routine for the Part model.
-
-        Ensures that custom serializer fields (without matching model fields) are removed
-        """
-
-        # Remote image specified during creation via API
-        kwargs.pop('remote_image', None)
-
-        super().__init__(*args, **kwargs)
-
     @staticmethod
     def get_api_url():
         """Return the list API endpoint URL associated with the Part model"""

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -340,7 +340,7 @@ class InitialStockSerializer(serializers.Serializer):
 
     quantity = serializers.DecimalField(
         max_digits=15, decimal_places=5, validators=[MinValueValidator(0)],
-        label=_('Initial Stock Quantity'), help_text=_('Specify initial stock quantity for this Part'),
+        label=_('Initial Stock Quantity'), help_text=_('Specify initial stock quantity for this Part. If quantity is zero, no stock is added.'),
         required=True,
     )
 
@@ -356,7 +356,7 @@ class InitialSupplierSerializer(serializers.Serializer):
 
     supplier = serializers.PrimaryKeyRelatedField(
         queryset=company.models.Company.objects.all(),
-        label=_('Supplier'), help_text=_('Select supplier'),
+        label=_('Supplier'), help_text=_('Select supplier (or leave blank to skip)'),
         allow_null=True, required=False,
     )
 
@@ -367,7 +367,7 @@ class InitialSupplierSerializer(serializers.Serializer):
 
     manufacturer = serializers.PrimaryKeyRelatedField(
         queryset=company.models.Company.objects.all(),
-        label=_('Manufacturer'), help_text=_('Select manufacturer'),
+        label=_('Manufacturer'), help_text=_('Select manufacturer (or leave blank to skip)'),
         allow_null=True, required=False,
     )
 

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -321,17 +321,17 @@ class DuplicatePartSerializer(serializers.Serializer):
 
     copy_image = serializers.BooleanField(
         label=_('Copy Image'), help_text=_('Copy image from original part'),
-        default=False,
+        required=False, default=False,
     )
 
     copy_bom = serializers.BooleanField(
         label=_('Copy BOM'), help_text=_('Copy bill of materials from original part'),
-        default=False,
+        required=False, default=False,
     )
 
     copy_parameters = serializers.BooleanField(
         label=_('Copy Parameters'), help_text=_('Copy parameter data from original part'),
-        default=False,
+        required=False, default=False,
     )
 
 

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -382,11 +382,15 @@ class InitialSupplierSerializer(serializers.Serializer):
         if not company.is_supplier:
             raise serializers.ValidationError(_('Selected company is not a valid supplier'))
 
+        return company
+
     def validate_manufacturer(self, company):
         """Validation for the provided Manufacturer"""
 
         if not company.is_manufacturer:
             raise serializers.ValidationError(_('Selected company is not a valid manufacturer'))
+
+        return company
 
     def validate(self, data):
         """Extra validation for this serializer"""
@@ -406,6 +410,8 @@ class InitialSupplierSerializer(serializers.Serializer):
             raise serializers.ValidationError({
                 'sku': _('Supplier part matching this SKU already exists')
             })
+
+        return data
 
 
 class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
@@ -667,8 +673,8 @@ class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
         # Create initial supplier information
         if initial_supplier:
 
-            manufacturer = initial_stock.get('manufacturer', None)
-            mpn = initial_stock.get('mpn', '')
+            manufacturer = initial_supplier.get('manufacturer', None)
+            mpn = initial_supplier.get('mpn', '')
 
             if manufacturer and mpn:
                 manu_part = company.models.ManufacturerPart.objects.create(
@@ -679,8 +685,8 @@ class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
             else:
                 manu_part = None
 
-            supplier = initial_stock.get('supplier', None)
-            sku = initial_stock.get('sku', '')
+            supplier = initial_supplier.get('supplier', None)
+            sku = initial_supplier.get('sku', '')
 
             if supplier and sku:
                 company.models.SupplierPart.objects.create(

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -379,7 +379,7 @@ class InitialSupplierSerializer(serializers.Serializer):
     def validate_supplier(self, company):
         """Validation for the provided Supplier"""
 
-        if not company.is_supplier:
+        if company and not company.is_supplier:
             raise serializers.ValidationError(_('Selected company is not a valid supplier'))
 
         return company
@@ -387,7 +387,7 @@ class InitialSupplierSerializer(serializers.Serializer):
     def validate_manufacturer(self, company):
         """Validation for the provided Manufacturer"""
 
-        if not company.is_manufacturer:
+        if company and not company.is_manufacturer:
             raise serializers.ValidationError(_('Selected company is not a valid manufacturer'))
 
         return company

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -361,7 +361,7 @@ class InitialSupplierSerializer(serializers.Serializer):
     )
 
     sku = serializers.CharField(
-        max_length=100, required=False,
+        max_length=100, required=False, allow_blank=True,
         label=_('SKU'), help_text=_('Supplier stock keeping unit'),
     )
 
@@ -372,7 +372,7 @@ class InitialSupplierSerializer(serializers.Serializer):
     )
 
     mpn = serializers.CharField(
-        max_length=100, required=False,
+        max_length=100, required=False, allow_blank=True,
         label=_('MPN'), help_text=_('Manufacturer part number'),
     )
 

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -536,6 +536,30 @@ class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
             'barcode_hash',
         ]
 
+    @transaction.atomic
+    def create(self, validated_data):
+        """Custom method for creating a new Part instance using this serializer"""
+
+        duplicate = validated_data.pop('duplicate', None)
+
+        instance = super().create(validated_data)
+
+        if duplicate:
+            # Copy data from original Part
+            original = duplicate['part']
+
+            if duplicate['copy_bom']:
+                instance.copy_bom_from(original)
+
+            if duplicate['copy_image']:
+                instance.image = original.image
+                instance.save()
+
+            if duplicate['copy_parameters']:
+                instance.copy_parameters_from(original)
+
+        return instance
+
     def save(self):
         """Save the Part instance"""
 

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -336,30 +336,9 @@
 
     {% if roles.part.add %}
     $("#part-create").click(function() {
-
-        var fields = partFields({
-            create: true,
+        createPart({
+            {% if category %}category: {{ category.pk }},{% endif %}
         });
-
-        {% if category %}
-        fields.category.value = {{ category.pk }};
-        {% endif %}
-
-        constructForm('{% url "api-part-list" %}', {
-            method: 'POST',
-            fields: fields,
-            groups: partGroups(),
-            title: '{% trans "Create Part" %}',
-            reloadFormAfterSuccess: true,
-            persist: true,
-            persistMessage: '{% trans "Create another part after this one" %}',
-            successMessage: '{% trans "Part created successfully" %}',
-            onSuccess: function(data) {
-                // Follow the new part
-                location.href = `/part/${data.pk}/`;
-            },
-        });
-
     });
     {% endif %}
 

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -2604,7 +2604,7 @@ class PartParameterTest(InvenTreeAPITestCase):
 
         response = self.get(url)
 
-        self.assertEqual(len(response.data), 5)
+        self.assertEqual(len(response.data), 7)
 
         # Filter by part
         response = self.get(
@@ -2624,7 +2624,7 @@ class PartParameterTest(InvenTreeAPITestCase):
             }
         )
 
-        self.assertEqual(len(response.data), 3)
+        self.assertEqual(len(response.data), 4)
 
     def test_create_param(self):
         """Test that we can create a param via the API."""
@@ -2643,7 +2643,7 @@ class PartParameterTest(InvenTreeAPITestCase):
 
         response = self.get(url)
 
-        self.assertEqual(len(response.data), 6)
+        self.assertEqual(len(response.data), 8)
 
     def test_param_detail(self):
         """Tests for the PartParameter detail endpoint."""

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -574,6 +574,19 @@ class PartAPITestBase(InvenTreeAPITestCase):
 class PartAPITest(PartAPITestBase):
     """Series of tests for the Part DRF API."""
 
+    fixtures = [
+        'category',
+        'part',
+        'location',
+        'bom',
+        'company',
+        'test_templates',
+        'manufacturer_part',
+        'params',
+        'supplier_part',
+        'order',
+    ]
+
     def test_get_categories(self):
         """Test that we can retrieve list of part categories, with various filtering options."""
         url = reverse('api-part-category-list')

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -1302,6 +1302,10 @@ class PartCreationTests(PartAPITestBase):
         self.assertEqual(response.data['name'], name)
         self.assertEqual(response.data['description'], description)
 
+    def test_duplication(self):
+        """Test part duplication options"""
+        ...
+
 
 class PartDetailTests(PartAPITestBase):
     """Test that we can create / edit / delete Part objects via the API."""

--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -556,6 +556,7 @@ class PartAPITestBase(InvenTreeAPITestCase):
         'company',
         'test_templates',
         'manufacturer_part',
+        'params',
         'supplier_part',
         'order',
         'stock',
@@ -1331,7 +1332,32 @@ class PartCreationTests(PartAPITestBase):
 
     def test_duplication(self):
         """Test part duplication options"""
-        ...
+
+        # Run a matrix of tests
+        for bom in [True, False]:
+            for img in [True, False]:
+                for params in [True, False]:
+                    response = self.post(
+                        reverse('api-part-list'),
+                        {
+                            'name': f'thing_{bom}{img}{params}',
+                            'description': 'Some description',
+                            'category': 1,
+                            'duplicate': {
+                                'part': 100,
+                                'copy_bom': bom,
+                                'copy_image': img,
+                                'copy_parameters': params,
+                            }
+                        },
+                        expected_code=201,
+                    )
+
+                    part = Part.objects.get(pk=response.data['pk'])
+
+                    # Check new part
+                    self.assertEqual(part.bom_items.count(), 4 if bom else 0)
+                    self.assertEqual(part.parameters.count(), 2 if params else 0)
 
 
 class PartDetailTests(PartAPITestBase):

--- a/InvenTree/part/test_part.py
+++ b/InvenTree/part/test_part.py
@@ -255,10 +255,6 @@ class PartTest(TestCase):
         self.assertIn('InvenTree', barcode)
         self.assertIn('"part": {"id": 3}', barcode)
 
-    def test_copy(self):
-        """Test that we can 'deep copy' a Part instance"""
-        self.r2.deep_copy(self.r1, image=True, bom=True)
-
     def test_sell_pricing(self):
         """Check that the sell pricebreaks were loaded"""
         self.assertTrue(self.r1.has_price_breaks)

--- a/InvenTree/templates/InvenTree/settings/part.html
+++ b/InvenTree/templates/InvenTree/settings/part.html
@@ -17,6 +17,7 @@
         {% include "InvenTree/settings/setting.html" with key="PART_NAME_FORMAT" %}
         {% include "InvenTree/settings/setting.html" with key="PART_SHOW_RELATED" icon="fa-random" %}
         {% include "InvenTree/settings/setting.html" with key="PART_CREATE_INITIAL" icon="fa-boxes" %}
+        {% include "InvenTree/settings/setting.html" with key="PART_CREATE_SUPPLIER" icon="fa-shopping-cart" %}
         <tr><td colspan='5'></td></tr>
         {% include "InvenTree/settings/setting.html" with key="PART_TEMPLATE" icon="fa-clone" %}
         {% include "InvenTree/settings/setting.html" with key="PART_ASSEMBLY" icon="fa-tools" %}

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -860,7 +860,16 @@ function submitFormData(fields, options) {
                 // Normal field (not a file or image)
                 form_data.append(name, value);
 
-                data[name] = value;
+                if (field.parent_name && field.child_name) {
+                    // "Nested" fields are handled a little differently
+                    if (!(field.parent_name in data)) {
+                        data[field.parent_name] = {};
+                    }
+
+                    data[field.parent_name][field.child_name] = value;
+                } else {
+                    data[name] = value;
+                }
             }
         } else {
             console.warn(`Could not find field matching '${name}'`);

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -1376,9 +1376,7 @@ function handleFormErrors(errors, fields={}, options={}) {
 
                 addFieldErrorMessage(sub_field_name, sub_field_errors, options);
             }
-
-        }
-        else if ((field.type == 'field') && ('child' in field)) {
+        } else if ((field.type == 'field') && ('child' in field)) {
             // This is a "nested" array field
             handleNestedArrayErrors(errors, field_name, options);
         } else {

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -2151,7 +2151,7 @@ function constructField(name, parameters, options={}) {
                 html += `<div>`;
             }
 
-            html += `<h4 style='display: inline;'>${group_options.title || group}</h4>`;
+            html += `<h5 style='display: inline;'>${group_options.title || group}</h5>`;
 
             if (group_options.collapsible) {
                 html += `</a>`;

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -1380,9 +1380,15 @@ function handleFormErrors(errors, fields={}, options={}) {
 
     if (first_error_field) {
         // Ensure that the field in question is visible
-        document.querySelector(`#div_id_${field_name}`).scrollIntoView({
-            behavior: 'smooth',
-        });
+        var error_element = document.querySelector(`#div_id_${field_name}`);
+
+        if (error_element) {
+            error_element.scrollIntoView({
+                behavior: 'smooth',
+            });
+        } else {
+            console.warn(`Could not scroll to field '${field_name}' - element not found`);
+        }
     } else {
         // Scroll to the top of the form
         $(options.modal).find('.modal-form-content-wrapper').scrollTop(0);

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -230,7 +230,7 @@ function partFields(options={}) {
 
         fields.duplicate__copy_bom = {
             value: global_settings.PART_COPY_BOM,
-        }
+        };
 
         fields.duplicate__copy_parameters = {
             value: global_settings.PART_COPY_PARAMETERS,

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -261,35 +261,23 @@ function partFields(options={}) {
     // Additional fields when "duplicating" a part
     if (options.duplicate) {
 
-        fields.copy_from = {
-            type: 'integer',
-            hidden: true,
+        // The following fields exist under the child serializer named 'duplicate'
+
+        fields.duplicate__part = {
             value: options.duplicate,
-            group: 'duplicate',
-        },
-
-        fields.copy_image = {
-            type: 'boolean',
-            label: '{% trans "Copy Image" %}',
-            help_text: '{% trans "Copy image from original part" %}',
-            value: true,
-            group: 'duplicate',
-        },
-
-        fields.copy_bom = {
-            type: 'boolean',
-            label: '{% trans "Copy BOM" %}',
-            help_text: '{% trans "Copy bill of materials from original part" %}',
-            value: global_settings.PART_COPY_BOM,
-            group: 'duplicate',
+            hidden: true,
         };
 
-        fields.copy_parameters = {
-            type: 'boolean',
-            label: '{% trans "Copy Parameters" %}',
-            help_text: '{% trans "Copy parameter data from original part" %}',
+        fields.duplicate__copy_image = {
+            value: true,
+        };
+
+        fields.duplicate__copy_bom = {
+            value: global_settings.PART_COPY_BOM,
+        }
+
+        fields.duplicate__copy_parameters = {
             value: global_settings.PART_COPY_PARAMETERS,
-            group: 'duplicate',
         };
     }
 

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -64,11 +64,16 @@ function partGroups() {
             title: '{% trans "Part Duplication Options" %}',
             collapsible: true,
         },
-        supplier: {
-            title: '{% trans "Supplier Options" %}',
+        initial_stock: {
+            title: '{% trans "Initial Stock" %}',
             collapsible: true,
-            hidden: !global_settings.PART_PURCHASEABLE,
-        }
+            hidden: !global_settings.PART_CREATE_INITIAL,
+        },
+        initial_supplier: {
+            title: '{% trans "Initial Supplier Data" %}',
+            collapsible: true,
+            hidden: !global_settings.PART_CREATE_SUPPLIER,
+        },
     };
 }
 
@@ -166,38 +171,33 @@ function partFields(options={}) {
     }
 
     if (options.create || options.duplicate) {
+
+        // Add fields for creating initial supplier data
+
+        // Add fields for creating initial stock
         if (global_settings.PART_CREATE_INITIAL) {
 
-            fields.initial_stock = {
-                type: 'boolean',
-                label: '{% trans "Create Initial Stock" %}',
-                help_text: '{% trans "Create an initial stock item for this part" %}',
-                group: 'create',
+            fields.initial_stock__quantity = {
+                value: 0,
             };
-
-            fields.initial_stock_quantity = {
-                type: 'decimal',
-                value: 1,
-                label: '{% trans "Initial Stock Quantity" %}',
-                help_text: '{% trans "Specify initial stock quantity for this part" %}',
-                group: 'create',
-            };
-
-            // TODO - Allow initial location of stock to be specified
-            fields.initial_stock_location = {
-                label: '{% trans "Location" %}',
-                help_text: '{% trans "Select destination stock location" %}',
-                type: 'related field',
-                required: true,
-                api_url: `/api/stock/location/`,
-                model: 'stocklocation',
-                group: 'create',
-            };
+            fields.initial_stock__location = {};
         }
-    }
 
-    // Additional fields when "creating" a new part
-    if (options.create) {
+        // Add fields for creating initial supplier data
+        if (global_settings.PART_CREATE_SUPPLIER) {
+            fields.initial_supplier__supplier = {
+                filters: {
+                    is_supplier: true,
+                }
+            };
+            fields.initial_supplier__sku = {};
+            fields.initial_supplier__manufacturer = {
+                filters: {
+                    is_manufacturer: true,
+                }
+            };
+            fields.initial_supplier__mpn = {};
+        }
 
         // No supplier parts available yet
         delete fields['default_supplier'];
@@ -209,53 +209,6 @@ function partFields(options={}) {
             value: global_settings.PART_CATEGORY_PARAMETERS,
             group: 'create',
         };
-
-        // Supplier options
-        fields.add_supplier_info = {
-            type: 'boolean',
-            label: '{% trans "Add Supplier Data" %}',
-            help_text: '{% trans "Create initial supplier data for this part" %}',
-            group: 'supplier',
-        };
-
-        fields.supplier = {
-            type: 'related field',
-            model: 'company',
-            label: '{% trans "Supplier" %}',
-            help_text: '{% trans "Select supplier" %}',
-            filters: {
-                'is_supplier': true,
-            },
-            api_url: '{% url "api-company-list" %}',
-            group: 'supplier',
-        };
-
-        fields.SKU = {
-            type: 'string',
-            label: '{% trans "SKU" %}',
-            help_text: '{% trans "Supplier stock keeping unit" %}',
-            group: 'supplier',
-        };
-
-        fields.manufacturer = {
-            type: 'related field',
-            model: 'company',
-            label: '{% trans "Manufacturer" %}',
-            help_text: '{% trans "Select manufacturer" %}',
-            filters: {
-                'is_manufacturer': true,
-            },
-            api_url: '{% url "api-company-list" %}',
-            group: 'supplier',
-        };
-
-        fields.MPN = {
-            type: 'string',
-            label: '{% trans "MPN" %}',
-            help_text: '{% trans "Manufacturer Part Number" %}',
-            group: 'supplier',
-        };
-
     }
 
     // Additional fields when "duplicating" a part
@@ -285,6 +238,9 @@ function partFields(options={}) {
 }
 
 
+/*
+ * Construct a set of fields for a PartCategory intance
+ */
 function categoryFields() {
     return {
         parent: {

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -20,6 +20,7 @@
 */
 
 /* exported
+    createPart,
     deletePart,
     deletePartCategory,
     duplicateBom,
@@ -87,7 +88,8 @@ function partFields(options={}) {
             },
             filters: {
                 structural: false,
-            }
+            },
+            value: options.category || null,
         },
         name: {},
         IPN: {},
@@ -378,6 +380,32 @@ function deletePartCategory(pk, options={}) {
 }
 
 
+/*
+ * Launches a form to create a new Part instance
+ */
+function createPart(options={}) {
+
+    options.create = true;
+
+    constructForm('{% url "api-part-list" %}', {
+        method: 'POST',
+        fields: partFields(options),
+        groups: partGroups(),
+        title: '{% trans "Create Part" %}',
+        reloadFormAfterSuccess: true,
+        persistMessage: '{% trans "Create another part after this one" %}',
+        successMessage: '{% trans "Part created successfully" %}',
+        onSuccess: function(data) {
+            // Follow the new part
+            location.href = `/part/${data.pk}/`;
+        },
+    });
+}
+
+
+/*
+ * Launches a form to edit an existing Part instance
+ */
 function editPart(pk) {
 
     var url = `/api/part/${pk}/`;

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -94,7 +94,6 @@ function partFields(options={}) {
             filters: {
                 structural: false,
             },
-            value: options.category || null,
         },
         name: {},
         IPN: {},
@@ -157,6 +156,10 @@ function partFields(options={}) {
             group: 'attributes',
         },
     };
+
+    if (options.category) {
+        fields.category.value = options.category;
+    }
 
     // If editing a part, we can set the "active" status
     if (options.edit) {


### PR DESCRIPTION
This started as a simple PR to fix https://github.com/inventree/InvenTree/issues/4266

However there were some issues which cropped up, so fixing those also. 

The main thrust of this PR is bringing the extra "part creation" fields into the DRF serializer, rather than hacking them in manually. This has multiple advantages:

- Exposes the fields to the API auto-doc
- Runs validators on the fields
- Exposes the fields to the self-describing metadata framework

------------

- Fixes https://github.com/inventree/InvenTree/issues/4266
- Fixes https://github.com/inventree/InvenTree/issues/4279

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4281"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

