### PR TITLE
[BUG] Increase worker-timeout to account for install times

### DIFF
--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -18,8 +18,8 @@ worker_tmp_dir = '/dev/shm'  # Write temp file to RAM (faster)
 threads = 4
 
 
-# Worker timeout (default = 30 seconds)
-timeout = os.environ.get('INVENTREE_GUNICORN_TIMEOUT', 30)
+# Worker timeout (default = 90 seconds)
+timeout = os.environ.get('INVENTREE_GUNICORN_TIMEOUT', 90)
 
 # Number of worker processes
 workers = os.environ.get('INVENTREE_GUNICORN_WORKERS', None)


### PR DESCRIPTION
This PR increases the default gunicorn timeout to 90 seconds. That can lead to longer times till hanging/erroring out threads get recycled. I have multiple gunicorn-served services running with 120 seconds (was already that way when I took over) without problems so I think it should be fine. 

Fixes #4284

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4285"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

