### PR TITLE
Backup task fixes

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -624,7 +624,7 @@ Q_CLUSTER = {
     'workers': int(get_setting('INVENTREE_BACKGROUND_WORKERS', 'background.workers', 4)),
     'timeout': _q_worker_timeout,
     'retry': min(120, _q_worker_timeout + 30),
-    'max_attempts': 5,
+    'max_attempts': int(get_setting('INVENTREE_BACKGROUND_MAX_ATTEMPTS', 'background.max_attempts', 5)),
     'queue_limit': 50,
     'catch_up': False,
     'bulk': 10,

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -615,13 +615,15 @@ else:
         },
     }
 
+_q_worker_timeout = int(get_setting('INVENTREE_BACKGROUND_TIMEOUT', 'background.timeout', 90))
+
 # django-q background worker configuration
 Q_CLUSTER = {
     'name': 'InvenTree',
     'label': 'Background Tasks',
     'workers': int(get_setting('INVENTREE_BACKGROUND_WORKERS', 'background.workers', 4)),
-    'timeout': int(get_setting('INVENTREE_BACKGROUND_TIMEOUT', 'background.timeout', 90)),
-    'retry': 120,
+    'timeout': _q_worker_timeout,
+    'retry': min(120, _q_worker_timeout + 30),
     'max_attempts': 5,
     'queue_limit': 50,
     'catch_up': False,

--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -483,6 +483,7 @@ def run_backup():
 
         if last_success > threshold:
             logger.info('Last successful backup was too recent - skipping backup operation')
+            return
 
     call_command("dbbackup", noinput=True, clean=True, compress=True, interactive=False)
     call_command("mediabackup", noinput=True, clean=True, compress=True, interactive=False)

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -969,6 +969,16 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'default': False,
         },
 
+        'INVENTREE_BACKUP_DAYS': {
+            'name': _('Days Between Backup'),
+            'description': _('Specify number of days between automated backup events'),
+            'validator': [
+                int,
+                MinValueValidator(1),
+            ],
+            'default': 1,
+        },
+
         'INVENTREE_DELETE_TASKS_DAYS': {
             'name': _('Delete Old Tasks'),
             'description': _('Background task results will be deleted after specified number of days'),

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -152,6 +152,7 @@ backup_storage: django.core.files.storage.FileSystemStorage
 background:
   workers: 4
   timeout: 90
+  max_attempts: 5
 
 # Optional URL schemes to allow in URL fields
 # By default, only the following schemes are allowed: ['http', 'https', 'ftp', 'ftps']

--- a/InvenTree/templates/InvenTree/settings/global.html
+++ b/InvenTree/templates/InvenTree/settings/global.html
@@ -25,6 +25,7 @@
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_REQUIRE_CONFIRM" icon="fa-check" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_TREE_DEPTH" icon="fa-sitemap" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_BACKUP_ENABLE" icon="fa-hdd" %}
+        {% include "InvenTree/settings/setting.html" with key="INVENTREE_BACKUP_DAYS" icon="fa-calendar-alt" %}
         <tr><td colspan='5'></td></tr>
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DELETE_TASKS_DAYS" icon="fa-calendar-alt" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DELETE_ERRORS_DAYS" icon="fa-calendar-alt" %}


### PR DESCRIPTION
This PR makes some adjustments to the daily backup task, to prevent some of the ongoing issues.

- Prevent backup from occurring immediately when the server starts
- Prevent multiple backup attempts within the same day
- Adds user-configurable setting to control how many days between backup attempts

----------------------------

- Closes https://github.com/inventree/InvenTree/issues/4290
- Closes https://github.com/inventree/InvenTree/issues/4180

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4307"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

