### PR TITLE
add libwebp-dev dependency (fixes #4269)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get install -y  --no-install-recommends \
     # Weasyprint requirements : https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#debian-11
     poppler-utils libpango-1.0-0 libpangoft2-1.0-0 \
     # Image format support
-    libjpeg-dev webp \
+    libjpeg-dev webp libwebp-dev \
     # SQLite support
     sqlite3 \
     # PostgreSQL support


### PR DESCRIPTION
adds `libwebp-dev` package to Dockerfile (required on `Raspbian GNU/Linux 11 (bullseye)`)

<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4335"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

