### PR TITLE
Show units next to [No Stock]-badge in part search (implements #4330)

### DIFF
--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -617,7 +617,12 @@ function partStockLabel(part, options={}) {
             return `<span class='badge rounded-pill bg-info ${options.classes}'>{% trans "Building" %}: ${part.building} ${units}</span>`;
         } else {
             // There is no stock
-            return `<span class='badge rounded-pill bg-danger ${options.classes}'>{% trans "No Stock" %}</span>`;
+            var unit_badge = '';
+            if (units) {
+                // show units next to [No Stock] badge
+                unit_badge = `<span class='badge rounded-pill text-muted bg-muted ${options.classes}'>{% trans "Unit" %}: ${units}</span> `;
+            }
+            return `${unit_badge}<span class='badge rounded-pill bg-danger ${options.classes}'>{% trans "No Stock" %}</span>`;
         }
     }
 


### PR DESCRIPTION
Implementation of FR #4330 - This adds a notice about the unit of measurement that is used for a part next to the `[No Stock]` badge in part search results (general search, Add BOM Item drop-down etc).
This way it is clear which quantity to use when manually adding BOM items to an assembly if there is no stock of that part.

Examples:
![Bildschirmfoto vom 2023-02-13 16-41-55](https://user-images.githubusercontent.com/296454/218506949-9cfe6aee-a1b5-4c56-89a2-9de00e448e64.png)
![Bildschirmfoto vom 2023-02-13 16-42-28](https://user-images.githubusercontent.com/296454/218506970-c7112764-9d7a-492c-bcd0-ae5dc1a6927f.png)
![Bildschirmfoto vom 2023-02-13 16-42-57](https://user-images.githubusercontent.com/296454/218506973-386a4e11-0710-40ff-bdd7-796e29fed15c.png)

Also for parts with no units specified:
![Bildschirmfoto vom 2023-02-13 17-18-32](https://user-images.githubusercontent.com/296454/218512815-9d33f3b7-8ef4-4b10-957f-d1eb411ddb0a.png)


<a href="https://gitpod.io/#https://github.com/inventree/InvenTree/pull/4339"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

