### PR TITLE
show units in [Add Stock] modal (fixes #4351)

### DIFF
--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -1046,6 +1046,10 @@ function adjustStock(action, items, options={}) {
 
         var quantity = item.quantity;
 
+        if (item.part_detail.units != null) {
+            quantity += ` ${item.part_detail.units}`;
+        }
+
         var location = locationDetail(item, false);
 
         if (item.location_detail) {


### PR DESCRIPTION
quick fix to add missing units in `Add Stock` modal.

![Bildschirmfoto vom 2023-02-16 16-28-16](https://user-images.githubusercontent.com/296454/219412112-6b733560-94dc-4af0-8c2b-b808d620b949.png)
