### PR TITLE
Support podman and selinux for dev setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
             - POSTGRES_DB=inventree
         volumes:
           # Map 'data' volume such that postgres database is stored externally
-          - ./data:/var/lib/postgresql/data
+          - ./data:/var/lib/postgresql/data:z
         restart: unless-stopped
 
     # InvenTree web server service
@@ -40,7 +40,7 @@ services:
         container_name: inventree-dev-server
         depends_on:
           - inventree-dev-db
-        build:
+        build: &build_config
             context: .
             target: dev
         # Cache the built image to be used by the inventree-dev-worker process
@@ -50,7 +50,7 @@ services:
             - 8000:8000
         volumes:
             # Mount local source directory to /home/inventree
-            - ./:/home/inventree
+            - ./:/home/inventree:z
         env_file:
             - docker.dev.env
         restart: unless-stopped
@@ -59,12 +59,13 @@ services:
     inventree-dev-worker:
         container_name: inventree-dev-worker
         image: inventree-dev-image
+        build: *build_config
         command: invoke worker
         depends_on:
             - inventree-dev-server
         volumes:
             # Mount local source directory to /home/inventree
-            - ./:/home/inventree
+            - ./:/home/inventree:z
         env_file:
             - docker.dev.env
         restart: unless-stopped


### PR DESCRIPTION
This PR includes the changes required to get the InvenTree dev setup to work on my local machine which requires podman and SELinux. The following changes are included in this PR:

- SELinux labels are required in order to mount the volumes into the dev containers.
- The build config has been added to the dev-worker to prevent podman from trying to pull from docker hub