### PR TITLE
Add FAQ link to issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,7 +6,7 @@ body:
     id: no-duplicate-issues
     attributes:
       label: "Please verify that this bug has NOT been raised before."
-      description: "Search in the issues sections by clicking [HERE](https://github.com/inventree/inventree/issues?q=)"
+      description: "Search in the issues sections by clicking [HERE](https://github.com/inventree/inventree/issues?q=) and read the [Frequently Asked Questions](https://docs.inventree.org/en/latest/faq/)!"
       options:
         - label: "I checked and didn't find a similar issue"
           required: true


### PR DESCRIPTION
When submitting a bug report via the template, users will see a link to the FAQ (on the docs page)