### PR TITLE
Part duplicate bug fix

### DIFF
--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -2,7 +2,6 @@
 
 import functools
 
-from django.db import transaction
 from django.db.models import Count, F, Q
 from django.http import JsonResponse
 from django.urls import include, path, re_path

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -1204,35 +1204,6 @@ class PartList(APIDownloadMixin, ListCreateAPI):
         else:
             return Response(data)
 
-    @transaction.atomic
-    def create(self, request, *args, **kwargs):
-        """We wish to save the user who created this part!
-
-        Note: Implementation copied from DRF class CreateModelMixin
-        """
-        # TODO: Unit tests for this function!
-
-        # Clean up input data
-        data = self.clean_data(request.data)
-
-        serializer = self.get_serializer(data=data)
-        serializer.is_valid(raise_exception=True)
-
-        part = serializer.save()
-        part.creation_user = self.request.user
-
-        # Optionally copy templates from category or parent category
-        copy_templates = {
-            'main': str2bool(data.get('copy_category_templates', False)),
-            'parent': str2bool(data.get('copy_parent_templates', False))
-        }
-
-        part.save(**{'add_category_templates': copy_templates})
-
-        headers = self.get_success_headers(serializer.data)
-
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
-
     def get_queryset(self, *args, **kwargs):
         """Return an annotated queryset object"""
         queryset = super().get_queryset(*args, **kwargs)

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -443,9 +443,6 @@ class Part(InvenTreeBarcodeMixin, MetadataMixin, MPTTModel):
         If the part image has been updated, then check if the "old" (previous) image is still used by another part.
         If not, it is considered "orphaned" and will be deleted.
         """
-        # Get category templates settings
-
-        add_category_templates = kwargs.pop('add_category_templates', False)
 
         if self.pk:
             previous = Part.objects.get(pk=self.pk)
@@ -468,34 +465,6 @@ class Part(InvenTreeBarcodeMixin, MetadataMixin, MPTTModel):
             raise ValidationError({
                 'variant_of': _('Invalid choice for parent part'),
             })
-
-        if add_category_templates:
-            # Get part category
-            category = self.category
-
-            if category is not None:
-
-                template_list = []
-
-                parent_categories = category.get_ancestors(include_self=True)
-
-                for category in parent_categories:
-                    for template in category.get_parameter_templates():
-                        # Check that template wasn't already added
-                        if template.parameter_template not in template_list:
-
-                            template_list.append(template.parameter_template)
-
-                            try:
-                                PartParameter.create(
-                                    part=self,
-                                    template=template.parameter_template,
-                                    data=template.default_value,
-                                    save=True
-                                )
-                            except IntegrityError:
-                                # PartParameter already exists
-                                pass
 
     def __str__(self):
         """Return a string representation of the Part (for use in the admin interface)"""

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -3,7 +3,6 @@
 import imghdr
 import io
 import logging
-
 from decimal import Decimal
 
 from django.core.files.base import ContentFile

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -620,7 +620,7 @@ class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
     )
 
     copy_category_parameters = serializers.BooleanField(
-        default=True,
+        default=True, required=False,
         label=_('Copy Category Parameters'),
         help_text=_('Copy parameter templates from selected part category'),
     )

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -2,11 +2,13 @@
 
 import imghdr
 import io
+import logging
+
 from decimal import Decimal
 
 from django.core.files.base import ContentFile
 from django.core.validators import MinValueValidator
-from django.db import models, transaction
+from django.db import IntegrityError, models, transaction
 from django.db.models import ExpressionWrapper, F, FloatField, Q
 from django.db.models.functions import Coalesce
 from django.urls import reverse_lazy
@@ -41,6 +43,8 @@ from .models import (BomItem, BomItemSubstitute, Part, PartAttachment,
                      PartParameterTemplate, PartPricing, PartRelated,
                      PartSellPriceBreak, PartStar, PartStocktake,
                      PartStocktakeReport, PartTestTemplate)
+
+logger = logging.getLogger("inventree")
 
 
 class CategorySerializer(InvenTreeModelSerializer):
@@ -650,6 +654,34 @@ class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
 
             if duplicate['copy_parameters']:
                 instance.copy_parameters_from(original)
+
+        # Duplicate parameter data from part category (and parents)
+        if copy_category_parameters and instance.category is not None:
+            # Get flattened list of parent categories
+            categories = instance.category.get_ancestors(include_self=True)
+            
+            # All parameter templates within these categories
+            templates = PartCategoryParameterTemplate.objects.filter(
+                category__in=categories
+            )
+
+            for template in templates:
+                # First ensure that the part doesn't have that parameter
+                if PartParameter.objects.filter(
+                    part=instance,
+                    template=template.parameter_template
+                ).exists():
+                    continue
+
+                try:
+                    PartParameter.create(
+                        part=instance,
+                        template=template.parameter_template,
+                        data=template.default_value,
+                        save=True
+                    )
+                except IntegrityError:
+                    logger.error(f"Could not create new PartParameter for part {instance}")
 
         # Create initial stock entry
         if initial_stock:

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -659,7 +659,7 @@ class PartSerializer(RemoteImageMixin, InvenTreeModelSerializer):
         if copy_category_parameters and instance.category is not None:
             # Get flattened list of parent categories
             categories = instance.category.get_ancestors(include_self=True)
-            
+
             # All parameter templates within these categories
             templates = PartCategoryParameterTemplate.objects.filter(
                 category__in=categories

--- a/InvenTree/part/test_param.py
+++ b/InvenTree/part/test_param.py
@@ -76,15 +76,3 @@ class TestCategoryTemplates(TransactionTestCase):
 
         # Get part parameters count
         n_param = part.get_parameters().count()
-
-        add_category_templates = {
-            'main': True,
-            'parent': True,
-        }
-
-        # Save it with category parameters
-        part.save(**{'add_category_templates': add_category_templates})
-
-        # Check new part parameters count
-        # Only 2 parameters should be added as one already existed with same template
-        self.assertEqual(n_param + 2, part.get_parameters().count())

--- a/InvenTree/part/test_param.py
+++ b/InvenTree/part/test_param.py
@@ -3,7 +3,7 @@
 import django.core.exceptions as django_exceptions
 from django.test import TestCase, TransactionTestCase
 
-from .models import (Part, PartCategory, PartCategoryParameterTemplate,
+from .models import (PartCategory, PartCategoryParameterTemplate,
                      PartParameter, PartParameterTemplate)
 
 
@@ -70,9 +70,3 @@ class TestCategoryTemplates(TransactionTestCase):
 
         n = PartCategoryParameterTemplate.objects.all().count()
         self.assertEqual(n, 3)
-
-        # Get test part
-        part = Part.objects.get(pk=1)
-
-        # Get part parameters count
-        n_param = part.get_parameters().count()

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -209,9 +209,6 @@ function partFields(options={}) {
         delete fields['default_supplier'];
 
         fields.copy_category_parameters = {
-            type: 'boolean',
-            label: '{% trans "Copy Category Parameters" %}',
-            help_text: '{% trans "Copy parameter templates from selected part category" %}',
             value: global_settings.PART_CATEGORY_PARAMETERS,
             group: 'create',
         };


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/4353

This PR fixes a bug which exists when duplicating a part with existing parameters.

Not only would the old code throw an error, it would not have worked anyway... 