### PR TITLE
add missing units to Build Order view (#4386)

### DIFF
--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1978,7 +1978,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                     if (row.sub_part_detail && row.sub_part_detail.units) {
                         progressbar_text += ` ${row.sub_part_detail.units}`;
                     }
-                    return makeProgressBar(allocated, required, {text:progressbar_text});
+                    return makeProgressBar(allocated, required, {text: progressbar_text});
                 },
                 sorter: function(valA, valB, rowA, rowB) {
                     // Custom sorting function for progress bars

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1890,8 +1890,8 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                 title: '{% trans "Quantity Per" %}',
                 sortable: true,
                 switchable: false,
-                formatter: function(value,row){
-                    var text = value; //parseFloat(value);
+                formatter: function(value, row) {
+                    var text = value;
 
                     if (row.sub_part_detail && row.sub_part_detail.units) {
                         text += ` <small>${row.sub_part_detail.units}</small>`;

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -479,6 +479,9 @@ function completeBuildOutputs(build_id, outputs, options={}) {
             output_html += `{% trans "Serial Number" %}: ${output.serial}`;
         } else {
             output_html += `{% trans "Quantity" %}: ${output.quantity}`;
+            if (output.part_detail && output.part_detail.units) {
+                output_html += ` ${output.part_detail.units}  `;
+            }
         }
 
         var buttons = `<div class='btn-group float-right' role='group'>`;
@@ -635,6 +638,9 @@ function deleteBuildOutputs(build_id, outputs, options={}) {
             output_html += `{% trans "Serial Number" %}: ${output.serial}`;
         } else {
             output_html += `{% trans "Quantity" %}: ${output.quantity}`;
+            if (output.part_detail && output.part_detail.units) {
+                output_html += ` ${output.part_detail.units}  `;
+            }
         }
 
         var buttons = `<div class='btn-group float-right' role='group'>`;
@@ -1245,6 +1251,9 @@ function loadBuildOutputTable(build_info, options={}) {
                         text = `{% trans "Serial Number" %}: ${row.serial}`;
                     } else {
                         text = `{% trans "Quantity" %}: ${row.quantity}`;
+                        if (row.part_detail && row.part_detail.units) {
+                            text += ` <small>${row.part_detail.units}</small>`;
+                        }
                     }
 
                     if (row.batch) {
@@ -1746,6 +1755,9 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                                 text = `{% trans "Serial Number" %}: ${serial}`;
                             } else {
                                 text = `{% trans "Quantity" %}: ${row.quantity}`;
+                                if (row.part_detail && row.part_detail.units) {
+                                    text += ` <small>${row.part_detail.units}</small>`;
+                                }
                             }
 
                             var pk = row.stock_item || row.pk;
@@ -1878,6 +1890,14 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                 title: '{% trans "Quantity Per" %}',
                 sortable: true,
                 switchable: false,
+                formatter: function(value,row){
+                    var text = value; //parseFloat(value);
+
+                    if (row.sub_part_detail && row.sub_part_detail.units) {
+                        text += ` <small>${row.sub_part_detail.units}</small>`;
+                    }
+                    return text;
+                }
             },
             {
                 field: 'available_stock',
@@ -1901,6 +1921,9 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
 
                     if (available_stock > 0) {
                         text += `${available_stock}`;
+                        if (row.sub_part_detail && row.sub_part_detail.units) {
+                            text += ` <small>${row.sub_part_detail.units}</small>`;
+                        }
                     }
 
                     var icons = '';
@@ -1951,7 +1974,11 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                 formatter: function(value, row) {
                     var required = requiredQuantity(row);
                     var allocated = row.consumable ? required : allocatedQuantity(row);
-                    return makeProgressBar(allocated, required);
+                    var progressbar_text = `${allocated} / ${required}`;
+                    if (row.sub_part_detail && row.sub_part_detail.units) {
+                        progressbar_text += ` ${row.sub_part_detail.units}`;
+                    }
+                    return makeProgressBar(allocated, required, {text:progressbar_text});
                 },
                 sorter: function(valA, valB, rowA, rowB) {
                     // Custom sorting function for progress bars


### PR DESCRIPTION
This adds units to all places in the Build Order view where part quantities are shown.

Fixes #4386 and some more spots as well.