### PR TITLE
fix stock health calculation to account for allocated stock (#4385)

### DIFF
--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -644,7 +644,7 @@ function partStockLabel(part, options={}) {
     }
 
     // Determine badge color based on overall stock health
-    var stock_health = part.in_stock + part.building + part.ordering - part.minimum_stock - demand;
+    var stock_health = part.in_stock + part.building + part.ordering - part.allocated_to_build_orders - part.minimum_stock - demand;
     var bg_class = '';
     if (stock_health < 0) {
         // Unsatisfied demand and/or below minimum stock


### PR DESCRIPTION
The calculation of the `stock_health` variable did not account for allocated stock - which created too optimistic color codes in some cases.