### PR TITLE
Allow pricing updates when PartPricing object does not yet exist

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1687,10 +1687,8 @@ class Part(InvenTreeBarcodeMixin, MetadataMixin, MPTTModel):
         Ref: https://github.com/inventree/InvenTree/pull/3986
         """
 
-        try:
-            self.pricing.schedule_for_update()
-        except (PartPricing.DoesNotExist, IntegrityError):
-            pass
+        pricing = self.pricing
+        pricing.schedule_for_update()
 
     def get_price_info(self, quantity=1, buy=True, bom=True, internal=False):
         """Return a simplified pricing string for this part.
@@ -2264,9 +2262,11 @@ class PartPricing(common.models.MetaMixin):
         """Schedule this pricing to be updated"""
 
         try:
-            self.refresh_from_db()
+            if self.pk:
+                self.refresh_from_db()
         except (PartPricing.DoesNotExist, IntegrityError):
             # Error thrown if this PartPricing instance has already been removed
+            logger.warning(f"Error refreshing PartPricing instance for part '{self.part}'")
             return
 
         # Ensure that the referenced part still exists in the database
@@ -2274,6 +2274,7 @@ class PartPricing(common.models.MetaMixin):
             p = self.part
             p.refresh_from_db()
         except IntegrityError:
+            logger.error(f"Could not update PartPricing as Part '{self.part}' does not exist")
             return
 
         if self.scheduled_for_update:
@@ -2291,6 +2292,7 @@ class PartPricing(common.models.MetaMixin):
             self.save()
         except IntegrityError:
             # An IntegrityError here likely indicates that the referenced part has already been deleted
+            logger.error(f"Could not save PartPricing for part '{self.part}' to the database")
             return
 
         import part.tasks as part_tasks


### PR DESCRIPTION
- Previously if the Part did not have a referenced PartPricing object, the schedule_pricing_update method would fail
- Required a PartPricing object to actually exist (i.e. be manually created)
- This patch fixes a logic error which resulted in updating being skipped if a PartPricing instance did not already exist

Closes https://github.com/inventree/InvenTree/issues/4375