### PR TITLE
Backport for data migration fix

### DIFF
--- a/InvenTree/stock/migrations/0071_auto_20211205_1733.py
+++ b/InvenTree/stock/migrations/0071_auto_20211205_1733.py
@@ -22,7 +22,13 @@ def delete_scheduled(apps, schema_editor):
 
     if items.count() > 0:
         logger.info(f"Removing {items.count()} stock items scheduled for deletion")
-        items.delete()
+
+        # Ensure any parent / child relationships are updated!
+        for item in items:
+            childs = StockItem.objects.filter(parent=item)
+            childs.update(parent=item.parent)
+
+            item.delete()
 
     Task = apps.get_model('django_q', 'schedule')
 

--- a/InvenTree/stock/test_migrations.py
+++ b/InvenTree/stock/test_migrations.py
@@ -110,7 +110,7 @@ class TestScheduledForDeletionMigration(MigratorTestCase):
             scheduled_for_deletion=True,
         )
 
-        for ii in range(3):
+        for _ii in range(3):
             StockItem.objects.create(
                 part=part,
                 quantity=200,


### PR DESCRIPTION
* Add migration test

Looking at older data migration which removes stock items which are "scheduled_for_deletion"

* Account for parent / child relationships

(cherry picked from commit 89ac0a623b51256748d346f4e95ae371c2a14d47)