### PR TITLE
Filter build orders by responsible owner (#4383)

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 97
+INVENTREE_API_VERSION = 98
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v98 -> 2023-02-24 : https://github.com/inventree/InvenTree/pull/4408
+    - Adds "responsible" filter to Build API
 
 v97 -> 2023-02-20 : https://github.com/inventree/InvenTree/pull/4377
     - Adds "external" attribute to StockLocation model

--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -66,18 +66,16 @@ class BuildFilter(rest_filters.FilterSet):
 
         return queryset
 
-    assigned_to = rest_filters.CharFilter(label='assigned_to', method='filter_assigned_to')
+    assigned_to = rest_filters.NumberFilter(label='assigned_to', method='filter_assigned_to')
 
     def filter_assigned_to(self, queryset, name, value):
-        """Filter by orders which are assigned to the specified user or group."""
-        user_or_group = User.objects.get(username=value)
+        """Filter by orders which are assigned to the specified owner."""
         owners = []
-        owners.append(Owner.get_owner(value))
-        print(owners)
+        owners.append(Owner.objects.get(pk=value))
 
-        # if we query by a user name, also find all ownerships through group memberships
-        if type(owners[0]) is User:
-            owners.append(Owner.get_owners_matching_user(owners[0]))
+        # if we query by a user, also find all ownerships through group memberships
+        if owners[0].label() == 'user':
+            owners = Owner.get_owners_matching_user(User.objects.get(pk=owners[0].owner_id))
 
         queryset = queryset.filter(responsible__in=owners)
 

--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -66,9 +66,9 @@ class BuildFilter(rest_filters.FilterSet):
 
         return queryset
 
-    assigned_to = rest_filters.NumberFilter(label='assigned_to', method='filter_assigned_to')
+    assigned_to = rest_filters.NumberFilter(label='responsible', method='filter_responsible')
 
-    def filter_assigned_to(self, queryset, name, value):
+    def filter_responsible(self, queryset, name, value):
         """Filter by orders which are assigned to the specified owner."""
         owners = []
         owners.append(Owner.objects.get(pk=value))

--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -2,7 +2,7 @@
 
 from django.urls import include, re_path
 from django.utils.translation import gettext_lazy as _
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import User
 
 from rest_framework import filters
 from rest_framework.exceptions import ValidationError

--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -70,11 +70,10 @@ class BuildFilter(rest_filters.FilterSet):
 
     def filter_responsible(self, queryset, name, value):
         """Filter by orders which are assigned to the specified owner."""
-        owners = []
-        owners.append(Owner.objects.get(pk=value))
+        owners = list(Owner.objects.filter(pk=value))
 
         # if we query by a user, also find all ownerships through group memberships
-        if owners[0].label() == 'user':
+        if len(owners) > 0 and owners[0].label() == 'user':
             owners = Owner.get_owners_matching_user(User.objects.get(pk=owners[0].owner_id))
 
         queryset = queryset.filter(responsible__in=owners)

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -2694,11 +2694,19 @@ function loadBuildTable(table, options) {
                 title: '{% trans "Responsible" %}',
                 sortable: true,
                 formatter: function(value, row) {
-                    if (value) {
-                        return row.responsible_detail.name;
-                    } else {
+                    if (!row.responsible_detail) {
                         return '-';
                     }
+
+                    var html = row.responsible_detail.name;
+
+                    if (row.responsible_detail.label == 'group') {
+                        html += `<span class='float-right fas fa-users'></span>`;
+                    } else {
+                        html += `<span class='float-right fas fa-user'></span>`;
+                    }
+
+                    return html;
                 }
             },
             {

--- a/InvenTree/templates/js/translated/filters.js
+++ b/InvenTree/templates/js/translated/filters.js
@@ -243,7 +243,7 @@ function generateFilterInput(tableKey, filterKey) {
 
         // options can be an object or a function, in which case we need to run
         // this callback first
-        if (options instanceof Function){
+        if (options instanceof Function) {
             options = options();
         }
         for (var key in options) {

--- a/InvenTree/templates/js/translated/filters.js
+++ b/InvenTree/templates/js/translated/filters.js
@@ -241,6 +241,11 @@ function generateFilterInput(tableKey, filterKey) {
         // Return a 'select' input with the available values
         html = `<select class='form-control filter-input' id='${id}' name='value'>`;
 
+        // options can be an object or a function, in which case we need to run
+        // this callback first
+        if (options instanceof Function){
+            options = options();
+        }
         for (var key in options) {
             var option = options[key];
             html += `<option value='${key}'>${option.value}</option>`;

--- a/InvenTree/templates/js/translated/table_filters.js
+++ b/InvenTree/templates/js/translated/table_filters.js
@@ -338,19 +338,6 @@ function getAvailableTableFilters(tableKey) {
 
     // Filters for the "Build" table
     if (tableKey == 'build') {
-        var ownersList = {};
-        inventreeGet(`/api/user/owner/`, {}, {
-            async: false,
-            success: function(response) {
-                for (key in response) {
-                    var owner = response[key];
-                    ownersList[owner.pk] = {
-                        key: owner.pk,
-                        value: `${owner.name} (${owner.label})`,
-                    };
-                }
-            }
-        });
         return {
             status: {
                 title: '{% trans "Build status" %}',
@@ -370,7 +357,22 @@ function getAvailableTableFilters(tableKey) {
             },
             assigned_to: {
                 title: '{% trans "Responsible" %}',
-                options: ownersList,
+                options: function() {
+                    var ownersList = {};
+                    inventreeGet(`/api/user/owner/`, {}, {
+                        async: false,
+                        success: function(response) {
+                            for (key in response) {
+                                var owner = response[key];
+                                ownersList[owner.pk] = {
+                                    key: owner.pk,
+                                    value: `${owner.name} (${owner.label})`,
+                                };
+                            }
+                        }
+                    });
+                    return ownersList;
+                },
             },
         };
     }

--- a/InvenTree/templates/js/translated/table_filters.js
+++ b/InvenTree/templates/js/translated/table_filters.js
@@ -338,6 +338,19 @@ function getAvailableTableFilters(tableKey) {
 
     // Filters for the "Build" table
     if (tableKey == 'build') {
+        var ownersList = {};
+        inventreeGet(`/api/user/owner/`, {}, {
+            async: false,
+            success: function(response) {
+                for (key in response) {
+                    var owner = response[key];
+                    ownersList[owner.pk] = {
+                        key: owner.pk,
+                        value: `${owner.name} (${owner.label})`,
+                    };
+                }
+            }
+        });
         return {
             status: {
                 title: '{% trans "Build status" %}',
@@ -354,6 +367,10 @@ function getAvailableTableFilters(tableKey) {
             assigned_to_me: {
                 type: 'bool',
                 title: '{% trans "Assigned to me" %}',
+            },
+            assigned_to: {
+                title: '{% trans "Responsible" %}',
+                options: ownersList,
             },
         };
     }


### PR DESCRIPTION
I have implemented the API+UI filters for filtering build orders by their responsible users/groups as discussed in #4383.

Filtering by a user also shows build orders assigned to groups he is part of - like the `assigned_to_me` filter does.
Along the way I added a user/group icon to the `Responsible` column, which is taken from the sales orders table.

Full table including the icons:

![Bildschirmfoto vom 2023-02-24 12-40-39](https://user-images.githubusercontent.com/296454/221171545-328cd531-d5d5-4495-9793-04db52090015.png)

Filtered by a responsible group:

![Bildschirmfoto vom 2023-02-24 12-41-04](https://user-images.githubusercontent.com/296454/221171557-3acaddb1-3f9e-459b-8eaf-877d369324fe.png)

Filtered by a responsible user:

![Bildschirmfoto vom 2023-02-24 12-41-30](https://user-images.githubusercontent.com/296454/221171568-0d303ed9-eda3-450f-9a81-5753a86757c8.png)

Closes #4383
