### PR TITLE
Bug fix for build detail template

### DIFF
--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -281,11 +281,6 @@
                         </ul>
                     </div>
 
-                    {% if build.has_tracked_bom_items %}
-                    {% include "expand_rows.html" with label="outputs" %}
-                    {% include "collapse_rows.html" with label="outputs" %}
-                    {% endif %}
-
                     {% include "filter_list.html" with id='incompletebuilditems' %}
                 </div>
                 {% endif %}

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1217,10 +1217,10 @@ function loadBuildOutputTable(build_info, options={}) {
             setupBuildOutputButtonCallbacks();
         },
         onLoadSuccess: function(rows) {
-
             updateAllocationData(rows);
             updateTestResultData(rows);
         },
+        buttons: constructExpandCollapseButtons(table),
         columns: [
             {
                 title: '',
@@ -1713,6 +1713,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
         detailFilter: function(index, row) {
             return allocatedQuantity(row) > 0;
         },
+        buttons: constructExpandCollapseButtons(table),
         detailFormatter: function(index, row, element) {
             // Contruct an 'inner table' which shows which stock items have been allocated
 


### PR DESCRIPTION
- Remove reference to old expand/collapse templates (which no longer exist)
- Update tables to use javascript buttons

Closes https://github.com/inventree/InvenTree/issues/4411