### PR TITLE
Bugfix for auto-backup task (#4406)

### DIFF
--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -377,7 +377,7 @@ def check_for_updates():
 
     # Save the version to the database
     common.models.InvenTreeSetting.set_setting(
-        'INVENTREE_LATEST_VERSION',
+        '_INVENTREE_LATEST_VERSION',
         tag,
         None
     )
@@ -440,11 +440,11 @@ def run_backup():
     time.sleep(random.randint(1, 5))
 
     # Check for records of previous backup attempts
-    last_attempt = InvenTreeSetting.get_setting('INVENTREE_BACKUP_ATTEMPT', '', cache=False)
-    last_success = InvenTreeSetting.get_setting('INVENTREE_BACKUP_SUCCESS', '', cache=False)
+    last_attempt = InvenTreeSetting.get_setting('_INVENTREE_BACKUP_ATTEMPT', '', cache=False)
+    last_success = InvenTreeSetting.get_setting('_INVENTREE_BACKUP_SUCCESS', '', cache=False)
 
     try:
-        backup_n_days = int(InvenTreeSetting.get_setting('INVENTREE_BACKUP_DAYS', 1, cache=False))
+        backup_n_days = int(InvenTreeSetting.get_setting('_INVENTREE_BACKUP_DAYS', 1, cache=False))
     except Exception:
         backup_n_days = 1
 
@@ -456,14 +456,14 @@ def run_backup():
 
     if last_attempt:
         # Do not attempt if the 'last attempt' at backup was within 12 hours
-        threshold = timezone.now() - timezone.timedelta(hours=12)
+        threshold = datetime.now() - timedelta(hours=12)
 
         if last_attempt > threshold:
             logger.info('Last backup attempt was too recent - skipping backup operation')
             return
 
     # Record the timestamp of most recent backup attempt
-    InvenTreeSetting.set_setting('INVENTREE_BACKUP_ATTEMPT', timezone.now().isoformat(), None)
+    InvenTreeSetting.set_setting('_INVENTREE_BACKUP_ATTEMPT', datetime.now().isoformat(), None)
 
     if not last_attempt:
         # If there is no record of a previous attempt, exit quickly
@@ -479,7 +479,7 @@ def run_backup():
 
     # Exit early if the backup was successful within the number of required days
     if last_success:
-        threshold = timezone.now() - timezone.timedelta(days=backup_n_days)
+        threshold = datetime.now() - timedelta(days=backup_n_days)
 
         if last_success > threshold:
             logger.info('Last successful backup was too recent - skipping backup operation')
@@ -489,7 +489,7 @@ def run_backup():
     call_command("mediabackup", noinput=True, clean=True, compress=True, interactive=False)
 
     # Record the timestamp of most recent backup success
-    InvenTreeSetting.set_setting('INVENTREE_BACKUP_SUCCESS', datetime.now().isoformat(), None)
+    InvenTreeSetting.set_setting('_INVENTREE_BACKUP_SUCCESS', datetime.now().isoformat(), None)
 
 
 def send_email(subject, body, recipients, from_email=None, html_message=None):

--- a/InvenTree/InvenTree/test_tasks.py
+++ b/InvenTree/InvenTree/test_tasks.py
@@ -108,12 +108,12 @@ class InvenTreeTaskTests(TestCase):
     def test_task_check_for_updates(self):
         """Test the task check_for_updates."""
         # Check that setting should be empty
-        self.assertEqual(InvenTreeSetting.get_setting('INVENTREE_LATEST_VERSION'), '')
+        self.assertEqual(InvenTreeSetting.get_setting('_INVENTREE_LATEST_VERSION'), '')
 
         # Get new version
         InvenTree.tasks.offload_task(InvenTree.tasks.check_for_updates)
 
         # Check that setting is not empty
-        response = InvenTreeSetting.get_setting('INVENTREE_LATEST_VERSION')
+        response = InvenTreeSetting.get_setting('_INVENTREE_LATEST_VERSION')
         self.assertNotEqual(response, '')
         self.assertTrue(bool(response))

--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -64,9 +64,9 @@ def inventreeDocsVersion():
 def isInvenTreeUpToDate():
     """Test if the InvenTree instance is "up to date" with the latest version.
 
-    A background task periodically queries GitHub for latest version, and stores it to the database as INVENTREE_LATEST_VERSION
+    A background task periodically queries GitHub for latest version, and stores it to the database as "_INVENTREE_LATEST_VERSION"
     """
-    latest = common.models.InvenTreeSetting.get_setting('INVENTREE_LATEST_VERSION', backup_value=None, create=False)
+    latest = common.models.InvenTreeSetting.get_setting('_INVENTREE_LATEST_VERSION', backup_value=None, create=False)
 
     # No record for "latest" version - we must assume we are up to date!
     if not latest:

--- a/InvenTree/common/api.py
+++ b/InvenTree/common/api.py
@@ -187,7 +187,7 @@ class SettingsList(ListAPI):
 class GlobalSettingsList(SettingsList):
     """API endpoint for accessing a list of global settings objects."""
 
-    queryset = common.models.InvenTreeSetting.objects.all()
+    queryset = common.models.InvenTreeSetting.objects.exclude(key__startswith="_")
     serializer_class = common.serializers.GlobalSettingsSerializer
 
 
@@ -216,7 +216,7 @@ class GlobalSettingsDetail(RetrieveUpdateAPI):
     """
 
     lookup_field = 'key'
-    queryset = common.models.InvenTreeSetting.objects.all()
+    queryset = common.models.InvenTreeSetting.objects.exclude(key__startswith="_")
     serializer_class = common.serializers.GlobalSettingsSerializer
 
     def get_object(self):

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -179,6 +179,10 @@ class BaseInvenTreeSetting(models.Model):
         """
         results = cls.objects.all()
 
+        if exclude_hidden:
+            # Keys which start with an undersore are used for internal functionality
+            results = results.exclude(key__startswith='_')
+
         # Optionally filter by user
         if user is not None:
             results = results.filter(user=user)


### PR DESCRIPTION
* Bugfix for auto-backup task

- Dont' mix datetime with timezone

* Use different variable names

- If old names are stuck in the database, error could still occur

* Exclude internal settings from API

* Make INVENTREE_LATEST_VERSION setting an internal one

(cherry picked from commit fd84e590ece9a41e8a5868a718cedab29267926d)