### PR TITLE
Add unallocated quantity to StockItem renderer

### DIFF
--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -2296,6 +2296,7 @@ function allocateStockToBuild(build_id, part_id, bom_items, options={}) {
                         render_part_detail: true,
                         render_location_detail: true,
                         render_pk: false,
+                        render_available_quantity: true,
                         auto_fill: true,
                         auto_fill_filters: auto_fill_filters,
                         onSelect: function(data, field, opts) {

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -111,6 +111,12 @@ function renderStockItem(name, data, parameters={}, options={}) {
         location_detail = ` <small>- (<em>${data.location_detail.name}</em>)</small>`;
     }
 
+    var render_available_quantity = false;
+
+    if ('render_available_quantity' in parameters) {
+        render_available_quantity = parameters['render_available_quantity'];
+    }
+
     var stock_detail = '';
 
     if (data.quantity == 0) {
@@ -119,8 +125,12 @@ function renderStockItem(name, data, parameters={}, options={}) {
         if (data.serial && data.quantity == 1) {
             stock_detail = `{% trans "Serial Number" %}: ${data.serial}`;
         } else {
-            var available = data.quantity - data.allocated;
-            stock_detail = `{% trans "Available" %}: ${available}/${data.quantity}`;
+            if (render_available_quantity) {
+                var available = data.quantity - data.allocated;
+                stock_detail = `{% trans "Available" %}: ${available}`;
+            } else {
+                stock_detail = `{% trans "Quantity" %}: ${data.quantity}`;
+            }
         }
 
         if (data.batch) {

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -119,7 +119,8 @@ function renderStockItem(name, data, parameters={}, options={}) {
         if (data.serial && data.quantity == 1) {
             stock_detail = `{% trans "Serial Number" %}: ${data.serial}`;
         } else {
-            stock_detail = `{% trans "Quantity" %}: ${data.quantity}`;
+            var available = data.quantity - data.allocated;
+            stock_detail = `{% trans "Available" %}: ${available}/${data.quantity}`;
         }
 
         if (data.batch) {


### PR DESCRIPTION
In the "Allocate Stock to Build Orders" workflow I noticed that the StockItems offered in the allocation modal only present their total quantity, not the quantity that is actually available for allocation. That can lead to confusion to why the quantity-field for allocation takes a smaller value than expected if much of that StockItem was already allocated before.

[EDITED]

Therefor I canged the `renderStockItem()` output to show the available stock instead of total stock in the allocation modal:

With changes:

![Bildschirmfoto vom 2023-02-27 21-44-23](https://user-images.githubusercontent.com/296454/221681495-7c896fba-b527-416c-906a-eda5d591f672.png)

Before:

![Bildschirmfoto vom 2023-02-27 20-50-13](https://user-images.githubusercontent.com/296454/221672308-242d4378-6bbc-41f6-be5a-99a89bd020ec.png)