### PR TITLE
Add base part info to [Add Supplier Part] modal form

### DIFF
--- a/InvenTree/templates/js/translated/company.js
+++ b/InvenTree/templates/js/translated/company.js
@@ -146,7 +146,7 @@ function supplierPartFields(options={}) {
 }
 
 /*
- * Launch a form to create a new ManufacturerPart
+ * Launch a form to create a new SupplierPart
  */
 function createSupplierPart(options={}) {
 
@@ -194,11 +194,26 @@ function createSupplierPart(options={}) {
         }
     };
 
+    var header = '';
+    if (options.part) {
+        var part_model = {};
+        inventreeGet(`/api/part/${options.part}/.*`, {}, {
+            async: false,
+            success: function(response) {
+                part_model = response;
+            }
+        });
+        header = constructLabel('Base Part',{});
+        header += renderPart('header', part_model);
+        header += `<div>&nbsp;</div>`;
+    }
+
     constructForm('{% url "api-supplier-part-list" %}', {
         fields: fields,
         method: 'POST',
         title: '{% trans "Add Supplier Part" %}',
         onSuccess: options.onSuccess,
+        header_html: header,
     });
 }
 

--- a/InvenTree/templates/js/translated/company.js
+++ b/InvenTree/templates/js/translated/company.js
@@ -203,7 +203,7 @@ function createSupplierPart(options={}) {
                 part_model = response;
             }
         });
-        header = constructLabel('Base Part',{});
+        header = constructLabel('Base Part', {});
         header += renderPart('header', part_model);
         header += `<div>&nbsp;</div>`;
     }

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -487,6 +487,11 @@ function constructFormBody(fields, options) {
 
     var html = '';
 
+    // add additional content as a header on top (provided as html by the caller)
+    if (options.header_html) {
+        html += options.header_html;
+    }
+
     // Client must provide set of fields to be displayed,
     // otherwise *all* fields will be displayed
     var displayed_fields = options.fields || fields;


### PR DESCRIPTION
In the `Part Detail --> New Supplier Part` modal there is currently no reference to the part units - which is sometimes needed to fill out the packing quantity and packaging fields correctly (like "was is meters or millimeters?", "g or kg?").

For this I added an optional `header_html` parameter to the `constructFormBody()` function and passed a `renderPart()` block into the modal form, displayed on top.

By this now the `Part Detail --> New Supplier Part` and `Company --> New Supplier Part` forms offer the equal amount of information:

Updated `Part Detail --> New Supplier Part`:

![Bildschirmfoto vom 2023-02-28 12-36-32](https://user-images.githubusercontent.com/296454/221847935-c6051766-747f-4a5b-9c3c-1adafe60d0e5.png)


Comparison to `Company --> New Supplier Part`:

![Bildschirmfoto vom 2023-02-28 12-51-30](https://user-images.githubusercontent.com/296454/221847535-33fc56e0-1324-498d-ad02-ebc8f2e58935.png)

