### PR TITLE
Fix some regressions in new "Responsible" filter for build orders

### DIFF
--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -2702,7 +2702,7 @@ function loadBuildTable(table, options) {
 
                     var html = row.responsible_detail.name;
 
-                    if (row.responsible_detail.label == 'group') {
+                    if (row.responsible_detail.label == '{% trans "group" %}') {
                         html += `<span class='float-right fas fa-users'></span>`;
                     } else {
                         html += `<span class='float-right fas fa-user'></span>`;

--- a/InvenTree/templates/js/translated/filters.js
+++ b/InvenTree/templates/js/translated/filters.js
@@ -455,6 +455,12 @@ function getFilterOptionValue(tableKey, filterKey, valueKey) {
 
     // Iterate through a list of options
     if ('options' in filter) {
+        // options can be an object or a function, in which case we need to run
+        // this callback first
+        if (filter.options instanceof Function) {
+            filter.options = filter.options();
+        }
+
         for (var key in filter.options) {
 
             if (key == valueKey) {


### PR DESCRIPTION
This fixes two issues introduced with the latest addition of filtering by responsible user/group in build orders:

- The active filter did not show the human readable value due to the introduction of dynamically loaded filter options
- The user/group icon was not correctly selected in translated interfaces

Fixed:

![Bildschirmfoto vom 2023-02-28 16-52-32](https://user-images.githubusercontent.com/296454/221906471-72842397-dfe9-4321-bddf-df6d3e01e912.png)

Before:

![Bildschirmfoto vom 2023-02-28 16-53-49](https://user-images.githubusercontent.com/296454/221906848-b92da726-bc3e-496b-9a62-2bbc6e039838.png)
