### PR TITLE
Translation Fixes

### DIFF
--- a/InvenTree/InvenTree/management/commands/prerender.py
+++ b/InvenTree/InvenTree/management/commands/prerender.py
@@ -12,8 +12,15 @@ from django.utils.translation import override as lang_over
 
 def render_file(file_name, source, target, locales, ctx):
     """Renders a file into all provided locales."""
+
     for locale in locales:
+
+        # Enforce lower-case for locale names
+        locale = locale.lower()
+        locale = locale.replace('_', '-')
+
         target_file = os.path.join(target, locale + '.' + file_name)
+
         with open(target_file, 'w') as localised_file:
             with lang_over(locale):
                 renderd = render_to_string(os.path.join(source, file_name), ctx)

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -718,7 +718,7 @@ LANGUAGES = [
     ('th', _('Thai')),
     ('tr', _('Turkish')),
     ('vi', _('Vietnamese')),
-    ('zh-cn', _('Chinese')),
+    ('zh-hans', _('Chinese')),
 ]
 
 # Testing interface translations

--- a/InvenTree/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/InvenTree/locale/zh_Hans/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: inventree\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 21:17+0000\n"
+"POT-Creation-Date: 2023-03-01 10:01+0000\n"
 "PO-Revision-Date: 2023-02-28 22:38\n"
 "Last-Translator: \n"
 "Language-Team: Chinese Simplified\n"
@@ -11550,7 +11550,8 @@ msgstr ""
 
 #: templates/socialaccount/signup.html:10
 #, python-format
-msgid "You are about to use your %(provider_name)s account to login to\n"
+msgid ""
+"You are about to use your %(provider_name)s account to login to\n"
 "%(site_name)s.<br>As a final step, please complete the following form:"
 msgstr ""
 
@@ -11737,4 +11738,3 @@ msgstr "编辑项目权限"
 #: users/models.py:231
 msgid "Permission to delete items"
 msgstr "删除项目权限"
-

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -601,7 +601,7 @@ class I18nStaticNode(StaticNode):
 
 
 # use the dynamic url - tag if in Debugging-Mode
-if False and settings.DEBUG:
+if settings.DEBUG:
 
     @register.simple_tag()
     def i18n_static(url_name):

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -570,7 +570,29 @@ class I18nStaticNode(StaticNode):
             self.original = self.path.var
 
         if hasattr(context, 'request'):
-            self.path.var = self.original.format(lng=context.request.LANGUAGE_CODE)
+
+            # Find the "requested" language code
+            language_code = context.request.LANGUAGE_CODE.lower().strip()
+
+            # Find the first "best" match:
+            # - First, try the original requested code, e.g. 'pt-br'
+            # - Next, try a simpler version of the code e.g. 'pt'
+            # - Finally, fall back to english
+            options = [
+                language_code,
+                language_code.split('-')[0],
+                'en',
+            ]
+
+            for lng in options:
+                lng_file = os.path.join(
+                    djangosettings.STATIC_ROOT,
+                    self.original.format(lng=lng)
+                )
+
+                if os.path.exists(lng_file):
+                    self.path.var = self.original.format(lng=lng)
+                    break
 
         ret = super().render(context)
 

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -571,8 +571,9 @@ class I18nStaticNode(StaticNode):
 
         if hasattr(context, 'request'):
 
-            # Find the "requested" language code
+            # Convert the "requested" language code to a standard format
             language_code = context.request.LANGUAGE_CODE.lower().strip()
+            language_code = language_code.replace('_', '-')
 
             # Find the first "best" match:
             # - First, try the original requested code, e.g. 'pt-br'
@@ -600,7 +601,7 @@ class I18nStaticNode(StaticNode):
 
 
 # use the dynamic url - tag if in Debugging-Mode
-if settings.DEBUG:
+if False and settings.DEBUG:
 
     @register.simple_tag()
     def i18n_static(url_name):


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/4431

This PR fixes an issue relating to running translations in a production build.

Static javascript files are pre-rendered by running `invoke static` - and a copy produced for each supported language. However, there were some issues related to the requested language code not exactly matching the translated language code.

This PR serves to standardize the language code representations, and also provides a backup path if the requested javascript files are not found.