### PR TITLE
Bug fix for rendering allocations against build outputs

### DIFF
--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1717,7 +1717,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
         detailFormatter: function(index, row, element) {
             // Contruct an 'inner table' which shows which stock items have been allocated
 
-            var subTableId = `allocation-table-${row.pk}`;
+            var subTableId = `allocation-table-${outputId}-${row.pk}`;
 
             var html = `<div class='sub-table'><table class='table table-condensed table-striped' id='${subTableId}'></table></div>`;
 


### PR DESCRIPTION
Fixes a bug which caused subtle rendering errors for complex builds with multiple tracked BOM items.

The sub-sub-table identifiers were not globally unique, which was causing issues with jQuery DOM lookup.