### PR TITLE
Email settings not configured - remove need for user and password

### DIFF
--- a/InvenTree/InvenTree/status.py
+++ b/InvenTree/InvenTree/status.py
@@ -61,19 +61,13 @@ def is_email_configured():
         if not settings.TESTING:  # pragma: no cover
             logger.debug("EMAIL_HOST is not configured")
 
-    if not settings.EMAIL_HOST_USER:
-        configured = False
+    # Display warning unless in test mode
+    if not settings.TESTING:  # pragma: no cover
+        logger.debug("EMAIL_HOST_USER is not configured")
 
-        # Display warning unless in test mode
-        if not settings.TESTING:  # pragma: no cover
-            logger.debug("EMAIL_HOST_USER is not configured")
-
-    if not settings.EMAIL_HOST_PASSWORD:
-        configured = False
-
-        # Display warning unless in test mode
-        if not settings.TESTING:  # pragma: no cover
-            logger.debug("EMAIL_HOST_PASSWORD is not configured")
+    # Display warning unless in test mode
+    if not settings.TESTING:  # pragma: no cover
+        logger.debug("EMAIL_HOST_PASSWORD is not configured")
 
     return configured
 


### PR DESCRIPTION
Fixes #4473

This PR removes the need to set password and user for email.