### PR TITLE
Optionally hide 'revision' field

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1071,6 +1071,13 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'validator': bool,
         },
 
+        'PART_ENABLE_REVISION': {
+            'name': _('Part Revisions'),
+            'description': _('Enable revision field for Part'),
+            'validator': bool,
+            'default': True,
+        },
+
         'PART_IPN_REGEX': {
             'name': _('IPN Regex'),
             'description': _('Regular expression pattern for matching Part IPN')

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -273,7 +273,8 @@
                 <td>{{ part.IPN }}{% include "clip.html"%}</td>
             </tr>
             {% endif %}
-            {% if part.revision %}
+            {% settings_value "PART_ENABLE_REVISION" as show_revision %}
+            {% if show_revision and part.revision %}
             <tr>
                 <td><span class='fas fa-code-branch'></span></td>
                 <td>{% trans "Revision" %}</td>

--- a/InvenTree/templates/InvenTree/settings/part.html
+++ b/InvenTree/templates/InvenTree/settings/part.html
@@ -11,6 +11,7 @@
 
 <table class='table table-striped table-condensed'>
     <tbody>
+        {% include "InvenTree/settings/setting.html" with key="PART_ENABLE_REVISION" %}
         {% include "InvenTree/settings/setting.html" with key="PART_IPN_REGEX" %}
         {% include "InvenTree/settings/setting.html" with key="PART_ALLOW_DUPLICATE_IPN" %}
         {% include "InvenTree/settings/setting.html" with key="PART_ALLOW_EDIT_IPN" %}

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -1160,6 +1160,8 @@ function loadPartVariantTable(table, partId, options={}) {
         {
             field: 'revision',
             title: '{% trans "Revision" %}',
+            switchable: global_settings.PART_ENABLE_REVISION,
+            visible: global_settings.PART_ENABLE_REVISION,
             sortable: true,
         },
         {
@@ -1883,6 +1885,14 @@ function loadPartTable(table, url, options={}) {
         field: 'IPN',
         title: '{% trans "IPN" %}',
         sortable: !options.params.ordering
+    });
+
+    columns.push({
+        field: 'revision',
+        title: '{% trans "Revision" %}',
+        switchable: global_settings.PART_ENABLE_REVISION,
+        visible: global_settings.PART_ENABLE_REVISION,
+        sortable: true,
     });
 
     columns.push({

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -98,7 +98,9 @@ function partFields(options={}) {
         },
         name: {},
         IPN: {},
-        revision: {},
+        revision: {
+            icon: 'fa-code-branch',
+        },
         description: {},
         variant_of: {},
         keywords: {
@@ -174,9 +176,14 @@ function partFields(options={}) {
         };
     }
 
-    // Pop expiry field
+    // Pop 'expiry' field
     if (!global_settings.STOCK_ENABLE_EXPIRY) {
         delete fields['default_expiry'];
+    }
+
+    // Pop 'revision' field
+    if (!global_settings.PART_ENABLE_REVISION) {
+        delete fields['revision'];
     }
 
     if (options.create || options.duplicate) {

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -1120,19 +1120,7 @@ function loadPartVariantTable(table, partId, options={}) {
             formatter: function(value, row) {
                 var html = '';
 
-                var name = '';
-
-                if (row.IPN) {
-                    name += row.IPN;
-                    name += ' | ';
-                }
-
-                name += value;
-
-                if (row.revision) {
-                    name += ' | ';
-                    name += row.revision;
-                }
+                var name = row.full_name || row.name;
 
                 if (row.is_template) {
                     name = '<i>' + name + '</i>';


### PR DESCRIPTION
Option to hide the 'revision' field in the user interface.

No changes to backend or API, just remove 'revision' field for installs where it is not used (and is confusing)