### PR TITLE
Bypass cache when displaying settings on "settings" page

### DIFF
--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -185,7 +185,7 @@ class LabelPrintMixin(LabelFilterMixin):
         outputs = []
 
         # In debug mode, generate single HTML output, rather than PDF
-        debug_mode = common.models.InvenTreeSetting.get_setting('REPORT_DEBUG_MODE')
+        debug_mode = common.models.InvenTreeSetting.get_setting('REPORT_DEBUG_MODE', cache=False)
 
         label_name = "label.pdf"
 
@@ -260,7 +260,7 @@ class LabelPrintMixin(LabelFilterMixin):
 
             pdf = outputs[0].get_document().copy(pages).write_pdf()
 
-            inline = common.models.InvenTreeUserSetting.get_setting('LABEL_INLINE', user=request.user)
+            inline = common.models.InvenTreeUserSetting.get_setting('LABEL_INLINE', user=request.user, cache=False)
 
             return InvenTree.helpers.DownloadFile(
                 pdf,

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -318,20 +318,23 @@ def setting_object(key, *args, **kwargs):
     (Or return None if the setting does not exist)
     if a user-setting was requested return that
     """
+
+    cache = kwargs.get('cache', True)
+
     if 'plugin' in kwargs:
         # Note, 'plugin' is an instance of an InvenTreePlugin class
 
         plugin = kwargs['plugin']
 
-        return PluginSetting.get_setting_object(key, plugin=plugin)
+        return PluginSetting.get_setting_object(key, plugin=plugin, cache=cache)
 
     if 'method' in kwargs:
-        return NotificationUserSetting.get_setting_object(key, user=kwargs['user'], method=kwargs['method'])
+        return NotificationUserSetting.get_setting_object(key, user=kwargs['user'], method=kwargs['method'], cache=cache)
 
     if 'user' in kwargs:
-        return InvenTreeUserSetting.get_setting_object(key, user=kwargs['user'])
+        return InvenTreeUserSetting.get_setting_object(key, user=kwargs['user'], cache=cache)
 
-    return InvenTreeSetting.get_setting_object(key)
+    return InvenTreeSetting.get_setting_object(key, cache=cache)
 
 
 @register.simple_tag()

--- a/InvenTree/report/api.py
+++ b/InvenTree/report/api.py
@@ -185,7 +185,7 @@ class ReportPrintMixin:
         outputs = []
 
         # In debug mode, generate single HTML output, rather than PDF
-        debug_mode = common.models.InvenTreeSetting.get_setting('REPORT_DEBUG_MODE')
+        debug_mode = common.models.InvenTreeSetting.get_setting('REPORT_DEBUG_MODE', cache=False)
 
         # Start with a default report name
         report_name = "report.pdf"
@@ -254,7 +254,7 @@ class ReportPrintMixin:
                     status=400,
                 )
 
-            inline = common.models.InvenTreeUserSetting.get_setting('REPORT_INLINE', user=request.user)
+            inline = common.models.InvenTreeUserSetting.get_setting('REPORT_INLINE', user=request.user, cache=False)
 
             return InvenTree.helpers.DownloadFile(
                 pdf,
@@ -342,7 +342,7 @@ class StockItemTestReportPrint(RetrieveAPI, StockItemReportMixin, ReportPrintMix
     def report_callback(self, item, report, request):
         """Callback to (optionally) save a copy of the generated report"""
 
-        if common.models.InvenTreeSetting.get_setting('REPORT_ATTACH_TEST_REPORT'):
+        if common.models.InvenTreeSetting.get_setting('REPORT_ATTACH_TEST_REPORT', cache=False):
 
             # Construct a PDF file object
             pdf = report.get_document().write_pdf()

--- a/InvenTree/report/tests.py
+++ b/InvenTree/report/tests.py
@@ -375,7 +375,7 @@ class BuildReportTest(ReportTest):
         self.assertEqual(headers['Content-Disposition'], 'attachment; filename="report.pdf"')
 
         # Now, set the download type to be "inline"
-        inline = InvenTreeUserSetting.get_setting_object('REPORT_INLINE', user=self.user)
+        inline = InvenTreeUserSetting.get_setting_object('REPORT_INLINE', cache=False, user=self.user)
         inline.value = True
         inline.save()
 

--- a/InvenTree/templates/InvenTree/settings/setting.html
+++ b/InvenTree/templates/InvenTree/settings/setting.html
@@ -2,13 +2,13 @@
 {% load i18n %}
 
 {% if plugin %}
-{% setting_object key plugin=plugin as setting %}
+{% setting_object key cache=False plugin=plugin as setting %}
 {% elif user_setting %}
-{% setting_object key user=request.user as setting %}
+{% setting_object key cache=False user=request.user as setting %}
 {% elif notification_setting %}
-{% setting_object key method=method user=request.user as setting %}
+{% setting_object key cache=False method=method user=request.user as setting %}
 {% else %}
-{% setting_object key as setting %}
+{% setting_object key cache=False as setting %}
 {% endif %}
 
 <tr>


### PR DESCRIPTION
- Sometimes caching issues can cause "old" values to be stored (depends on the worker)
- Until we have a shared cache, this is a problem
- Force the settings to be re-loaded from the database when displaying
- Further improvement would be to render them via the API

Note: We should really address having a proper caching system which is shared between the background workers and the front-end workers

Ref: https://docs.djangoproject.com/en/4.1/topics/cache/