### PR TITLE
Add link column to PO LineItem table

### DIFF
--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -2463,6 +2463,18 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                 },
             },
             {
+                sortable: false,
+                field: 'supplier_part_detail.link',
+                title: '{% trans "Link" %}',
+                formatter: function(value, row, index, field) {
+                    if (value) {
+                            return renderLink(value, value);
+                    } else {
+                        return '';
+                    }
+                },
+            },
+            {
                 sortable: true,
                 sortName: 'MPN',
                 field: 'supplier_part_detail.manufacturer_part_detail.MPN',


### PR DESCRIPTION
I have added a column providing the external link for a supplier part to the purchase order line items table - when issuing a PO through a supplier online-shop that does not provide bulk-import functionality from CSV or such, this makes it much quicker to transfer the line items into the suppliers' shopping cart.

Some online shops are set up particularly bad, where you cannot even use a fulltext search to find their own products via the SKU reliably. Or SKU strings contain specific configurations (cable length, color etc) - but the shop only has one article for the base-SKU with manual dropdowns for those configurations. In these cases it helps a lot to use the link for each line item directly from the list.

Screenshot with links:
![Bildschirmfoto vom 2023-03-16 15-34-28](https://user-images.githubusercontent.com/296454/225652686-f67232d4-2b68-4200-b86b-0080c56ddc14.png)
