### PR TITLE
Report template caching

### DIFF
--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -45,7 +45,7 @@ class LabelFilterMixin:
         ids = []
 
         # Construct a list of possible query parameter value options
-        # e.g. if self.ITEM_KEY = 'part' -> ['part', 'part', 'parts', parts[]']
+        # e.g. if self.ITEM_KEY = 'part' -> ['part', 'part[]', 'parts', parts[]']
         for k in [self.ITEM_KEY + x for x in ['', '[]', 's', 's[]']]:
             if ids := self.request.query_params.getlist(k, []):
                 # Return the first list of matches

--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -270,7 +270,17 @@ class LabelPrintMixin(LabelFilterMixin):
             )
 
 
-class StockItemLabelList(LabelListView):
+class StockItemLabelMixin:
+    """Mixin for StockItemLabel endpoints"""
+
+    queryset = StockItemLabel.objects.all()
+    serializer_class = StockItemLabelSerializer
+
+    ITEM_MODEL = StockItem
+    ITEM_KEY = 'item'
+
+
+class StockItemLabelList(StockItemLabelMixin, LabelListView):
     """API endpoint for viewing list of StockItemLabel objects.
 
     Filterable by:
@@ -279,32 +289,30 @@ class StockItemLabelList(LabelListView):
     - item: Filter by single stock item
     - items: Filter by list of stock items
     """
-
-    queryset = StockItemLabel.objects.all()
-    serializer_class = StockItemLabelSerializer
-
-    ITEM_MODEL = StockItem
-    ITEM_KEY = 'item'
+    pass
 
 
-class StockItemLabelDetail(RetrieveUpdateDestroyAPI):
+class StockItemLabelDetail(StockItemLabelMixin, RetrieveUpdateDestroyAPI):
     """API endpoint for a single StockItemLabel object."""
-
-    queryset = StockItemLabel.objects.all()
-    serializer_class = StockItemLabelSerializer
+    pass
 
 
-class StockItemLabelPrint(LabelPrintMixin, RetrieveAPI):
+class StockItemLabelPrint(StockItemLabelMixin, LabelPrintMixin, RetrieveAPI):
     """API endpoint for printing a StockItemLabel object."""
-
-    queryset = StockItemLabel.objects.all()
-    serializer_class = StockItemLabelSerializer
-
-    ITEM_MODEL = StockItem
-    ITEM_KEY = 'item'
+    pass
 
 
-class StockLocationLabelList(LabelListView):
+class StockLocationLabelMixin:
+    """Mixin for StockLocationLabel endpoints"""
+
+    queryset = StockLocationLabel.objects.all()
+    serializer_class = StockLocationLabelSerializer
+
+    ITEM_MODEL = StockLocation
+    ITEM_KEY = 'location'
+
+
+class StockLocationLabelList(StockLocationLabelMixin, LabelListView):
     """API endpoint for viewiing list of StockLocationLabel objects.
 
     Filterable by:
@@ -313,56 +321,41 @@ class StockLocationLabelList(LabelListView):
     - location: Filter by a single stock location
     - locations: Filter by list of stock locations
     """
-
-    queryset = StockLocationLabel.objects.all()
-    serializer_class = StockLocationLabelSerializer
-
-    ITEM_MODEL = StockLocation
-    ITEM_KEY = 'location'
+    pass
 
 
-class StockLocationLabelDetail(RetrieveUpdateDestroyAPI):
+class StockLocationLabelDetail(StockLocationLabelMixin, RetrieveUpdateDestroyAPI):
     """API endpoint for a single StockLocationLabel object."""
-
-    queryset = StockLocationLabel.objects.all()
-    serializer_class = StockLocationLabelSerializer
+    pass
 
 
-class StockLocationLabelPrint(LabelPrintMixin, RetrieveAPI):
+class StockLocationLabelPrint(StockLocationLabelMixin, LabelPrintMixin, RetrieveAPI):
     """API endpoint for printing a StockLocationLabel object."""
-
-    queryset = StockLocationLabel.objects.all()
-    seiralizer_class = StockLocationLabelSerializer
-
-    ITEM_MODEL = StockLocation
-    ITEM_KEY = 'location'
+    pass
 
 
-class PartLabelList(LabelListView):
+class PartLabelMixin:
+    """Mixin for PartLabel endpoints"""
+    queryset = PartLabel.objects.all()
+    serializer_class = PartLabelSerializer
+
+    ITEM_MODEL = Part
+    ITEM_KEY = 'part'
+
+
+class PartLabelList(PartLabelMixin, LabelListView):
     """API endpoint for viewing list of PartLabel objects."""
-
-    queryset = PartLabel.objects.all()
-    serializer_class = PartLabelSerializer
-
-    ITEM_MODEL = Part
-    ITEM_KEY = 'part'
+    pass
 
 
-class PartLabelDetail(RetrieveUpdateDestroyAPI):
+class PartLabelDetail(PartLabelMixin, RetrieveUpdateDestroyAPI):
     """API endpoint for a single PartLabel object."""
-
-    queryset = PartLabel.objects.all()
-    serializer_class = PartLabelSerializer
+    pass
 
 
-class PartLabelPrint(LabelPrintMixin, RetrieveAPI):
+class PartLabelPrint(PartLabelMixin, LabelPrintMixin, RetrieveAPI):
     """API endpoint for printing a PartLabel object."""
-
-    queryset = PartLabel.objects.all()
-    serializer_class = PartLabelSerializer
-
-    ITEM_MODEL = Part
-    ITEM_KEY = 'part'
+    pass
 
 
 label_api_urls = [

--- a/InvenTree/label/api.py
+++ b/InvenTree/label/api.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.core.exceptions import FieldError, ValidationError
 from django.http import HttpResponse, JsonResponse
 from django.urls import include, re_path
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page, never_cache
 
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters
@@ -134,8 +136,14 @@ class LabelListView(LabelFilterMixin, ListAPI):
     ]
 
 
+@method_decorator(cache_page(5), name='dispatch')
 class LabelPrintMixin(LabelFilterMixin):
     """Mixin for printing labels."""
+
+    @method_decorator(never_cache)
+    def dispatch(self, *args, **kwargs):
+        """Prevent caching when printing report templates"""
+        return super().dispatch(*args, **kwargs)
 
     def get(self, request, *args, **kwargs):
         """Perform a GET request against this endpoint to print labels"""

--- a/InvenTree/report/api.py
+++ b/InvenTree/report/api.py
@@ -5,7 +5,9 @@ from django.core.files.base import ContentFile
 from django.http import HttpResponse
 from django.template.exceptions import TemplateDoesNotExist
 from django.urls import include, path, re_path
+from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
+from django.views.decorators.cache import cache_page, never_cache
 
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters
@@ -138,8 +140,14 @@ class ReportFilterMixin:
         return queryset
 
 
+@method_decorator(cache_page(5), name='dispatch')
 class ReportPrintMixin:
     """Mixin for printing reports."""
+
+    @method_decorator(never_cache)
+    def dispatch(self, *args, **kwargs):
+        """Prevent caching when printing report templates"""
+        return super().dispatch(*args, **kwargs)
 
     def report_callback(self, object, report, request):
         """Callback function for each object/report combination.

--- a/InvenTree/report/api.py
+++ b/InvenTree/report/api.py
@@ -341,7 +341,7 @@ class BuildReportMixin(ReportFilterMixin):
     """Mixin for the BuildReport report template"""
 
     ITEM_MODEL = build.models.Build
-    ITE_KEY = 'build'
+    ITEM_KEY = 'build'
 
     queryset = BuildReport.objects.all()
     serializer_class = BuildReportSerializer


### PR DESCRIPTION
Prevent report and label template printing from using cached templates

Fixes a very subtle bug in which a new report or label template is uploaded, but the *cached* (old) version of the template is used for printing.

Note: also features some of the refactoring work from https://github.com/inventree/InvenTree/pull/4488