### PR TITLE
Search refactor

### DIFF
--- a/InvenTree/InvenTree/api.py
+++ b/InvenTree/InvenTree/api.py
@@ -241,7 +241,7 @@ class APISearchView(APIView):
             'part': part.api.PartList,
             'partcategory': part.api.CategoryList,
             'purchaseorder': order.api.PurchaseOrderList,
-            'stock': stock.api.StockList,
+            'stockitem': stock.api.StockList,
             'stocklocation': stock.api.StockLocationList,
             'salesorder': order.api.SalesOrderList,
         }

--- a/InvenTree/InvenTree/api.py
+++ b/InvenTree/InvenTree/api.py
@@ -251,11 +251,18 @@ class APISearchView(APIView):
 
         data = request.data
 
+        search = data.get('search', '')
+
         # Enforce a 'limit' parameter
         try:
             limit = int(data.get('limit', 1))
         except ValueError:
             limit = 1
+
+        try:
+            offset = int(data.get('offset', 0))
+        except ValueError:
+            offset = 0
 
         results = {}
 
@@ -265,8 +272,14 @@ class APISearchView(APIView):
 
                 params = data[key]
 
+                params['search'] = search
+
                 # Enforce limit
                 params['limit'] = limit
+                params['offset'] = offset
+
+                # Enforce json encoding
+                params['format'] = 'json'
 
                 # Ignore if the params are wrong
                 if type(params) is not dict:
@@ -277,6 +290,7 @@ class APISearchView(APIView):
                 # Override regular query params with specific ones for this search request
                 request._request.GET = params
                 view.request = request
+                view.format_kwarg = 'format'
 
                 # Update results dict with particular query
                 results[key] = view.list(request, *args, **kwargs).data

--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 101
+INVENTREE_API_VERSION = 102
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v102 -> 2023-03-18 : https://github.com/inventree/InvenTree/pull/4505
+    - Adds global search API endpoint for consolidated search results
 
 v101 -> 2023-03-07 : https://github.com/inventree/InvenTree/pull/4462
     - Adds 'total_in_stock' to Part serializer, and supports API ordering

--- a/InvenTree/InvenTree/test_api.py
+++ b/InvenTree/InvenTree/test_api.py
@@ -301,3 +301,133 @@ class BulkDeleteTests(InvenTreeAPITestCase):
         )
 
         self.assertIn("'filters' must be supplied as a dict object", str(response.data))
+
+
+class SearchTests(InvenTreeAPITestCase):
+    """Unit tests for global search endpoint"""
+
+    fixtures = [
+        'category',
+        'part',
+        'company',
+        'location',
+        'supplier_part',
+        'stock',
+        'order',
+        'sales_order',
+    ]
+
+    def test_results(self):
+        """Test individual result types"""
+
+        response = self.post(
+            reverse('api-search'),
+            {
+                'search': 'chair',
+                'limit': 3,
+                'part': {},
+                'build': {},
+            },
+            expected_code=200
+        )
+
+        # No build results
+        self.assertEqual(response.data['build']['count'], 0)
+
+        # 3 (of 5) part results
+        self.assertEqual(response.data['part']['count'], 5)
+        self.assertEqual(len(response.data['part']['results']), 3)
+
+        # Other results not included
+        self.assertNotIn('purchaseorder', response.data)
+        self.assertNotIn('salesorder', response.data)
+
+        # Search for orders
+        response = self.post(
+            reverse('api-search'),
+            {
+                'search': '01',
+                'limit': 2,
+                'purchaseorder': {},
+                'salesorder': {},
+            },
+            expected_code=200,
+        )
+
+        self.assertEqual(response.data['purchaseorder']['count'], 1)
+        self.assertEqual(response.data['salesorder']['count'], 0)
+
+        self.assertNotIn('stockitem', response.data)
+        self.assertNotIn('build', response.data)
+
+    def test_permissions(self):
+        """Test that users with insufficient permissions are handled correctly"""
+
+        # First, remove all roles
+        for ruleset in self.group.rule_sets.all():
+            ruleset.can_view = False
+            ruleset.can_change = False
+            ruleset.can_delete = False
+            ruleset.can_add = False
+            ruleset.save()
+
+        models = [
+            'build',
+            'company',
+            'manufacturerpart',
+            'supplierpart',
+            'part',
+            'partcategory',
+            'purchaseorder',
+            'stockitem',
+            'stocklocation',
+            'salesorder',
+        ]
+
+        query = {
+            'search': 'c',
+            'limit': 3,
+        }
+
+        for mdl in models:
+            query[mdl] = {}
+
+        response = self.post(
+            reverse('api-search'),
+            query,
+            expected_code=200
+        )
+
+        # Check for 'permission denied' error
+        for mdl in models:
+            self.assertEqual(response.data[mdl]['error'], 'User does not have permission to view this model')
+
+        # Assign view roles for some parts
+        self.assignRole('build.view')
+        self.assignRole('part.view')
+
+        response = self.post(
+            reverse('api-search'),
+            query,
+            expected_code=200
+        )
+
+        # Check for expected results, based on permissions
+        # We expect results to be returned for the following model types
+        has_permission = [
+            'build',
+            'manufacturerpart',
+            'supplierpart',
+            'part',
+            'partcategory',
+            'stocklocation',
+            'stockitem',
+        ]
+
+        for mdl in models:
+            result = response.data[mdl]
+            if mdl in has_permission:
+                self.assertIn('count', result)
+            else:
+                self.assertIn('error', result)
+                self.assertEqual(result['error'], 'User does not have permission to view this model')

--- a/InvenTree/InvenTree/urls.py
+++ b/InvenTree/InvenTree/urls.py
@@ -30,7 +30,7 @@ from stock.api import stock_api_urls
 from stock.urls import stock_urls
 from users.api import user_urls
 
-from .api import InfoView, NotFoundView
+from .api import APISearchView, InfoView, NotFoundView
 from .views import (AboutView, AppearanceSelectView, CustomConnectionsView,
                     CustomEmailView, CustomLoginView,
                     CustomPasswordResetFromKeyView,
@@ -43,6 +43,10 @@ admin.site.site_header = "InvenTree Admin"
 
 
 apipatterns = [
+
+    # Global search
+    path('search/', APISearchView.as_view(), name='api-search'),
+
     re_path(r'^settings/', include(settings_api_urls)),
     re_path(r'^part/', include(part_api_urls)),
     re_path(r'^bom/', include(bom_api_urls)),
@@ -58,7 +62,7 @@ apipatterns = [
     # Plugin endpoints
     path('', include(plugin_api_urls)),
 
-    # Webhook enpoint
+    # Webhook endpoints
     path('', include(common_api_urls)),
 
     # InvenTree information endpoint

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -1875,7 +1875,7 @@ function initializeRelatedField(field, fields, options={}) {
             // Custom formatting for the search results
             if (field.model) {
                 // If the 'model' is specified, hand it off to the custom model render
-                var html = renderModelData(name, field.model, data, field, options);
+                var html = renderModelData(name, field.model, data, field);
                 return $(html);
             } else {
                 // Return a simple renderering
@@ -1905,7 +1905,7 @@ function initializeRelatedField(field, fields, options={}) {
             // Custom formatting for selected item
             if (field.model) {
                 // If the 'model' is specified, hand it off to the custom model render
-                var html = renderModelData(name, field.model, data, field, options);
+                var html = renderModelData(name, field.model, data, field);
                 return $(html);
             } else {
                 // Return a simple renderering
@@ -2016,7 +2016,7 @@ function searching() {
  * - parameters: The field definition (OPTIONS) request
  * - options: Other options provided at time of modal creation by the client
  */
-function renderModelData(name, model, data, parameters, options) {
+function renderModelData(name, model, data, parameters) {
 
     if (!data) {
         return parameters.placeholder || '';
@@ -2027,7 +2027,7 @@ function renderModelData(name, model, data, parameters, options) {
     var renderer = getModelRenderer(model);
 
     if (renderer != null) {
-        html = renderer(name, data, parameters, options);
+        html = renderer(data, parameters);
     }
 
     if (html != null) {

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -9,18 +9,7 @@
     global_settings,
     modalEnable,
     modalShowSubmitButton,
-    renderBuild,
-    renderCompany,
-    renderGroup,
-    renderManufacturerPart,
-    renderOwner,
-    renderPart,
-    renderPartCategory,
-    renderPartParameterTemplate,
-    renderStockItem,
-    renderStockLocation,
-    renderSupplierPart,
-    renderUser,
+    getModelRenderer,
     showAlertOrCache,
     showApiError,
 */
@@ -2033,62 +2022,9 @@ function renderModelData(name, model, data, parameters, options) {
         return parameters.placeholder || '';
     }
 
-    // TODO: Implement this function for various models
-
     var html = null;
 
-    var renderer = null;
-
-    // Find a custom renderer
-    switch (model) {
-    case 'company':
-        renderer = renderCompany;
-        break;
-    case 'stockitem':
-        renderer = renderStockItem;
-        break;
-    case 'stocklocation':
-        renderer = renderStockLocation;
-        break;
-    case 'part':
-        renderer = renderPart;
-        break;
-    case 'partcategory':
-        renderer = renderPartCategory;
-        break;
-    case 'partparametertemplate':
-        renderer = renderPartParameterTemplate;
-        break;
-    case 'purchaseorder':
-        renderer = renderPurchaseOrder;
-        break;
-    case 'salesorder':
-        renderer = renderSalesOrder;
-        break;
-    case 'salesordershipment':
-        renderer = renderSalesOrderShipment;
-        break;
-    case 'manufacturerpart':
-        renderer = renderManufacturerPart;
-        break;
-    case 'supplierpart':
-        renderer = renderSupplierPart;
-        break;
-    case 'build':
-        renderer = renderBuild;
-        break;
-    case 'owner':
-        renderer = renderOwner;
-        break;
-    case 'user':
-        renderer = renderUser;
-        break;
-    case 'group':
-        renderer = renderGroup;
-        break;
-    default:
-        break;
-    }
+    var renderer = getModelRenderer(model);
 
     if (renderer != null) {
         html = renderer(name, data, parameters, options);

--- a/InvenTree/templates/js/translated/helpers.js
+++ b/InvenTree/templates/js/translated/helpers.js
@@ -58,7 +58,7 @@ function deleteButton(url, text='{% trans "Delete" %}') {
 function shortenString(input_string, options={}) {
 
     // Maximum length can be provided via options argument, or via a user-configurable setting
-    var max_length = options.max_length || user_settings.TABLE_STRING_MAX_LENGTH;
+    var max_length = options.max_length || user_settings.TABLE_STRING_MAX_LENGTH || 100;
 
     if (!max_length || !input_string) {
         return input_string;

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -42,40 +42,40 @@ function getModelRenderer(model) {
 
     // Find a custom renderer
     switch (model) {
-        case 'company':
-            return renderCompany;
-        case 'stockitem':
-            return renderStockItem;
-        case 'stocklocation':
-            return renderStockLocation;
-        case 'part':
-            return renderPart;
-        case 'partcategory':
-            return renderPartCategory;
-        case 'partparametertemplate':
-            return renderPartParameterTemplate;
-        case 'purchaseorder':
-            return renderPurchaseOrder;
-        case 'salesorder':
-            return renderSalesOrder;
-        case 'salesordershipment':
-            return renderSalesOrderShipment;
-        case 'manufacturerpart':
-            return renderManufacturerPart;
-        case 'supplierpart':
-            return renderSupplierPart;
-        case 'build':
-            return renderBuild;
-        case 'owner':
-            return renderOwner;
-        case 'user':
-            return renderUser;
-        case 'group':
-            return renderGroup;
-        default:
-            // Un-handled model type
-            console.error(`Rendering not implemented for model '${model}'`);
-            return null;
+    case 'company':
+        return renderCompany;
+    case 'stockitem':
+        return renderStockItem;
+    case 'stocklocation':
+        return renderStockLocation;
+    case 'part':
+        return renderPart;
+    case 'partcategory':
+        return renderPartCategory;
+    case 'partparametertemplate':
+        return renderPartParameterTemplate;
+    case 'purchaseorder':
+        return renderPurchaseOrder;
+    case 'salesorder':
+        return renderSalesOrder;
+    case 'salesordershipment':
+        return renderSalesOrderShipment;
+    case 'manufacturerpart':
+        return renderManufacturerPart;
+    case 'supplierpart':
+        return renderSupplierPart;
+    case 'build':
+        return renderBuild;
+    case 'owner':
+        return renderOwner;
+    case 'user':
+        return renderUser;
+    case 'group':
+        return renderGroup;
+    default:
+        // Un-handled model type
+        console.error(`Rendering not implemented for model '${model}'`);
+        return null;
     }
 }
 

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -3,6 +3,7 @@
 /* globals
     blankImage,
     select2Thumbnail
+    shortenString
 */
 
 /* exported
@@ -33,17 +34,6 @@
  * - options: User options provided by the client
  */
 
-
-/*
- * Trim the supplied string to ensure the string length is limited to the provided value
- */
-function trim(data, max_length=100) {
-    if (data.length > max_length) {
-        data = data.slice(0, max_length - 3) + '...';
-    }
-
-    return data;
-}
 
 
 // Should the ID be rendered for this string
@@ -115,7 +105,7 @@ function renderCompany(name, data, parameters={}, options={}) {
 
     var html = select2Thumbnail(data.image);
 
-    html += `<span><b>${data.name}</b></span> - <i>${trim(data.description)}</i>`;
+    html += `<span><b>${data.name}</b></span> - <i>${shortenString(data.description)}</i>`;
 
     html += renderId('{% trans "Company ID" %}', data.pk, parameters);
 
@@ -212,7 +202,7 @@ function renderStockLocation(name, data, parameters={}, options={}) {
     }
 
     if (render_description && data.description) {
-        html += ` - <i>${trim(data.description)}</i>`;
+        html += ` - <i>${shortenString(data.description)}</i>`;
     }
 
     html += renderId('{% trans "Location ID" %}', data.pk, parameters);
@@ -248,7 +238,7 @@ function renderPart(name, data, parameters={}, options={}) {
     html += ` <span>${data.full_name || data.name}</span>`;
 
     if (data.description) {
-        html += ` - <i><small>${trim(data.description)}</small></i>`;
+        html += ` - <i><small>${shortenString(data.description)}</small></i>`;
     }
 
     var stock_data = '';
@@ -342,7 +332,7 @@ function renderPurchaseOrder(name, data, parameters={}, options={}) {
     }
 
     if (data.description) {
-        html += ` - <em>${trim(data.description)}</em>`;
+        html += ` - <em>${shortenString(data.description)}</em>`;
     }
 
     html += renderId('{% trans "Order ID" %}', data.pk, parameters);
@@ -367,7 +357,7 @@ function renderSalesOrder(name, data, parameters={}, options={}) {
     }
 
     if (data.description) {
-        html += ` - <em>${trim(data.description)}</em>`;
+        html += ` - <em>${shortenString(data.description)}</em>`;
     }
 
     html += renderId('{% trans "Order ID" %}', data.pk, parameters);
@@ -402,7 +392,7 @@ function renderPartCategory(name, data, parameters={}, options={}) {
     var html = `<span>${level}${data.pathstring}</span>`;
 
     if (data.description) {
-        html += ` - <i>${trim(data.description)}</i>`;
+        html += ` - <i>${shortenString(data.description)}</i>`;
     }
 
     html += renderId('{% trans "Category ID" %}', data.pk, parameters);

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -35,25 +35,6 @@
  */
 
 
-
-// Should the ID be rendered for this string
-function renderId(title, pk, parameters={}) {
-
-    // Default = do not render
-    var render = false;
-
-    if ('render_pk' in parameters) {
-        render = parameters['render_pk'];
-    }
-
-    if (render) {
-        return `<span class='float-right'><small>${title}: ${pk}</small></span>`;
-    } else {
-        return '';
-    }
-}
-
-
 /*
  * Return an appropriate model renderer based on the 'name' of the model
  */
@@ -99,61 +80,99 @@ function getModelRenderer(model) {
 }
 
 
-// Renderer for "Company" model
-// eslint-disable-next-line no-unused-vars
-function renderCompany(name, data, parameters={}, options={}) {
+/*
+ * Generic method for rendering model data in a consistent fashion:
+ *
+ * data:
+ *  - image: Render an image (optional)
+ *  - imageSecondary: Render a secondary image (optional)
+ *  - text: Primary text
+ *  - pk: primary key (unique ID) of the model instance
+ *  - textSecondary: Secondary text
+ *  - link: href for link target (is enabled or disabled by showLink option)
+ *  - labels: extra labels to display
+ *
+ * options:
+ *  - showImage: Option to create image(s) (default = true)
+ *  - showLink: Option to create link (default = false)
+ *  - showLabels: Option to show or hide extra labels (default = true)
+ */
+function renderModel(data, options={}) {
 
-    var html = select2Thumbnail(data.image);
+    let showImage = ('showImage' in options) ? options.showImage : true;
+    let showLink = ('showLink' in options) ? options.showLink : false;
+    let showLabels = ('showLabels' in options) ? options.showLabels : true;
 
-    html += `<span><b>${data.name}</b></span> - <i>${shortenString(data.description)}</i>`;
+    let html = '';
 
-    html += renderId('{% trans "Company ID" %}', data.pk, parameters);
+    if (showImage) {
+        if (data.image) {
+            html += select2Thumbnail(data.image);
+        }
+        if (data.imageSecondary) {
+            html += select2Thumbnail(data.imageSecondary);
+        }
+    }
+
+    let text = `<span>${data.text}</span>`;
+
+    if (data.textSecondary) {
+        text += ` - <small><em>${data.textSecondary}</em></small>`;
+    }
+
+    if (showLink && data.url) {
+        text = renderLink(text, data.url);
+    }
+
+    html += text;
+
+    if (showLabels && data.labels) {
+        html += `<span class='float-right'><small>${data.labels}</small></span>`;
+    }
 
     return html;
+
+}
+
+
+// Renderer for "Company" model
+function renderCompany(data, parameters={}) {
+
+    return renderModel(
+        {
+            image: data.image || blankImage(),
+            text: data.name,
+            textSecondary: shortenString(data.description),
+            link: `/company/${data.pk}/`,
+        },
+        parameters
+    );
 }
 
 
 // Renderer for "StockItem" model
-// eslint-disable-next-line no-unused-vars
-function renderStockItem(name, data, parameters={}, options={}) {
+function renderStockItem(data, parameters={}) {
 
-    var image = blankImage();
+    let part_image = null;
+    let render_part_detail = ('render_part_detail' in parameters) ? parameters.render_part_detail : true;
+    let render_location_detail = ('render_location_detail' in parameters) ? parameters.render_location_detail : false;
+    let render_available_quantity = ('render_available_quantity' in parameters) ? parameters.render_available_quantity : false;
 
-    if (data.part_detail) {
-        image = data.part_detail.thumbnail || data.part_detail.image || blankImage();
+    if (render_part_detail) {
     }
 
-    var render_part_detail = true;
-
-    if ('render_part_detail' in parameters) {
-        render_part_detail = parameters['render_part_detail'];
-    }
-
-    var part_detail = '';
+    let text = '';
+    let stock_detail = '';
 
     if (render_part_detail && data.part_detail) {
-        part_detail = `<img src='${image}' class='select2-thumbnail'><span>${data.part_detail.full_name}</span> - `;
+        part_image = data.part_detail.thumbnail || data.part_detail.image || blankImage();
+
+        text += data.part_detail.full_name;
     }
-
-    var render_location_detail = false;
-
-    if ('render_location_detail' in parameters) {
-        render_location_detail = parameters['render_location_detail'];
-    }
-
-    var location_detail = '';
 
     if (render_location_detail && data.location_detail) {
-        location_detail = ` <small>- (<em>${data.location_detail.name}</em>)</small>`;
+        text += ` <small>- (<em>${data.location_detail.name}</em>)</small>`;
     }
-
-    var render_available_quantity = false;
-
-    if ('render_available_quantity' in parameters) {
-        render_available_quantity = parameters['render_available_quantity'];
-    }
-
-    var stock_detail = '';
 
     if (data.quantity == 0) {
         stock_detail = `<span class='badge rounded-pill bg-danger'>{% trans "No Stock"% }</span>`;
@@ -174,313 +193,246 @@ function renderStockItem(name, data, parameters={}, options={}) {
         }
     }
 
-    var html = `
-    <span>
-        ${part_detail}
-        ${stock_detail}
-        ${location_detail}
-        ${renderId('{% trans "Stock ID" %}', data.pk, parameters)}
-    </span>
-    `;
-
-    return html;
+    return renderModel(
+        {
+            image: part_image,
+            text: text,
+            textSecondary: stock_detail,
+            url: data.url || `/stock/item/${data.pk}/`,
+        },
+        parameters
+    );
 }
 
 
 // Renderer for "StockLocation" model
-// eslint-disable-next-line no-unused-vars
-function renderStockLocation(name, data, parameters={}, options={}) {
+function renderStockLocation(data, parameters={}) {
 
-    var level = '- '.repeat(data.level);
+    let render_description = ('render_description' in parameters) ? parameters.render_description : true;
+    let level = '- '.repeat(data.level);
 
-    var html = `<span>${level}${data.pathstring}</span>`;
-
-    var render_description = true;
-
-    if ('render_description' in parameters) {
-        render_description = parameters['render_description'];
-    }
-
-    if (render_description && data.description) {
-        html += ` - <i>${shortenString(data.description)}</i>`;
-    }
-
-    html += renderId('{% trans "Location ID" %}', data.pk, parameters);
-
-    return html;
+    return renderModel(
+        {
+            text: `${level}${data.pathstring}`,
+            textSecondary: render_description ? shortenString(data.description) : '',
+            url: data.url || `/stock/location/${data.pk}/`,
+        },
+        parameters
+    );
 }
 
-// eslint-disable-next-line no-unused-vars
-function renderBuild(name, data, parameters={}, options={}) {
+function renderBuild(data, parameters={}) {
 
-    var image = null;
+    var image = blankImage();
 
     if (data.part_detail && data.part_detail.thumbnail) {
-        image = data.part_detail.thumbnail;
+        image = data.part_detail.thumbnail || data.part_detail.image || blankImage();
     }
 
-    var html = select2Thumbnail(image);
-
-    html += `<span><b>${data.reference}</b> - ${data.quantity} x ${data.part_detail.full_name}</span>`;
-
-    html += renderId('{% trans "Build ID" %}', data.pk, parameters);
-
-    return html;
+    return renderModel(
+        {
+            image: image,
+            text: data.reference,
+            textSecondary: `${data.quantity} x ${data.part_detail.full_name}`,
+            url: data.url || `/build/${data.pk}/`,
+        },
+        parameters
+    );
 }
 
 
 // Renderer for "Part" model
-// eslint-disable-next-line no-unused-vars
-function renderPart(name, data, parameters={}, options={}) {
+function renderPart(data, parameters={}) {
 
-    var html = select2Thumbnail(data.image);
-
-    html += ` <span>${data.full_name || data.name}</span>`;
-
-    if (data.description) {
-        html += ` - <i><small>${shortenString(data.description)}</small></i>`;
-    }
-
-    var stock_data = '';
+    let labels = '';
 
     if (user_settings.PART_SHOW_QUANTITY_IN_FORMS) {
-        stock_data = partStockLabel(data);
+        labels = partStockLabel(data);
+
+        if (!data.active) {
+            labels += `<span class='badge badge-right rounded-pill bg-danger'>{% trans "Inactive" %}</span>`;
+        }
     }
 
-    var extra = '';
-
-    if (!data.active) {
-        extra += `<span class='badge badge-right rounded-pill bg-danger'>{% trans "Inactive" %}</span>`;
-    }
-
-    html += `
-    <span class='float-right'>
-        <small>
-            ${stock_data}
-            ${extra}
-            ${renderId('{% trans "Part ID" %}', data.pk, parameters)}
-            </small>
-    </span>`;
-
-    return html;
+    return renderModel(
+        {
+            image: data.image || blankImage(),
+            text: data.full_name || data.name,
+            textSecondary: shortenString(data.description),
+            labels: labels,
+            url: data.url || `/part/${data.pk}/`,
+        },
+        parameters,
+    );
 }
 
 
 // Renderer for "Group" model
-// eslint-disable-next-line no-unused-vars
-function renderGroup(name, data, parameters={}, options={}) {
+function renderGroup(data, parameters={}) {
 
-    var html = `<span>${data.name}</span>`;
-
-    return html;
-
+    return renderModel(
+        {
+            text: data.name,
+        },
+        parameters
+    );
 }
 
 // Renderer for "User" model
-// eslint-disable-next-line no-unused-vars
-function renderUser(name, data, parameters={}, options={}) {
+function renderUser(data, parameters={}) {
 
-    var html = `<span>${data.username}</span>`;
-
-    if (data.first_name && data.last_name) {
-        html += ` - <i>${data.first_name} ${data.last_name}</i>`;
-    }
-
-    return html;
+    return renderModel(
+        {
+            text: data.username,
+            textSecondary: `${data.first_name} ${data.last_name}`,
+        },
+        parameters
+    );
 }
 
 
 // Renderer for "Owner" model
-// eslint-disable-next-line no-unused-vars
-function renderOwner(name, data, parameters={}, options={}) {
+function renderOwner(data, parameters={}) {
 
-    var html = `<span>${data.name}</span>`;
+    let label = '';
 
     switch (data.label) {
     case 'user':
-        html += `<span class='float-right fas fa-user'></span>`;
+        label = `<span class='float-right fas fa-user'></span>`;
         break;
     case 'group':
-        html += `<span class='float-right fas fa-users'></span>`;
+        label = `<span class='float-right fas fa-users'></span>`;
         break;
     default:
         break;
     }
 
-    return html;
+    return renderModel(
+        {
+            text: data.name,
+            labels: label,
+        },
+        parameters
+    );
+
 }
 
 
 // Renderer for "PurchaseOrder" model
-// eslint-disable-next-line no-unused-vars
-function renderPurchaseOrder(name, data, parameters={}, options={}) {
+function renderPurchaseOrder(data, parameters={}) {
 
-    var html = '';
-
-    if (data.supplier_detail) {
-        thumbnail = data.supplier_detail.thumbnail || data.supplier_detail.image;
-
-        html += select2Thumbnail(thumbnail);
-    }
-
-    html += `<span>${data.reference}</span>`;
-
-    var thumbnail = null;
+    let image = blankImage();
 
     if (data.supplier_detail) {
-        html += ` - <span>${data.supplier_detail.name}</span>`;
+        image = data.supplier_detail.thumbnail || data.supplier_detail.image || blankImage();
     }
 
-    if (data.description) {
-        html += ` - <em>${shortenString(data.description)}</em>`;
-    }
-
-    html += renderId('{% trans "Order ID" %}', data.pk, parameters);
-
-    return html;
+    return renderModel(
+        {
+            image: image,
+            text: `${data.reference} - ${data.supplier_detail.name}`,
+            textSecondary: shortenString(data.description),
+            url: data.url || `/order/purchase-order/${data.pk}/`,
+        },
+        parameters
+    );
 }
 
 
 // Renderer for "SalesOrder" model
-// eslint-disable-next-line no-unused-vars
-function renderSalesOrder(name, data, parameters={}, options={}) {
+function renderSalesOrder(data, parameters={}) {
 
-    var html = `<span>${data.reference}</span>`;
-
-    var thumbnail = null;
+    let image = blankImage();
 
     if (data.customer_detail) {
-        thumbnail = data.customer_detail.thumbnail || data.customer_detail.image;
-
-        html += ' - ' + select2Thumbnail(thumbnail);
-        html += `<span>${data.customer_detail.name}</span>`;
+        image = data.customer_detail.thumbnail || data.customer_detail.image || blankImage();
     }
 
-    if (data.description) {
-        html += ` - <em>${shortenString(data.description)}</em>`;
-    }
-
-    html += renderId('{% trans "Order ID" %}', data.pk, parameters);
-
-    return html;
+    return renderModel(
+        {
+            image: image,
+            text: `${data.reference} - ${data.customer_detail.name}`,
+            textSecondary: shortenString(data.description),
+            url: data.url || `/order/sales-order/${data.pk}/`,
+        },
+        parameters
+    );
 }
 
 
 // Renderer for "SalesOrderShipment" model
-// eslint-disable-next-line no-unused-vars
-function renderSalesOrderShipment(name, data, parameters={}, options={}) {
+function renderSalesOrderShipment(data, parameters={}) {
 
-    var html = `
-    <span>${data.order_detail.reference} - {% trans "Shipment" %} ${data.reference}</span>
-    <span class='float-right'>
-        <small>{% trans "Shipment ID" %}: ${data.pk}</small>
-    </span>
-    `;
-
-    html += renderId('{% trans "Shipment ID" %}', data.pk, parameters);
-
-    return html;
+    return renderModel(
+        {
+            text: data.order_detail.reference,
+            textSecondary: `{% trans "Shipment" %} ${data.reference}`,
+        },
+        parameters
+    );
 }
 
 
 // Renderer for "PartCategory" model
-// eslint-disable-next-line no-unused-vars
-function renderPartCategory(name, data, parameters={}, options={}) {
+function renderPartCategory(data, parameters={}) {
 
-    var level = '- '.repeat(data.level);
+    let level = '- '.repeat(data.level);
 
-    var html = `<span>${level}${data.pathstring}</span>`;
-
-    if (data.description) {
-        html += ` - <i>${shortenString(data.description)}</i>`;
-    }
-
-    html += renderId('{% trans "Category ID" %}', data.pk, parameters);
-
-    return html;
+    return renderModel(
+        {
+            text: `${level}${data.pathstring}`,
+            textSecondary: shortenString(data.description),
+            url: data.url || `/part/category/${data.pk}/`,
+        },
+        parameters
+    );
 }
 
-// eslint-disable-next-line no-unused-vars
-function renderPartParameterTemplate(name, data, parameters={}, options={}) {
 
-    var units = '';
+function renderPartParameterTemplate(data, parameters={}) {
+
+    let units = '';
 
     if (data.units) {
         units = ` [${data.units}]`;
     }
 
-    var html = `<span>${data.name}${units}</span>`;
-
-    return html;
+    return renderModel(
+        {
+            text: `${data.name}${units}`,
+        },
+        parameters
+    );
 }
 
 
 // Renderer for "ManufacturerPart" model
-// eslint-disable-next-line no-unused-vars
-function renderManufacturerPart(name, data, parameters={}, options={}) {
+function renderManufacturerPart(data, parameters={}) {
 
-    var manufacturer_image = null;
-    var part_image = null;
-
-    if (data.manufacturer_detail) {
-        manufacturer_image = data.manufacturer_detail.image;
-    }
-
-    if (data.part_detail) {
-        part_image = data.part_detail.thumbnail || data.part_detail.image;
-    }
-
-    var html = '';
-
-    html += select2Thumbnail(manufacturer_image);
-    html += select2Thumbnail(part_image);
-
-    if (data.manufacturer_detail) {
-        html += ` <span><b>${data.manufacturer_detail.name}</b> - ${data.MPN}</span>`;
-    }
-
-    if (data.part_detail) {
-        html += ` - <i>${data.part_detail.full_name}</i>`;
-    }
-
-    html += renderId('{% trans "Manufacturer Part ID" %}', data.pk, parameters);
-
-    return html;
+    return renderModel(
+        {
+            image: data.manufacturer_detail ? data.manufacturer_detail.thumbnail || data.manufacturer_detail.image || blankImage() : null,
+            imageSecondary: data.part.detail ? data.part_detail.thumbnail || data.part_detail.image || blankImage() : null,
+            text: `${data.manufacturer_detail.name} - ${data.MPN}`,
+            textSecondary: data.part_detail.full_name,
+            url: data.url || `/manufacturer-part/${data.pk}/`,
+        },
+        parameters
+    );
 }
 
 
 // Renderer for "SupplierPart" model
-// eslint-disable-next-line no-unused-vars
-function renderSupplierPart(name, data, parameters={}, options={}) {
+function renderSupplierPart(data, parameters={}) {
 
-    var supplier_image = null;
-    var part_image = null;
-
-    if (data.supplier_detail) {
-        supplier_image = data.supplier_detail.image;
-    }
-
-    if (data.part_detail) {
-        part_image = data.part_detail.thumbnail || data.part_detail.image;
-    }
-
-    var html = '';
-
-    html += select2Thumbnail(supplier_image);
-
-    if (data.part_detail) {
-        html += select2Thumbnail(part_image);
-    }
-
-    if (data.supplier_detail) {
-        html += ` <span><b>${data.supplier_detail.name}</b> - ${data.SKU}</span>`;
-    }
-
-    if (data.part_detail) {
-        html += ` - <i>${data.part_detail.full_name}</i>`;
-    }
-
-    html += renderId('{% trans "Supplier Part ID" %}', data.pk, parameters);
-
-    return html;
+    return renderModel(
+        {
+            image: data.supplier_detail ? data.supplier_detail.thumbnail || data.supplier_detail.image || blankImage() : null,
+            imageSecondary: data.part_detail ? data.part_detail.thumbnail || data.part_detail.image || blankImage() : null,
+            text: `${data.supplier_detail.name} - ${data.SKU}`,
+            textSecondary: data.part_detail.full_name,
+            url: data.url || `/supplier-part/${data.pk}/`
+        },
+        parameters
+    );
 }

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -6,6 +6,7 @@
 */
 
 /* exported
+    getModelRenderer,
     renderBuild,
     renderCompany,
     renderGroup,
@@ -59,6 +60,51 @@ function renderId(title, pk, parameters={}) {
         return `<span class='float-right'><small>${title}: ${pk}</small></span>`;
     } else {
         return '';
+    }
+}
+
+
+/*
+ * Return an appropriate model renderer based on the 'name' of the model
+ */
+function getModelRenderer(model) {
+
+    // Find a custom renderer
+    switch (model) {
+        case 'company':
+            return renderCompany;
+        case 'stockitem':
+            return renderStockItem;
+        case 'stocklocation':
+            return renderStockLocation;
+        case 'part':
+            return renderPart;
+        case 'partcategory':
+            return renderPartCategory;
+        case 'partparametertemplate':
+            return renderPartParameterTemplate;
+        case 'purchaseorder':
+            return renderPurchaseOrder;
+        case 'salesorder':
+            return renderSalesOrder;
+        case 'salesordershipment':
+            return renderSalesOrderShipment;
+        case 'manufacturerpart':
+            return renderManufacturerPart;
+        case 'supplierpart':
+            return renderSupplierPart;
+        case 'build':
+            return renderBuild;
+        case 'owner':
+            return renderOwner;
+        case 'user':
+            return renderUser;
+        case 'group':
+            return renderGroup;
+        default:
+            // Un-handled model type
+            console.error(`Rendering not implemented for model '${model}'`);
+            return null;
     }
 }
 

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -89,7 +89,7 @@ function getModelRenderer(model) {
  *  - text: Primary text
  *  - pk: primary key (unique ID) of the model instance
  *  - textSecondary: Secondary text
- *  - link: href for link target (is enabled or disabled by showLink option)
+ *  - url: href for link target (is enabled or disabled by showLink option)
  *  - labels: extra labels to display
  *
  * options:
@@ -143,7 +143,7 @@ function renderCompany(data, parameters={}) {
             image: data.image || blankImage(),
             text: data.name,
             textSecondary: shortenString(data.description),
-            link: `/company/${data.pk}/`,
+            url: data.url || `/company/${data.pk}/`,
         },
         parameters
     );

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -640,7 +640,7 @@ function partStockLabel(part, options={}) {
     var stock_health = part.unallocated_stock + part.building + part.ordering - part.minimum_stock;
 
     // TODO: Refactor the API to include this information, so we don't have to request it!
-    if (!options.noDemandInfo) {
+    if (options.showDemandInfo) {
 
         // Check for demand from unallocated build orders
         var required_build_order_quantity = null;

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -351,7 +351,6 @@ function addSearchResults(results, resultType) {
 
     let key = resultType.key;
     let title = resultType.title;
-    let url = resultType.url;
     let renderer = resultType.renderer;
     let renderParams = resultType.renderParams;
 

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -256,7 +256,7 @@ function updateSearch() {
     `);
 
     // Send off the search query
-    searchQuery = inventreePut(
+    searchRequest = inventreePut(
         '{% url "api-search" %}',
         searchQuery,
         {

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -255,8 +255,6 @@ function updateSearch() {
                     if (resultType.key in response) {
                         let result = response[resultType.key];
 
-                        console.log(resultType.key, '->', result);
-
                         if (result.count != null && result.count > 0 && result.results) {
                             addSearchResults(result.results, resultType);
                         }
@@ -297,6 +295,10 @@ function addSearchQuery(key, title, query_params, render_params={}) {
 
     searchQuery[key] = query_params;
 
+    render_params.showImage = true;
+    render_params.showLink = true;
+    render_params.showLabels = true;
+
     searchResultTypes.push({
         key: key,
         title: title,
@@ -321,6 +323,7 @@ function addSearchResults(results, resultType) {
 
     let key = resultType.key;
     let title = resultType.title;
+    let url = resultType.url;
     let renderer = resultType.renderer;
     let renderParams = resultType.renderParams;
 
@@ -350,11 +353,7 @@ function addSearchResults(results, resultType) {
 
         var pk = result.pk || result.id;
 
-        var html = renderer(key, result, renderParams);
-
-        if (renderParams.url) {
-            html = `<a href='${renderParams.url}/${pk}/'>` + html + `</a>`;
-        }
+        var html = renderer(result, renderParams);
 
         var result_html = `
         <div class='search-result-entry' id='search-result-${key}-${pk}'>

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -303,44 +303,6 @@ function addSearchQuery(key, title, query_params, render_params={}) {
         renderer: getModelRenderer(key),
         renderParams: render_params,
     });
-
-    // TODO: DELETE M
-    return;
-
-    // Include current search term
-    query_params.search = searchTextCurrent;
-
-    // How many results to show in each group?
-    query_params.offset = 0;
-    query_params.limit = user_settings.SEARCH_PREVIEW_RESULTS;
-
-    // Do not display "pk" value for search results
-    render_params.render_pk = false;
-
-    // Add the result group to the panel
-    $('#offcanvas-search').find('#search-results').append(`
-    <div class='search-result-group-wrapper' id='search-results-wrapper-${key}'></div>
-    `);
-
-    var request = inventreeGet(
-        query_url,
-        query_params,
-        {
-            success: function(response) {
-                addSearchResults(
-                    key,
-                    response.results,
-                    title,
-                    render_func,
-                    render_params,
-                );
-            }
-        },
-    );
-
-    // Add the query to the stack
-    searchQueries.push(request);
-
 }
 
 

--- a/InvenTree/templates/search.html
+++ b/InvenTree/templates/search.html
@@ -12,11 +12,6 @@
           <button id='search-clear' class='btn btn-outline-secondary' title='{% trans "Clear search" %}'>
             <span class='fas fa-backspace'></span>
           </button>
-          <!--
-            <button id='search-filter' class="btn btn-outline-secondary" title='{% trans "Filter results" %}'>
-              <span class='fas fa-filter'></span>
-            </button>
-          -->
           <button id='search-close' class="btn btn-outline-secondary" data-bs-dismiss='offcanvas' title='{% trans "Close search menu" %}'>
             <span class='fas fa-times icon-red'></span>
           </button>
@@ -25,15 +20,11 @@
     </div>
     <div class="offcanvas-body">
       <div id="search-center">
-        <p id='search-pending' class='text-muted' display='none'>
-          <em>{% trans "Searching" %}...</em>
-          <span class='float-right'>
-            <span class='fas fa-spinner fa-spin'></span>
-          </span>
-        </p>
-        <p id='search-no-results' class='text-muted'>
-          <em>{% trans "No search results" %}</em>
-        </p>
+        <div id='search-context'>
+          <div class='alert alert-block alert-info'>
+            <span class='fas fa-search'></span> <em>{% trans "Enter search query" %}</em>
+          </div>
+        </div>
         <div id='search-results'>
           <!-- Search results go here -->
         </div>

--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -261,8 +261,7 @@ class RuleSet(models.Model):
 
         # Print message instead of throwing an error
         name = getattr(user, 'name', user.pk)
-
-        logger.info(f"User '{name}' failed permission check for {table}.{permission}")
+        logger.debug(f"User '{name}' failed permission check for {table}.{permission}")
 
         return False
 
@@ -451,7 +450,7 @@ def update_group_roles(group, debug=False):
             group.permissions.add(permission)
 
         if debug:  # pragma: no cover
-            logger.info(f"Adding permission {perm} to group {group.name}")
+            logger.debug(f"Adding permission {perm} to group {group.name}")
 
     # Remove any extra permissions from the group
     for perm in permissions_to_delete:
@@ -466,7 +465,7 @@ def update_group_roles(group, debug=False):
             group.permissions.remove(permission)
 
         if debug:  # pragma: no cover
-            logger.info(f"Removing permission {perm} from group {group.name}")
+            logger.debug(f"Removing permission {perm} from group {group.name}")
 
     # Enable all action permissions for certain children models
     # if parent model has 'change' permission
@@ -488,7 +487,7 @@ def update_group_roles(group, debug=False):
                     permission = get_permission_object(child_perm)
                     if permission:
                         group.permissions.add(permission)
-                        logger.info(f"Adding permission {child_perm} to group {group.name}")
+                        logger.debug(f"Adding permission {child_perm} to group {group.name}")
 
 
 def clear_user_role_cache(user):


### PR DESCRIPTION
This PR refactors the "quick search" functionality, bringing significant speed and usability improvements.

Basically, we introduce a single API endpoint for global search, which simply consolidates search results into a single query. This means that only one API request is needed for *all* search results, and this means that all the web workers are no longer consumed with a single set of search requests.

### TODO

- [x] Reimplement links for search results
- [x] Unit testing
- [x] Unit testing without necessary permissions
- [x] Remove "no results" text when searching
- [x] Handle "no results found"