### PR TITLE
Decimal rendering - support "minimum places" setting

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -1112,7 +1112,7 @@ def notify_responsible(instance, sender, content: NotificationBody = InvenTreeNo
         )
 
 
-def render_currency(money, decimal_places=None, currency=None, include_symbol=True):
+def render_currency(money, decimal_places=None, currency=None, include_symbol=True, min_decimal_places=None):
     """Render a currency / Money object to a formatted string (e.g. for reports)
 
     Arguments:
@@ -1120,6 +1120,7 @@ def render_currency(money, decimal_places=None, currency=None, include_symbol=Tr
         decimal_places: The number of decimal places to render to. If unspecified, uses the PRICING_DECIMAL_PLACES setting.
         currency: Optionally convert to the specified currency
         include_symbol: Render with the appropriate currency symbol
+        min_decimal_places: The minimum number of decimal places to render to. If unspecified, uses the PRICING_DECIMAL_PLACES_MIN setting.
     """
 
     if money is None or money.amount is None:
@@ -1136,13 +1137,16 @@ def render_currency(money, decimal_places=None, currency=None, include_symbol=Tr
     if decimal_places is None:
         decimal_places = InvenTreeSetting.get_setting('PRICING_DECIMAL_PLACES', 6)
 
+    if min_decimal_places is None:
+        min_decimal_places = InvenTreeSetting.get_setting('PRICING_DECIMAL_PLACES_MIN', 0)
+
     value = Decimal(str(money.amount)).normalize()
     value = str(value)
 
     if '.' in value:
         decimals = len(value.split('.')[-1])
 
-        decimals = max(decimals, 2)
+        decimals = max(decimals, min_decimal_places)
         decimals = min(decimals, decimal_places)
 
         decimal_places = decimals

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1216,9 +1216,20 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'default': '',
         },
 
+        'PRICING_DECIMAL_PLACES_MIN': {
+            'name': _('Minimum Pricing Decimal Places'),
+            'description': _('Minimum number of decimal places to display when rendering pricing data'),
+            'default': 0,
+            'validator': [
+                int,
+                MinValueValidator(0),
+                MaxValueValidator(4),
+            ]
+        },
+
         'PRICING_DECIMAL_PLACES': {
-            'name': _('Pricing Decimal Places'),
-            'description': _('Number of decimal places to display when rendering pricing data'),
+            'name': _('Maximum Pricing Decimal Places'),
+            'description': _('Maximum umber of decimal places to display when rendering pricing data'),
             'default': 6,
             'validator': [
                 int,

--- a/InvenTree/templates/InvenTree/settings/pricing.html
+++ b/InvenTree/templates/InvenTree/settings/pricing.html
@@ -14,7 +14,8 @@
             {% include "InvenTree/settings/setting.html" with key="INVENTREE_DEFAULT_CURRENCY" icon="fa-globe" %}
             {% include "InvenTree/settings/setting.html" with key="PART_INTERNAL_PRICE" %}
             {% include "InvenTree/settings/setting.html" with key="PART_BOM_USE_INTERNAL_PRICE" %}
-            {% include "InvenTree/settings/setting.html" with key="PRICING_DECIMAL_PLACES" %}
+            {% include "InvenTree/settings/setting.html" with key="PRICING_DECIMAL_PLACES_MIN" icon='fa-dollar-sign' %}
+            {% include "InvenTree/settings/setting.html" with key="PRICING_DECIMAL_PLACES" icon='fa-dollar-sign' %}
             {% include "InvenTree/settings/setting.html" with key="PRICING_UPDATE_DAYS" icon='fa-calendar-alt' %}
             <tr><td colspan='5'></td></tr>
             {% include "InvenTree/settings/setting.html" with key="PRICING_USE_SUPPLIER_PRICING" icon='fa-check-circle' %}

--- a/InvenTree/templates/js/translated/pricing.js
+++ b/InvenTree/templates/js/translated/pricing.js
@@ -45,24 +45,22 @@ function formatCurrency(value, options={}) {
         return null;
     }
 
-    var digits = options.digits || global_settings.PRICING_DECIMAL_PLACES || 6;
-
-    // Strip out any trailing zeros, etc
-    value = formatDecimal(value, digits);
+    let maxDigits = options.digits || global_settings.PRICING_DECIMAL_PLACES || 6;
+    let minDigits = options.minDigits || global_settings.PRICING_DECIMAL_PLACES_MIN || 0;
 
     // Extract default currency information
-    var currency = options.currency || global_settings.INVENTREE_DEFAULT_CURRENCY || 'USD';
+    let currency = options.currency || global_settings.INVENTREE_DEFAULT_CURRENCY || 'USD';
 
     // Exctract locale information
-    var locale = options.locale || navigator.language || 'en-US';
+    let locale = options.locale || navigator.language || 'en-US';
 
-
-    var formatter = new Intl.NumberFormat(
+    let formatter = new Intl.NumberFormat(
         locale,
         {
             style: 'currency',
             currency: currency,
-            maximumSignificantDigits: digits,
+            maximumFractionDigits: maxDigits,
+            minimumFractionDigits: minDigits,
         }
     );
 


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/4526

This PR adds a new setting to control the "minimum decimal places" used when rendering pricing data.

Also fixes a bug when rendering this data via javascript