### PR TITLE
Add option to use InvenTree as OIDC provider

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -842,6 +842,10 @@ ACCOUNT_FORMS = {
 SOCIALACCOUNT_ADAPTER = 'InvenTree.forms.CustomSocialAccountAdapter'
 ACCOUNT_ADAPTER = 'InvenTree.forms.CustomAccountAdapter'
 
+OIDC_PROVIDER_ENABLED = get_boolean_setting('INVENTREE_OIDC_PROVIDER_ENABLED', 'oidc_provider_enabled', False)
+if OIDC_PROVIDER_ENABLED:
+    INSTALLED_APPS.append('oidc_provider')
+
 # Markdownify configuration
 # Ref: https://django-markdownify.readthedocs.io/en/latest/settings.html
 

--- a/InvenTree/InvenTree/urls.py
+++ b/InvenTree/InvenTree/urls.py
@@ -195,6 +195,9 @@ urlpatterns = [
     re_path('', include(backendpatterns)),
 ]
 
+if settings.OIDC_PROVIDER_ENABLED:
+    urlpatterns.append(path('accounts/oidc-provider/', include('oidc_provider.urls', namespace='oidc_provider')))
+
 # Server running in "DEBUG" mode?
 if settings.DEBUG:
     # Static file access

--- a/requirements.in
+++ b/requirements.in
@@ -17,6 +17,7 @@ django-maintenance-mode                 # Shut down application while reloading 
 django-markdownify                      # Markdown rendering
 django-money<3.0.0                      # Django app for currency management  # FIXED 2022-06-26 to make sure py-moneyed is not conflicting
 django-mptt==0.11.0                     # Modified Preorder Tree Traversal
+django-oidc-provider                    # Allow to use InvenTree as an OIDC Proivder for other services
 django-redis>=5.0.0                     # Redis integration
 django-q                                # Background task scheduling
 django-q-sentry                         # sentry.io integration for django-q

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,6 +104,8 @@ django-money==2.1.1
     # via -r requirements.in
 django-mptt==0.11.0
     # via -r requirements.in
+django-oidc-provider==0.7.0
+    # via -r requirements.in
 django-otp==1.1.4
     # via django-allauth-2fa
 django-picklefield==3.1
@@ -136,6 +138,8 @@ feedparser==6.0.10
     # via -r requirements.in
 fonttools[woff]==4.38.0
     # via weasyprint
+future==0.18.3
+    # via pyjwkest
 gunicorn==20.1.0
     # via -r requirements.in
 html5lib==1.1
@@ -178,8 +182,12 @@ py-moneyed==1.2
     #   django-money
 pycparser==2.21
     # via cffi
+pycryptodomex==3.17
+    # via pyjwkest
 pydyf==0.5.0
     # via weasyprint
+pyjwkest==1.4.2
+    # via django-oidc-provider
 pyjwt[crypto]==2.6.0
     # via django-allauth
 pyphen==0.13.2
@@ -222,6 +230,7 @@ requests==2.28.2
     # via
     #   coreapi
     #   django-allauth
+    #   pyjwkest
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via django-allauth
@@ -236,6 +245,7 @@ six==1.16.0
     #   bleach
     #   blessed
     #   html5lib
+    #   pyjwkest
     #   python-dateutil
 sqlparse==0.4.3
     # via


### PR DESCRIPTION
This draft utilizes the `django-oidc-provider` package to allow InvenTree to act as an OIDC provider to other services. This feature can be enabled by setting `INVENTREE_OIDC_PROVIDER_ENABLED` to true (default value is false). This allows InvenTree users to integrate other services with the InvenTree account management system.

I am currently working towards a PoC of federation between InvenTree instances, which I wanted to develop as a separate plugin initially. Using InvenTree as an identity provider is the first step towards this goal which I could not implement into a separate plugin because I required an unprotected route for the the `.well-known/openid-configuration`. The only way I could make this route unprotected was to serve it under the `accounts/` route.

If you would like to accept this PR I will also create some documentation to configure the OIDC provider.