### PR TITLE
Sales Order Allocation Improvements

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -1766,9 +1766,6 @@ class ReturnOrder(TotalPriceMixin, Order):
 
         stock_item = line.item
 
-        # Remove any allocations against the returned StockItem
-        stock_item.clearAllocations()
-
         deltas = {
             'status': StockStatus.QUARANTINED,
             'returnorder': self.pk,

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -1013,7 +1013,6 @@ class StockItem(InvenTreeBarcodeMixin, MetadataMixin, common.models.MetaMixin, M
             location=location
         )
 
-        self.clearAllocations()
         self.customer = None
         self.belongs_to = None
         self.sales_order = None

--- a/InvenTree/stock/templates/stock/item.html
+++ b/InvenTree/stock/templates/stock/item.html
@@ -59,7 +59,7 @@
                 {% include "filter_list.html" with id="salesorderallocation" %}
             </div>
         </div>
-        <table class='table table-striped table-condensed' data-toolbar='#sales-order-allocation-toolbar' id='sales-order-allocation-table'></table>
+        <table class='table table-striped table-condensed' data-toolbar='#sales-order-allocations-toolbar' id='sales-order-allocation-table'></table>
     </div>
     {% endif %}
 </div>

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -266,6 +266,12 @@
 
 <div class='info-messages'>
 
+    {% if not item.in_stock %}
+    <div class='alert alert-block alert-danger'>
+        <span class='fas fa-info-circle'></span> {% trans "This stock item is unavailable" %}
+    </div>
+    {% endif %}
+
     {% if item.is_building %}
     <div class='alert alert-block alert-info'>
         {% trans "This stock item is in production and cannot be edited." %}<br>
@@ -281,7 +287,7 @@
     {% endif %}
 
     {% if item.hasRequiredTests and not item.passedAllRequiredTests %}
-    <div class='alert alert-block alert-danger'>
+    <div class='alert alert-block alert-warning'>
         {% trans "This stock item has not passed all required tests" %}
     </div>
     {% endif %}

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -292,7 +292,7 @@
     </div>
     {% endif %}
 
-    {% for allocation in item.sales_order_allocations.all %}
+    {% for allocation in item.get_sales_order_allocations.all %}
     <div class='alert alert-block alert-info'>
         {% object_link 'so-detail' allocation.line.order.id allocation.line.order as link %}
         {% decimal allocation.quantity as qty %}
@@ -307,12 +307,6 @@
         {% trans "This stock item is allocated to Build Order" %} {{ link }} {% if qty < item.quantity %}({% trans "Quantity" %}: {{ qty }}){% endif %}
     </div>
     {% endfor %}
-
-    {% if item.serialized %}
-    <div class='alert alert-block alert-warning'>
-        {% trans "This stock item is serialized - it has a unique serial number and the quantity cannot be adjusted." %}
-    </div>
-    {% endif %}
 </div>
 {% endblock details %}
 
@@ -326,7 +320,7 @@
             <h5><span class='fas fa-hashtag'></span></h5>
         </td>
         <td>
-            <h5>{% trans "Serial Number" %}</h5>
+            <h5 title='{% trans "This stock item is serialized. It has a unique serial number and the quantity cannot be adjusted" %}'>{% trans "Serial Number" %}</h5>
         </td>
         <td><h5>
             {{ item.serial }}
@@ -373,7 +367,7 @@
     </tr>
     {% elif item.sales_order %}
     <tr>
-        <td><span class='fas fa-user-tie'></span></td>
+        <td><span class='fas fa-th-list'></span></td>
         <td>{% trans "Sales Order" %}</td>
         <td><a href="{% url 'so-detail' item.sales_order.id %}">{{ item.sales_order.reference }}</a> - <a href="{% url 'company-detail' item.sales_order.customer.id %}">{{ item.sales_order.customer.name }}</a></td>
     </tr>

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -348,7 +348,11 @@
             <h5><div class='fas fa-boxes'></div></h5>
         </td>
         <td>
+            {% if item.in_stock %}
             <h5>{% trans "Available Quantity" %}</h5>
+            {% else %}
+            <h5>{% trans "Quantity" %}</h5>
+            {% endif %}
         </td>
         <td>
             <h5>{% if item.quantity != available %}{% decimal available %} / {% endif %}{% decimal item.quantity %} {% include "part/part_units.html" with part=item.part %}</h5>

--- a/InvenTree/templates/js/translated/sales_order.js
+++ b/InvenTree/templates/js/translated/sales_order.js
@@ -1387,6 +1387,7 @@ function loadSalesOrderAllocationTable(table, options={}) {
             },
             {
                 field: 'item',
+                switchable: false,
                 title: '{% trans "Stock Item" %}',
                 formatter: function(value, row) {
                     // Render a link to the particular stock item
@@ -1409,6 +1410,18 @@ function loadSalesOrderAllocationTable(table, options={}) {
                 title: '{% trans "Quantity" %}',
                 sortable: true,
             },
+            {
+                field: 'shipment_date',
+                title: '{% trans "Shipped" %}',
+                sortable: true,
+                formatter: function(value, row) {
+                    if (value) {
+                        return renderDate(value);
+                    } else {
+                        return `<em>{% trans "Not shipped" %}</em>`;
+                    }
+                }
+            }
         ]
     });
 }


### PR DESCRIPTION
Improves display of sales order allocations on stock item page

- Don't show "inactive" allocations against orders which have been shipped
- Don't delete old allocations when returning items from customer
- Other small bug fixes and tweaks along the way

Ref: https://github.com/inventree/InvenTree/pull/4542
Ref: https://github.com/inventree/InvenTree/pull/4541