### PR TITLE
Cryptography version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@ ARG commit_tag=""
 
 ENV PYTHONUNBUFFERED 1
 
-# Ref: https://github.com/pyca/cryptography/issues/5776
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST 1
-
 ENV INVENTREE_LOG_LEVEL="WARNING"
 ENV INVENTREE_DOCKER="true"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # Please keep this list sorted - if you pin a version provide a reason
 Django>=3.2.14,<4                       # Django package
 coreapi                                 # API documentation for djangorestframework
-cryptography==3.4.8                     # Core cryptographic functionality
+cryptography>=40.0.0                    # Core cryptographic functionality
 django-allauth                          # SSO for external providers via OpenID
 django-allauth-2fa                      # MFA / 2FA
 django-cleanup                          # Automated deletion of old / unused uploaded files

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-ansicon==1.89.0
-    # via jinxed
 arrow==1.2.3
     # via django-q
 asgiref==3.6.0
@@ -28,8 +26,6 @@ cffi==1.15.1
     #   weasyprint
 charset-normalizer==3.1.0
     # via requests
-colorama==0.4.6
-    # via qrcode
 coreapi==2.3.3
     # via -r requirements.in
 coreschema==0.0.4
@@ -154,8 +150,6 @@ itypes==1.2.0
     # via coreapi
 jinja2==3.1.2
     # via coreschema
-jinxed==1.2.0
-    # via blessed
 markdown==3.4.3
     # via django-markdownify
 markuppy==1.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+ansicon==1.89.0
+    # via jinxed
 arrow==1.2.3
     # via django-q
 asgiref==3.6.0
@@ -26,11 +28,13 @@ cffi==1.15.1
     #   weasyprint
 charset-normalizer==3.1.0
     # via requests
+colorama==0.4.6
+    # via qrcode
 coreapi==2.3.3
     # via -r requirements.in
 coreschema==0.0.4
     # via coreapi
-cryptography==3.4.8
+cryptography==40.0.1
     # via
     #   -r requirements.in
     #   pyjwt
@@ -150,6 +154,8 @@ itypes==1.2.0
     # via coreapi
 jinja2==3.1.2
     # via coreschema
+jinxed==1.2.0
+    # via blessed
 markdown==3.4.3
     # via django-markdownify
 markuppy==1.14


### PR DESCRIPTION
Major version update to cryptography library

This was pinned way back when we built our docker image from an "alpine" base - now we use "python:slim" and the original problem we were trying to fix no longer exists anyway