### PR TITLE
Fix sentry.io integration for DRF exceptions

### DIFF
--- a/InvenTree/InvenTree/exceptions.py
+++ b/InvenTree/InvenTree/exceptions.py
@@ -55,9 +55,16 @@ def exception_handler(exc, context):
     """Custom exception handler for DRF framework.
 
     Ref: https://www.django-rest-framework.org/api-guide/exceptions/#custom-exception-handling
-    Catches any errors not natively handled by DRF, and re-throws as an error DRF can handle
+    Catches any errors not natively handled by DRF, and re-throws as an error DRF can handle.
+
+    If sentry error reporting is enabled, we will also provide the original exception to sentry.io
     """
     response = None
+
+    if settings.SENTRY_ENABLED and settings.SENTRY_DSN:
+        # Report this exception to sentry.io
+        from sentry_sdk import capture_exception
+        capture_exception(exc)
 
     # Catch any django validation error, and re-throw a DRF validation error
     if isinstance(exc, DjangoValidationError):

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -568,6 +568,9 @@ SENTRY_DSN = get_setting('INVENTREE_SENTRY_DSN', 'sentry_dsn', INVENTREE_DSN)
 SENTRY_SAMPLE_RATE = float(get_setting('INVENTREE_SENTRY_SAMPLE_RATE', 'sentry_sample_rate', 0.1))
 
 if SENTRY_ENABLED and SENTRY_DSN:  # pragma: no cover
+
+    logger.info("Running with sentry.io integration enabled")
+
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[DjangoIntegration(), ],


### PR DESCRIPTION
- Previous work to "consume" exceptions raised during API access prevented exception information from reaching sentry.io
- Makes subsequent debugging much more difficult
- Now these exceptions are explicitly sent to sentry.io (if the integration is enabled)