### PR TITLE
Ignore validation errors when uploading to sentry.io

### DIFF
--- a/InvenTree/InvenTree/exceptions.py
+++ b/InvenTree/InvenTree/exceptions.py
@@ -64,6 +64,16 @@ def exception_handler(exc, context):
     if settings.SENTRY_ENABLED and settings.SENTRY_DSN and not settings.DEBUG:
         # Report this exception to sentry.io
         from sentry_sdk import capture_exception
+
+        # The following types of errors are ignored, they are "expected"
+        do_not_report = [
+            DjangoValidationError,
+            DRFValidationError,
+        ]
+
+        if any([isinstance(exc, err) for err in do_not_report]):
+            return
+
         capture_exception(exc)
 
     # Catch any django validation error, and re-throw a DRF validation error

--- a/InvenTree/InvenTree/exceptions.py
+++ b/InvenTree/InvenTree/exceptions.py
@@ -71,10 +71,8 @@ def exception_handler(exc, context):
             DRFValidationError,
         ]
 
-        if any([isinstance(exc, err) for err in do_not_report]):
-            return
-
-        capture_exception(exc)
+        if not any([isinstance(exc, err) for err in do_not_report]):
+            capture_exception(exc)
 
     # Catch any django validation error, and re-throw a DRF validation error
     if isinstance(exc, DjangoValidationError):


### PR DESCRIPTION
These error types are part of the normal validation routine, and should not be uploaded.