### PR TITLE
Simplify translated msg

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -722,15 +722,17 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
             counter = 0
             sequence_count = max(0, expected_quantity - len(serials))
 
+            error_msg = _("Invalid group sequence") + f": {group}"
+
             if len(items) > 2 or len(items) == 0:
-                add_error(_("Invalid group sequence: {g}").format(g=group))
+                add_error(error_msg)
                 continue
             elif len(items) == 2:
                 try:
                     if items[1]:
                         sequence_count = int(items[1]) + 1
                 except ValueError:
-                    add_error(_("Invalid group sequence: {g}").format(g=group))
+                    add_error(error_msg)
                     continue
 
             value = items[0]
@@ -745,7 +747,7 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
                 for item in sequence_items:
                     add_serial(item)
             else:
-                add_error(_("Invalid group sequence: {g}").format(g=group))
+                add_error(error_msg)
 
         else:
             # At this point, we assume that the 'group' is just a single serial value

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -670,7 +670,7 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
 
                 if a == b:
                     # Invalid group
-                    add_error(_("Invalid group range: {g}").format(g=group))
+                    add_error(_("Invalid group range") + f": {group}")
                     continue
 
                 group_items = []
@@ -705,7 +705,7 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
                     for item in group_items:
                         add_serial(item)
                 else:
-                    add_error(_("Invalid group range: {g}").format(g=group))
+                    add_error(_("Invalid group range") + f": {group}")
 
             else:
                 # In the case of a different number of hyphens, simply add the entire group

--- a/InvenTree/common/files.py
+++ b/InvenTree/common/files.py
@@ -59,7 +59,8 @@ class FileManager:
                 # Reset stream position to beginning of file
                 file.seek(0)
             else:
-                raise ValidationError(_(f'Unsupported file format: {ext.upper()}'))
+                msg = _("Unsupported file format") + f": {ext.upper()}"
+                raise ValidationError(msg)
         except UnicodeEncodeError:
             raise ValidationError(_('Error reading file (invalid encoding)'))
 

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -1383,7 +1383,8 @@ class StockItem(InvenTreeBarcodeMixin, MetadataMixin, common.models.MetaMixin, M
 
         if len(existing) > 0:
             exists = ','.join([str(x) for x in existing])
-            raise ValidationError({"serial_numbers": _("Serial numbers already exist: {exists}").format(exists=exists)})
+            msg = _("Serial numbers already exist") + ":" + exists
+            raise ValidationError({"serial_numbers": msg})
 
         # Create a new stock item for each unique serial number
         for serial in serials:

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -1383,7 +1383,7 @@ class StockItem(InvenTreeBarcodeMixin, MetadataMixin, common.models.MetaMixin, M
 
         if len(existing) > 0:
             exists = ','.join([str(x) for x in existing])
-            msg = _("Serial numbers already exist") + ":" + exists
+            msg = _("Serial numbers already exist") + f": {exists}"
             raise ValidationError({"serial_numbers": msg})
 
         # Create a new stock item for each unique serial number

--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -1370,7 +1370,8 @@ class StockItem(InvenTreeBarcodeMixin, MetadataMixin, common.models.MetaMixin, M
             raise ValidationError({"quantity": _("Quantity must be greater than zero")})
 
         if quantity > self.quantity:
-            raise ValidationError({"quantity": _("Quantity must not exceed available stock quantity ({n})").format(n=self.quantity)})
+            msg = _("Quantity must not exceed available stock quantity") + f"({self.quantity})"
+            raise ValidationError({"quantity": msg})
 
         if type(serials) not in [list, tuple]:
             raise ValidationError({"serial_numbers": _("Serial numbers must be a list of integers")})

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -290,8 +290,8 @@ class SerializeStockItemSerializer(serializers.Serializer):
             raise ValidationError(_("Quantity must be greater than zero"))
 
         if quantity > item.quantity:
-            q = item.quantity
-            raise ValidationError(_(f"Quantity must not exceed available stock quantity ({q})"))
+            msg = _("Quantity must not exceed available stock quantity") + f"({item.quantity})"
+            raise ValidationError(msg)
 
         return quantity
 

--- a/InvenTree/templates/js/translated/pricing.js
+++ b/InvenTree/templates/js/translated/pricing.js
@@ -607,8 +607,8 @@ function loadPriceBreakTable(table, options={}) {
 
                     let buttons = '';
 
-                    buttons += makeEditButton(`button-${name}-edit`, row.pk, `{% trans "Edit ${human_name}" %}`);
-                    buttons += makeDeleteButton(`button-${name}-delete`, row.pk, `{% trans "Delete ${human_name}" %}`);
+                    buttons += makeEditButton(`button-${name}-edit`, row.pk, `{% trans "Edit" %} ${human_name}`);
+                    buttons += makeDeleteButton(`button-${name}-delete`, row.pk, `{% trans "Delete" %} ${human_name}`);
 
                     html += wrapButtons(buttons);
 


### PR DESCRIPTION
Some improvements / changes to translatable strings, removing "non translated" parts from the string body