### PR TITLE
Fix typo in Update Check Interval setting

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1013,7 +1013,7 @@ class InvenTreeSetting(BaseInvenTreeSetting):
         },
 
         'INVENTREE_UPDATE_CHECK_INTERVAL': {
-            'name': _('Update Check Inverval'),
+            'name': _('Update Check Interval'),
             'description': _('How often to check for updates (set to zero to disable)'),
             'validator': [
                 int,


### PR DESCRIPTION
Change will create a new translation key
The following locales have added strings to the old key:

DE
Intervall für die Suche nach Updates

HU
Frissítés keresés gyakorisága

PT
Atualizar Verificação de Intervalo