### PR TITLE
Fix for "focus" field in forms

### DIFF
--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -692,6 +692,21 @@ function constructFormBody(fields, options) {
 
     // Scroll to the top
     $(options.modal).find('.modal-form-content-wrapper').scrollTop(0);
+
+    // Focus on a particular field
+    let focus_field = options.focus;
+
+    if (focus_field == null && field_names.length > 0) {
+        // If no focus field is specified, focus on the first field
+        focus_field = field_names[0];
+    }
+
+    let el = $(options.modal + ` #id_${focus_field}`);
+
+    // Add a callback to focus on the first field
+    $(options.modal).on('shown.bs.modal', function() {
+        el.focus();
+    });
 }
 
 


### PR DESCRIPTION
- Reimplements ability to auto-focus fields when launching modal forms
- Can specify with the "focus" option
- Otherwise, will focus on the first available field