### PR TITLE
Fix sorting by location in stock item table

### DIFF
--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -1003,6 +1003,7 @@ class StockList(APIDownloadMixin, ListCreateDestroyAPIView):
     filter_backends = SEARCH_ORDER_FILTER_ALIAS
 
     ordering_field_aliases = {
+        'location': 'location__pathstring',
         'SKU': 'supplier_part__SKU',
         'stock': ['quantity', 'serial_int', 'serial'],
     }


### PR DESCRIPTION
Currently, when sorting the stock item table by location, it gets sorted by location id.

This changes the sorting criterion to pathstring.