### PR TITLE
Disable httpstat.us tests

### DIFF
--- a/InvenTree/InvenTree/tests.py
+++ b/InvenTree/InvenTree/tests.py
@@ -14,7 +14,6 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 
-import requests
 from djmoney.contrib.exchange.exceptions import MissingRate
 from djmoney.contrib.exchange.models import Rate, convert_money
 from djmoney.money import Money
@@ -287,10 +286,12 @@ class TestHelpers(TestCase):
                     time.sleep(10 * tries)
 
         # Attempt to download an image which throws a 404
-        dl_helper("https://httpstat.us/404", requests.exceptions.HTTPError, timeout=10)
+        # TODO: Re-implement this test when we are happier with the external service
+        # dl_helper("https://httpstat.us/404", requests.exceptions.HTTPError, timeout=10)
 
         # Attempt to download, but timeout
-        dl_helper("https://httpstat.us/200?sleep=5000", requests.exceptions.ReadTimeout, timeout=1)
+        # TODO: Re-implement this test when we are happier with the external service
+        # dl_helper("https://httpstat.us/200?sleep=5000", requests.exceptions.ReadTimeout, timeout=1)
 
         large_img = "https://github.com/inventree/InvenTree/raw/master/InvenTree/InvenTree/static/img/paper_splash_large.jpg"
 


### PR DESCRIPTION
- Uptime of the eternal service is not great
- For now, disable tests
- Potentially reintroduce these at some point in the future