### PR TITLE
Remove restriction on manual stock item installation

### DIFF
--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -1171,10 +1171,6 @@ class StockItem(InvenTreeBarcodeMixin, InvenTreeNotesMixin, MetadataMixin, commo
             user: The user performing the operation
             notes: Any notes associated with the operation
         """
-        # Cannot be already installed in another stock item!
-        if self.belongs_to is not None:
-            return False
-
         # If the quantity is less than the stock item, split the stock!
         stock_item = other_item.splitStock(quantity, None, user)
 


### PR DESCRIPTION
- Allow stock item to be manually inside an item which is iteself installed in an item
- No practical reason for this limitation to exist