### PR TITLE
Fix various devcontainer issues

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y install --no-install-recommends \
-    git gcc g++ gettext gnupg libffi-dev \
+    git gcc g++ gettext gnupg2 libffi-dev \
     # Weasyprint requirements : https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#debian-11
     poppler-utils libpango-1.0-0 libpangoft2-1.0-0 \
     # Image format support

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -82,7 +82,7 @@
     // Python config
     "PIP_USER": "no",
 
-    // used to load the venv into the PATH and avtivate it
+    // used to load the venv into the PATH and activate it
     // Ref: https://stackoverflow.com/a/56286534
     "VIRTUAL_ENV": "/workspaces/InvenTree/dev/venv",
     "PATH": "/workspaces/InvenTree/dev/venv/bin:${containerEnv:PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,8 @@
       "extensions": [
         "ms-python.python",
         "ms-python.vscode-pylance",
-        "batisteo.vscode-django"
+        "batisteo.vscode-django",
+        "eamodio.gitlens"
       ]
     }
   },
@@ -74,6 +75,7 @@
     "INVENTREE_BACKUP_DIR": "/workspaces/InvenTree/dev/backup",
     "INVENTREE_CONFIG_FILE": "/workspaces/InvenTree/dev/config.yaml",
     "INVENTREE_SECRET_KEY_FILE": "/workspaces/InvenTree/dev/secret_key.txt",
+    "INVENTREE_PLUGINS_ENABLED": "True",
     "INVENTREE_PLUGIN_DIR": "/workspaces/InvenTree/dev/plugins",
     "INVENTREE_PLUGIN_FILE": "/workspaces/InvenTree/dev/plugins.txt",
 

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -8,7 +8,15 @@ cd /workspaces/InvenTree
 python3 -m venv dev/venv
 . dev/venv/bin/activate
 
+# Avoiding Dubious Ownership in Dev Containers for setup commands that use git
+git config --global --add safe.directory /workspaces/InvenTree
+
 # setup InvenTree server
 pip install invoke
 inv update
 inv setup-dev
+
+# remove existing gitconfig created by "Avoiding Dubious Ownership" step
+# so that it gets copyied from host to the container to have your global 
+# git config in container
+rm -f /home/vscode/.gitconfig


### PR DESCRIPTION
With this changes I'm able to commit with gpg signing and push the changes all from within the devcontainer.

## Things I encountered while setting this up on macOS
- you need to enable full disk access for vscode, otherwise your sshkeys are not available inside the container (https://github.com/microsoft/vscode-remote-release/issues/4024#issuecomment-831671081)
- you need to have `gnupg` and `pinentry-mac` installed and set up correctly [see medium post](https://medium.com/@jma/setup-gpg-for-git-on-macos-4ad69e8d3733)

## Changes
- fix dubious git ownership during postCreateCommand
- fix gpg signing in container
- fix local gitconfig in container
- add gitlens extension to devcontainer
- enable plugins in devcontainer

## How to develop plugins with this setup
1. Mount your plugin repo into the workspace
   ```json
   "mounts": [
     "source=/path/to/your/local/inventree-plugin,target=/workspaces/inventree-plugin,type=bind,consistency=cached"
   ],
   ```
2. Add `/workspaces/inventree-plugin` to your vscode workspace folders
3. Install your plugin as pip editable install
   ```bash
   pip install -e /workspaces/inventree-plugin
   ```
