### PR TITLE
Restore shopping cart icon in BO/Allocate Parts

### DIFF
--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1939,9 +1939,7 @@ function loadBuildOutputAllocationTable(buildInfo, output, options={}) {
                     }
 
                     if (row.on_order && row.on_order > 0) {
-                        makeIconBadge('fa-shopping-cart', '{% trans "On Order" %}', {
-                            content: row.on_order,
-                        });
+                        icons += makeIconBadge('fa-shopping-cart', '{% trans "On Order" %}: ' + row.on_order);
                     }
 
                     return renderLink(text, url) + icons;


### PR DESCRIPTION
The shopping cart icon for parts already on order was originally implemented in 1b421fb59a but got broken in 27aa16d55d as the return value of `makeIconBadge` is discarded.

Additionally, the FontAwesome JS renderer doesn't seem to like non-empty content for this, so even when adding it back to `icons`, it didn't get rendered properly. Instead, the count has to be added to the title.