### PR TITLE
Fix metadatalookup

### DIFF
--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -366,7 +366,7 @@ class InvenTreePlugin(VersionMixin, MixinBase, MetaBase):
 
         try:
             website = meta['Project-URL'].split(', ')[1]
-        except (ValueError, IndexError, ):
+        except (ValueError, IndexError, AttributeError, ):
             website = meta['Project-URL']
 
         return {


### PR DESCRIPTION
I'm not really sure where this `Project-URL` comes from, but I get the following error raised without that changes loading my [inventree-bulk-plugin](https://github.com/wolflu05/inventree-bulk-plugin), however my [inventree-cups-plugin](https://github.com/wolflu05/inventree-cups-plugin) loads fine.

![image](https://user-images.githubusercontent.com/76838159/236632188-b66ac081-a7f2-4882-a29f-23c685d13947.png)
I investigated that issue by using the debugger and found out after going through the call stack that it gets thrown here.
![image](https://user-images.githubusercontent.com/76838159/236632388-4840818d-f859-4918-84e0-62c967668f74.png)

Maybe we should know why my bulk plugin raises that and my cups plugin not, I cannot find any difference in setup.
