### PR TITLE
Cleanup plugin mixin registry

### DIFF
--- a/InvenTree/plugin/base/integration/test_mixins.py
+++ b/InvenTree/plugin/base/integration/test_mixins.py
@@ -24,9 +24,9 @@ class BaseMixinDefinition:
     def test_mixin_name(self):
         """Test that the mixin registers itseld correctly."""
         # mixin name
-        self.assertIn(self.MIXIN_NAME, [item['key'] for item in self.mixin.registered_mixins])
+        self.assertIn(self.MIXIN_NAME, {item['key'] for item in self.mixin.registered_mixins.values()})
         # human name
-        self.assertIn(self.MIXIN_HUMAN_NAME, [item['human_name'] for item in self.mixin.registered_mixins])
+        self.assertIn(self.MIXIN_HUMAN_NAME, {item['human_name'] for item in self.mixin.registered_mixins.values()})
 
 
 class SettingsMixinTest(BaseMixinDefinition, InvenTreeTestCase):

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -1,5 +1,6 @@
 """Plugin model definitions."""
 
+import inspect
 import warnings
 
 from django.conf import settings
@@ -58,6 +59,8 @@ class PluginConfig(models.Model):
     def mixins(self):
         """Returns all registered mixins."""
         try:
+            if inspect.isclass(self.plugin):
+                return self.plugin.get_registered_mixins(self, with_base=True, with_cls=False)
             return self.plugin.get_registered_mixins(with_base=True, with_cls=False)
         except (AttributeError, ValueError):  # pragma: no cover
             return {}

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -166,7 +166,9 @@ class PluginSetting(common.models.BaseInvenTreeSetting):
                 if issubclass(plugin.__class__, InvenTreePlugin):
                     plugin = plugin.plugin_config()
 
-                kwargs['settings'] = registry.mixins_settings.get(plugin.key, {})
+                mixin_settings = registry.get('mixins_settings')
+                if mixin_settings:
+                    kwargs['settings'] = mixin_settings.get(plugin.key, {})
 
         return super().get_setting_definition(key, **kwargs)
 

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -166,7 +166,7 @@ class PluginSetting(common.models.BaseInvenTreeSetting):
                 if issubclass(plugin.__class__, InvenTreePlugin):
                     plugin = plugin.plugin_config()
 
-                mixin_settings = registry.get('mixins_settings')
+                mixin_settings = getattr(registry, 'mixins_settings')
                 if mixin_settings:
                     kwargs['settings'] = mixin_settings.get(plugin.key, {})
 

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -58,7 +58,7 @@ class PluginConfig(models.Model):
     def mixins(self):
         """Returns all registered mixins."""
         try:
-            return self.plugin._mixinreg
+            return self.plugin.get_registered_mixins(with_base=True, with_cls=False)
         except (AttributeError, ValueError):  # pragma: no cover
             return {}
 

--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -166,7 +166,7 @@ class MixinBase:
 
     def get_registered_mixins(self, with_base: bool = False):
         """Get all registered mixins for the plugin."""
-        mixins = getattr(self, '_mixinreg', None)
+        mixins = getattr(self, '_mixinreg', None).copy()
         if mixins:
             # filter out base
             if not with_base and 'base' in mixins:

--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -161,10 +161,10 @@ class MixinBase:
         self._mixinreg[key] = {
             'key': key,
             'human_name': human_name,
+            'cls': cls,
         }
 
-    @property
-    def registered_mixins(self, with_base: bool = False):
+    def get_registered_mixins(self, with_base: bool = False):
         """Get all registered mixins for the plugin."""
         mixins = getattr(self, '_mixinreg', None)
         if mixins:
@@ -174,6 +174,11 @@ class MixinBase:
             # only return dict
             mixins = list(mixins.values())
         return mixins
+
+    @property
+    def registered_mixins(self, with_base: bool = False):
+        """Get all registered mixins for the plugin."""
+        return self.get_registered_mixins(with_base=with_base)
 
 
 class VersionMixin:

--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -166,18 +166,18 @@ class MixinBase:
 
     def get_registered_mixins(self, with_base: bool = False, with_cls: bool = True):
         """Get all registered mixins for the plugin."""
-        mixins = getattr(self, '_mixinreg', None).copy()
-        if mixins:
-            # filter out base
-            if not with_base and 'base' in mixins:
-                del mixins['base']
-            # only return dict
-            mixins = list(mixins.values())
+        mixins = getattr(self, '_mixinreg', None)
+        if not mixins:
+            return {}
+
+        mixins = mixins.copy()
+        # filter out base
+        if not with_base and 'base' in mixins:
+            del mixins['base']
 
         # Do not return the mixin class if flas is set
         if not with_cls:
-            a_mixins = {key: {k: v for k, v in mixin.items() if k != 'cls'} for key, mixin in mixins.items()}
-            return a_mixins
+            return {key: {k: v for k, v in mixin.items() if k != 'cls'} for key, mixin in mixins.items()}
         return mixins
 
     @property

--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -164,7 +164,7 @@ class MixinBase:
             'cls': cls,
         }
 
-    def get_registered_mixins(self, with_base: bool = False):
+    def get_registered_mixins(self, with_base: bool = False, with_cls: bool = True):
         """Get all registered mixins for the plugin."""
         mixins = getattr(self, '_mixinreg', None).copy()
         if mixins:
@@ -173,6 +173,11 @@ class MixinBase:
                 del mixins['base']
             # only return dict
             mixins = list(mixins.values())
+
+        # Do not return the mixin class if flas is set
+        if not with_cls:
+            a_mixins = {key: {k: v for k, v in mixin.items() if k != 'cls'} for key, mixin in mixins.items()}
+            return a_mixins
         return mixins
 
     @property

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -53,7 +53,7 @@ class PluginsRegistry:
         self.plugins_full: Dict[str, InvenTreePlugin] = {}      # List of all plugin instances
 
         self.plugin_modules: List(InvenTreePlugin) = []         # Holds all discovered plugins
-        self.mixin_modules: List() = []                         # Holds all discovered mixins
+        self.mixin_modules: Dict[str, any] = {}                 # Holds all discovered mixins
 
         self.errors = {}                                        # Holds discovering errors
 
@@ -321,10 +321,10 @@ class PluginsRegistry:
 
     def discover_mixins(self):
         """Discover all mixins from plugins and register them."""
-        collected_mixins = []
+        collected_mixins = {}
 
         for plugin in self.plugins.items():
-            collected_mixins += plugin[1].get_registered_mixins()
+            collected_mixins.update(plugin[1].get_registered_mixins())
 
         self.mixin_modules = collected_mixins
 
@@ -480,7 +480,7 @@ class PluginsRegistry:
         order = self.DEFAULT_MIXIN_ORDER
 
         # Append mixins that are not defined
-        addition_mixins = [m.get('cls') for m in self.mixin_modules if m.get('cls') not in order]
+        addition_mixins = [m.get('cls') for m in self.mixin_modules.values() if m.get('cls') not in order]
         order += addition_mixins
 
         # Final list of mixins

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -64,9 +64,6 @@ class PluginsRegistry:
 
         self.installed_apps = []                                # Holds all added plugin_paths
 
-        # mixins
-        self.mixins_settings = {}
-
     def get_plugin(self, slug):
         """Lookup plugin by slug (unique key)."""
         if slug not in self.plugins:

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -42,7 +42,7 @@ class PluginsRegistry:
 
     DEFAULT_MIXIN_ORDER = [SettingsMixin, ScheduleMixin, AppMixin, UrlsMixin]
 
-    def __init__(self, mixin_order: list = None) -> None:
+    def __init__(self) -> None:
         """Initialize registry.
 
         Set up all needed references for internal and external states.
@@ -66,7 +66,6 @@ class PluginsRegistry:
 
         # mixins
         self.mixins_settings = {}
-        self.mixin_order = mixin_order or self.DEFAULT_MIXIN_ORDER
 
     def get_plugin(self, slug):
         """Lookup plugin by slug (unique key)."""
@@ -481,7 +480,7 @@ class PluginsRegistry:
     def _get_mixin_order(self):
         """Returns a list of mixin classes, in the order that they should be activated."""
         # Preset list of mixins
-        order = self.mixin_order
+        order = self.DEFAULT_MIXIN_ORDER
 
         # Append mixins that are not defined
         addition_mixins = [m.get('cls') for m in self.mixin_modules if m.get('cls') not in order]

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -323,8 +323,8 @@ class PluginsRegistry:
         """Discover all mixins from plugins and register them."""
         collected_mixins = {}
 
-        for plugin in self.plugins.items():
-            collected_mixins.update(plugin[1].get_registered_mixins())
+        for plg in self.plugins.values():
+            collected_mixins.update(plg.get_registered_mixins())
 
         self.mixin_modules = collected_mixins
 
@@ -474,14 +474,13 @@ class PluginsRegistry:
             else:  # pragma: no cover
                 safe_reference(plugin=plg, key=plg_key, active=False)
 
-    def _get_mixin_order(self):
+    def __get_mixin_order(self):
         """Returns a list of mixin classes, in the order that they should be activated."""
         # Preset list of mixins
         order = self.DEFAULT_MIXIN_ORDER
 
-        # Append mixins that are not defined
-        addition_mixins = [m.get('cls') for m in self.mixin_modules.values() if m.get('cls') not in order]
-        order += addition_mixins
+        # Append mixins that are not defined in the default list
+        order += [m.get('cls') for m in self.mixin_modules.values() if m.get('cls') not in order]
 
         # Final list of mixins
         return order
@@ -500,7 +499,7 @@ class PluginsRegistry:
         plugins = self.plugins.items()
         logger.info(f'Found {len(plugins)} active plugins')
 
-        for mixin in self._get_mixin_order():
+        for mixin in self.__get_mixin_order():
             if hasattr(mixin, '_activate_mixin'):
                 mixin._activate_mixin(self, plugins, force_reload=force_reload, full_reload=full_reload)
 
@@ -512,7 +511,7 @@ class PluginsRegistry:
         Args:
             force_reload (bool, optional): Also reload base apps. Defaults to False.
         """
-        for mixin in reversed(self._get_mixin_order()):
+        for mixin in reversed(self.__get_mixin_order()):
             if hasattr(mixin, '_deactivate_mixin'):
                 mixin._deactivate_mixin(self, force_reload=force_reload)
 

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -53,7 +53,7 @@ class PluginsRegistry:
         self.plugins_full: Dict[str, InvenTreePlugin] = {}      # List of all plugin instances
 
         self.plugin_modules: List(InvenTreePlugin) = []         # Holds all discovered plugins
-        self.mixin_modules: List() = []                         # Holdes all discovered mixins
+        self.mixin_modules: List() = []                         # Holds all discovered mixins
 
         self.errors = {}                                        # Holds discovering errors
 
@@ -496,7 +496,7 @@ class PluginsRegistry:
         # Collect mixins
         self.discover_mixins()
 
-        # activate integrations
+        # Activate integrations
         plugins = self.plugins.items()
         logger.info(f'Found {len(plugins)} active plugins')
 

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -53,6 +53,7 @@ class PluginsRegistry:
         self.plugins_full: Dict[str, InvenTreePlugin] = {}      # List of all plugin instances
 
         self.plugin_modules: List(InvenTreePlugin) = []         # Holds all discovered plugins
+        self.mixin_modules: List() = []                         # Holdes all discovered mixins
 
         self.errors = {}                                        # Holds discovering errors
 
@@ -322,6 +323,15 @@ class PluginsRegistry:
 
         return collected_plugins
 
+    def discover_mixins(self):
+        """Discover all mixins from plugins and register them."""
+        collected_mixins = []
+
+        for plugin in self.plugins.items():
+            collected_mixins += plugin[1].get_registered_mixins()
+
+        self.mixin_modules = collected_mixins
+
     def install_plugin_file(self):
         """Make sure all plugins are installed in the current environment."""
         if settings.PLUGIN_FILE_CHECKED:
@@ -468,6 +478,18 @@ class PluginsRegistry:
             else:  # pragma: no cover
                 safe_reference(plugin=plg, key=plg_key, active=False)
 
+    def _get_mixin_order(self):
+        """Returns a list of mixin classes, in the order that they should be activated."""
+        # Preset list of mixins
+        order = self.mixin_order
+
+        # Append mixins that are not defined
+        addition_mixins = [m.get('cls') for m in self.mixin_modules if m.get('cls') not in order]
+        order += addition_mixins
+
+        # Final list of mixins
+        return order
+
     def _activate_plugins(self, force_reload=False, full_reload: bool = False):
         """Run activation functions for all plugins.
 
@@ -475,11 +497,14 @@ class PluginsRegistry:
             force_reload (bool, optional): Also reload base apps. Defaults to False.
             full_reload (bool, optional): Reload everything - including plugin mechanism. Defaults to False.
         """
+        # Collect mixins
+        self.discover_mixins()
+
         # activate integrations
         plugins = self.plugins.items()
         logger.info(f'Found {len(plugins)} active plugins')
 
-        for mixin in self.mixin_order:
+        for mixin in self._get_mixin_order():
             if hasattr(mixin, '_activate_mixin'):
                 mixin._activate_mixin(self, plugins, force_reload=force_reload, full_reload=full_reload)
 
@@ -491,7 +516,7 @@ class PluginsRegistry:
         Args:
             force_reload (bool, optional): Also reload base apps. Defaults to False.
         """
-        for mixin in self.mixin_order:
+        for mixin in reversed(self._get_mixin_order()):
             if hasattr(mixin, '_deactivate_mixin'):
                 mixin._deactivate_mixin(self, force_reload=force_reload)
 

--- a/InvenTree/plugin/test_api.py
+++ b/InvenTree/plugin/test_api.py
@@ -167,7 +167,7 @@ class PluginDetailAPITest(PluginMixin, InvenTreeAPITestCase):
         plg = self.plugin_confs.first()
         mixin_dict = plg.mixins()
         self.assertIn('base', mixin_dict)
-        self.assertDictContainsSubset({'base': {'key': 'base', 'human_name': 'base'}}, mixin_dict)
+        self.assertDictContainsSubset({'base': {'key': 'base', 'human_name': 'base', 'cls': None}}, mixin_dict)
 
         # check reload on save
         with self.assertWarns(Warning) as cm:

--- a/InvenTree/plugin/test_api.py
+++ b/InvenTree/plugin/test_api.py
@@ -167,7 +167,7 @@ class PluginDetailAPITest(PluginMixin, InvenTreeAPITestCase):
         plg = self.plugin_confs.first()
         mixin_dict = plg.mixins()
         self.assertIn('base', mixin_dict)
-        self.assertDictContainsSubset({'base': {'key': 'base', 'human_name': 'base', 'cls': None}}, mixin_dict)
+        self.assertDictContainsSubset({'base': {'key': 'base', 'human_name': 'base'}}, mixin_dict)
 
         # check reload on save
         with self.assertWarns(Warning) as cm:

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,6 +154,8 @@ icalendar==5.0.5
     # via django-ical
 idna==3.4
     # via requests
+importlib-metadata==6.6.0
+    # via markdown
 inflection==0.5.1
     # via drf-spectacular
 itypes==1.2.0
@@ -291,6 +293,8 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
+zipp==3.15.0
+    # via importlib-metadata
 zopfli==0.2.2
     # via fonttools
 


### PR DESCRIPTION
This PR cleans up the registry mechanisms a bit:
- Adds a central mixin registry
- Discovers mixins dynamically
- Checks all mixins for registration/deregistration functions
- Removes the option to change the built-in order - that part is not documented or used to my knowledge; I found it introducing unreliability when used in container production envs
- Cleans up the registry from vars needed for mixins