### PR TITLE
Docker build fix

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -37,6 +37,8 @@ jobs:
         filters: |
           server:
             - 'InvenTree/**'
+            - 'requirements.txt'
+            - 'requirements-dev.txt'
 
   pep_style:
     name: Style [Python]

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # Please keep this list sorted - if you pin a version provide a reason
 Django>=3.2.14,<4                       # Django package
 coreapi                                 # API documentation for djangorestframework
-cryptography>=40.0.0                    # Core cryptographic functionality
+cryptography>=40.0.0,!=40.0.2           # Core cryptographic functionality
 django-allauth                          # SSO for external providers via OpenID
 django-allauth-2fa                      # MFA / 2FA
 django-cleanup                          # Automated deletion of old / unused uploaded files

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ coreapi==2.3.3
     # via -r requirements.in
 coreschema==0.0.4
     # via coreapi
-cryptography==40.0.2
+cryptography==40.0.1
     # via
     #   -r requirements.in
     #   pyjwt


### PR DESCRIPTION
Docker builds have recently broken on raspberry pi / armv7

Attempting to fix this!

Looks to be related to the pinwheels build for the latest revision of the cryptography library:

- Ref: https://www.piwheels.org/project/cryptography/
- Ref: https://github.com/piwheels/packages/issues/359
- Ref: https://github.com/inventree/InvenTree/pull/4598