### PR TITLE
Refactor: BaseInvenTreeSetting

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timedelta
 from enum import Enum
 from secrets import compare_digest
-from typing import Any, Callable, Dict, List, Tuple, TypedDict
+from typing import Any, Callable, Dict, List, Tuple, TypedDict, Union
 
 from django.apps import apps
 from django.conf import settings
@@ -131,9 +131,9 @@ class SettingsKeyType(TypedDict, total=False):
     name: str
     description: str
     units: str
-    validator: Callable | List[Callable] | Tuple[Callable]
-    default: Callable | Any
-    choices: Tuple[str, str] | Callable[[], Tuple[str, str]]
+    validator: Union[Callable, List[Callable], Tuple[Callable]]
+    default: Union[Callable, Any]
+    choices: Union[Tuple[str, str], Callable[[], Tuple[str, str]]]
     hidden: bool
     before_save: Callable[..., None]
     after_save: Callable[..., None]

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -16,6 +16,7 @@ import uuid
 from datetime import datetime, timedelta
 from enum import Enum
 from secrets import compare_digest
+from typing import Any, Callable, Dict, List, Tuple, TypedDict
 
 from django.apps import apps
 from django.conf import settings
@@ -112,10 +113,36 @@ class ProjectCode(InvenTree.models.MetadataMixin, models.Model):
     )
 
 
+class SettingsKeyType(TypedDict, total=False):
+    """Type definitions for a SettingsKeyType
+
+    Attributes:
+        name: Translatable string name of the setting (required)
+        description: Translatable string description of the setting (required)
+        units: Units of the particular setting (optional)
+        validator: Validation function/list of functions for the setting (optional, default: None, e.g: bool, int, str, MinValueValidator, ...)
+        default: Default value or function that returns default value (optional)
+        choices: (Function that returns) Tuple[str: key, str: display value] (optional)
+        hidden: Hide this setting from settings page (optional)
+        before_save: Function that gets called after save with *args, **kwargs (optional)
+        after_save: Function that gets called after save with *args, **kwargs (optional)
+    """
+
+    name: str
+    description: str
+    units: str
+    validator: Callable | List[Callable] | Tuple[Callable]
+    default: Callable | Any
+    choices: Tuple[str, str] | Callable[[], Tuple[str, str]]
+    hidden: bool
+    before_save: Callable[..., None]
+    after_save: Callable[..., None]
+
+
 class BaseInvenTreeSetting(models.Model):
     """An base InvenTreeSetting object is a key:value pair used for storing single values (e.g. one-off settings values)."""
 
-    SETTINGS = {}
+    SETTINGS: Dict[str, SettingsKeyType] = {}
 
     class Meta:
         """Meta options for BaseInvenTreeSetting -> abstract stops creation of database entry."""

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -140,9 +140,16 @@ class SettingsKeyType(TypedDict, total=False):
 
 
 class BaseInvenTreeSetting(models.Model):
-    """An base InvenTreeSetting object is a key:value pair used for storing single values (e.g. one-off settings values)."""
+    """An base InvenTreeSetting object is a key:value pair used for storing single values (e.g. one-off settings values).
+
+    Attributes:
+        SETTINGS: definition of all available settings
+        extra_unique_fields: List of extra fields used to be unique, e.g. for PluginConfig -> plugin
+    """
 
     SETTINGS: Dict[str, SettingsKeyType] = {}
+
+    extra_unique_fields: List[str] = []
 
     class Meta:
         """Meta options for BaseInvenTreeSetting -> abstract stops creation of database entry."""
@@ -226,7 +233,16 @@ class BaseInvenTreeSetting(models.Model):
         return key.replace(" ", "")
 
     @classmethod
-    def allValues(cls, user=None, exclude_hidden=False):
+    def get_filters(cls, **kwargs):
+        """Enable to filter by other kwargs defined in cls.extra_unique_fields"""
+        return {key: value for key, value in kwargs.items() if key in cls.extra_unique_fields}
+
+    def get_filters_for_instance(self):
+        """Enable to filter by other fields defined in self.extra_unique_fields"""
+        return {key: getattr(self, key, None) for key in self.extra_unique_fields if hasattr(self, key)}
+
+    @classmethod
+    def allValues(cls, exclude_hidden=False, **kwargs):
         """Return a dict of "all" defined global settings.
 
         This performs a single database lookup,
@@ -239,9 +255,8 @@ class BaseInvenTreeSetting(models.Model):
             # Keys which start with an undersore are used for internal functionality
             results = results.exclude(key__startswith='_')
 
-        # Optionally filter by user
-        if user is not None:
-            results = results.filter(user=user)
+        # Optionally filter by other keys
+        results = results.filter(**cls.get_filters(**kwargs))
 
         # Query the database
         settings = {}
@@ -388,31 +403,10 @@ class BaseInvenTreeSetting(models.Model):
 
         filters = {
             'key__iexact': key,
+
+            # Optionally filter by other keys
+            **cls.get_filters(**kwargs),
         }
-
-        # Filter by user
-        user = kwargs.get('user', None)
-
-        if user is not None:
-            filters['user'] = user
-
-        # Filter by plugin
-        plugin = kwargs.get('plugin', None)
-
-        if plugin is not None:
-            from plugin import InvenTreePlugin
-
-            if issubclass(plugin.__class__, InvenTreePlugin):
-                plugin = plugin.plugin_config()
-
-            filters['plugin'] = plugin
-            kwargs['plugin'] = plugin
-
-        # Filter by method
-        method = kwargs.get('method', None)
-
-        if method is not None:
-            filters['method'] = method
 
         # Perform cache lookup by default
         do_cache = kwargs.pop('cache', True)
@@ -520,21 +514,10 @@ class BaseInvenTreeSetting(models.Model):
 
         filters = {
             'key__iexact': key,
+
+            # Optionally filter by other keys
+            **cls.get_filters(**kwargs),
         }
-
-        user = kwargs.get('user', None)
-        plugin = kwargs.get('plugin', None)
-
-        if user is not None:
-            filters['user'] = user
-
-        if plugin is not None:
-            from plugin import InvenTreePlugin
-
-            if issubclass(plugin.__class__, InvenTreePlugin):
-                filters['plugin'] = plugin.plugin_config()
-            else:
-                filters['plugin'] = plugin
 
         try:
             setting = cls.objects.get(**filters)
@@ -652,16 +635,10 @@ class BaseInvenTreeSetting(models.Model):
 
         filters = {
             'key__iexact': self.key,
+
+            # Optionally filter by other keys
+            **self.get_filters_for_instance(),
         }
-
-        user = getattr(self, 'user', None)
-        plugin = getattr(self, 'plugin', None)
-
-        if user is not None:
-            filters['user'] = user
-
-        if plugin is not None:
-            filters['plugin'] = plugin
 
         try:
             # Check if a duplicate setting already exists
@@ -2132,6 +2109,7 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
     }
 
     typ = 'user'
+    extra_unique_fields = ['user']
 
     key = models.CharField(
         max_length=50,

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -126,6 +126,7 @@ class SettingsKeyType(TypedDict, total=False):
         hidden: Hide this setting from settings page (optional)
         before_save: Function that gets called after save with *args, **kwargs (optional)
         after_save: Function that gets called after save with *args, **kwargs (optional)
+        protected: Protected values are not returned to the client, instead "***" is returned (optional, default: False)
     """
 
     name: str
@@ -137,6 +138,7 @@ class SettingsKeyType(TypedDict, total=False):
     hidden: bool
     before_save: Callable[..., None]
     after_save: Callable[..., None]
+    protected: bool
 
 
 class BaseInvenTreeSetting(models.Model):

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -19,6 +19,7 @@ from common.settings import currency_code_default
 from InvenTree import settings, version
 from plugin import registry
 from plugin.models import NotificationUserSetting, PluginSetting
+from plugin.plugin import InvenTreePlugin
 
 register = template.Library()
 
@@ -325,6 +326,8 @@ def setting_object(key, *args, **kwargs):
         # Note, 'plugin' is an instance of an InvenTreePlugin class
 
         plugin = kwargs['plugin']
+        if issubclass(plugin.__class__, InvenTreePlugin):
+            plugin = plugin.plugin_config()
 
         return PluginSetting.get_setting_object(key, plugin=plugin, cache=cache)
 

--- a/InvenTree/plugin/api.py
+++ b/InvenTree/plugin/api.py
@@ -232,7 +232,7 @@ class PluginSettingDetail(RetrieveUpdateAPI):
         if key not in settings:
             raise NotFound(detail=f"Plugin '{plugin.slug}' has no setting matching '{key}'")
 
-        return PluginSetting.get_setting_object(key, plugin=plugin)
+        return PluginSetting.get_setting_object(key, plugin=plugin.plugin_config())
 
     # Staff permission required
     permission_classes = [

--- a/InvenTree/plugin/base/integration/SettingsMixin.py
+++ b/InvenTree/plugin/base/integration/SettingsMixin.py
@@ -1,13 +1,24 @@
 """Plugin mixin class for SettingsMixin."""
 import logging
+from typing import TYPE_CHECKING, Dict
 
 from django.db.utils import OperationalError, ProgrammingError
 
 logger = logging.getLogger('inventree')
 
+# import only for typechecking, otherwise this throws a model is unready error
+if TYPE_CHECKING:
+    from common.models import SettingsKeyType
+else:
+    class SettingsKeyType:
+        """Dummy class, so that python throws no error"""
+        pass
+
 
 class SettingsMixin:
     """Mixin that enables global settings for the plugin."""
+
+    SETTINGS: Dict[str, SettingsKeyType] = {}
 
     class MixinMeta:
         """Meta for mixin."""

--- a/InvenTree/plugin/base/integration/SettingsMixin.py
+++ b/InvenTree/plugin/base/integration/SettingsMixin.py
@@ -67,7 +67,7 @@ class SettingsMixin:
         """
         from plugin.models import PluginSetting
 
-        return PluginSetting.get_setting(key, plugin=self, cache=cache)
+        return PluginSetting.get_setting(key, plugin=self.plugin_config(), cache=cache)
 
     def set_setting(self, key, value, user=None):
         """Set plugin setting value by key."""

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -172,12 +172,6 @@ class PluginSetting(common.models.BaseInvenTreeSetting):
 
         return super().get_setting_definition(key, **kwargs)
 
-    def get_kwargs(self):
-        """Explicit kwargs required to uniquely identify a particular setting object, in addition to the 'key' parameter."""
-        return {
-            'plugin': self.plugin,
-        }
-
 
 class NotificationUserSetting(common.models.BaseInvenTreeSetting):
     """This model represents notification settings for a user."""
@@ -199,13 +193,6 @@ class NotificationUserSetting(common.models.BaseInvenTreeSetting):
         kwargs['settings'] = storage.user_settings
 
         return super().get_setting_definition(key, **kwargs)
-
-    def get_kwargs(self):
-        """Explicit kwargs required to uniquely identify a particular setting object, in addition to the 'key' parameter."""
-        return {
-            'method': self.method,
-            'user': self.user,
-        }
 
     method = models.CharField(
         max_length=255,

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -166,10 +166,6 @@ class PluginSetting(common.models.BaseInvenTreeSetting):
             plugin = kwargs.pop('plugin', None)
 
             if plugin:
-
-                if issubclass(plugin.__class__, InvenTreePlugin):
-                    plugin = plugin.plugin_config()
-
                 mixin_settings = getattr(registry, 'mixins_settings')
                 if mixin_settings:
                     kwargs['settings'] = mixin_settings.get(plugin.key, {})

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -133,6 +133,7 @@ class PluginSetting(common.models.BaseInvenTreeSetting):
     """This model represents settings for individual plugins."""
 
     typ = 'plugin'
+    extra_unique_fields = ['plugin']
 
     class Meta:
         """Meta for PluginSetting."""
@@ -186,6 +187,7 @@ class NotificationUserSetting(common.models.BaseInvenTreeSetting):
     """This model represents notification settings for a user."""
 
     typ = 'notification'
+    extra_unique_fields = ['method', 'user']
 
     class Meta:
         """Meta for NotificationUserSetting."""


### PR DESCRIPTION
This PR tries to add typings for settings and make the `common.BaseInvenTreeSetting` model more generic. This simplifies the implementation for the #4824 , see https://github.com/inventree/InvenTree/pull/4824#discussion_r1193650747

Actually first, I planned to only add a `get_filters` method like the `get_kwargs` method until I now discovered that something like this was already there onetime and was removed. (See: 5ee9af7f0ebed1cb56ea488299824daf0db0afb8). Let me know if you have a better idea to make it more generic.

I tested this and discovered no bugs or issues that something doesnt work or break with this PR. Hopefully tests cover the other half 😄.