### PR TITLE
Improve cli experience

### DIFF
--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -9,7 +9,7 @@ import subprocess
 
 import django
 
-from InvenTree.api_version import INVENTREE_API_VERSION
+from .api_version import INVENTREE_API_VERSION
 
 # InvenTree software version
 INVENTREE_SW_VERSION = "0.12.0 dev"

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: env/bin/gunicorn --chdir $APP_HOME/InvenTree -c InvenTree/gunicorn.conf.py InvenTree.wsgi -b 0.0.0.0:$PORT
 worker: env/bin/python InvenTree/manage.py qcluster
-cli: env/bin/python -m invoke
+cli: . env/bin/activate && exec env/bin/python -m invoke

--- a/tasks.py
+++ b/tasks.py
@@ -11,8 +11,6 @@ from platform import python_version
 
 from invoke import task
 
-import InvenTree.InvenTree.version as InvenTreeVersion
-
 
 def apps():
     """Returns a list of installed apps."""
@@ -649,15 +647,27 @@ def schema(c, filename='schema.yml', overwrite=False):
 @task(default=True)
 def version(c):
     """Show the current version of InvenTree."""
+    import InvenTree.InvenTree.version as InvenTreeVersion
+    from InvenTree.InvenTree.config import (get_config_file, get_media_dir,
+                                            get_static_dir)
+
     print("\nInvenTree - inventree.org")
     print("The Open-Source Inventory Management System\n")
     print("========================================")
-    print(f"Base directory: {localDir()}")
+    print("Installation paths:")
+    print(f"Base        {localDir()}")
+    print(f"Config      {get_config_file()}")
+    print(f"Media       {get_media_dir()}")
+    print(f"Static      {get_static_dir()}")
     print("Versions:")
     print(f"Python      {python_version()}")
     print(f"Django      {InvenTreeVersion.inventreeDjangoVersion()}")
     print(f"InvenTree   {InvenTreeVersion.inventreeVersion()}")
     print(f"API         {InvenTreeVersion.inventreeApiVersion()}")
-    print("========================================")
+    print("")
     print(f"Commit hash:{InvenTreeVersion.inventreeCommitHash()}")
     print(f"Commit date:{InvenTreeVersion.inventreeCommitDate()}")
+    if len(sys.argv) == 1 and sys.argv[0].startswith('/opt/inventree/env/lib/python'):
+        print("\nYou are probably running the package installer / single-line installer. Please mentioned that in any bug reports!\n")
+        print("Use '--list' for a list of available commands")
+        print("Use '--help' for help on a specific command")

--- a/tasks.py
+++ b/tasks.py
@@ -7,8 +7,11 @@ import re
 import shutil
 import sys
 from pathlib import Path
+from platform import python_version
 
 from invoke import task
+
+import InvenTree.InvenTree.version as InvenTreeVersion
 
 
 def apps():
@@ -641,3 +644,20 @@ def schema(c, filename='schema.yml', overwrite=False):
     """Export current API schema."""
     check_file_existance(filename, overwrite)
     manage(c, f'spectacular --file {filename}')
+
+
+@task(default=True)
+def version(c):
+    """Show the current version of InvenTree."""
+    print("\nInvenTree - inventree.org")
+    print("The Open-Source Inventory Management System\n")
+    print("========================================")
+    print(f"Base directory: {localDir()}")
+    print("Versions:")
+    print(f"Python      {python_version()}")
+    print(f"Django      {InvenTreeVersion.inventreeDjangoVersion()}")
+    print(f"InvenTree   {InvenTreeVersion.inventreeVersion()}")
+    print(f"API         {InvenTreeVersion.inventreeApiVersion()}")
+    print("========================================")
+    print(f"Commit hash:{InvenTreeVersion.inventreeCommitHash()}")
+    print(f"Commit date:{InvenTreeVersion.inventreeCommitDate()}")

--- a/tasks.py
+++ b/tasks.py
@@ -651,23 +651,27 @@ def version(c):
     from InvenTree.InvenTree.config import (get_config_file, get_media_dir,
                                             get_static_dir)
 
-    print("\nInvenTree - inventree.org")
-    print("The Open-Source Inventory Management System\n")
-    print("========================================")
-    print("Installation paths:")
-    print(f"Base        {localDir()}")
-    print(f"Config      {get_config_file()}")
-    print(f"Media       {get_media_dir()}")
-    print(f"Static      {get_static_dir()}")
-    print("Versions:")
-    print(f"Python      {python_version()}")
-    print(f"Django      {InvenTreeVersion.inventreeDjangoVersion()}")
-    print(f"InvenTree   {InvenTreeVersion.inventreeVersion()}")
-    print(f"API         {InvenTreeVersion.inventreeApiVersion()}")
-    print("")
-    print(f"Commit hash:{InvenTreeVersion.inventreeCommitHash()}")
-    print(f"Commit date:{InvenTreeVersion.inventreeCommitDate()}")
+    print(f"""
+InvenTree - inventree.org
+The Open-Source Inventory Management System\n
+
+Installation paths:
+Base        {localDir()}
+Config      {get_config_file()}
+Media       {get_media_dir()}
+Static      {get_static_dir()}
+
+Versions:
+Python      {python_version()}
+Django      {InvenTreeVersion.inventreeDjangoVersion()}
+InvenTree   {InvenTreeVersion.inventreeVersion()}
+API         {InvenTreeVersion.inventreeApiVersion()}
+
+Commit hash:{InvenTreeVersion.inventreeCommitHash()}
+Commit date:{InvenTreeVersion.inventreeCommitDate()}""")
     if len(sys.argv) == 1 and sys.argv[0].startswith('/opt/inventree/env/lib/python'):
-        print("\nYou are probably running the package installer / single-line installer. Please mentioned that in any bug reports!\n")
-        print("Use '--list' for a list of available commands")
-        print("Use '--help' for help on a specific command")
+        print("""
+You are probably running the package installer / single-line installer. Please mentioned that in any bug reports!
+
+Use '--list' for a list of available commands
+Use '--help' for help on a specific command""")


### PR DESCRIPTION
This PR:
- Makes sure inventree run cli works without activation
- Adds a version task to the invoke tasks (set as a default)

Printout of the version task
```

InvenTree - inventree.org
The Open-Source Inventory Management System

========================================
Installation paths:
Base        /opt/inventree
Config      /etc/inventree/config.yaml
Media       /opt/inventree/data/media
Static      /opt/inventree/data/static

Versions:
Python      3.8.10
Django      3.2.18
InvenTree   0.11.0
API         107

Commit hash:None
Commit date:None

You are probably running the package installer / single-line installer. Please mentioned that in any bug reports!

Use '--list' for a list of available commands
Use '--help' for help on a specific command
```