### PR TITLE
Change target of PurchaseOrder notification

### DIFF
--- a/InvenTree/order/tests.py
+++ b/InvenTree/order/tests.py
@@ -367,18 +367,23 @@ class OrderTest(TestCase):
         - The creating user should *not* receive a notification
         """
 
-        PurchaseOrder.objects.create(
+        po = PurchaseOrder.objects.create(
             supplier=Company.objects.get(pk=1),
             reference='XYZABC',
             created_by=get_user_model().objects.get(pk=3),
             responsible=Owner.create(obj=get_user_model().objects.get(pk=4)),
         )
 
+        # Initially, no notifications
+
         messages = common.models.NotificationMessage.objects.filter(
             category='order.new_purchaseorder',
         )
 
-        self.assertEqual(messages.count(), 1)
+        self.assertEqual(messages.count(), 0)
+
+        # Place the order
+        po.place_order()
 
         # A notification should have been generated for user 4 (who is a member of group 3)
         self.assertTrue(messages.filter(user__pk=4).exists())


### PR DESCRIPTION
- Triggered when order is placed
- No longer when order is created

closes https://github.com/inventree/InvenTree/issues/4896