### PR TITLE
- Bump djLint to 1.29.0 (from 1.25.0) in the CI linting scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,6 @@ repos:
         args: [requirements.in, -o, requirements.txt]
         files: ^requirements\.(in|txt)$
 -   repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.25.0
+    rev: v1.29.0
     hooks:
       - id: djlint-django

--- a/InvenTree/build/templates/build/build_base.html
+++ b/InvenTree/build/templates/build/build_base.html
@@ -15,7 +15,7 @@
 {% endblock breadcrumbs %}
 
 {% block thumbnail %}
-<img class="part-thumb"
+<img alt="{% trans "Part thumbnail" %}" class="part-thumb"
 {% if build.part.image %}
 src="{{ build.part.image.preview.url }}"
 {% else %}

--- a/InvenTree/order/templates/order/order_base.html
+++ b/InvenTree/order/templates/order/order_base.html
@@ -92,7 +92,7 @@
 {% endblock actions %}
 
 {% block thumbnail %}
-<img class='part-thumb'
+<img alt="{% trans "Supplier part thumbnail" %}"  class='part-thumb'
 {% if order.supplier and order.supplier.image %}
 src="{{ order.supplier.image.url }}"
 {% else %}

--- a/InvenTree/order/templates/order/return_order_base.html
+++ b/InvenTree/order/templates/order/return_order_base.html
@@ -15,7 +15,7 @@
 {% endblock breadcrumbs %}
 
 {% block thumbnail %}
-<img class='part-thumb'
+<img alt="{% trans "Customer logo thumbnail" %}" class='part-thumb'
 {% if order.customer and order.customer.image %}
 src="{{ order.customer.image.url }}"
 {% else %}

--- a/InvenTree/order/templates/order/sales_order_base.html
+++ b/InvenTree/order/templates/order/sales_order_base.html
@@ -15,7 +15,7 @@
 {% endblock breadcrumbs %}
 
 {% block thumbnail %}
-<img class='part-thumb'
+<img alt="{% trans "Customer logo thumbnail" %}" class='part-thumb'
 {% if order.customer and order.customer.image %}
 src="{{ order.customer.image.url }}"
 {% else %}


### PR DESCRIPTION
- Add alt attribute to the img tags in the templates (required by the bump)