### PR TITLE
Add workflow for backporting PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,35 @@
+# Backport tagged issues to a stable branch.
+#
+# To enable backporting for a pullrequest, add the label "backport" to the PR.
+# Additionally, add a label with the prefix "backport-to-" and the target branch
+
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'backport')
+      && (
+        (github.event.action == 'labeled' && github.event.label.name == 'backport')
+        || (github.event.action == 'closed')
+      )
+    steps:
+      - name: Backport Action
+        uses: sqren/backport-github-action@v8.9.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+          add_original_reviewers: true
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log

--- a/backportrc.json
+++ b/backportrc.json
@@ -1,0 +1,13 @@
+{
+  // example repo info
+  "repoOwner": "Oliver Walters",
+  "repoName": "InvenTree",
+
+  // the branches available to backport to
+  "targetBranchChoices": [],
+
+  // In this case, adding the label "auto-backport-to-production" will backport the PR to the "production" branch
+  "branchLabelMapping": {
+    "^backport-to-(.+)$": "$1"
+  }
+}

--- a/backportrc.json
+++ b/backportrc.json
@@ -1,12 +1,7 @@
 {
-  // example repo info
   "repoOwner": "Oliver Walters",
   "repoName": "InvenTree",
-
-  // the branches available to backport to
   "targetBranchChoices": [],
-
-  // In this case, adding the label "auto-backport-to-production" will backport the PR to the "production" branch
   "branchLabelMapping": {
     "^backport-to-(.+)$": "$1"
   }


### PR DESCRIPTION
- Time saving for backporting bug fixes to stable branches
- Apply to PRs before closing

Uses the [backport-action](https://github.com/marketplace/actions/backport-action) github action.

