### PR TITLE
Fix/settings bugs and added model SettingKeyType typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,7 @@ node_modules/
 maintenance_mode_state.txt
 
 # plugin dev directory
-./plugins/
+InvenTree/plugins/
 
 # Compiled translation files
 *.mo

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -127,7 +127,7 @@ class SettingsKeyType(TypedDict, total=False):
         before_save: Function that gets called after save with *args, **kwargs (optional)
         after_save: Function that gets called after save with *args, **kwargs (optional)
         protected: Protected values are not returned to the client, instead "***" is returned (optional, default: False)
-        model: Auto create a dropdown menu to select an associated model instance (e.g. 'company.company', optional)
+        model: Auto create a dropdown menu to select an associated model instance (e.g. 'company.company', 'auth.user' and 'auth.group' are possible too, optional)
     """
 
     name: str

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -170,11 +170,11 @@ class BaseInvenTreeSetting(models.Model):
         # Execute before_save action
         self._call_settings_function('before_save', args, kwargs)
 
-        # Update this setting in the cache
+        super().save()
+
+        # Update this setting in the cache after it was saved so a pk exists
         if do_cache:
             self.save_to_cache()
-
-        super().save()
 
         # Execute after_save action
         self._call_settings_function('after_save', args, kwargs)
@@ -204,6 +204,10 @@ class BaseInvenTreeSetting(models.Model):
         """Save this setting object to cache"""
 
         ckey = self.cache_key
+
+        # skip saving to cache if no pk is set
+        if self.pk is None:
+            return
 
         logger.debug(f"Saving setting '{ckey}' to cache")
 

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -254,7 +254,7 @@ class BaseInvenTreeSetting(models.Model):
         results = cls.objects.all()
 
         if exclude_hidden:
-            # Keys which start with an undersore are used for internal functionality
+            # Keys which start with an underscore are used for internal functionality
             results = results.exclude(key__startswith='_')
 
         # Optionally filter by other keys
@@ -469,7 +469,7 @@ class BaseInvenTreeSetting(models.Model):
 
         If it does not exist, return the backup value (default = None)
         """
-        # If no backup value is specified, atttempt to retrieve a "default" value
+        # If no backup value is specified, attempt to retrieve a "default" value
         if backup_value is None:
             backup_value = cls.get_setting_default(key, **kwargs)
 

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -127,6 +127,7 @@ class SettingsKeyType(TypedDict, total=False):
         before_save: Function that gets called after save with *args, **kwargs (optional)
         after_save: Function that gets called after save with *args, **kwargs (optional)
         protected: Protected values are not returned to the client, instead "***" is returned (optional, default: False)
+        model: Auto create a dropdown menu to select an associated model instance (e.g. 'company.company', optional)
     """
 
     name: str
@@ -139,6 +140,7 @@ class SettingsKeyType(TypedDict, total=False):
     before_save: Callable[..., None]
     after_save: Callable[..., None]
     protected: bool
+    model: str
 
 
 class BaseInvenTreeSetting(models.Model):

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -315,7 +315,7 @@ def default_currency(*args, **kwargs):
 
 @register.simple_tag()
 def setting_object(key, *args, **kwargs):
-    """Return a setting object speciifed by the given key.
+    """Return a setting object specified by the given key.
 
     (Or return None if the setting does not exist)
     if a user-setting was requested return that

--- a/InvenTree/plugin/api.py
+++ b/InvenTree/plugin/api.py
@@ -258,7 +258,7 @@ plugin_api_urls = [
             re_path(r'^.*$', PluginDetail.as_view(), name='api-plugin-detail'),
         ])),
 
-        # Plugin managment
+        # Plugin management
         re_path(r'^install/', PluginInstall.as_view(), name='api-plugin-install'),
         re_path(r'^activate/', PluginActivate.as_view(), name='api-plugin-activate'),
 

--- a/InvenTree/plugin/api.py
+++ b/InvenTree/plugin/api.py
@@ -247,7 +247,7 @@ plugin_api_urls = [
     re_path(r'^plugins/', include([
         # Plugin settings URLs
         re_path(r'^settings/', include([
-            re_path(r'^(?P<plugin>\w+)/(?P<key>\w+)/', PluginSettingDetail.as_view(), name='api-plugin-setting-detail'),    # Used for admin interface
+            re_path(r'^(?P<plugin>[-\w]+)/(?P<key>\w+)/', PluginSettingDetail.as_view(), name='api-plugin-setting-detail'),    # Used for admin interface
             re_path(r'^.*$', PluginSettingList.as_view(), name='api-plugin-setting-list'),
         ])),
 

--- a/InvenTree/plugin/api.py
+++ b/InvenTree/plugin/api.py
@@ -164,7 +164,7 @@ class PluginSettingList(ListAPI):
 
 
 def check_plugin(plugin_slug: str, plugin_pk: int) -> InvenTreePlugin:
-    """Check that a plugin for the provided slug exsists and get the config.
+    """Check that a plugin for the provided slug exists and get the config.
 
     Args:
         plugin_slug (str): Slug for plugin.

--- a/InvenTree/templates/js/dynamic/settings.js
+++ b/InvenTree/templates/js/dynamic/settings.js
@@ -111,8 +111,13 @@ function editSetting(key, options={}) {
                     return data;
                 },
                 processBeforeUpload: function(data) {
-                    // Convert value to string
-                    data.value = data.value.toString();
+                    if(response.type === 'related field' && data.value === null) {
+                        // related fields throw an error because they are set to null on delete
+                        data.value = "";
+                    } else {
+                        // Convert value to string
+                        data.value = data.value.toString();
+                    }
 
                     return data;
                 },


### PR DESCRIPTION
This PR fixes various issues related to settings:

- setting get cached even there are not saved yet (have no pk) which leads to trying to recreate them which fails
   This was pretty hard to find, I located that issue with `git bisect` using 61481b4eb as bad commit, 0ffe7861a as good commit and got 16ff1936 as first bad commit. 
- add `model` key to `SettingsKeyType` (was actually the initiator of this PR)
- plugin slugs that contain `-` can't use settings because the API `re_path` doesn't include `-` chars
- related fields cannot be reseted, instead there is an js error thrown that `data.value.toString()` cannot be called on `null`
- spelling mistakes discovered while debugging in the code (I have this [extension](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) installed to prevent them while I'm coding)