### PR TITLE
Add "can reproduce" checkbox to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -52,14 +52,13 @@ body:
       label: "Version Information"
       description: "The version info block."
       placeholder: "You can get this by going to the `About InvenTree` section in the upper right corner and clicking on the `copy version information` button"
-  - type: dropdown
+  - type: checkboxes
     id: can-reproduce
     attributes:
       label: "I can reproduce this bug on the demo site."
       description: "You can sign in at [InvenTree Demo](https://demo.inventree.org) with admin:inventree."
       options:
-        - "Yes"
-        - "No"
+        - label: "Yes"
     validations:
         required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -56,7 +56,7 @@ body:
     id: can-reproduce
     attributes:
       label: "I can reproduce this bug on the demo site."
-      description: "[InvenTree Demo](https://demo.inventree.org)"
+      description: "You can sign in at [InvenTree Demo](https://demo.inventree.org) with admin:inventree."
       options:
         - "Yes"
         - "No"

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -55,12 +55,10 @@ body:
   - type: checkboxes
     id: can-reproduce
     attributes:
-      label: "I can reproduce this bug on the demo site."
+      label: "Please verify if you can reproduce this bug on the demo site."
       description: "You can sign in at [InvenTree Demo](https://demo.inventree.org) with admin:inventree."
       options:
-        - label: "Yes"
-    validations:
-        required: true
+        - label: "I can reproduce this bug on the demo site."
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -56,7 +56,7 @@ body:
     id: can-reproduce
     attributes:
       label: "Please verify if you can reproduce this bug on the demo site."
-      description: "You can sign in at [InvenTree Demo](https://demo.inventree.org) with admin:inventree."
+      description: "You can sign in at [InvenTree Demo](https://demo.inventree.org) with admin:inventree. Note that this instance runs on the latest dev version, so your bug may be fixed there."
       options:
         - label: "I can reproduce this bug on the demo site."
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -55,12 +55,11 @@ body:
   - type: dropdown
     id: can-reproduce
     attributes:
-      label: "I can reproduce this bug on the [InvenTree Demo](https://demo.inventree.org) site."
+      label: "I can reproduce this bug on the demo site."
+      description: "[InvenTree Demo](https://demo.inventree.org)"
       options:
-        - label: "I checked and didn't find a similar issue"
-          options:
-            - Yes
-            - No
+        - Yes
+        - No
     validations:
         required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -58,8 +58,8 @@ body:
       label: "I can reproduce this bug on the demo site."
       description: "[InvenTree Demo](https://demo.inventree.org)"
       options:
-        - Yes
-        - No
+        - "Yes"
+        - "No"
     validations:
         required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -61,7 +61,7 @@ body:
           options:
             - Yes
             - No
-      validations:
+    validations:
         required: true
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -52,6 +52,17 @@ body:
       label: "Version Information"
       description: "The version info block."
       placeholder: "You can get this by going to the `About InvenTree` section in the upper right corner and clicking on the `copy version information` button"
+  - type: dropdown
+    id: can-reproduce
+    attributes:
+      label: "I can reproduce this bug on the [InvenTree Demo](https://demo.inventree.org) site."
+      options:
+        - label: "I checked and didn't find a similar issue"
+          options:
+            - Yes
+            - No
+      validations:
+        required: true
   - type: textarea
     id: logs
     attributes:


### PR DESCRIPTION
This PR adds a "can reproduce" checkbox to the issue bug template. I think issues that have that box ticked are definitely (in most cases) not related to the users setup. If you can’t reproduce it there it’s most likely that something on your setup is not working correctly or that issue has been fixed with the dev version.

![image](https://github.com/inventree/InvenTree/assets/76838159/e79270c4-921e-457f-a529-76fe6fd758ec)
