### PR TITLE
Prevent div-by-zero error

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -1302,6 +1302,11 @@ class Part(InvenTreeBarcodeMixin, InvenTreeNotesMixin, MetadataMixin, MPTTModel)
         )
 
         for item in queryset.all():
+
+            if item.quantity <= 0:
+                # Ignore zero-quantity items
+                continue
+
             # Iterate through each item in the queryset, work out the limiting quantity
             quantity = item.available_stock + item.substitute_stock
 


### PR DESCRIPTION
- Div-by-zero could occur when calculating how many items can be built for a part
- Might result if (somehow) the BomItem has a quantity of zero