### PR TITLE
Fix reference to pack_size in stock migration

### DIFF
--- a/InvenTree/stock/migrations/0094_auto_20230220_0025.py
+++ b/InvenTree/stock/migrations/0094_auto_20230220_0025.py
@@ -16,12 +16,12 @@ def fix_purchase_price(apps, schema_editor):
     Due to an existing bug, if a PurchaseOrderLineItem was received,
     which had:
 
-    a) A SupplierPart with a non-unity pack size
+    a) A SupplierPart with a non-unity pack quantity
     b) A defined purchase_price
 
     then the StockItem.purchase_price was not calculated correctly!
 
-    Specifically, the purchase_price was not divided through by the pack_size attribute.
+    Specifically, the purchase_price was not divided through by the pack_quantity attribute.
 
     This migration fixes this by looking through all stock items which:
 
@@ -57,7 +57,7 @@ def fix_purchase_price(apps, schema_editor):
             if line.part == item.supplier_part:
                 # Unit price matches original PurchaseOrder (and is thus incorrect)
                 if item.purchase_price == line.purchase_price:
-                    item.purchase_price /= item.supplier_part.pack_size
+                    item.purchase_price /= item.supplier_part.pack_quantity
                     item.save()
 
                     n_updated += 1


### PR DESCRIPTION
5dd6f18 renamed the pack_size field of SupplierPart to pack_quantity, but this migration was missed in the change. Trying to migrate from a DB older than two weeks ago therefore fails.