### PR TITLE
Place uninstalled items back in stock

### DIFF
--- a/InvenTree/stock/models.py
+++ b/InvenTree/stock/models.py
@@ -1261,6 +1261,7 @@ class StockItem(InvenTreeBarcodeMixin, InvenTreeNotesMixin, MetadataMixin, commo
 
         # Mark this stock item as *not* belonging to anyone
         self.belongs_to = None
+        self.consumed_by = None
         self.location = location
 
         self.save()


### PR DESCRIPTION
reset the consumed_by field as well as belongs_to, so an uninstalled item can be reused.

Fixes: #4992