### PR TITLE
Migration fix

### DIFF
--- a/InvenTree/stock/migrations/0071_auto_20211205_1733.py
+++ b/InvenTree/stock/migrations/0071_auto_20211205_1733.py
@@ -38,6 +38,7 @@ def delete_scheduled(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('django_q', '0007_ormq'),
         ('stock', '0070_auto_20211128_0151'),
     ]
 


### PR DESCRIPTION
- Ensure initial django_q migrations are applied before operating on the table
- Why on earth is this failing now?
- Found as part of https://github.com/inventree/InvenTree/pull/4855