### PR TITLE
Migration fixes

### DIFF
--- a/InvenTree/InvenTree/status.py
+++ b/InvenTree/InvenTree/status.py
@@ -38,7 +38,14 @@ def is_worker_running(**kwargs):
     )
 
     # If any results are returned, then the background worker is running!
-    return results.exists()
+    try:
+        result = results.exists()
+    except Exception:
+        # We may throw an exception if the database is not ready,
+        # or if the django_q table is not yet created (i.e. in CI testing)
+        result = False
+
+    return result
 
 
 def check_system_health(**kwargs):

--- a/InvenTree/InvenTree/tasks.py
+++ b/InvenTree/InvenTree/tasks.py
@@ -186,6 +186,8 @@ def offload_task(taskname, *args, force_async=False, force_sync=False, **kwargs)
             task.run()
         except ImportError:
             raise_warning(f"WARNING: '{taskname}' not started - Function not found")
+        except Exception as exc:
+            raise_warning(f"WARNING: '{taskname}' not started due to {type(exc)}")
     else:
 
         if callable(taskname):

--- a/InvenTree/common/migrations/0001_initial.py
+++ b/InvenTree/common/migrations/0001_initial.py
@@ -4,15 +4,40 @@ import django.core.validators
 from django.db import migrations, models
 
 
+class CreateModelOrSkip(migrations.CreateModel):
+    """Custom migration operation to create a model if it does not already exist.
+
+    - If the model already exists, the migration is skipped
+    - This class has been added to deal with some errors being thrown in CI tests
+    - The 'common_currency' table doesn't exist anymore anyway!
+    - In the future, these migrations will be squashed
+    """
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state) -> None:
+        """Forwards migration *attempts* to create the model, but will fail gracefully if it already exists"""
+
+        try:
+            super().database_forwards(app_label, schema_editor, from_state, to_state)
+        except Exception:
+            pass
+
+    def state_forwards(self, app_label, state) -> None:
+        try:
+            super().state_forwards(app_label, state)
+        except Exception:
+            pass
+
+
 class Migration(migrations.Migration):
 
     initial = True
+    atomic = False
 
     dependencies = [
     ]
 
     operations = [
-        migrations.CreateModel(
+        CreateModelOrSkip(
             name='Currency',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),

--- a/InvenTree/company/test_migrations.py
+++ b/InvenTree/company/test_migrations.py
@@ -222,7 +222,7 @@ class TestManufacturerPart(MigratorTestCase):
 class TestCurrencyMigration(MigratorTestCase):
     """Tests for upgrade from basic currency support to django-money."""
 
-    migrate_from = ('company', '0025_auto_20201110_1001')
+    migrate_from = ('company', '0020_auto_20200413_0839')
     migrate_to = ('company', '0026_auto_20201110_1011')
 
     def prepare(self):

--- a/InvenTree/company/test_migrations.py
+++ b/InvenTree/company/test_migrations.py
@@ -222,7 +222,7 @@ class TestManufacturerPart(MigratorTestCase):
 class TestCurrencyMigration(MigratorTestCase):
     """Tests for upgrade from basic currency support to django-money."""
 
-    migrate_from = ('company', '0020_auto_20200413_0839')
+    migrate_from = ('company', '0022_auto_20200613_1045')
     migrate_to = ('company', '0026_auto_20201110_1011')
 
     def prepare(self):

--- a/InvenTree/company/test_migrations.py
+++ b/InvenTree/company/test_migrations.py
@@ -222,7 +222,7 @@ class TestManufacturerPart(MigratorTestCase):
 class TestCurrencyMigration(MigratorTestCase):
     """Tests for upgrade from basic currency support to django-money."""
 
-    migrate_from = ('company', '0022_auto_20200613_1045')
+    migrate_from = ('company', '0025_auto_20201110_1001')
     migrate_to = ('company', '0026_auto_20201110_1011')
 
     def prepare(self):


### PR DESCRIPTION
Further work towards some spurious errors in CI.

These errors seem to be related to the "order of migrations" when running migration tests. Sometimes will pass initial tests, only to fail after the PR is actually merged in

### Runs

- https://github.com/inventree/InvenTree/actions/runs/5239140398/jobs/9458741977
- https://github.com/inventree/InvenTree/actions/runs/5242743649/jobs/9466606203
- https://github.com/inventree/InvenTree/actions/runs/5242743649/jobs/9466605957

### PRs

- https://github.com/inventree/InvenTree/pull/4814
- https://github.com/inventree/InvenTree/pull/4808
- https://github.com/inventree/InvenTree/pull/4732