### PR TITLE
Skip pricing updates when importing data

### DIFF
--- a/InvenTree/InvenTree/ready.py
+++ b/InvenTree/InvenTree/ready.py
@@ -13,6 +13,11 @@ def isImportingData():
     return 'loaddata' in sys.argv
 
 
+def isRunningMigrations():
+    """Return True if the database is currently running migrations."""
+    return 'migrate' in sys.argv or 'makemigrations' in sys.argv
+
+
 def canAppAccessDatabase(allow_test: bool = False, allow_plugins: bool = False, allow_shell: bool = False):
     """Returns True if the apps.py file can access database records.
 

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2363,6 +2363,16 @@ class PartPricing(common.models.MetaMixin):
     def schedule_for_update(self, counter: int = 0):
         """Schedule this pricing to be updated"""
 
+        import InvenTree.ready
+
+        # If importing data, skip pricing update
+        if InvenTree.ready.isImportingData():
+            return
+
+        # If running data migrations, skip pricing update
+        if InvenTree.ready.isRunningDataMigrations():
+            return
+
         if not self.part or not self.part.pk or not Part.objects.filter(pk=self.part.pk).exists():
             logger.warning("Referenced part instance does not exist - skipping pricing update.")
             return
@@ -2414,6 +2424,14 @@ class PartPricing(common.models.MetaMixin):
 
     def update_pricing(self, counter: int = 0, cascade: bool = True):
         """Recalculate all cost data for the referenced Part instance"""
+
+        # If importing data, skip pricing update
+        if InvenTree.ready.isImportingData():
+            return
+
+        # If running data migrations, skip pricing update
+        if InvenTree.ready.isRunningDataMigrations():
+            return
 
         if self.pk is not None:
             try:

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2370,7 +2370,7 @@ class PartPricing(common.models.MetaMixin):
             return
 
         # If running data migrations, skip pricing update
-        if InvenTree.ready.isRunningDataMigrations():
+        if InvenTree.ready.isRunningMigrations():
             return
 
         if not self.part or not self.part.pk or not Part.objects.filter(pk=self.part.pk).exists():
@@ -2430,7 +2430,7 @@ class PartPricing(common.models.MetaMixin):
             return
 
         # If running data migrations, skip pricing update
-        if InvenTree.ready.isRunningDataMigrations():
+        if InvenTree.ready.isRunningMigrations():
             return
 
         if self.pk is not None:


### PR DESCRIPTION
- Depending on migration state, pricing table might not exist
- post-save hooks can call update_pricing
- So, ignore if running data migration or import

Ref: https://github.com/inventree/InvenTree/pull/4984