### PR TITLE
Fix migration order

### DIFF
--- a/InvenTree/company/migrations/0059_supplierpart_pack_units.py
+++ b/InvenTree/company/migrations/0059_supplierpart_pack_units.py
@@ -8,6 +8,7 @@ import InvenTree.fields
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('stock', '0094_auto_20230220_0025'),
         ('company', '0058_auto_20230515_0004'),
     ]
 


### PR DESCRIPTION
- Ensure stock.0094 runs before company.0059
- Ref https://github.com/inventree/InvenTree/pull/4984
- Ideally addresses historical migration issues