### PR TITLE
Improve StockItem API speed

### DIFF
--- a/InvenTree/company/serializers.py
+++ b/InvenTree/company/serializers.py
@@ -334,7 +334,7 @@ class SupplierPartSerializer(InvenTreeTagModelSerializer):
 
     MPN = serializers.CharField(read_only=True)
 
-    manufacturer_part_detail = ManufacturerPartSerializer(source='manufacturer_part', read_only=True)
+    manufacturer_part_detail = ManufacturerPartSerializer(source='manufacturer_part', part_detail=False, read_only=True)
 
     url = serializers.CharField(source='get_absolute_url', read_only=True)
 

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -795,15 +795,6 @@ class StockList(APIDownloadMixin, ListCreateDestroyAPIView):
 
         queryset = StockSerializers.StockItemSerializer.annotate_queryset(queryset)
 
-        # Also ensure that we pre-fecth all the related items
-        queryset = queryset.prefetch_related(
-            'part',
-            'part__category',
-            'location',
-            'test_results',
-            'tags',
-        )
-
         return queryset
 
     def filter_queryset(self, queryset):

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -231,10 +231,17 @@ class StockItemSerializer(InvenTree.serializers.InvenTreeTagModelSerializer):
         """Add some extra annotations to the queryset, performing database queries as efficiently as possible."""
 
         queryset = queryset.prefetch_related(
+            'location',
             'sales_order',
             'purchase_order',
             'part',
+            'part__category',
             'part__pricing_data',
+            'supplier_part',
+            'supplier_part__manufacturer_part',
+            'supplier_part__tags',
+            'test_results',
+            'tags',
         )
 
         # Annotate the queryset with the total allocated to sales orders
@@ -280,7 +287,7 @@ class StockItemSerializer(InvenTree.serializers.InvenTreeTagModelSerializer):
     status_text = serializers.CharField(source='get_status_display', read_only=True)
 
     # Optional detail fields, which can be appended via query parameters
-    supplier_part_detail = SupplierPartSerializer(source='supplier_part', many=False, read_only=True)
+    supplier_part_detail = SupplierPartSerializer(source='supplier_part', supplier_detail=False, manufacturer_detail=False, part_detail=False, many=False, read_only=True)
     part_detail = PartBriefSerializer(source='part', many=False, read_only=True)
     location_detail = LocationBriefSerializer(source='location', many=False, read_only=True)
     tests = StockItemTestResultSerializer(source='test_results', many=True, read_only=True)


### PR DESCRIPTION
- Removes child detail fields which cannot be effectively annotated
- Prefetch required fields
- Add unit test method for checking query count

In a test setup, reduces a query of 200 items from ~1s to ~200ms (200 DB hits down to 18)