### PR TITLE
Stock status change API

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 124
+INVENTREE_API_VERSION = 125
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v125 -> 2023-06-17 : https://github.com/inventree/InvenTree/pull/5064
+    - Adds API endpoint for setting the "status" field for multiple stock items simultaneously
 
 v124 -> 2023-06-17 : https://github.com/inventree/InvenTree/pull/5057
     - Add "created_before" and "created_after" filters to the Part API

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -158,6 +158,12 @@ class StockAdjustView(CreateAPI):
         return context
 
 
+class StockChangeStatus(StockAdjustView):
+    """API endpoint to change the status code of multiple StockItem objects."""
+
+    serializer_class = StockSerializers.StockChangeStatusSerializer
+
+
 class StockCount(StockAdjustView):
     """Endpoint for counting stock (performing a stocktake)."""
 
@@ -1371,6 +1377,7 @@ stock_api_urls = [
     re_path(r'^transfer/', StockTransfer.as_view(), name='api-stock-transfer'),
     re_path(r'^assign/', StockAssign.as_view(), name='api-stock-assign'),
     re_path(r'^merge/', StockMerge.as_view(), name='api-stock-merge'),
+    re_path(r'^change_status/', StockChangeStatus.as_view(), name='api-stock-change-status'),
 
     # StockItemAttachment API endpoints
     re_path(r'^attachment/', include([

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -722,7 +722,7 @@ class StockChangeStatusSerializer(serializers.Serializer):
             transaction_notes.append(
                 StockItemTracking(
                     item=item,
-                    tracking_type=InvenTree.status_codes.StockHistoryCode.EDITED,
+                    tracking_type=InvenTree.status_codes.StockHistoryCode.EDITED.value,
                     date=now,
                     deltas=deltas,
                     user=user,

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -731,7 +731,7 @@ class StockChangeStatusSerializer(serializers.Serializer):
             )
 
         # Update status
-        StockItem.objects.bulk_update(items_to_update, ['status'])
+        StockItem.objects.bulk_update(items_to_update, ['status', 'updated'])
 
         # Create entries
         StockItemTracking.objects.bulk_create(transaction_notes)

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -1138,7 +1138,7 @@ function adjustStock(action, items, options={}) {
     if (itemCount == 0) {
         showAlertDialog(
             '{% trans "Select Stock Items" %}',
-            '{% trans "You must select at least one available stock item" %}',
+            '{% trans "Select at least one available stock item" %}',
         );
 
         return;
@@ -2297,22 +2297,27 @@ function loadStockTable(table, options) {
         });
     }
 
+    // Callback for 'stocktake' button
     $('#multi-item-stocktake').click(function() {
         stockAdjustment('count');
     });
 
+    // Callback for 'remove stock' button
     $('#multi-item-remove').click(function() {
         stockAdjustment('take');
     });
 
+    // Callback for 'add stock' button
     $('#multi-item-add').click(function() {
         stockAdjustment('add');
     });
 
+    // Callback for 'move stock' button
     $('#multi-item-move').click(function() {
         stockAdjustment('move');
     });
 
+    // Callback for 'merge stock' button
     $('#multi-item-merge').click(function() {
         var items = getTableData(table);
 
@@ -2327,6 +2332,7 @@ function loadStockTable(table, options) {
         });
     });
 
+    // Callback for 'assign stock' button
     $('#multi-item-assign').click(function() {
 
         var items = getTableData(table);
@@ -2338,6 +2344,7 @@ function loadStockTable(table, options) {
         });
     });
 
+    // Callback for 'un-assign stock' button
     $('#multi-item-order').click(function() {
 
         var selections = getTableData(table);
@@ -2355,6 +2362,7 @@ function loadStockTable(table, options) {
         orderParts(parts, {});
     });
 
+    // Callback for 'delete stock' button
     $('#multi-item-delete').click(function() {
         var selections = getTableData(table);
 
@@ -2365,6 +2373,46 @@ function loadStockTable(table, options) {
         });
 
         stockAdjustment('delete');
+    });
+
+    // Callback for 'change status' button
+    $('#multi-item-status').click(function() {
+        let selections = getTableData(table);
+        let items = [];
+
+        selections.forEach(function(item) {
+            items.push(item.pk);
+        });
+
+        if (items.length == 0) {
+            showAlertDialog(
+                '{% trans "Select Stock Items" %}',
+                '{% trans "Select one or more stock items" %}'
+            );
+            return;
+        }
+
+        let html = `
+        <div class='alert alert-info alert-block>
+        {% trans "Selected stock items" %}: ${items.length}
+        </div>`;
+
+        constructForm('{% url "api-stock-change-status" %}', {
+            title: '{% trans "Change Stock Status" %}',
+            method: 'POST',
+            preFormContent: html,
+            fields: {
+                status: {},
+                note: {},
+            },
+            processBeforeUpload: function(data) {
+                data.items = items;
+                return data;
+            },
+            onSuccess: function() {
+                $(table).bootstrapTable('refresh');
+            }
+        });
     });
 }
 

--- a/InvenTree/templates/stock_table.html
+++ b/InvenTree/templates/stock_table.html
@@ -34,6 +34,7 @@
                     <li><a class='dropdown-item' href="#" id='multi-item-remove' title='{% trans "Remove from selected stock items" %}'><span class='fas fa-minus-circle icon-red'></span> {% trans "Remove stock" %}</a></li>
                     <li><a class='dropdown-item' href="#" id='multi-item-stocktake' title='{% trans "Stocktake selected stock items" %}'><span class='fas fa-check-circle icon-green'></span> {% trans "Count stock" %}</a></li>
                     <li><a class='dropdown-item' href='#' id='multi-item-move' title='{% trans "Move selected stock items" %}'><span class='fas fa-exchange-alt icon-blue'></span> {% trans "Transfer stock" %}</a></li>
+                    <li><a class='dropdown-item' href='#' id='multi-item-status' title='{% trans "Change stock status" %}'><span class='fas fa-info-circle icon-blue'></span> {% trans "Change stock status" %}</a></li>
                     <li><a class='dropdown-item' href='#' id='multi-item-merge' title='{% trans "Merge selected stock items" %}'><span class='fas fa-object-group'></span> {% trans "Merge stock" %}</a></li>
                     <li><a class='dropdown-item' href='#' id='multi-item-order' title='{% trans "Order selected items" %}'><span class='fas fa-shopping-cart'></span> {% trans "Order stock" %}</a></li>
                     <li><a class='dropdown-item' href='#' id='multi-item-assign' title='{% trans "Assign to customer" %}'><span class='fas fa-user-tie'></span> {% trans "Assign to customer" %}</a></li>


### PR DESCRIPTION
Fixes https://github.com/inventree/InvenTree/issues/4948

Reintroduced the ability to change the "status" field for multiple stock items simultaneously.

Previously this was achieved with multiple (sequential) API calls, which is super inefficient and also error prone. 

This PR adds a new API endpoint where this can all be achieved with two database hits.