### PR TITLE
Get git log fix

### DIFF
--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -349,10 +349,6 @@ class InvenTreePlugin(VersionMixin, MixinBase, MetaBase):
     def _get_package_commit(self):
         """Get last git commit for the plugin."""
 
-        import cProfile
-
-        cProfile.runctx('get_git_log(str(self.file()))', globals(), locals(), filename=f'get-git-log-{self.slug}.prof')
-
         return get_git_log(str(self.file()))
 
     @classmethod

--- a/InvenTree/plugin/plugin.py
+++ b/InvenTree/plugin/plugin.py
@@ -348,6 +348,11 @@ class InvenTreePlugin(VersionMixin, MixinBase, MetaBase):
     # region package info
     def _get_package_commit(self):
         """Get last git commit for the plugin."""
+
+        import cProfile
+
+        cProfile.runctx('get_git_log(str(self.file()))', globals(), locals(), filename=f'get-git-log-{self.slug}.prof')
+
         return get_git_log(str(self.file()))
 
     @classmethod


### PR DESCRIPTION
- Closes https://github.com/inventree/InvenTree/issues/5081
- Replaces https://github.com/inventree/InvenTree/pull/5106

This PR simplfies the process for extracting git commit information for externally loaded plugins.

In a simple test environment, reduces plugin load times from 90 seconds to 0.2 seconds

@matmair would you be able to test on your end? I have verified that it provides correct data for plugins dropped into the "plugin" directory, if they have commit information supplied. However this approach does not have "depth of discovery" - can you expand on why this is required?