### PR TITLE
Fix for index page badge

### DIFF
--- a/InvenTree/templates/js/translated/index.js
+++ b/InvenTree/templates/js/translated/index.js
@@ -66,6 +66,11 @@ function addHeaderAction(label, title, icon, options) {
 
         let count = options.totalRows;
 
+        if (count == undefined || count == null) {
+            let data = $(table_name).bootstrapTable('getData');
+            count = data.length;
+        }
+
         let badge = $(`#sidebar-badge-${label}`);
 
         badge.html(count);


### PR DESCRIPTION
- If table was not paginated, totalRows did not exist
- Handle this case by looking at length of actual data