### PR TITLE
fix: add missing build model property

### DIFF
--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -361,6 +361,11 @@ class Build(MPTTModel, InvenTree.models.InvenTreeBarcodeMixin, InvenTree.models.
 
         return self.build_lines.filter(bom_item__sub_part__trackable=False)
 
+    @property
+    def are_untracked_parts_allocated(self):
+        """Returns True if all untracked parts are allocated"""
+        return self.is_fully_allocated(tracked=False)
+
     def has_untracked_line_items(self):
         """Returns True if this BuildOrder has non trackable BomItems."""
         return self.has_untracked_line_items.count() > 0

--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -363,7 +363,7 @@ class Build(MPTTModel, InvenTree.models.InvenTreeBarcodeMixin, InvenTree.models.
 
     @property
     def are_untracked_parts_allocated(self):
-        """Returns True if all untracked parts are allocated"""
+        """Returns True if all untracked parts are allocated for this BuildOrder."""
         return self.is_fully_allocated(tracked=False)
 
     def has_untracked_line_items(self):


### PR DESCRIPTION
This PR fixes an issue where build orders would always show "Stock has not been fully allocated to this Build Order" even if all parts have been allocated.

Why is this happening?
The template for the build order uses the property `build.are_untracked_parts_allocated`:
https://github.com/inventree/InvenTree/blob/a81ac8960357d75cbfa035fdbf40f66bee105c99/InvenTree/build/templates/build/build_base.html#L138-L141
which was removed from the model in this commit: 6ba777d363170976fb50c93e48b0bab91c32a67d (see old line 1120 in file `InvenTree/InvenTree/build/models.py`)

I've just re-added the missing property and tested it a few times

How to reproduce:
- Create an assemblied part and add some components
- Create a build order for this part and allocate all components
- The "Stock has not been fully allocated to this Build Order" message is still showing even after allocating everything

With this PR the message disappears after allocating all components

Before:
<img width="1358" alt="Before" src="https://github.com/inventree/InvenTree/assets/59475466/a4932482-58d3-4077-8db6-bfed75b864fa">

After:
<img width="1358" alt="After" src="https://github.com/inventree/InvenTree/assets/59475466/2d342a54-3831-4096-baf2-3066111131d6">
