### PR TITLE
change invoke setup-dev to invoke setup-test --dev

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -15,7 +15,7 @@ python3 -m venv dev/venv
 # setup InvenTree server
 pip install invoke
 invoke update
-invoke setup-dev
+invoke setup-test --dev
 
 # remove existing gitconfig created by "Avoiding Dubious Ownership" step
 # so that it gets copied from host to the container to have your global


### PR DESCRIPTION
Chnage postCreateCommand in .devcontainer to invoke setup-test --dev.

This will setup this dev container with all demo data (which is from my perspective the right way).

Setup-dev will "only" insall all required things for development, setup-test --dev will first setup the demo data and then run setup-dev. 

We can also do setup-dev --tests, but they way i choos is documented in the docs.