### PR TITLE
Fix some documentation issues

### DIFF
--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -191,9 +191,8 @@ InvenTree requires some external directories for storing files:
 
 | Environment Variable | Configuration File | Description | Default |
 | --- | --- | --- | --- |
-| INVENTREE_STATIC_ROOT | static_root | List of allowed hosts | *Not specified* |
-| INVENTREE_MEDIA_ROOT | media_root | Allow all remote URLS for CORS checks | *Not specified* |
-| INVENTREE_BACKUP_DIR | backup_dir | List of whitelisted CORS URLs | *Not specified* |
+| INVENTREE_STATIC_ROOT | static_root | [Static files](./serving_files.md#static-files) directory | *Not specified* |
+| INVENTREE_MEDIA_ROOT | media_root | [Media files](./serving_files.md#media-files) directory | *Not specified* |
 
 !!! tip "Serving Files"
     Read the [Serving Files](./serving_files.md) section for more information on hosting *static* and *media* files


### PR DESCRIPTION
Hi, firstly, thanks for this project

I saw some issues on the Inventree documentation, on the `start/config` files. 

Here is my changes:
* Change the description of `File Storage Locations` variables
* Remove `INVENTREE_BACKUP_DIR` that is already explain on the backup documentation and bellow in this documentation