### PR TITLE
Fix link to background tasks documentation

### DIFF
--- a/InvenTree/templates/stats.html
+++ b/InvenTree/templates/stats.html
@@ -63,7 +63,7 @@
         <td><span class='fas fa-tasks'></span></td>
         <td>{% trans "Background Worker" %}</td>
         <td>
-            <a href='{% inventree_docs_url %}/admin/tasks'>
+            <a href='{% inventree_docs_url %}/settings/tasks'>
                 <span class='badge rounded-pill bg-danger'>{% trans "Background worker not running" %}</span>
             </a>
         </td>


### PR DESCRIPTION
This fixes the link to the "Background Tasks" documentation.