### PR TITLE
Do not enforce unit type conversion for part parameters

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -3532,15 +3532,6 @@ class PartParameter(MetadataMixin, models.Model):
 
         super().clean()
 
-        # Validate the parameter data against the template units
-        if self.template.units:
-            try:
-                InvenTree.conversion.convert_physical_value(self.data, self.template.units)
-            except ValidationError as e:
-                raise ValidationError({
-                    'data': e.message
-                })
-
         # Validate the parameter data against the template choices
         if choices := self.template.get_choices():
             if self.data not in choices:

--- a/InvenTree/part/test_param.py
+++ b/InvenTree/part/test_param.py
@@ -168,11 +168,10 @@ class ParameterTests(TestCase):
             param = PartParameter(part=prt, template=template, data=value)
             param.full_clean()
 
-        # Test that invalid parameters fail
+        # Invalid units also pass, but will be converted to the template units
         for value in ['3 Amps', '-3 zogs', '3.14F']:
             param = PartParameter(part=prt, template=template, data=value)
-            with self.assertRaises(django_exceptions.ValidationError):
-                param.full_clean()
+            param.full_clean()
 
     def test_param_unit_conversion(self):
         """Test that parameters are correctly converted to template units"""


### PR DESCRIPTION
- Still convert to "native value" (if possible)
- Reference: https://github.com/inventree/InvenTree/discussions/5140#discussioncomment-6352154