### PR TITLE
fix: generic status import

### DIFF
--- a/InvenTree/build/api.py
+++ b/InvenTree/build/api.py
@@ -11,7 +11,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django_filters import rest_framework as rest_filters
 
 from InvenTree.api import AttachmentMixin, APIDownloadMixin, ListCreateDestroyAPIView, MetadataView
-from generic.states import StatusView
+from generic.states.api import StatusView
 from InvenTree.helpers import str2bool, isNull, DownloadFile
 from InvenTree.status_codes import BuildStatus, BuildStatusGroups
 from InvenTree.mixins import CreateAPI, RetrieveUpdateDestroyAPI, ListCreateAPI

--- a/InvenTree/generic/states/__init__.py
+++ b/InvenTree/generic/states/__init__.py
@@ -6,10 +6,8 @@ There is a rendered state for each state value. The rendered state is used for d
 States can be extended with custom options for each InvenTree instance - those options are stored in the database and need to link back to state values.
 """
 
-from .api import StatusView
 from .states import StatusCode
 
 __all__ = [
-    StatusView,
     StatusCode,
 ]

--- a/InvenTree/order/api.py
+++ b/InvenTree/order/api.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 import common.models as common_models
 from common.settings import settings
 from company.models import SupplierPart
-from generic.states import StatusView
+from generic.states.api import StatusView
 from InvenTree.api import (APIDownloadMixin, AttachmentMixin,
                            ListCreateDestroyAPIView, MetadataView)
 from InvenTree.filters import SEARCH_ORDER_FILTER, SEARCH_ORDER_FILTER_ALIAS

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -22,7 +22,7 @@ from build.models import Build
 from build.serializers import BuildSerializer
 from company.models import Company, SupplierPart
 from company.serializers import CompanySerializer
-from generic.states import StatusView
+from generic.states.api import StatusView
 from InvenTree.api import (APIDownloadMixin, AttachmentMixin,
                            ListCreateDestroyAPIView, MetadataView)
 from InvenTree.filters import (ORDER_FILTER, SEARCH_ORDER_FILTER,


### PR DESCRIPTION
This fixes an issue where you cannot import `StatusCode` at some point where the App are not initialized yet so you get an `AppRegistryNotReady` error raised. (needed for #4824)