### PR TITLE
Update InvenTree demo url

### DIFF
--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -233,8 +233,8 @@ remote_login_header: HTTP_REMOTE_USER
 # Add custom messages to the login page or main interface navbar or exchange the logo
 # Use environment variable INVENTREE_CUSTOMIZE or INVENTREE_CUSTOM_LOGO
 # customize:
-#   login_message: InvenTree demo instance - <a href='https://docs.inventree.org/en/latest/demo/'> Click here for login details</a>
-#   navbar_message: <h6>InvenTree demo mode <a href='https://docs.inventree.org/en/latest/demo/'><span class='fas fa-info-circle'></span></a></h6>
+#   login_message: InvenTree demo instance - <a href='https://inventree.org/demo.html'> Click here for login details</a>
+#   navbar_message: <h6>InvenTree demo mode <a href='https://inventree.org/demo.html'><span class='fas fa-info-circle'></span></a></h6>
 #   logo: logo.png
 #   splash: splash_screen.jpg
 #   hide_admin_link: true


### PR DESCRIPTION
When customizing InvenTree on the `config.yaml` file I found that the url to the demo page is outdated.
Although there is a clickable url redirection I think it's better to update the url unless it's planned to change again.