### PR TITLE
Fix selecting the default stock item label template

### DIFF
--- a/InvenTree/templates/js/translated/label.js
+++ b/InvenTree/templates/js/translated/label.js
@@ -94,8 +94,8 @@ function selectLabel(labels, items, options={}) {
                 return item.pk == user_settings.DEFAULT_PART_LABEL_TEMPLATE;
             else if (options.key == 'location')
                 return item.pk == user_settings.DEFAULT_LOCATION_LABEL_TEMPLATE;
-            else if (options.key == 'stock')
-                return item.pk == user_settings.DEFAULT_STOCK_LABEL_TEMPLATE;
+            else if (options.key == 'item')
+                return item.pk == user_settings.DEFAULT_ITEM_LABEL_TEMPLATE;
             return '';
         }
     );


### PR DESCRIPTION
I have discovered an another mistake in the #4938: the auto selection of the stock item label type did not functioned due to using bad key/default value settings name. I apologize for the issue, I will take more care next time.