### PR TITLE
Email config fix

### DIFF
--- a/InvenTree/InvenTree/email.py
+++ b/InvenTree/InvenTree/email.py
@@ -17,6 +17,7 @@ def is_email_configured():
     NOTE: This does not check if the configuration is valid!
     """
     configured = True
+    testing = settings.TESTING
 
     if InvenTree.ready.isInTestMode():
         return False
@@ -28,16 +29,23 @@ def is_email_configured():
         configured = False
 
         # Display warning unless in test mode
-        if not settings.TESTING:  # pragma: no cover
+        if not testing:  # pragma: no cover
             logger.debug("EMAIL_HOST is not configured")
 
     # Display warning unless in test mode
-    if not settings.EMAIL_HOST_USER and not settings.TESTING:  # pragma: no cover
+    if not settings.EMAIL_HOST_USER and not testing:  # pragma: no cover
         logger.debug("EMAIL_HOST_USER is not configured")
 
     # Display warning unless in test mode
-    if not settings.EMAIL_HOST_PASSWORD and not settings.TESTING:  # pragma: no cover
+    if not settings.EMAIL_HOST_PASSWORD and testing:  # pragma: no cover
         logger.debug("EMAIL_HOST_PASSWORD is not configured")
+
+    # Email sender must be configured
+    if not settings.DEFAULT_FROM_EMAIL:
+        configured = False
+
+        if not testing:  # pragma: no cover
+            logger.warning("DEFAULT_FROM_EMAIL is not configured")
 
     return configured
 

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -832,6 +832,10 @@ EMAIL_USE_SSL = get_boolean_setting('INVENTREE_EMAIL_SSL', 'email.ssl', False)
 
 DEFAULT_FROM_EMAIL = get_setting('INVENTREE_EMAIL_SENDER', 'email.sender', '')
 
+# If "from" email not specified, default to the username
+if not DEFAULT_FROM_EMAIL:
+    DEFAULT_FROM_EMAIL = get_setting('INVENTREE_EMAIL_USERNAME', 'email.username', '')
+
 EMAIL_USE_LOCALTIME = False
 EMAIL_TIMEOUT = 60
 

--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -155,8 +155,15 @@ The following email settings are available:
 | INVENTREE_EMAIL_PASSWORD | email.password | Email account password | *Not specified* |
 | INVENTREE_EMAIL_TLS | email.tls | Enable TLS support | False |
 | INVENTREE_EMAIL_SSL | email.ssl | Enable SSL support | False |
-| INVENTREE_EMAIL_SENDER | email.sender | Name of sender | *Not specified* |
+| INVENTREE_EMAIL_SENDER | email.sender | Sending email address | *Not specified* |
 | INVENTREE_EMAIL_PREFIX | email.prefix | Prefix for subject text | [InvenTree] |
+
+### Sender Email
+
+The "sender" email address is the address from which InvenTree emails are sent (by default) and must be specified for outgoing emails to function:
+
+!!! info "Fallback"
+     If `INVENTREE_EMAIL_SENDER` is not provided, the system will fall back to `INVENTREE_EMAIL_USERNAME` (if the username is a valid email address)
 
 ## Supported Currencies
 


### PR DESCRIPTION
- Handle case where `DEFAULT_FROM_EMAIL` is not specified
- Use "username" by default instead
- Visibility when `DEFAULT_FROM_EMAIL` is not set at all