### PR TITLE
Remove `container-name:`s from Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     # Use PostgreSQL as the database backend
     # Note: This can be changed to a different backend if required
     inventree-dev-db:
-        container_name: inventree-dev-db
         image: postgres:13
         expose:
             - 5432/tcp
@@ -37,7 +36,6 @@ services:
     # InvenTree web server service
     # Runs the django built-in webserver application
     inventree-dev-server:
-        container_name: inventree-dev-server
         depends_on:
           - inventree-dev-db
         build: &build_config
@@ -57,7 +55,6 @@ services:
 
     # Background worker process handles long-running or periodic tasks
     inventree-dev-worker:
-        container_name: inventree-dev-worker
         image: inventree-dev-image
         build: *build_config
         command: invoke worker

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -38,7 +38,6 @@ services:
     # Database service
     # Use PostgreSQL as the database backend
     inventree-db:
-        container_name: inventree-db
         image: postgres:13
         expose:
             - ${INVENTREE_DB_PORT:-5432}/tcp
@@ -55,7 +54,6 @@ services:
     # redis acts as database cache manager
     # only runs under the "redis" profile : https://docs.docker.com/compose/profiles/
     inventree-cache:
-        container_name: inventree-cache
         image: redis:7.0
         depends_on:
             - inventree-db
@@ -70,7 +68,6 @@ services:
     # InvenTree web server service
     # Uses gunicorn as the web server
     inventree-server:
-        container_name: inventree-server
         # If you wish to specify a particular InvenTree version, do so here
         image: inventree/inventree:${INVENTREE_TAG:-stable}
         # Only change this port if you understand the stack.
@@ -90,7 +87,6 @@ services:
 
     # Background worker process handles long-running or periodic tasks
     inventree-worker:
-        container_name: inventree-worker
         # If you wish to specify a particular InvenTree version, do so here
         image: inventree/inventree:${INVENTREE_TAG:-stable}
         command: invoke worker
@@ -109,7 +105,6 @@ services:
     # web requests are redirected to gunicorn
     # NOTE: You will need to provide a working nginx.conf file!
     inventree-proxy:
-        container_name: inventree-proxy
         image: nginx:stable
         depends_on:
             - inventree-server


### PR DESCRIPTION
`container-name:` overrides any use of the [command line option `-p`](https://docs.docker.com/engine/reference/commandline/compose/#use--p-to-specify-a-project-name).  By not overriding container names, users may use `-p` to run multiple instances of InvenTree, for example: `docker compose -p personal up` creates containers `personal-inventree-worker-1`, `personal-inventree-proxy-1`, etc. while `docker compose -p business up` creates containers `business-inventree-worker-1` and so forth.