### PR TITLE
Fix SSO check comparing id against name and extend log output

### DIFF
--- a/InvenTree/part/templatetags/sso.py
+++ b/InvenTree/part/templatetags/sso.py
@@ -38,12 +38,12 @@ def sso_check_provider(provider):
     from allauth.socialaccount.models import SocialApp
 
     # First, check that the provider is enabled
-    apps = SocialApp.objects.filter(provider__iexact=provider.name)
+    apps = SocialApp.objects.filter(provider__iexact=provider.id)
 
     if not apps.exists():
         logging.error(
             "SSO SocialApp %s does not exist (known providers: %s)",
-            provider.name, [obj.provider for obj in SocialApp.objects.all()]
+            provider.id, [obj.provider for obj in SocialApp.objects.all()]
         )
         return False
 

--- a/InvenTree/part/templatetags/sso.py
+++ b/InvenTree/part/templatetags/sso.py
@@ -41,6 +41,10 @@ def sso_check_provider(provider):
     apps = SocialApp.objects.filter(provider__iexact=provider.name)
 
     if not apps.exists():
+        logging.error(
+            "SSO SocialApp %s does not exist (known providers: %s)",
+            provider.name, [obj.provider for obj in SocialApp.objects.all()]
+        )
         return False
 
     # Next, check that the provider is correctly configured


### PR DESCRIPTION
While trying to debug my problems described in #5330 I found that the failing check was the problem. This adds some error log to inform the user about the failure, otherwise there is no indication that the check has not passed.