### PR TITLE
Exclude some common fields from django-import-export

### DIFF
--- a/InvenTree/InvenTree/admin.py
+++ b/InvenTree/InvenTree/admin.py
@@ -31,3 +31,15 @@ class InvenTreeResource(ModelResource):
                 row[idx] = val
 
         return row
+
+    def get_fields(self, **kwargs):
+        """Return fields, with some common exclusions"""
+
+        fields = super().get_fields(**kwargs)
+
+        fields_to_exclude = [
+            'metadata',
+            'lft', 'rght', 'tree_id', 'level',
+        ]
+
+        return [f for f in fields if f.column_name not in fields_to_exclude]


### PR DESCRIPTION
- Add "get_fields()" method to InvenTreeResource
- Override default behaviour and exclude some common fields
- Will flow down to any inheriting classes
- Closes https://github.com/inventree/InvenTree/issues/5348