### PR TITLE
Fix for migration - updating from old version

### DIFF
--- a/InvenTree/stock/migrations/0094_auto_20230220_0025.py
+++ b/InvenTree/stock/migrations/0094_auto_20230220_0025.py
@@ -69,6 +69,7 @@ def fix_purchase_price(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('company', '0047_supplierpart_pack_size'),
         ('stock', '0093_auto_20230217_2140'),
     ]
 


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/5357

Updating from significantly old version (v7) can cause issues due to order of migration operations.