### PR TITLE
Pin mkdocs version to 1.4.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+mkdocs==1.4.3
 mkdocs-macros-plugin>=0.7,<1.0
 mkdocs-material>=9.0,<10.0
 mkdocs-git-revision-date-localized-plugin>=1.1,<2.0


### PR DESCRIPTION
- Updates to readthedocs policy mean that this needs to be pinned
- Moving to 1.5.0 breaks current documentation set