### PR TITLE
Fix plugin pickeling

### DIFF
--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -103,6 +103,12 @@ class PluginConfig(InvenTree.models.MetadataMixin, models.Model):
         # Save plugin
         self.plugin: InvenTreePlugin = plugin
 
+    def __getstate__(self):
+        """Customize pickeling behaviour."""
+        state = super().__getstate__()
+        state.pop("plugin", None)  # plugin cannot be pickelt in some circumstances when used with drf views, remove it (#5408)
+        return state
+
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
         """Extend save method to reload plugins if the 'active' status changes."""
         reload = kwargs.pop('no_reload', False)  # check if no_reload flag is set


### PR DESCRIPTION
This is a simple fix that just removes the plugin from the model state for pickling, as pickling somehow does not work for views. But afaik the actual plugin instance is not needed to be stored in cache.

resolves #5408 