### PR TITLE
Fix build output unallocate button

### DIFF
--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -2708,6 +2708,7 @@ function loadBuildLineTable(table, build_id, options={}) {
 
         deallocateStock(build_id, {
             build_line: pk,
+            output: output,
             onSuccess: function() {
                 $(table).bootstrapTable('refresh');
             }


### PR DESCRIPTION
Fixes bug which prevented the "unallocate stock" button from working correctly for tracked parts in a build order