### PR TITLE
Disable "add rate" button in Admin interface

### DIFF
--- a/InvenTree/InvenTree/admin.py
+++ b/InvenTree/InvenTree/admin.py
@@ -1,5 +1,10 @@
 """Admin classes"""
 
+from django.contrib import admin
+from django.http.request import HttpRequest
+
+from djmoney.contrib.exchange.admin import RateAdmin
+from djmoney.contrib.exchange.models import Rate
 from import_export.resources import ModelResource
 
 
@@ -43,3 +48,15 @@ class InvenTreeResource(ModelResource):
         ]
 
         return [f for f in fields if f.column_name not in fields_to_exclude]
+
+
+class CustomRateAdmin(RateAdmin):
+    """Admin interface for the Rate class"""
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        """Disable the 'add' permission for Rate objects"""
+        return False
+
+
+admin.site.unregister(Rate)
+admin.site.register(Rate, CustomRateAdmin)


### PR DESCRIPTION
- Does not work with custom backend
- Throws error if the button is pressed
- So, remove the button