### PR TITLE
Login form fix

### DIFF
--- a/InvenTree/InvenTree/forms.py
+++ b/InvenTree/InvenTree/forms.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from allauth.account.adapter import DefaultAccountAdapter
-from allauth.account.forms import SignupForm, set_form_field_order
+from allauth.account.forms import LoginForm, SignupForm, set_form_field_order
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth_2fa.adapter import OTPAdapter
@@ -166,6 +166,24 @@ class SetPasswordForm(HelperForm):
 
 
 # override allauth
+class CustomLoginForm(LoginForm):
+    """Custom login form to override default allauth behaviour"""
+
+    def login(self, request, redirect_url=None):
+        """Perform login action.
+
+        First check that:
+        - A valid user has been supplied
+        """
+
+        if not self.user:
+            # No user supplied - redirect to the login page
+            return HttpResponseRedirect(reverse('account_login'))
+
+        # Now perform default login action
+        super().login(request, redirect_url)
+
+
 class CustomSignupForm(SignupForm):
     """Override to use dynamic settings."""
 

--- a/InvenTree/InvenTree/forms.py
+++ b/InvenTree/InvenTree/forms.py
@@ -181,7 +181,7 @@ class CustomLoginForm(LoginForm):
             return HttpResponseRedirect(reverse('account_login'))
 
         # Now perform default login action
-        super().login(request, redirect_url)
+        return super().login(request, redirect_url)
 
 
 class CustomSignupForm(SignupForm):

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -891,7 +891,7 @@ REMOVE_SUCCESS_URL = 'settings'
 
 # override forms / adapters
 ACCOUNT_FORMS = {
-    'login': 'allauth.account.forms.LoginForm',
+    'login': 'InvenTree.forms.CustomLoginForm',
     'signup': 'InvenTree.forms.CustomSignupForm',
     'add_email': 'allauth.account.forms.AddEmailForm',
     'change_password': 'allauth.account.forms.ChangePasswordForm',


### PR DESCRIPTION
Correctly handle case where login form is supplied with credentials, but they are not valid for any user.

Default allauth form will fail under these conditions.