### PR TITLE
Paginate notifications on the server

### DIFF
--- a/InvenTree/templates/js/translated/notification.js
+++ b/InvenTree/templates/js/translated/notification.js
@@ -37,6 +37,7 @@ function loadNotificationTable(table, options={}, enableDelete=false) {
             ordering: 'age',
             read: read,
         },
+        sidePagination: 'server',
         paginationVAlign: 'bottom',
         formatNoMatches: options.no_matches,
         columns: [


### PR DESCRIPTION
Utilize server-side pagination for displaying notifications.

When there are a very large number of notifications, this is much more efficient.