### PR TITLE
Transfer fields

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -7,7 +7,7 @@ INVENTREE_API_VERSION = 133
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
 
-v133 -> 2023-09-08 :
+v133 -> 2023-09-08 : https://github.com/inventree/InvenTree/pull/5518
     - Add extra optional fields which can be used for StockAdjustment endpoints
 
 v132 -> 2023-09-07 : https://github.com/inventree/InvenTree/pull/5515

--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 132
+INVENTREE_API_VERSION = 133
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v133 -> 2023-09-08 :
+    - Add extra optional fields which can be used for StockAdjustment endpoints
 
 v132 -> 2023-09-07 : https://github.com/inventree/InvenTree/pull/5515
     - Add 'issued_by' filter to BuildOrder API list endpoint

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -1146,6 +1146,8 @@ class StockAdjustmentItemSerializer(serializers.Serializer):
         - status: Change StockItem status code
         - packaging: Change StockItem packaging
         - batch: Change StockItem batch code
+
+    The optional fields can be used to adjust values for individual stock items
     """
 
     class Meta:
@@ -1174,7 +1176,7 @@ class StockAdjustmentItemSerializer(serializers.Serializer):
 
     batch = serializers.CharField(
         max_length=100,
-        required=False,
+        required=False, allow_blank=True,
         label=_('Batch Code'),
         help_text=_('Batch code for this stock item'),
     )
@@ -1184,12 +1186,12 @@ class StockAdjustmentItemSerializer(serializers.Serializer):
         default=InvenTree.status_codes.StockStatus.OK.value,
         label=_('Status'),
         help_text=_('Stock item status code'),
-        required=False,
+        required=False, allow_blank=True,
     )
 
     packaging = serializers.CharField(
         max_length=50,
-        required=False,
+        required=False, allow_blank=True,
         label=_('Packaging'),
         help_text=_('Packaging this stock item is stored in'),
     )

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -1138,9 +1138,14 @@ class StockMergeSerializer(serializers.Serializer):
 class StockAdjustmentItemSerializer(serializers.Serializer):
     """Serializer for a single StockItem within a stock adjument request.
 
-    Fields:
+    Required Fields:
         - item: StockItem object
         - quantity: Numerical quantity
+
+    Optional Fields (may be used by external tools)
+        - status: Change StockItem status code
+        - packaging: Change StockItem packaging
+        - batch: Change StockItem batch code
     """
 
     class Meta:
@@ -1165,6 +1170,28 @@ class StockAdjustmentItemSerializer(serializers.Serializer):
         decimal_places=5,
         min_value=0,
         required=True
+    )
+
+    batch = serializers.CharField(
+        max_length=100,
+        required=False,
+        label=_('Batch Code'),
+        help_text=_('Batch code for this stock item'),
+    )
+
+    status = serializers.ChoiceField(
+        choices=InvenTree.status_codes.StockStatus.items(),
+        default=InvenTree.status_codes.StockStatus.OK.value,
+        label=_('Status'),
+        help_text=_('Stock item status code'),
+        required=False,
+    )
+
+    packaging = serializers.CharField(
+        max_length=50,
+        required=False,
+        label=_('Packaging'),
+        help_text=_('Packaging this stock item is stored in'),
     )
 
 

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -1333,12 +1333,21 @@ class StockTransferSerializer(StockAdjustmentSerializer):
         with transaction.atomic():
             for item in items:
 
+                # Required fields
                 stock_item = item['pk']
                 quantity = item['quantity']
+
+                # Optional fields
+                kwargs = {}
+
+                for field_name in StockItem.optional_transfer_fields():
+                    if field_name in item:
+                        kwargs[field_name] = item[field_name]
 
                 stock_item.move(
                     location,
                     notes,
                     request.user,
-                    quantity=quantity
+                    quantity=quantity,
+                    **kwargs
                 )


### PR DESCRIPTION
Adds extra (optional) fields which can be specified when performing a stock transfer. These fields apply at the individual item level.

This allows external API calls to adjust these fields at the point of transfer. 

Optional fields are:

- status
- batch
- packaging