### PR TITLE
Fix for `%` (percent) unit (missing unary operator "%")

### DIFF
--- a/InvenTree/InvenTree/conversion.py
+++ b/InvenTree/InvenTree/conversion.py
@@ -106,7 +106,7 @@ def convert_physical_value(value: str, unit: str = None, strip_units=True):
                 val = ureg.Quantity(value, unit)
             else:
                 # Convert to the provided unit (may raise an exception)
-                val = val.to(unit)
+                val = val.to(ureg.Unit(unit))
 
         # At this point we *should* have a valid pint value
         # To double check, look at the maginitude
@@ -134,7 +134,7 @@ def convert_physical_value(value: str, unit: str = None, strip_units=True):
     # So, we ensure that it is converted to a floating point value
     # If we wish to return a "raw" value, some trickery is required
     if unit:
-        magnitude = ureg.Quantity(val.to(unit)).magnitude
+        magnitude = ureg.Quantity(val.to(ureg.Unit(unit))).magnitude
     else:
         magnitude = ureg.Quantity(val.to_base_units()).magnitude
 

--- a/InvenTree/part/test_param.py
+++ b/InvenTree/part/test_param.py
@@ -144,7 +144,7 @@ class ParameterTests(TestCase):
         """Test validation of 'units' field for PartParameterTemplate"""
 
         # Test that valid units pass
-        for unit in [None, '', 'mm', 'A', 'm^2', 'Pa', 'V', 'C', 'F', 'uF', 'mF', 'millifarad']:
+        for unit in [None, '', '%', 'mm', 'A', 'm^2', 'Pa', 'V', 'C', 'F', 'uF', 'mF', 'millifarad']:
             tmp = PartParameterTemplate(name='test', units=unit)
             tmp.full_clean()
 
@@ -169,6 +169,15 @@ class ParameterTests(TestCase):
             param = PartParameter(part=prt, template=template, data=value)
             param.full_clean()
 
+        # Test that percent unit is working
+        template2 = PartParameterTemplate.objects.create(
+            name='My Template 2',
+            units='%',
+        )
+        for value in ["1", "1%", "1 percent"]:
+            param = PartParameter(part=prt, template=template2, data=value)
+            param.full_clean()
+  
         bad_values = ['3 Amps', '-3 zogs', '3.14F']
 
         # Disable enforcing of part parameter units

--- a/InvenTree/part/test_param.py
+++ b/InvenTree/part/test_param.py
@@ -177,7 +177,7 @@ class ParameterTests(TestCase):
         for value in ["1", "1%", "1 percent"]:
             param = PartParameter(part=prt, template=template2, data=value)
             param.full_clean()
-  
+
         bad_values = ['3 Amps', '-3 zogs', '3.14F']
 
         # Disable enforcing of part parameter units


### PR DESCRIPTION
If using the newest version from [`master`](https://github.com/inventree/InvenTree/tree/master), adding a `PartParameter` with a `PartParameterTemplate` that uses `%` as its unit results in a `pint.errors.DefinitionSyntaxError: missing unary operator "%"` error.

This seems to be a pint issue (see [pint #1758](https://github.com/hgrecco/pint/issues/1758)) which is sadly still present on pint 0.22 and 0.23. The user who created the mentioned issue provided a workaround though, which this patch applies. Imo this is the way to go for now, because otherwise the `%` unit is just unusable.