### PR TITLE
Remove --no-frontend option

### DIFF
--- a/docs/docs/start/docker_dev.md
+++ b/docs/docs/start/docker_dev.md
@@ -68,7 +68,7 @@ If desired, the user may edit the environment variables, located in the `.env` f
 Perform the initial database setup by running the following command:
 
 ```bash
-docker compose run inventree-dev-server invoke update --no-frontend
+docker compose run inventree-dev-server invoke update
 ```
 
 If this is the first time you are configuring the development server, this command will build a development version of the inventree docker image.
@@ -229,7 +229,7 @@ Any updates which require a database schema change must be reflected in the data
 To run database migrations inside the docker container, run the following command:
 
 ```
-docker compose run inventree-dev-server invoke update --no-frontend
+docker compose run inventree-dev-server invoke update
 ```
 
 ### Docker Image Updates

--- a/docs/docs/start/docker_prod.md
+++ b/docs/docs/start/docker_prod.md
@@ -135,7 +135,7 @@ The first step is to edit the environment variables, located in the `.env` file.
 Perform the initial database setup by running the following command:
 
 ```bash
-docker compose run inventree-server invoke update --no-frontend
+docker compose run inventree-server invoke update
 ```
 
 This command performs the following steps:
@@ -213,7 +213,7 @@ This ensures that the InvenTree containers will be running the latest version of
 Run the following command to ensure that the InvenTree database is updated:
 
 ```
-docker compose run inventree-server invoke update --no-frontend
+docker compose run inventree-server invoke update
 ```
 
 !!! info "Skip Backup"

--- a/tasks.py
+++ b/tasks.py
@@ -320,11 +320,10 @@ def migrate(c):
     post=[static, clean_settings, translate_stats],
     help={
         'skip_backup': 'Skip database backup step (advanced users)',
-        'no_frontend': 'Skip frontend compilation/download step (is already included with docker image)',
         'frontend': 'Force frontend compilation/download step (ignores INVENTREE_DOCKER)',
     }
 )
-def update(c, skip_backup=False, no_frontend: bool = False, frontend: bool = False):
+def update(c, skip_backup=False, frontend: bool = False):
     """Update InvenTree installation.
 
     This command should be invoked after source code has been updated,
@@ -354,7 +353,8 @@ def update(c, skip_backup=False, no_frontend: bool = False, frontend: bool = Fal
     # If:
     # - INVENTREE_DOCKER is set (by the docker image eg.) and not overridden by `--frontend` flag
     # - `--no-frontend` flag is set
-    if (os.environ.get('INVENTREE_DOCKER', False) and not frontend) or no_frontend:
+    # if (os.environ.get('INVENTREE_DOCKER', False) and not frontend) or no_frontend:
+    if not frontend:
         return
 
     # Decide if we should compile the frontend or try to download it


### PR DESCRIPTION
- Until the new frontend is fully ready to be shipped, adding this option only serves to confuse users (and break the install process potentially)
- Remove this option entirely from the invoke script
- Update documentation accordingly

@matmair we have a lot of changes ready to push for [0.13.0](https://github.com/inventree/InvenTree/milestone/44) but the frontend is still far from ready to ship.

I would like to tweak the current invoke script (and docs) so that the process is unchanged from 0.13.0 (i.e. users do not have to include the "--no-frontend" option).

This will aid us to shipping 0.13.0 asap. The frontend options are still there for anyone who wants to test drive, but won't get in the way of everyone else doing an upgrade.