### PR TITLE
Attachment URL method

### DIFF
--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -576,7 +576,8 @@ class InvenTreeAttachment(models.Model):
             return self.link
 
         if self.attachment:
-            return InvenTree.helpers.getMediaUrl(self.attachment.url)
+            media_url = InvenTree.helpers.getMediaUrl(self.attachment.url)
+            return InvenTree.helpers_model.construct_absolute_url(media_url)
 
         return ''
 

--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -440,7 +440,8 @@ class InvenTreeAttachment(models.Model):
     An attachment can be either an uploaded file, or an external URL
 
     Attributes:
-        attachment: File
+        attachment: Upload file
+        link: External URL
         comment: String descriptor for the attachment
         user: User associated with file upload
         upload_date: Date the file was uploaded
@@ -563,6 +564,21 @@ class InvenTreeAttachment(models.Model):
             self.save()
         except Exception:
             raise ValidationError(_("Error renaming file"))
+
+    def fully_qualified_url(self):
+        """Return a 'fully qualified' URL for this attachment.
+
+        - If the attachment is a link to an external resource, return the link
+        - If the attachment is an uploaded file, return the fully qualified media URL
+        """
+
+        if self.link:
+            return self.link
+
+        if self.attachment:
+            return InvenTree.helpers.getMediaUrl(self.attachment.url)
+
+        return ''
 
 
 class InvenTreeTree(MPTTModel):


### PR DESCRIPTION
Adds a method to the abstract `Attachment` class to provide a fully-qualified URL for the attachment.

- If the attachment is a link to an external resource, simply return that
- If the attachment is an uploaded file, return a fully qualified link to that file