### PR TITLE
Feature/Tree picker

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -7,7 +7,7 @@ INVENTREE_API_VERSION = 136
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
 
-v136 -> 2023-0-23 : https://github.com/inventree/InvenTree/pull/5595
+v136 -> 2023-09-23 : https://github.com/inventree/InvenTree/pull/5595
     - Adds structural to StockLocation and PartCategory tree endpoints
 
 v135 -> 2023-09-19 : https://github.com/inventree/InvenTree/pull/5569

--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 135
+INVENTREE_API_VERSION = 136
 
 """
 Increment this API version number whenever there is a significant change to the API that any clients need to know about
+
+v136 -> 2023-0-23 : https://github.com/inventree/InvenTree/pull/5595
+    - Adds structural to StockLocation and PartCategory tree endpoints
 
 v135 -> 2023-09-19 : https://github.com/inventree/InvenTree/pull/5569
     - Adds location path detail to StockLocation and StockItem API endpoints

--- a/InvenTree/InvenTree/static/css/inventree.css
+++ b/InvenTree/InvenTree/static/css/inventree.css
@@ -1097,3 +1097,7 @@ a {
     align-items: center;
     justify-content: space-between;
 }
+
+.large-treeview-icon {
+    font-size: 1em;
+}

--- a/InvenTree/InvenTree/static/css/inventree.css
+++ b/InvenTree/InvenTree/static/css/inventree.css
@@ -1101,3 +1101,11 @@ a {
 .large-treeview-icon {
     font-size: 1em;
 }
+
+/* 
+ * For the custom disabled treeview, use checked as disabled instead of
+ * disabled, because disabled doesn't allow expansion.
+*/
+.treeview.custom-disabled-treeview .node-checked {
+    color: gray;
+}

--- a/InvenTree/InvenTree/static/css/inventree.css
+++ b/InvenTree/InvenTree/static/css/inventree.css
@@ -1101,11 +1101,3 @@ a {
 .large-treeview-icon {
     font-size: 1em;
 }
-
-/* 
- * For the custom disabled treeview, use checked as disabled instead of
- * disabled, because disabled doesn't allow expansion.
-*/
-.treeview.custom-disabled-treeview .node-checked {
-    color: gray;
-}

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -113,6 +113,7 @@ class CategoryTree(InvenTree.serializers.InvenTreeModelSerializer):
             'name',
             'parent',
             'icon',
+            'structural',
         ]
 
 

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -239,6 +239,10 @@
         generateStocktakeReport({
             category: {
                 {% if category %}value: {{ category.pk }},{% endif %}
+                tree_picker: {
+                    url: '{% url "api-part-category-tree" %}',
+                    default_icon: global_settings.PART_CATEGORY_DEFAULT_ICON,
+                },
             },
             location: {
                 tree_picker: {

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -240,7 +240,12 @@
             category: {
                 {% if category %}value: {{ category.pk }},{% endif %}
             },
-            location: {},
+            location: {
+                tree_picker: {
+                    url: '{% url "api-location-tree" %}',
+                    default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                },
+            },
             generate_report: {},
             update_parts: {},
         });

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -436,7 +436,12 @@
                 part: {
                     value: {{ part.pk }}
                 },
-                location: {},
+                location: {
+                    tree_picker: {
+                        url: '{% url "api-location-tree" %}',
+                        default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                    },
+                },
                 generate_report: {
                     value: false,
                 },

--- a/InvenTree/stock/serializers.py
+++ b/InvenTree/stock/serializers.py
@@ -775,6 +775,7 @@ class LocationTreeSerializer(InvenTree.serializers.InvenTreeModelSerializer):
             'name',
             'parent',
             'icon',
+            'structural',
         ]
 
 

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -650,6 +650,10 @@ $("#stock-return-from-customer").click(function() {
                 {% if item.part.default_location %}
                 value: {{ item.part.default_location.pk }},
                 {% endif %}
+                tree_picker: {
+                    url: '{% url "api-location-tree" %}',
+                    default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                },
             },
             notes: {
                 icon: 'fa-sticky-note',

--- a/InvenTree/stock/templates/stock/location.html
+++ b/InvenTree/stock/templates/stock/location.html
@@ -238,7 +238,12 @@
     {% if stocktake_enable and roles.stocktake.add %}
     $('#location-stocktake').click(function() {
         generateStocktakeReport({
-            category: {},
+            category: {
+                tree_picker: {
+                    url: '{% url "api-part-category-tree" %}',
+                    default_icon: global_settings.PART_CATEGORY_DEFAULT_ICON,
+                },
+            },
             location: {
                 {% if location %}value: {{ location.pk }},{% endif %}
                 tree_picker: {

--- a/InvenTree/stock/templates/stock/location.html
+++ b/InvenTree/stock/templates/stock/location.html
@@ -241,6 +241,10 @@
             category: {},
             location: {
                 {% if location %}value: {{ location.pk }},{% endif %}
+                tree_picker: {
+                    url: '{% url "api-location-tree" %}',
+                    default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                },
             },
             generate_report: {},
             update_parts: {},

--- a/InvenTree/templates/InvenTree/settings/settings_staff_js.html
+++ b/InvenTree/templates/InvenTree/settings/settings_staff_js.html
@@ -454,7 +454,12 @@ onPanelLoad('stocktake', function() {
         generateStocktakeReport({
             part: {},
             category: {},
-            location: {},
+            location: {
+                tree_picker: {
+                    url: '{% url "api-location-tree" %}',
+                    default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                },
+            },
             generate_report: {},
             update_parts: {},
         });

--- a/InvenTree/templates/InvenTree/settings/settings_staff_js.html
+++ b/InvenTree/templates/InvenTree/settings/settings_staff_js.html
@@ -308,6 +308,10 @@ onPanelLoad('category', function() {
                 parameter_template: {},
                 category: {
                     icon: 'fa-sitemap',
+                    tree_picker: {
+                        url: '{% url "api-part-category-tree" %}',
+                        default_icon: global_settings.PART_CATEGORY_DEFAULT_ICON,
+                    },
                 },
                 default_value: {},
             },
@@ -368,6 +372,10 @@ onPanelLoad('category', function() {
                 category: {
                     icon: 'fa-sitemap',
                     value: pk,
+                    tree_picker: {
+                        url: '{% url "api-part-category-tree" %}',
+                        default_icon: global_settings.PART_CATEGORY_DEFAULT_ICON,
+                    },
                 },
                 default_value: {},
             },
@@ -453,7 +461,12 @@ onPanelLoad('stocktake', function() {
     $('#btn-generate-stocktake').click(function() {
         generateStocktakeReport({
             part: {},
-            category: {},
+            category: {
+                tree_picker: {
+                    url: '{% url "api-part-category-tree" %}',
+                    default_icon: global_settings.PART_CATEGORY_DEFAULT_ICON,
+                },
+            },
             location: {
                 tree_picker: {
                     url: '{% url "api-location-tree" %}',

--- a/InvenTree/templates/js/dynamic/nav.js
+++ b/InvenTree/templates/js/dynamic/nav.js
@@ -165,14 +165,14 @@ function generateTreeStructure(data, options) {
         nodes[node.pk] = node;
         node.selectable = false;
 
-        if (options.processNode) {
-            node = options.processNode(node);
-        }
-
         node.state = {
             expanded: node.pk == options.selected,
             selected: node.pk == options.selected,
         };
+
+        if (options.processNode) {
+            node = options.processNode(node);
+        }
     }
 
     for (var i = 0; i < data.length; i++) {

--- a/InvenTree/templates/js/dynamic/nav.js
+++ b/InvenTree/templates/js/dynamic/nav.js
@@ -6,6 +6,7 @@
     addSidebarHeader,
     addSidebarItem,
     addSidebarLink,
+    generateTreeStructure,
     enableBreadcrumbTree,
     enableSidebar,
     onPanelLoad,
@@ -147,6 +148,59 @@ function enableSidebar(label, options={}) {
 }
 
 /**
+ * Generate nested tree structure for jquery treeview from flattened list of
+ * tree nodes with refs to their parents
+ * @param {Array} data flat tree data as list of objects
+ * @param {Object} options custom options
+ * @param {Function} options.processNode Function that can change the treeview node obj
+ * @param {Number} options.selected pk of the node that should be preselected
+ */
+function generateTreeStructure(data, options) {
+    const nodes = {};
+    const roots = [];
+    let node = null;
+
+    for (var i = 0; i < data.length; i++) {
+        node = data[i];
+        nodes[node.pk] = node;
+        node.selectable = false;
+
+        if (options.processNode) {
+            node = options.processNode(node);
+        }
+
+        node.state = {
+            expanded: node.pk == options.selected,
+            selected: node.pk == options.selected,
+        };
+    }
+
+    for (var i = 0; i < data.length; i++) {
+        node = data[i];
+
+        if (node.parent != null) {
+            if (nodes[node.parent].nodes) {
+                nodes[node.parent].nodes.push(node);
+            } else {
+                nodes[node.parent].nodes = [node];
+            }
+
+            if (node.state.expanded) {
+                while (node.parent != null) {
+                    nodes[node.parent].state.expanded = true;
+                    node = nodes[node.parent];
+                }
+            }
+
+        } else {
+            roots.push(node);
+        }
+    }
+
+    return roots;
+}
+
+/**
  * Enable support for breadcrumb tree navigation on this page
  */
 function enableBreadcrumbTree(options) {
@@ -168,47 +222,7 @@ function enableBreadcrumbTree(options) {
 
                 // Data are returned from the InvenTree server as a flattened list;
                 // We need to convert this into a tree structure
-
-                var nodes = {};
-                var roots = [];
-                var node = null;
-
-                for (var i = 0; i < data.length; i++) {
-                    node = data[i];
-                    nodes[node.pk] = node;
-                    node.selectable = false;
-
-                    if (options.processNode) {
-                        node = options.processNode(node);
-                    }
-
-                    node.state = {
-                        expanded: node.pk == options.selected,
-                        selected: node.pk == options.selected,
-                    };
-                }
-
-                for (var i = 0; i < data.length; i++) {
-                    node = data[i];
-
-                    if (node.parent != null) {
-                        if (nodes[node.parent].nodes) {
-                            nodes[node.parent].nodes.push(node);
-                        } else {
-                            nodes[node.parent].nodes = [node];
-                        }
-
-                        if (node.state.expanded) {
-                            while (node.parent != null) {
-                                nodes[node.parent].state.expanded = true;
-                                node = nodes[node.parent];
-                            }
-                        }
-
-                    } else {
-                        roots.push(node);
-                    }
-                }
+                const roots = generateTreeStructure(data, options);
 
                 $('#breadcrumb-tree').treeview({
                     data: roots,

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -605,6 +605,10 @@ function completeBuildOutputs(build_id, outputs, options={}) {
                 filters: {
                     structural: false,
                 },
+                tree_picker: {
+                    url: '{% url "api-location-tree" %}',
+                    default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                },
             },
             notes: {
                 icon: 'fa-sticky-note',
@@ -734,7 +738,11 @@ function scrapBuildOutputs(build_id, outputs, options={}) {
             location: {
                 filters: {
                     structural: false,
-                }
+                },
+                tree_picker: {
+                    url: '{% url "api-location-tree" %}',
+                    default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                },
             },
             notes: {},
             discard_allocations: {},
@@ -1926,7 +1934,11 @@ function autoAllocateStockToBuild(build_id, bom_items=[], options={}) {
             value: options.location,
             filters: {
                 structural: false,
-            }
+            },
+            tree_picker: {
+                url: '{% url "api-location-tree" %}',
+                default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+            },
         },
         exclude_location: {},
         interchangeable: {

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -2041,7 +2041,7 @@ function initializeRelatedField(field, fields, options={}) {
                         <button class="input-group-text" id="${name}_tree_search_btn"><i class="fas fa-search"></i></button>
                     </div>
 
-                    <div id="${tree_id}" style="height: 65vh; overflow-y: scroll;">
+                    <div id="${tree_id}" class="custom-disabled-treeview" style="height: 65vh; overflow-y: auto;">
                         <div class="d-flex justify-content-center">
                             <div class="spinner-border" role="status"></div>
                         </div>
@@ -2073,6 +2073,20 @@ function initializeRelatedField(field, fields, options={}) {
                         processNode: (node) => {
                             node.selectable = true;
                             node.text = node.name;
+
+                            // disable this node, if it doesn't match the filter criteria
+                            if (field.filters) {
+                                for (const [k, v] of Object.entries(field.filters)) {
+                                    if (node[k] !== v) {
+                                        node.selectable = false;
+                                        // we use checked with custom classes to make this row grayed out, because
+                                        // the disabled state wouldn't allow expansion
+                                        node.state.checked = true;
+                                        break;
+                                    }
+                                }
+                            }
+
                             return node;
                         }
                     });

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -2022,6 +2022,80 @@ function initializeRelatedField(field, fields, options={}) {
             }
         });
     }
+
+    if(field.tree_picker) {
+        // construct button
+        const button = $(`<button class="input-group-text px-2"><i class="fas fa-external-link-alt"></i></button>`);
+
+        // insert open tree picker button after select
+        select.parent().find(".select2").after(button);
+
+        button.on("click", () => {
+            const tree_id = `${name}_tree`;
+
+            const title = '{% trans "Select" %}' + " " + options.actions[name].label;
+            const content = `
+                <div class="mb-1">
+                    <div class="input-group mb-2">
+                        <input class="form-control" type="text" id="${name}_tree_search" placeholder="{% trans "Search" %} ${options.actions[name].label}..." />
+                        <button class="input-group-text" id="${name}_tree_search_btn"><i class="fas fa-search"></i></button>
+                    </div>
+
+                    <div id="${tree_id}" style="height: 65vh; overflow-y: scroll;">
+                        <div class="d-flex justify-content-center">
+                            <div class="spinner-border" role="status"></div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            showQuestionDialog(title, content, {
+                accept_text: '{% trans "Select" %}',
+                accept: () => {
+                    const selectedNode = $(`#${tree_id}`).treeview('getSelected');
+                    if(selectedNode.length > 0) {
+                        const url = `${field.api_url}/${selectedNode[0].pk}/`.replace('//', '/');
+
+                        inventreeGet(url, field.filters || {}, {
+                            success: function(data) {
+                                setRelatedFieldData(name, data, options);
+                            }
+                        });
+                    }
+                }
+            });
+
+            inventreeGet(field.tree_picker.url, {}, {
+                success: (data) => {
+                    const current_value = getFormFieldValue(name, field, options);
+
+                    const rootNodes = generateTreeStructure(data, {
+                        selected: current_value,
+                        processNode: (node) => {
+                            node.selectable = true;
+                            node.text = node.name;
+                            return node;
+                        }
+                    });
+
+                    $(`#${tree_id}`).treeview({
+                        data: rootNodes,
+                        expandIcon: 'fas fa-plus-square large-treeview-icon',
+                        collapseIcon: 'fa fa-minus-square large-treeview-icon',
+                        nodeIcon: field.tree_picker.defaultIcon,
+                    });
+                }
+            });
+
+            $(`#${name}_tree_search_btn`).on("click", () => {
+                const searchValue = $(`#${name}_tree_search`).val();
+                $(`#${tree_id}`).treeview("search", [searchValue, {
+                    ignoreCase: true,
+                    exactMatch: false,
+                    revealResults: true,
+                }]);
+            });
+        });
+    }
 }
 
 
@@ -2282,9 +2356,9 @@ function constructField(name, parameters, options={}) {
 
         if (!parameters.required && !options.hideClearButton) {
             html += `
-            <span class='input-group-text form-clear' id='clear_${field_name}' title='{% trans "Clear input" %}'>
+            <button class='input-group-text form-clear' id='clear_${field_name}' title='{% trans "Clear input" %}'>
                 <span class='icon-red fas fa-backspace'></span>
-            </span>`;
+            </button>`;
         }
 
         html += `</div>`; // input-group

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -2030,6 +2030,9 @@ function initializeRelatedField(field, fields, options={}) {
         // insert open tree picker button after select
         select.parent().find(".select2").after(button);
 
+        // save copy of filters, because of possible side effects
+        const filters = field.filters ? { ...field.filters } : {};
+
         button.on("click", () => {
             const tree_id = `${name}_tree`;
 
@@ -2075,15 +2078,13 @@ function initializeRelatedField(field, fields, options={}) {
                             node.text = node.name;
 
                             // disable this node, if it doesn't match the filter criteria
-                            if (field.filters) {
-                                for (const [k, v] of Object.entries(field.filters)) {
-                                    if (node[k] !== v) {
-                                        node.selectable = false;
-                                        // we use checked with custom classes to make this row grayed out, because
-                                        // the disabled state wouldn't allow expansion
-                                        node.state.checked = true;
-                                        break;
-                                    }
+                            for (const [k, v] of Object.entries(filters)) {
+                                if (k in node && node[k] !== v) {
+                                    node.selectable = false;
+                                    // we use checked with custom classes to make this row grayed out, because
+                                    // the disabled state wouldn't allow expansion
+                                    node.state.checked = true;
+                                    break;
                                 }
                             }
 
@@ -2332,7 +2333,7 @@ function constructField(name, parameters, options={}) {
     html += `<div class='controls'>`;
 
     // Does this input deserve "extra" decorators?
-    var extra = (parameters.icon != null) || (parameters.prefix != null) || (parameters.prefixRaw != null);
+    var extra = (parameters.icon != null) || (parameters.prefix != null) || (parameters.prefixRaw != null) || (parameters.tree_picker != null);
 
     // Some fields can have 'clear' inputs associated with them
     if (!parameters.required && !parameters.read_only) {
@@ -2353,7 +2354,7 @@ function constructField(name, parameters, options={}) {
     }
 
     if (extra) {
-        html += `<div class='input-group'>`;
+        html += `<div class='input-group flex-nowrap'>`;
 
         if (parameters.prefix) {
             html += `<span class='input-group-text'>${parameters.prefix}</span>`;

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -2044,7 +2044,7 @@ function initializeRelatedField(field, fields, options={}) {
                         <button class="input-group-text" id="${name}_tree_search_btn"><i class="fas fa-search"></i></button>
                     </div>
 
-                    <div id="${tree_id}" class="custom-disabled-treeview" style="height: 65vh; overflow-y: auto;">
+                    <div id="${tree_id}" style="height: 65vh; overflow-y: auto;">
                         <div class="d-flex justify-content-center">
                             <div class="spinner-border" role="status"></div>
                         </div>
@@ -2081,9 +2081,7 @@ function initializeRelatedField(field, fields, options={}) {
                             for (const [k, v] of Object.entries(filters)) {
                                 if (k in node && node[k] !== v) {
                                     node.selectable = false;
-                                    // we use checked with custom classes to make this row grayed out, because
-                                    // the disabled state wouldn't allow expansion
-                                    node.state.checked = true;
+                                    node.color = "grey";
                                     break;
                                 }
                             }
@@ -2097,6 +2095,7 @@ function initializeRelatedField(field, fields, options={}) {
                         expandIcon: 'fas fa-plus-square large-treeview-icon',
                         collapseIcon: 'fa fa-minus-square large-treeview-icon',
                         nodeIcon: field.tree_picker.defaultIcon,
+                        color: "black",
                     });
                 }
             });

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -19,6 +19,8 @@
     showMessage,
     showModalSpinner,
     toBool,
+    showQuestionDialog,
+    generateTreeStructure,
 */
 
 /* exported

--- a/InvenTree/templates/js/translated/modals.js
+++ b/InvenTree/templates/js/translated/modals.js
@@ -44,6 +44,9 @@ function createNewModal(options={}) {
         if (modal_id >= id) {
             id = modal_id + 1;
         }
+
+        // move all other modals behind the backdrops
+        $(this).css('z-index', 1000);
     });
 
     var submitClass = options.submitClass || 'primary';
@@ -125,6 +128,9 @@ function createNewModal(options={}) {
     // Automatically remove the modal when it is deleted!
     $(modal_name).on('hidden.bs.modal', function() {
         $(modal_name).remove();
+
+        // restore all modals before backdrop
+        $('.inventree-modal').last().css("z-index", 10000);
     });
 
     // Capture "enter" key input

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -128,6 +128,10 @@ function partFields(options={}) {
             filters: {
                 structural: false,
             },
+            tree_picker: {
+                url: '{% url "api-part-category-tree" %}',
+                default_icon: global_settings.PART_CATEGORY_DEFAULT_ICON,
+            },
         },
         name: {},
         IPN: {},
@@ -2193,7 +2197,12 @@ function setPartCategory(data, options={}) {
         method: 'POST',
         preFormContent: html,
         fields: {
-            category: {},
+            category: {
+                tree_picker: {
+                    url: '{% url "api-part-category-tree" %}',
+                    default_icon: global_settings.PART_CATEGORY_DEFAULT_ICON,
+                },
+            },
         },
         processBeforeUpload: function(data) {
             data.parts = parts;

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -147,7 +147,11 @@ function partFields(options={}) {
             icon: 'fa-sitemap',
             filters: {
                 structural: false,
-            }
+            },
+            tree_picker: {
+                url: '{% url "api-location-tree" %}',
+                default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+            },
         },
         default_supplier: {
             icon: 'fa-building',
@@ -303,7 +307,11 @@ function categoryFields(options={}) {
             icon: 'fa-sitemap',
             filters: {
                 structural: false,
-            }
+            },
+            tree_picker: {
+                url: '{% url "api-location-tree" %}',
+                default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+            },
         },
         default_keywords: {
             icon: 'fa-key',

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -304,6 +304,10 @@ function categoryFields(options={}) {
         parent: {
             help_text: '{% trans "Parent part category" %}',
             required: false,
+            tree_picker: {
+                url: '{% url "api-part-category-tree" %}',
+                default_icon: global_settings.PART_CATEGORY_DEFAULT_ICON,
+            },
         },
         name: {},
         description: {},

--- a/InvenTree/templates/js/translated/purchase_order.js
+++ b/InvenTree/templates/js/translated/purchase_order.js
@@ -1306,7 +1306,11 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
             location: {
                 filters: {
                     structural: false,
-                }
+                },
+                tree_picker: {
+                    url: '{% url "api-location-tree" %}',
+                    default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                },
             },
         },
         preFormContent: html,

--- a/InvenTree/templates/js/translated/return_order.js
+++ b/InvenTree/templates/js/translated/return_order.js
@@ -547,7 +547,11 @@ function receiveReturnOrderItems(order_id, line_items, options={}) {
             location: {
                 filters: {
                     strucutral: false,
-                }
+                },
+                tree_picker: {
+                    url: '{% url "api-location-tree" %}',
+                    default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                },
             }
         },
         confirm: true,

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -327,6 +327,10 @@ function stockItemFields(options={}) {
             filters: {
                 structural: false,
             },
+            tree_picker: {
+                url: '{% url "api-location-tree" %}',
+                default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+            },
         },
         quantity: {
             help_text: '{% trans "Enter initial quantity for this stock item" %}',
@@ -882,7 +886,11 @@ function mergeStockItems(items, options={}) {
                 icon: 'fa-sitemap',
                 filters: {
                     structural: false,
-                }
+                },
+                tree_picker: {
+                    url: '{% url "api-location-tree" %}',
+                    default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                },
             },
             notes: {
                 icon: 'fa-sticky-note',
@@ -3099,7 +3107,11 @@ function uninstallStockItem(installed_item_id, options={}) {
                     icon: 'fa-sitemap',
                     filters: {
                         structural: false,
-                    }
+                    },
+                    tree_picker: {
+                        url: '{% url "api-location-tree" %}',
+                        default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+                    },
                 },
                 note: {
                     icon: 'fa-sticky-note',

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -136,6 +136,10 @@ function stockLocationFields(options={}) {
         parent: {
             help_text: '{% trans "Parent stock location" %}',
             required: false,
+            tree_picker: {
+                url: '{% url "api-location-tree" %}',
+                default_icon: global_settings.STOCK_LOCATION_DEFAULT_ICON,
+            },
         },
         name: {},
         description: {},


### PR DESCRIPTION
This bothered me since a long time. It is very hard if one has locations with the same repeating name to search for them by a tree path. To improve the experience I added a tree picker to the forms which shows the tree in a new modal to select the correct path. Additionally, this improves the backdrop for secondary, ... modals, so that only the top modal is infront of the backdrop.

https://github.com/inventree/InvenTree/assets/76838159/e89aea4e-3ba7-4a96-848b-ffc1313fc08e

This could have some performance issues like the top navigation has them too, but this is related to the jQuery tree view library. I hope we can implement something like this in PUI sometime too. But for now this PR is ready to review.
