### PR TITLE
Fix controlling log level in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -68,7 +68,7 @@
   "remoteEnv": {
     // InvenTree config
     "INVENTREE_DEBUG": "True",
-    "INVENTREE_DEBUG_LEVEL": "INFO",
+    "INVENTREE_LOG_LEVEL": "INFO",
     "INVENTREE_DB_ENGINE": "sqlite3",
     "INVENTREE_DB_NAME": "${containerWorkspaceFolder}/dev/database.sqlite3",
     "INVENTREE_MEDIA_ROOT": "${containerWorkspaceFolder}/dev/media",


### PR DESCRIPTION
I followed https://docs.inventree.org/en/latest/develop/devcontainer/ (which is very nice by the way) to have a proper dev setup on my mac.

I was wondering why I do not see info logs, as I do on my production setup. Found this small thing, hope it helps.