### PR TITLE
Stop cascade update_pricing if prices didn't change

### DIFF
--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -2350,6 +2350,8 @@ class PartPricing(common.models.MetaMixin):
     - Detailed pricing information is very context specific in any case
     """
 
+    price_modified = False
+
     @property
     def is_valid(self):
         """Return True if the cached pricing is valid"""
@@ -2476,7 +2478,7 @@ class PartPricing(common.models.MetaMixin):
             pass
 
         # Update parent assemblies and templates
-        if cascade:
+        if cascade and self.price_modified:
             self.update_assemblies(counter)
             self.update_templates(counter)
 
@@ -2576,6 +2578,9 @@ class PartPricing(common.models.MetaMixin):
 
                 any_max_elements = True
 
+        old_bom_cost_min = self.bom_cost_min
+        old_bom_cost_max = self.bom_cost_max
+
         if any_min_elements:
             self.bom_cost_min = cumulative_min
         else:
@@ -2585,6 +2590,9 @@ class PartPricing(common.models.MetaMixin):
             self.bom_cost_max = cumulative_max
         else:
             self.bom_cost_max = None
+
+        if old_bom_cost_min != self.bom_cost_min or old_bom_cost_max != self.bom_cost_max:
+            self.price_modified = True
 
         if save:
             self.save()
@@ -2650,6 +2658,9 @@ class PartPricing(common.models.MetaMixin):
                 if purchase_max is None or cost > purchase_max:
                     purchase_max = cost
 
+        if self.purchase_cost_min != purchase_min or self.purchase_cost_max != purchase_max:
+            self.price_modified = True
+
         self.purchase_cost_min = purchase_min
         self.purchase_cost_max = purchase_max
 
@@ -2676,6 +2687,9 @@ class PartPricing(common.models.MetaMixin):
 
                 if max_int_cost is None or cost > max_int_cost:
                     max_int_cost = cost
+
+        if self.internal_cost_min != min_int_cost or self.internal_cost_max != max_int_cost:
+            self.price_modified = True
 
         self.internal_cost_min = min_int_cost
         self.internal_cost_max = max_int_cost
@@ -2716,6 +2730,9 @@ class PartPricing(common.models.MetaMixin):
                     if max_sup_cost is None or cost > max_sup_cost:
                         max_sup_cost = cost
 
+        if self.supplier_price_min != min_sup_cost or self.supplier_price_max != max_sup_cost:
+            self.price_modified = True
+
         self.supplier_price_min = min_sup_cost
         self.supplier_price_max = max_sup_cost
 
@@ -2752,6 +2769,9 @@ class PartPricing(common.models.MetaMixin):
                 if v_max is not None:
                     if variant_max is None or v_max > variant_max:
                         variant_max = v_max
+
+        if self.variant_cost_min != variant_min or self.variant_cost_max != variant_max:
+            self.price_modified = True
 
         self.variant_cost_min = variant_min
         self.variant_cost_max = variant_max
@@ -2876,6 +2896,9 @@ class PartPricing(common.models.MetaMixin):
 
             if max_sell_history is None or cost > max_sell_history:
                 max_sell_history = cost
+
+        if self.sale_history_min != min_sell_history or self.sale_history_max != max_sell_history:
+            self.price_modified = True
 
         self.sale_history_min = min_sell_history
         self.sale_history_max = max_sell_history


### PR DESCRIPTION
I analysed #5594 further and came across a thought which I think is worth sharing: Why cascade price changes if nothing changed? So I implemented a POC and improved number of events significantly (counter 25 down to 2).

# Steps to reproduce

1. Create P1 as variant
2. Create P2 as component with P1 in BOM
3. Wait for workers to finisih
4. In P2 BOM change quantity of P1 needed for Build
5. Debug (or review logs) how often `update_pricing` is executed

# Idea this change

If `update_pricing` whould cascade, but prices haven't changed, what's the matter? So the idea is to even if `cascade` is wanted, don't do it if no prices changed.

# POC implementation

I don't fully like the code change tbh. It looks a little heavy to maintain. But I have no idea what other implementation is better, maybe some more skilled dev can help me out? I'm open for feedback.