### PR TITLE
Let plugins decide if events should be processed or not

### DIFF
--- a/InvenTree/plugin/base/event/events.py
+++ b/InvenTree/plugin/base/event/events.py
@@ -68,13 +68,13 @@ def register_event(event, *args, **kwargs):
                 if not plugin.mixin_enabled('events'):
                     continue
 
+                # Only allow event registering for 'active' plugins
                 if not plugin.is_active():
                     continue
 
+                # Let the plugin decide if it wants to process this event
                 if not plugin.wants_process_event(event):
                     continue
-
-                # Only allow event registering for 'active' plugins
 
                 logger.debug("Registering callback for plugin '%s'", slug)
 

--- a/InvenTree/plugin/base/event/events.py
+++ b/InvenTree/plugin/base/event/events.py
@@ -65,27 +65,32 @@ def register_event(event, *args, **kwargs):
         with transaction.atomic():
 
             for slug, plugin in registry.plugins.items():
+                if not plugin.mixin_enabled('events'):
+                    continue
 
-                if plugin.mixin_enabled('events'):
+                if not plugin.is_active():
+                    continue
 
-                    if plugin.is_active():
-                        # Only allow event registering for 'active' plugins
+                if not plugin.wants_process_event(event):
+                    continue
 
-                        logger.debug(f"Registering callback for plugin '{slug}'")
+                # Only allow event registering for 'active' plugins
 
-                        # This task *must* be processed by the background worker,
-                        # unless we are running CI tests
-                        if 'force_async' not in kwargs and not settings.PLUGIN_TESTING_EVENTS:
-                            kwargs['force_async'] = True
+                logger.debug(f"Registering callback for plugin '{slug}'")
 
-                        # Offload a separate task for each plugin
-                        offload_task(
-                            process_event,
-                            slug,
-                            event,
-                            *args,
-                            **kwargs
-                        )
+                # This task *must* be processed by the background worker,
+                # unless we are running CI tests
+                if 'force_async' not in kwargs and not settings.PLUGIN_TESTING_EVENTS:
+                    kwargs['force_async'] = True
+
+                # Offload a separate task for each plugin
+                offload_task(
+                    process_event,
+                    slug,
+                    event,
+                    *args,
+                    **kwargs
+                )
 
 
 def process_event(plugin_slug, event, *args, **kwargs):

--- a/InvenTree/plugin/base/event/mixins.py
+++ b/InvenTree/plugin/base/event/mixins.py
@@ -9,6 +9,15 @@ class EventMixin:
     Implementing classes must provide a "process_event" function:
     """
 
+    def wants_process_event(self, event):
+        """Function to subscribe to events.
+
+        Return true if you're interested in the given event, false if not.
+        """
+
+        # Default implementation always returns true (backwards compatibility)
+        return True
+
     def process_event(self, event, *args, **kwargs):
         """Function to handle events.
 

--- a/InvenTree/plugin/samples/event/filtered_event_sample.py
+++ b/InvenTree/plugin/samples/event/filtered_event_sample.py
@@ -29,4 +29,4 @@ class FilteredEventPluginSample(EventMixin, InvenTreePlugin):
 
         # Issue warning that we can test for
         if settings.PLUGIN_TESTING:
-            logger.debug(f'Event `{event}` triggered in sample plugin')
+            logger.debug('Event `%s` triggered in sample plugin', event)

--- a/InvenTree/plugin/samples/event/filtered_event_sample.py
+++ b/InvenTree/plugin/samples/event/filtered_event_sample.py
@@ -1,0 +1,32 @@
+"""Sample plugin which responds to events."""
+
+import logging
+
+from django.conf import settings
+
+from plugin import InvenTreePlugin
+from plugin.mixins import EventMixin
+
+logger = logging.getLogger('inventree')
+
+
+class FilteredEventPluginSample(EventMixin, InvenTreePlugin):
+    """A sample plugin which provides supports for triggered events."""
+
+    NAME = "FilteredEventPlugin"
+    SLUG = "filteredsampleevent"
+    TITLE = "Triggered by test.event only"
+
+    def wants_process_event(self, event):
+        """Return whether given event should be processed or not."""
+        return event == "test.event"
+
+    def process_event(self, event, *args, **kwargs):
+        """Custom event processing."""
+        print(f"Processing triggered event: '{event}'")
+        print("args:", str(args))
+        print("kwargs:", str(kwargs))
+
+        # Issue warning that we can test for
+        if settings.PLUGIN_TESTING:
+            logger.debug(f'Event `{event}` triggered in sample plugin')

--- a/InvenTree/plugin/samples/event/test_filtered_event_sample.py
+++ b/InvenTree/plugin/samples/event/test_filtered_event_sample.py
@@ -1,0 +1,52 @@
+"""Unit tests for event_sample sample plugins."""
+
+from django.conf import settings
+from django.test import TestCase
+
+from common.models import InvenTreeSetting
+from plugin import registry
+from plugin.base.event.events import trigger_event
+
+from .filtered_event_sample import logger
+
+
+class FilteredEventPluginSampleTests(TestCase):
+    """Tests for EventPluginSample."""
+
+    def test_run_event(self):
+        """Check if the event is issued."""
+        # Activate plugin
+        config = registry.get_plugin('filteredsampleevent').plugin_config()
+        config.active = True
+        config.save()
+
+        InvenTreeSetting.set_setting('ENABLE_PLUGINS_EVENTS', True, change_user=None)
+
+        # Enable event testing
+        settings.PLUGIN_TESTING_EVENTS = True
+        # Check that an event is issued
+        with self.assertLogs(logger=logger, level="DEBUG") as cm:
+            trigger_event('test.event')
+        self.assertIn('DEBUG:inventree:Event `test.event` triggered in sample plugin', cm[1])
+
+        # Disable again
+        settings.PLUGIN_TESTING_EVENTS = False
+
+    def test_ignore_event(self):
+        """Check if the event is issued."""
+        # Activate plugin
+        config = registry.get_plugin('filteredsampleevent').plugin_config()
+        config.active = True
+        config.save()
+
+        InvenTreeSetting.set_setting('ENABLE_PLUGINS_EVENTS', True, change_user=None)
+
+        # Enable event testing
+        settings.PLUGIN_TESTING_EVENTS = True
+        # Check that an event is issued
+        with self.assertLogs(logger=logger, level="DEBUG") as cm:
+            trigger_event('test.some.other.event')
+        self.assertNotIn('DEBUG:inventree:Event `test.some.other.event` triggered in sample plugin', cm[1])
+
+        # Disable again
+        settings.PLUGIN_TESTING_EVENTS = False

--- a/docs/docs/extend/plugins/event.md
+++ b/docs/docs/extend/plugins/event.md
@@ -15,9 +15,9 @@ When a certain (server-side) event occurs, the background worker passes the even
 {% include 'img.html' %}
 {% endwith %}
 
-### Example
+### Example (all events)
 
-Implementing classes must provide a `process_event` function:
+Implementing classes must at least provide a `process_event` function:
 
 ```python
 class EventPlugin(EventMixin, InvenTreePlugin):
@@ -34,6 +34,34 @@ class EventPlugin(EventMixin, InvenTreePlugin):
 
     def process_event(self, event, *args, **kwargs):
         print(f"Processing triggered event: '{event}'")
+```
+
+### Example (specific events)
+
+If you want to process just some specific events, you can also implement the `wants_process_event` function to decide if you want to process this event or not. This function will be executed synchronously, so be aware that it should contain simple logic.
+
+Overall this function can reduce the workload on the background workers significantly since less events are queued to be processed.
+
+```python
+class EventPlugin(EventMixin, InvenTreePlugin):
+    """
+    A simple example plugin which responds to 'salesordershipment.completed' event on the InvenTree server.
+
+    This example simply prints out the event information.
+    A more complex plugin can run enhanced logic on this event.
+    """
+
+    NAME = "EventPlugin"
+    SLUG = "event"
+    TITLE = "Triggered Events"
+
+    def wants_process_event(self, event):
+        """Here you can decide if this event should be send to `process_event` or not."""
+        return event == "salesordershipment.completed"
+
+    def process_event(self, event, *args, **kwargs):
+        """Here you can run you'r specific logic."""
+        print(f"Sales order was completely shipped: '{args}' '{kwargs}'")
 ```
 
 ### Events


### PR DESCRIPTION
#5606 improved amount of events already, but did not finally fix #5594. @SchrodingersGat came up with the point, that all events are processed by all listening plugins. I have two of those, and even if their `process_event` is guarded

```python
    def process_event(self, event, *args, **kwargs):
        if event != "salesordershipment.completed":
            return
```

the background worker will roughly spend 1 second per event per plugin. Stock movements are "event-heavy" and most of the events at least my plugins are not interested in, so here we loose a lot of time, probably.

# Idea of this change
Introduce `EventMixin.wants_process_event`, a simple function that returns `True` or `False`. `register_event` will call that function before `offload_task` and just continue if the plugin returns `True`.

The default implementation of `EventMixin.wants_process_event` will always return true to guarantee backwards compatiblity.

I also implemented tests, but I'm not sure if I read the output correctly on my machine. The code change is not big, so I hope my brain processed it correctly :)

# Side changes
I reduced cognitive complexity in `register_event` a little, by inverting to `if`s and call `continue` to guard the following code, instead of increase nesting.

# Backporting
I would love to see this being backported to 0.12.x