### PR TITLE
Prevent plugin URL routing if ENABLE_PLUGINS_URL setting is disabled

### DIFF
--- a/InvenTree/plugin/samples/integration/test_sample.py
+++ b/InvenTree/plugin/samples/integration/test_sample.py
@@ -11,8 +11,24 @@ class SampleIntegrationPluginTests(InvenTreeTestCase):
 
     def test_view(self):
         """Check the function of the custom  sample plugin."""
-        response = self.client.get('/plugin/sample/ho/he/')
+
+        from common.models import InvenTreeSetting
+
+        # First, check with custom URLs disabled
+        InvenTreeSetting.set_setting('ENABLE_PLUGINS_URL', False, None)
+
+        url = '/plugin/sample/ho/he/'
+
+        # URL should redirect to index page
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+        # Now, check with custom URLs enabled
+        InvenTreeSetting.set_setting('ENABLE_PLUGINS_URL', True, None)
+
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
         self.assertEqual(response.content, b'Hi there testuser this works')
 
     def test_settings(self):

--- a/InvenTree/plugin/samples/integration/test_sample.py
+++ b/InvenTree/plugin/samples/integration/test_sample.py
@@ -14,10 +14,13 @@ class SampleIntegrationPluginTests(InvenTreeTestCase):
 
         from common.models import InvenTreeSetting
 
+        url = '/plugin/sample/ho/he/'
+
         # First, check with custom URLs disabled
         InvenTreeSetting.set_setting('ENABLE_PLUGINS_URL', False, None)
 
-        url = '/plugin/sample/ho/he/'
+        # Requires a full reload of the registry
+        registry.reload_plugins()
 
         # URL should redirect to index page
         response = self.client.get(url)
@@ -25,6 +28,12 @@ class SampleIntegrationPluginTests(InvenTreeTestCase):
 
         # Now, check with custom URLs enabled
         InvenTreeSetting.set_setting('ENABLE_PLUGINS_URL', True, None)
+
+        # Requires a full reload of the registry
+        registry.reload_plugins()
+
+        # And ensure that the plugin is enabled
+        registry.set_plugin_state('sample', True)
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/InvenTree/plugin/urls.py
+++ b/InvenTree/plugin/urls.py
@@ -7,12 +7,15 @@ PLUGIN_BASE = 'plugin'  # Constant for links
 
 def get_plugin_urls():
     """Returns a urlpattern that can be integrated into the global urls."""
+    from common.models import InvenTreeSetting
     from plugin import registry
 
     urls = []
 
-    for plugin in registry.plugins.values():
-        if plugin.mixin_enabled('urls'):
-            urls.append(plugin.urlpatterns)
+    # Only allow custom routing if the setting is enabled
+    if InvenTreeSetting.get_setting('ENABLE_PLUGINS_URL', False, create=False, cache=False):
+        for plugin in registry.plugins.values():
+            if plugin.mixin_enabled('urls'):
+                urls.append(plugin.urlpatterns)
 
     return re_path(f'^{PLUGIN_BASE}/', include((urls, 'plugin')))


### PR DESCRIPTION
Blanks out plugin URLs if the ENABLE_PLUGINS_URL setting is not active