### PR TITLE
Plugin reload mechanism

### DIFF
--- a/InvenTree/InvenTree/config.py
+++ b/InvenTree/InvenTree/config.py
@@ -319,7 +319,7 @@ def get_secret_key():
         key = ''.join([random.choice(options) for i in range(100)])
         secret_key_file.write_text(key)
 
-    logger.info("Loading SECRET_KEY from '%s'", secret_key_file)
+    logger.debug("Loading SECRET_KEY from '%s'", secret_key_file)
 
     key_data = secret_key_file.read_text().strip()
 

--- a/InvenTree/plugin/apps.py
+++ b/InvenTree/plugin/apps.py
@@ -42,9 +42,8 @@ class PluginAppConfig(AppConfig):
                 except Exception:  # pragma: no cover
                     pass
 
-                # get plugins and init them
-                registry.plugin_modules = registry.collect_plugins()
-                registry.load_plugins()
+                # Perform a full reload of the plugin registry
+                registry.reload_plugins(full_reload=True, force_reload=True, collect=True)
 
                 # drop out of maintenance
                 # makes sure we did not have an error in reloading and maintenance is still active

--- a/InvenTree/plugin/base/integration/ScheduleMixin.py
+++ b/InvenTree/plugin/base/integration/ScheduleMixin.py
@@ -57,7 +57,7 @@ class ScheduleMixin:
     @classmethod
     def _activate_mixin(cls, registry, plugins, *args, **kwargs):
         """Activate scheudles from plugins with the ScheduleMixin."""
-        logger.info('Activating plugin tasks')
+        logger.debug('Activating plugin tasks')
 
         from common.models import InvenTreeSetting
 

--- a/InvenTree/plugin/base/integration/SettingsMixin.py
+++ b/InvenTree/plugin/base/integration/SettingsMixin.py
@@ -37,7 +37,7 @@ class SettingsMixin:
         Add all defined settings form the plugins to a unified dict in the registry.
         This dict is referenced by the PluginSettings for settings definitions.
         """
-        logger.info('Activating plugin settings')
+        logger.debug('Activating plugin settings')
 
         registry.mixins_settings = {}
 
@@ -49,7 +49,7 @@ class SettingsMixin:
     @classmethod
     def _deactivate_mixin(cls, registry, **kwargs):
         """Deactivate all plugin settings."""
-        logger.info('Deactivating plugin settings')
+        logger.debug('Deactivating plugin settings')
         # clear settings cache
         registry.mixins_settings = {}
 


### PR DESCRIPTION
This PR fixes a long-running issue with the plugin ecosystem.

If a new plugin is installed into the registry (i.e. via the web interface) then the registry gets reloaded - but only for the running process.

If the background worker needs to access the new plugin (e.g. responding to an event) then this would **fail** - as the background worker has the "old" plugin registry.

This PR addresses this by keeping a hash of the plugins loaded into the registry, and updating a value in the database whenever the hash changes.

When any thread needs to call a plugin function, the registry first checks if the hash matches the latest value in the database. If not, the local registry is reloaded. This happens quite quickly and then the worker thread can proceed to perform the task.

This means that the whole server instance can keep running (without requiring a restart) when a new plugin is activated.

This PR *also* adds a mutex lock around the plugin registry reload procedure, to provide a safer and simpler reload process.