### PR TITLE
Plugin missing fix

### DIFF
--- a/InvenTree/plugin/api.py
+++ b/InvenTree/plugin/api.py
@@ -83,6 +83,18 @@ class PluginList(ListAPI):
 
             queryset = queryset.filter(pk__in=matches)
 
+        # Filter queryset by 'installed' flag
+        if 'installed' in params:
+            installed = str2bool(params['installed'])
+
+            matches = []
+
+            for result in queryset:
+                if result.is_installed() == installed:
+                    matches.append(result.pk)
+
+            queryset = queryset.filter(pk__in=matches)
+
         return queryset
 
     filter_backends = SEARCH_ORDER_FILTER

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -104,29 +104,38 @@ class PluginConfig(InvenTree.models.MetadataMixin, models.Model):
         self.plugin: InvenTreePlugin = plugin
 
     def __getstate__(self):
-        """Customize pickeling behaviour."""
+        """Customize pickling behavior."""
         state = super().__getstate__()
-        state.pop("plugin", None)  # plugin cannot be pickelt in some circumstances when used with drf views, remove it (#5408)
+        state.pop("plugin", None)  # plugin cannot be pickled in some circumstances when used with drf views, remove it (#5408)
         return state
 
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
         """Extend save method to reload plugins if the 'active' status changes."""
         reload = kwargs.pop('no_reload', False)  # check if no_reload flag is set
 
-        ret = super().save(force_insert, force_update, *args, **kwargs)
-
         if self.is_builtin():
             # Force active if builtin
             self.active = True
 
+        ret = super().save(force_insert, force_update, *args, **kwargs)
+
         if not reload:
-            if (self.active is False and self.__org_active is True) or \
-               (self.active is True and self.__org_active is False):
+            if self.active != self.__org_active:
                 if settings.PLUGIN_TESTING:
                     warnings.warn('A reload was triggered', stacklevel=2)
                 registry.reload_plugins()
 
         return ret
+
+    @admin.display(boolean=True, description=_('Installed'))
+    def is_installed(self) -> bool:
+        """Simple check to determine if this plugin is installed.
+
+        A plugin might not be installed if it has been removed from the system,
+        but the PluginConfig associated with it still exists.
+        """
+
+        return self.plugin is not None
 
     @admin.display(boolean=True, description=_('Sample plugin'))
     def is_sample(self) -> bool:

--- a/InvenTree/plugin/models.py
+++ b/InvenTree/plugin/models.py
@@ -113,11 +113,11 @@ class PluginConfig(InvenTree.models.MetadataMixin, models.Model):
         """Extend save method to reload plugins if the 'active' status changes."""
         reload = kwargs.pop('no_reload', False)  # check if no_reload flag is set
 
+        ret = super().save(force_insert, force_update, *args, **kwargs)
+
         if self.is_builtin():
             # Force active if builtin
             self.active = True
-
-        ret = super().save(force_insert, force_update, *args, **kwargs)
 
         if not reload:
             if self.active != self.__org_active:

--- a/InvenTree/plugin/serializers.py
+++ b/InvenTree/plugin/serializers.py
@@ -61,12 +61,14 @@ class PluginConfigSerializer(serializers.ModelSerializer):
             'mixins',
             'is_builtin',
             'is_sample',
+            'is_installed',
         ]
 
         read_only_fields = [
             'key',
             'is_builtin',
             'is_sample',
+            'is_installed',
         ]
 
     meta = serializers.DictField(read_only=True)

--- a/InvenTree/templates/js/translated/plugin.js
+++ b/InvenTree/templates/js/translated/plugin.js
@@ -46,32 +46,22 @@ function loadPluginTable(table, options={}) {
         },
         columns: [
             {
-                field: 'active',
-                title: '',
-                sortable: true,
-                formatter: function(value, row) {
-                    if (row.active) {
-                        return `<span class='fa fa-check-circle icon-green' title='{% trans "This plugin is active" %}'></span>`;
-                    } else {
-                        return `<span class='fa fa-times-circle icon-red' title ='{% trans "This plugin is not active" %}'></span>`;
-                    }
-                }
-            },
-            {
                 field: 'name',
-                title: '{% trans "Plugin Description" %}',
+                title: '{% trans "Plugin" %}',
                 sortable: true,
+                switchable: false,
                 formatter: function(value, row) {
                     let html = '';
 
-                    if (row.active) {
-                        html += `<strong>${value}</strong>`;
-                        if (row.meta && row.meta.description) {
-                            html += ` - <small>${row.meta.description}</small>`;
-                        }
+                    if (!row.is_installed) {
+                        html += `<span class='fa fa-question-circle' title='{% trans "This plugin is no longer installed" %}'></span>`;
+                    } else if (row.active) {
+                        html += `<span class='fa fa-check-circle icon-green' title='{% trans "This plugin is active" %}'></span>`;
                     } else {
-                        html += `<em>${value}</em>`;
+                        html += `<span class='fa fa-times-circle icon-red' title ='{% trans "This plugin is installed but not active" %}'></span>`;
                     }
+
+                    html += `&nbsp;<span>${value}</span>`;
 
                     if (row.is_builtin) {
                         html += `<span class='badge bg-success rounded-pill badge-right'>{% trans "Builtin" %}</span>`;
@@ -83,6 +73,12 @@ function loadPluginTable(table, options={}) {
 
                     return html;
                 }
+            },
+            {
+                field: 'meta.description',
+                title: '{% trans "Description" %}',
+                sortable: false,
+                switchable: true,
             },
             {
                 field: 'meta.version',

--- a/InvenTree/templates/js/translated/plugin.js
+++ b/InvenTree/templates/js/translated/plugin.js
@@ -100,15 +100,18 @@ function loadPluginTable(table, options={}) {
             {
                 field: 'meta.author',
                 title: '{% trans "Author" %}',
+                sortable: false,
             },
             {
                 field: 'actions',
                 title: '',
+                switchable: false,
+                sortable: false,
                 formatter: function(value, row) {
                     let buttons = '';
 
                     // Check if custom plugins are enabled for this instance
-                    if (options.custom && !row.is_builtin) {
+                    if (options.custom && !row.is_builtin && row.is_installed) {
                         if (row.active) {
                             buttons += makeIconButton('fa-stop-circle icon-red', 'btn-plugin-disable', row.pk, '{% trans "Disable Plugin" %}');
                         } else {

--- a/InvenTree/templates/js/translated/table_filters.js
+++ b/InvenTree/templates/js/translated/table_filters.js
@@ -471,6 +471,10 @@ function getPluginTableFilters() {
             type: 'bool',
             title: '{% trans "Sample" %}',
         },
+        installed: {
+            type: 'bool',
+            title: '{% trans "Installed" %}'
+        },
     };
 }
 


### PR DESCRIPTION
Replaces https://github.com/inventree/InvenTree/pull/5652

A simpler implementation which simply shows if a particular PluginConfig references a plugin which has since been uninstalled, or can no longer be found.

Rather than acting on it (i.e. deleting anything) it simply provides awareness to the user who can then take action.

@matmair a better approach, yah?

<img width="1045" alt="Screenshot 2023-10-03 at 6 47 01 pm" src="https://github.com/inventree/InvenTree/assets/10080325/52beb686-12bd-4eb5-acd7-f1b2c04105eb">
