### PR TITLE
Fix: Allow allocation of variants to sales order lines

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -1602,7 +1602,16 @@ class SalesOrderAllocation(models.Model):
 
         try:
             if self.line.part != self.item.part:
-                errors['item'] = _('Cannot allocate stock item to a line with a different part')
+                # Check for variant_of mapping on item.part to see if this trees up to line.part
+                matches = False
+                current_part = self.item.part
+                while current_part.variant_of is not None:
+                    current_part = current_part.variant_of
+                    if self.line.part == current_part:
+                        matches = True
+                        break
+                if not matches:
+                    errors['item'] = _('Cannot allocate stock item to a line with a different part')
         except PartModels.Part.DoesNotExist:
             errors['line'] = _('Cannot allocate stock to a line without a part')
 

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -1602,15 +1602,8 @@ class SalesOrderAllocation(models.Model):
 
         try:
             if self.line.part != self.item.part:
-                # Check for variant_of mapping on item.part to see if this trees up to line.part
-                matches = False
-                current_part = self.item.part
-                while current_part.variant_of is not None:
-                    current_part = current_part.variant_of
-                    if self.line.part == current_part:
-                        matches = True
-                        break
-                if not matches:
+                variants = self.line.part.get_descendants(include_self=True)
+                if self.line.part not in variants:
                     errors['item'] = _('Cannot allocate stock item to a line with a different part')
         except PartModels.Part.DoesNotExist:
             errors['line'] = _('Cannot allocate stock to a line without a part')

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -1716,7 +1716,7 @@ class SalesOrderAllocateTest(OrderTest):
         self.assertIn('Shipment is not associated with this order', str(response.data['shipment']))
 
     def test_allocate(self):
-        """Test the the allocation endpoint acts as expected, when provided with valid data!"""
+        """Test that the allocation endpoint acts as expected, when provided with valid data!"""
         # First, check that there are no line items allocated against this SalesOrder
         self.assertEqual(self.order.stock_allocations.count(), 0)
 
@@ -1744,6 +1744,41 @@ class SalesOrderAllocateTest(OrderTest):
 
         for line in self.order.lines.all():
             self.assertEqual(line.allocations.count(), 1)
+
+    def test_allocate_variant(self):
+        """Test that the allocation endpoint acts as expected, when provided with variant"""
+        # First, check that there are no line items allocated against this SalesOrder
+        self.assertEqual(self.order.stock_allocations.count(), 0)
+
+        data = {
+            "items": [],
+            "shipment": self.shipment.pk,
+        }
+
+        def check_template(line_item):
+            return line_item.part.is_template
+
+        for line in filter(check_template, self.order.lines.all()):
+
+            stock_item = None
+
+            # Allocate a matching variant
+            parts = Part.objects.filter(salable=True).filter(variant_of=line.part.pk)
+            for part in parts:
+                stock_item = part.stock_items.last()
+                break
+
+            # Fully-allocate each line
+            data['items'].append({
+                "line_item": line.pk,
+                "stock_item": stock_item.pk,
+                "quantity": 5
+            })
+
+        self.post(self.url, data, expected_code=201)
+
+        # At least one variant should have been allocated
+        self.assertGreater(self.order.stock_allocations.count(), 0)
 
     def test_shipment_complete(self):
         """Test that we can complete a shipment via the API."""

--- a/InvenTree/order/test_api.py
+++ b/InvenTree/order/test_api.py
@@ -1777,8 +1777,10 @@ class SalesOrderAllocateTest(OrderTest):
 
         self.post(self.url, data, expected_code=201)
 
-        # At least one variant should have been allocated
+        # At least one item should be allocated, and all should be variants
         self.assertGreater(self.order.stock_allocations.count(), 0)
+        for allocation in self.order.stock_allocations.all():
+            self.assertNotEquals(allocation.item.part.pk, allocation.line.part.pk)
 
     def test_shipment_complete(self):
         """Test that we can complete a shipment via the API."""

--- a/InvenTree/part/fixtures/part.yaml
+++ b/InvenTree/part/fixtures/part.yaml
@@ -142,6 +142,7 @@
     description: 'A variant chair part which is blue'
     variant_of: 10000
     trackable: true
+    salable: true
     category: 7
     tree_id: 1
     level: 0

--- a/InvenTree/part/fixtures/part.yaml
+++ b/InvenTree/part/fixtures/part.yaml
@@ -142,7 +142,6 @@
     description: 'A variant chair part which is blue'
     variant_of: 10000
     trackable: true
-    salable: true
     category: 7
     tree_id: 1
     level: 0
@@ -157,6 +156,7 @@
     variant_of: 10000
     IPN: "R.CH"
     trackable: true
+    salable: true
     category: 7
     tree_id: 1
     level: 0


### PR DESCRIPTION
**Demo Test Steps**

- Create a sales order with a line of 'Widget Assembly'
- Attempt to allocate 'Widget Assembly Variant' to it
- Server returns error 400 with payload items: `{"item":["Cannot allocate stock item to a line with a different part"]}`

**Changes**

- Add tests for allocating variants to sales order lines
- Add variant_of check to allow variants to be allocated to line items of their parent type