### PR TITLE
Fix tags table rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,8 +211,11 @@ HTML and javascript files are passed through the django templating engine. Trans
 ```
 
 ## Github use
+
 ### Tags
+
 The tags describe issues and PRs in multiple areas:
+
 | Area | Name | Description |
 | --- | --- | --- |
 | Triage Labels |  |  |


### PR DESCRIPTION
**Fixes**

The tags table in contributing page renders in github but not on the docs site:

Works: https://github.com/inventree/InvenTree/blob/master/CONTRIBUTING.md#tags

Doesn't work: https://docs.inventree.org/en/latest/develop/contributing/#tags

I was able to confirm through local testing that the lack of newlines before the table was causing the rendering problem.

**Changes**

- Add whitespace to fix markdown table rendering 

