### PR TITLE
Allow stock items to be reallocated for build items

### DIFF
--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -845,15 +845,6 @@ class BuildAllocationItemSerializer(serializers.Serializer):
         # Check that the quantity does not exceed the available amount from the stock item
         q = stock_item.unallocated_quantity()
 
-        # Check if an allocation for this stock item already exists
-        build_item = BuildItem.objects.filter(
-            build_line=build_line,
-            stock_item=stock_item,
-            install_into=output
-        ).first()
-        if build_item:
-            quantity += build_item.quantity
-
         if quantity > q:
 
             q = InvenTree.helpers.clean_decimal(q)

--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -845,6 +845,15 @@ class BuildAllocationItemSerializer(serializers.Serializer):
         # Check that the quantity does not exceed the available amount from the stock item
         q = stock_item.unallocated_quantity()
 
+        # Check if an allocation for this stock item already exists
+        build_item = BuildItem.objects.filter(
+            build_line=build_line,
+            stock_item=stock_item,
+            install_into=output
+        ).first()
+        if build_item:
+            quantity += build_item.quantity
+
         if quantity > q:
 
             q = InvenTree.helpers.clean_decimal(q)
@@ -865,10 +874,6 @@ class BuildAllocationItemSerializer(serializers.Serializer):
             raise ValidationError({
                 'output': _('Build output cannot be specified for allocation of untracked parts'),
             })
-
-        # Check if this allocation would be unique
-        if BuildItem.objects.filter(build_line=build_line, stock_item=stock_item, install_into=output).exists():
-            raise ValidationError(_('This stock item has already been allocated to this build output'))
 
         return data
 
@@ -914,12 +919,15 @@ class BuildAllocationSerializer(serializers.Serializer):
 
                 try:
                     # Create a new BuildItem to allocate stock
-                    BuildItem.objects.create(
+                    build_item, created = BuildItem.objects.get_or_create(
                         build_line=build_line,
                         stock_item=stock_item,
-                        quantity=quantity,
-                        install_into=output
+                        install_into=output,
                     )
+                    if created:
+                        build_item.quantity = 0
+                    build_item.quantity += quantity
+                    build_item.save()
                 except (ValidationError, DjangoValidationError) as exc:
                     # Catch model errors and re-throw as DRF errors
                     raise ValidationError(detail=serializers.as_serializer_error(exc))

--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -925,8 +925,9 @@ class BuildAllocationSerializer(serializers.Serializer):
                         install_into=output,
                     )
                     if created:
-                        build_item.quantity = 0
-                    build_item.quantity += quantity
+                        build_item.quantity = quantity
+                    else:
+                        build_item.quantity += quantity
                     build_item.save()
                 except (ValidationError, DjangoValidationError) as exc:
                     # Catch model errors and re-throw as DRF errors


### PR DESCRIPTION
Currently its not possible to allocate the same stock item multiple times for the same built item. This fixes this without (as far as I can see) causing any side effects/issues.

The use case because of which I ran into this was raising the Quantity of the Build Order and then trying to Allocate the remaining Stock required.