### PR TITLE
Refactor: replace multiple `==` checks with `in`

### DIFF
--- a/InvenTree/part/test_api.py
+++ b/InvenTree/part/test_api.py
@@ -293,11 +293,9 @@ class PartCategoryAPITest(InvenTreeAPITestCase):
             delete_child_categories: bool = False
             delete_parts: bool = False
 
-            if i == Target.move_subcategories_to_parent_delete_parts \
-                    or i == Target.delete_subcategories_delete_parts:
+            if i in (Target.move_subcategories_to_parent_delete_parts, Target.delete_subcategories_delete_parts):
                 delete_parts = True
-            if i == Target.delete_subcategories_move_parts_to_parent \
-                    or i == Target.delete_subcategories_delete_parts:
+            if i in (Target.delete_subcategories_move_parts_to_parent, Target.delete_subcategories_delete_parts):
                 delete_child_categories = True
 
             # Create a parent category

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -488,7 +488,7 @@ class PluginsRegistry:
             # - If this plugin has been explicitly enabled by the user
             if settings.PLUGIN_TESTING or builtin or (plg_db and plg_db.active):
                 # Check if the plugin was blocked -> threw an error; option1: package, option2: file-based
-                if disabled and ((plg.__name__ == disabled) or (plg.__module__ == disabled)):
+                if disabled and disabled in (plg.__name__, plg.__module__):
                     safe_reference(plugin=plg, key=plg_key, active=False)
                     continue  # continue -> the plugin is not loaded
 

--- a/InvenTree/stock/test_api.py
+++ b/InvenTree/stock/test_api.py
@@ -137,11 +137,9 @@ class StockLocationTest(StockAPITestCase):
             delete_sub_locations: bool = False
             delete_stock_items: bool = False
 
-            if i == Target.move_sub_locations_to_parent_delete_stockitems \
-                    or i == Target.delete_sub_locations_delete_stockitems:
+            if i in (Target.move_sub_locations_to_parent_delete_stockitems, Target.delete_sub_locations_delete_stockitems):
                 delete_stock_items = True
-            if i == Target.delete_sub_locations_move_stockitems_to_parent \
-                    or i == Target.delete_sub_locations_delete_stockitems:
+            if i in (Target.delete_sub_locations_move_stockitems_to_parent, Target.delete_sub_locations_delete_stockitems):
                 delete_sub_locations = True
 
             # Create a parent stock location


### PR DESCRIPTION
To check if a variable is equal to one of many values, combine the values into a tuple and check if the variable is contained `in` it instead of checking for equality against each of the values. This is faster, less verbose, and more readable.