### PR TITLE
Fix admin site - Custom admin URL

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -197,7 +197,18 @@ if DBBACKUP_STORAGE_OPTIONS is None:
         'location': config.get_backup_dir(),
     }
 
-# Application definition
+INVENTREE_ADMIN_ENABLED = get_boolean_setting(
+    'INVENTREE_ADMIN_ENABLED',
+    config_key='admin_enabled',
+    default_value=True
+)
+
+# Base URL for admin pages (default="admin")
+INVENTREE_ADMIN_URL = get_setting(
+    'INVENTREE_ADMIN_URL',
+    config_key='admin_url',
+    default_value='admin'
+)
 
 INSTALLED_APPS = [
     # Admin site integration
@@ -378,20 +389,6 @@ if DEBUG:
     INSTALLED_APPS.append('sslserver')
 
 # InvenTree URL configuration
-
-INVENTREE_ADMIN_ENABLED = get_boolean_setting(
-    'INVENTREE_ADMIN_ENABLED',
-    config_key='admin_enabled',
-    default_value=True
-)
-
-# Base URL for admin pages (default="admin")
-INVENTREE_ADMIN_URL = get_setting(
-    'INVENTREE_ADMIN_URL',
-    config_key='admin_url',
-    default_value='admin'
-)
-
 ROOT_URLCONF = 'InvenTree.urls'
 
 TEMPLATES = [

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -379,6 +379,12 @@ if DEBUG:
 
 # InvenTree URL configuration
 
+INVENTREE_ADMIN_ENABLED = get_boolean_setting(
+    'INVENTREE_ADMIN_ENABLED',
+    config_key='admin_enabled',
+    default_value=True
+)
+
 # Base URL for admin pages (default="admin")
 INVENTREE_ADMIN_URL = get_setting(
     'INVENTREE_ADMIN_URL',

--- a/InvenTree/InvenTree/urls.py
+++ b/InvenTree/InvenTree/urls.py
@@ -209,11 +209,14 @@ classic_frontendpatterns = [
 
 new_frontendpatterns = platform_urls
 
-urlpatterns = [
-    # admin sites
-    re_path(f'^{settings.INVENTREE_ADMIN_URL}/error_log/', include('error_report.urls')),
-    re_path(f'^{settings.INVENTREE_ADMIN_URL}/', admin.site.urls, name='inventree-admin'),
-]
+urlpatterns = []
+
+if settings.INVENTREE_ADMIN_ENABLED:
+    urlpatterns += [
+        re_path(f'^{settings.INVENTREE_ADMIN_URL}/error_log/', include('error_report.urls')),
+        re_path(f'^{settings.INVENTREE_ADMIN_URL}/', admin.site.urls, name='inventree-admin'),
+    ]
+
 
 urlpatterns += backendpatterns
 

--- a/InvenTree/InvenTree/urls.py
+++ b/InvenTree/InvenTree/urls.py
@@ -212,11 +212,11 @@ new_frontendpatterns = platform_urls
 urlpatterns = []
 
 if settings.INVENTREE_ADMIN_ENABLED:
+    admin_url = settings.INVENTREE_ADMIN_URL,
     urlpatterns += [
-        re_path(f'^{settings.INVENTREE_ADMIN_URL}/error_log/', include('error_report.urls')),
-        re_path(f'^{settings.INVENTREE_ADMIN_URL}/', admin.site.urls, name='inventree-admin'),
+        path(f'{admin_url}/error_log/', include('error_report.urls')),
+        path(f'{admin_url}/', admin.site.urls, name='inventree-admin'),
     ]
-
 
 urlpatterns += backendpatterns
 

--- a/InvenTree/build/templates/build/build_base.html
+++ b/InvenTree/build/templates/build/build_base.html
@@ -29,10 +29,9 @@ src="{% static 'img/blank_image.png' %}"
 
 {% block actions %}
 <!-- Admin Display -->
-{% if user.is_staff and roles.build.change %}
-{% url 'admin:build_build_change' build.pk as url %}
+{% admin_url user "build.build" build.pk as url %}
 {% include "admin_button.html" with url=url %}
-{% endif %}
+
 {% if barcodes %}
 <!-- Barcode actions menu -->
 <div class='btn-group' role='group'>

--- a/InvenTree/company/templates/company/company_base.html
+++ b/InvenTree/company/templates/company/company_base.html
@@ -14,10 +14,9 @@
 
 {% block actions %}
 <!-- Admin View -->
-{% if user.is_staff and perms.company.change_company %}
-{% url 'admin:company_company_change' company.pk as url %}
+{% admin_url user "company.company" company.pk as url %}
 {% include "admin_button.html" with url=url %}
-{% endif %}
+
 {% if company.is_supplier and roles.purchase_order.add %}
 <button type='button' class='btn btn-outline-primary' id='company-order-2' title='{% trans "Create Purchase Order" %}'>
     <span class='fas fa-shopping-cart'/>

--- a/InvenTree/company/templates/company/manufacturer_part.html
+++ b/InvenTree/company/templates/company/manufacturer_part.html
@@ -27,7 +27,7 @@
 
 {% block actions %}
 
-{% admin_url user 'company_manufacturerpart' part.pk as url %}
+{% admin_url user 'company.manufacturerpart' part.pk as url %}
 {% include "admin_button.html" with url=url %}
 
 {% if roles.purchase_order.change %}

--- a/InvenTree/company/templates/company/manufacturer_part.html
+++ b/InvenTree/company/templates/company/manufacturer_part.html
@@ -26,10 +26,10 @@
 {% endblock heading %}
 
 {% block actions %}
-{% if user.is_staff and perms.company.change_company %}
-{% url 'admin:company_manufacturerpart_change' part.pk as url %}
+
+{% admin_url user 'company_manufacturerpart' part.pk as url %}
 {% include "admin_button.html" with url=url %}
-{% endif %}
+
 {% if roles.purchase_order.change %}
 {% if roles.purchase_order.add and part.part.purchaseable %}
 <button type='button' class='btn btn-outline-secondary' id='order-part' title='{% trans "Order part" %}'>

--- a/InvenTree/company/templates/company/supplier_part.html
+++ b/InvenTree/company/templates/company/supplier_part.html
@@ -26,10 +26,9 @@
 {% endblock heading %}
 
 {% block actions %}
-{% if user.is_staff and perms.company.change_company %}
-{% url 'admin:company_supplierpart_change' part.pk as url %}
+{% admin_url user "company.supplierpart" part.pk as url %}
 {% include "admin_button.html" with url=url %}
-{% endif %}
+
 {% if barcodes %}
 <!-- Barcode actions menu -->
 <div class='btn-group' role='group'>

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -58,12 +58,12 @@ database:
 # Use the environment variable INVENTREE_DEBUG
 debug: True
 
-# Set to True to enable the admin interface
-# Use the environment variable INVENTREE_ADMIN_ENABLED
+# Set to False to disable the admin interface (default = True)
+# Or, use the environment variable INVENTREE_ADMIN_ENABLED
 #admin_enabled: True
 
 # Set the admin URL (default is 'admin')
-# Use the environment variable INVENTREE_ADMIN_URL
+# Or, use the environment variable INVENTREE_ADMIN_URL
 #admin_url: 'admin'
 
 # Set enabled frontends

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -58,6 +58,14 @@ database:
 # Use the environment variable INVENTREE_DEBUG
 debug: True
 
+# Set to True to enable the admin interface
+# Use the environment variable INVENTREE_ADMIN_ENABLED
+#admin_enabled: True
+
+# Set the admin URL (default is 'admin')
+# Use the environment variable INVENTREE_ADMIN_URL
+#admin_url: 'admin'
+
 # Set enabled frontends
 # Use the environment variable INVENTREE_CLASSIC_FRONTEND
 # classic_frontend: True

--- a/InvenTree/order/templates/order/order_base.html
+++ b/InvenTree/order/templates/order/order_base.html
@@ -19,10 +19,10 @@
 {% endblock heading %}
 
 {% block actions %}
-{% if user.is_staff and roles.purchase_order.change %}
-{% url 'admin:order_purchaseorder_change' order.pk as url %}
+
+{% admin_url user "order.purchaseorder" order.pk as url %}
 {% include "admin_button.html" with url=url %}
-{% endif %}
+
 {% if barcodes %}
 <!-- Barcode actions menu -->
 <div class='btn-group' role='group'>

--- a/InvenTree/order/templates/order/return_order_base.html
+++ b/InvenTree/order/templates/order/return_order_base.html
@@ -29,10 +29,9 @@ src="{% static 'img/blank_image.png' %}"
 {% endblock heading %}
 
 {% block actions %}
-{% if user.is_staff and roles.return_order.change %}
-{% url 'admin:order_returnorder_change' order.pk as url %}
+{% admin_url user "order.returnorder" order.pk as url %}
 {% include "admin_button.html" with url=url %}
-{% endif %}
+
 {% if barcodes %}
 <!-- Barcode actions menu -->
 <div class='btn-group' role='group'>

--- a/InvenTree/order/templates/order/sales_order_base.html
+++ b/InvenTree/order/templates/order/sales_order_base.html
@@ -29,10 +29,9 @@ src="{% static 'img/blank_image.png' %}"
 {% endblock heading %}
 
 {% block actions %}
-{% if user.is_staff and roles.sales_order.change %}
-{% url 'admin:order_salesorder_change' order.pk as url %}
+{% admin_url user "order.salesorder" order.pk as url %}
 {% include "admin_button.html" with url=url %}
-{% endif %}
+
 {% if barcodes %}
 <!-- Barcode actions menu -->
 <div class='btn-group' role='group'>

--- a/InvenTree/part/templates/part/category.html
+++ b/InvenTree/part/templates/part/category.html
@@ -25,10 +25,11 @@
 {% endblock heading %}
 
 {% block actions %}
-{% if category and user.is_staff and roles.part_category.change %}
-{% url 'admin:part_partcategory_change' category.pk as url %}
+{% if category %}
+{% admin_url user "part.partcategory" category.pk as url %}
 {% include "admin_button.html" with url=url %}
 {% endif %}
+
 {% settings_value "STOCKTAKE_ENABLE" as stocktake_enable %}
 {% if stocktake_enable and roles.stocktake.add %}
 <button type='button' class='btn btn-outline-secondary' id='category-stocktake' title='{% trans "Perform stocktake for this part category" %}'>

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -18,10 +18,8 @@
 
 {% block actions %}
 <!-- Admin View -->
-{% if user.is_staff and roles.part.change %}
-{% url 'admin:part_part_change' part.pk as url %}
+{% admin_url user "part.part" part.pk as url %}
 {% include "admin_button.html" with url=url %}
-{% endif %}
 
 {% if starred_directly %}
 <button type='button' class='btn btn-outline-secondary' id='toggle-starred' title='{% trans "You are subscribed to notifications for this part" %}'>

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -626,3 +626,54 @@ else:  # pragma: no cover
         token.contents = ' '.join(bits)
 
         return I18nStaticNode.handle_token(parser, token)
+
+
+@register.simple_tag()
+def admin_index(user):
+    """Return a URL for the admin interface"""
+
+    if not djangosettings.INVENTREE_ADMIN_ENABLED:
+        return ''
+
+    if not user.is_staff:
+        return ''
+
+    return reverse('admin:index')
+
+
+@register.simple_tag()
+def admin_url(user, table, pk):
+    """Generate a link to the admin site for the given model instance.
+
+    - If the admin site is disabled, an empty URL is returned
+    - If the user is not a staff user, an empty URL is returned
+    - If the user does not have the correct permission, an empty URL is returned
+    """
+
+    app, model = table.strip().split('.')
+
+    print("admin_url:", app, model, pk)
+
+    from django.urls import reverse
+
+    if not djangosettings.INVENTREE_ADMIN_ENABLED:
+        print("admin not enabled!")
+        return ""
+
+    if not user.is_staff:
+        print("user is not staff!")
+        return ""
+
+    if not pk:
+        print("no pk provided")
+        return ""
+
+    # Check the user has the correct permission
+    perm_string = f"{app}.change_{model}"
+    if not user.has_perm(perm_string):
+        print("user does not have permission!")
+        return ''
+
+    url = reverse(f'admin:{app}_{model}_change', args=(pk,))
+
+    return url

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -652,26 +652,20 @@ def admin_url(user, table, pk):
 
     app, model = table.strip().split('.')
 
-    print("admin_url:", app, model, pk)
-
     from django.urls import reverse
 
     if not djangosettings.INVENTREE_ADMIN_ENABLED:
-        print("admin not enabled!")
         return ""
 
     if not user.is_staff:
-        print("user is not staff!")
         return ""
 
     if not pk:
-        print("no pk provided")
         return ""
 
     # Check the user has the correct permission
     perm_string = f"{app}.change_{model}"
     if not user.has_perm(perm_string):
-        print("user does not have permission!")
         return ''
 
     url = reverse(f'admin:{app}_{model}_change', args=(pk,))

--- a/InvenTree/part/templatetags/inventree_extras.py
+++ b/InvenTree/part/templatetags/inventree_extras.py
@@ -8,7 +8,7 @@ from datetime import date, datetime
 from django import template
 from django.conf import settings as djangosettings
 from django.templatetags.static import StaticNode
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -660,14 +660,18 @@ def admin_url(user, table, pk):
     if not user.is_staff:
         return ""
 
-    if not pk:
-        return ""
-
     # Check the user has the correct permission
     perm_string = f"{app}.change_{model}"
     if not user.has_perm(perm_string):
         return ''
 
-    url = reverse(f'admin:{app}_{model}_change', args=(pk,))
+    # Fallback URL
+    url = reverse(f"admin:{app}_{model}_changelist")
+
+    if pk:
+        try:
+            url = reverse(f'admin:{app}_{model}_change', args=(pk,))
+        except NoReverseMatch:
+            pass
 
     return url

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -17,7 +17,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
 from django.db.utils import IntegrityError, OperationalError, ProgrammingError
-from django.urls import clear_url_caches, re_path
+from django.urls import clear_url_caches, path
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
@@ -620,13 +620,17 @@ class PluginsRegistry:
 
             app_name = getattr(url, 'app_name', None)
 
+            admin_url = settings.INVENTREE_ADMIN_URL
+
             if app_name == 'admin':
-                urlpatterns[index] = re_path(r'^admin/', admin.site.urls, name='inventree-admin')
+                urlpatterns[index] = path(f'{admin_url}/', admin.site.urls, name='inventree-admin')
+
             if app_name == 'plugin':
                 urlpatterns[index] = get_plugin_urls()
 
         # Refresh the URL cache
         clear_url_caches()
+
     # endregion
 
     # region plugin registry hash calculations

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -25,10 +25,9 @@
 
 {% block actions %}
 
-{% if user.is_staff and roles.stock.change %}
-{% url 'admin:stock_stockitem_change' item.pk as url %}
+{% admin_url user "stock.stockitem" item.pk as url %}
 {% include "admin_button.html" with url=url %}
-{% endif %}
+
 {% mixin_available "locate" as locate_available %}
 {% if plugins_enabled and locate_available %}
 <button id='locate-item-button' title='{% trans "Locate stock item" %}' class='btn btn-outline-secondary' typy='button'>

--- a/InvenTree/stock/templates/stock/location.html
+++ b/InvenTree/stock/templates/stock/location.html
@@ -28,10 +28,11 @@
 {% block actions %}
 
 <!-- Admin view -->
-{% if location and user.is_staff and roles.stock_location.change %}
-{% url 'admin:stock_stocklocation_change' location.pk as url %}
+{% if location %}
+{% admin_url user "stock.stocklocation" location.pk as url %}
 {% include "admin_button.html" with url=url %}
 {% endif %}
+
 {% settings_value "STOCKTAKE_ENABLE" as stocktake_enable %}
 {% if stocktake_enable and roles.stocktake.add %}
 <button type='button' class='btn btn-outline-secondary' id='location-stocktake' title='{% trans "Perform stocktake for this stock location" %}'>

--- a/InvenTree/templates/InvenTree/settings/plugin.html
+++ b/InvenTree/templates/InvenTree/settings/plugin.html
@@ -35,6 +35,8 @@
         <h4>{% trans "Plugins" %}</h4>
         {% include "spacer.html" %}
         <div class='btn-group' role='group'>
+            {% admin_url user "plugin.pluginconfig" None as url %}
+            {% include "admin_button.html" with url=url %}
             {% if plug %}
             <button class="btn btn-success" id="install-plugin" title="{% trans 'Install Plugin' %}"><span class='fas fa-plus-circle'></span> {% trans "Install Plugin" %}</button>
             {% endif %}

--- a/InvenTree/templates/InvenTree/settings/plugin.html
+++ b/InvenTree/templates/InvenTree/settings/plugin.html
@@ -35,8 +35,6 @@
         <h4>{% trans "Plugins" %}</h4>
         {% include "spacer.html" %}
         <div class='btn-group' role='group'>
-            {% url 'admin:plugin_pluginconfig_changelist' as url %}
-            {% include "admin_button.html" with url=url %}
             {% if plug %}
             <button class="btn btn-success" id="install-plugin" title="{% trans 'Install Plugin' %}"><span class='fas fa-plus-circle'></span> {% trans "Install Plugin" %}</button>
             {% endif %}

--- a/InvenTree/templates/admin_button.html
+++ b/InvenTree/templates/admin_button.html
@@ -3,7 +3,7 @@
 
 {% inventree_customize 'hide_admin_link' as hidden %}
 
-{% if not hidden and user.is_staff %}
+{% if url and not hidden and user.is_staff %}
 <a href='{{ url }}'>
     <button id='admin-button' href='{{ url }}' title='{% trans "View in administration panel" %}' type='button' class='btn btn-primary admin-button'>
         <span class='fas fa-user-shield'></span>

--- a/InvenTree/templates/navbar.html
+++ b/InvenTree/templates/navbar.html
@@ -139,7 +139,10 @@
         <ul class='dropdown-menu dropdown-menu-end inventree-navbar-menu'>
           {% if user.is_authenticated %}
           {% if user.is_staff and not hide_admin_link %}
-          <li><a class='dropdown-item' href="{% url 'admin:index' %}"><span class="fas fa-user-shield"></span> {% trans "Admin" %}</a></li>
+          {% admin_index user as admin_idx %}
+          {% if admin_idx %}
+          <li><a class='dropdown-item' href="{{ admin_idx }}"><span class="fas fa-user-shield"></span> {% trans "Admin" %}</a></li>
+          {% endif %}
           {% endif %}
           <li><a class='dropdown-item' href="{% url 'settings' %}"><span class="fas fa-cog"></span> {% trans "Settings" %}</a></li>
           <li><a class='dropdown-item' href="{% url 'account_logout' %}"><span class="fas fa-sign-out-alt"></span> {% trans "Logout" %}</a></li>

--- a/InvenTree/templates/registration/logged_out.html
+++ b/InvenTree/templates/registration/logged_out.html
@@ -1,10 +1,11 @@
 {% extends "registration/logged_out.html" %}
 {% load i18n %}
+{% load inventree_extras %}
 
 {% block content %}
 
 <p>{% translate "You were logged out successfully." %}</p>
 
-<p><a href="{% url 'admin:index' %}">{% translate 'Log in again' %}</a></p>
+<p><a href="{% url 'index' %}">{% translate 'Log in again' %}</a></p>
 
 {% endblock content %}

--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -55,10 +55,21 @@ The following basic options are available:
 | INVENTREE_LOG_LEVEL | log_level | Set level of logging to terminal | WARNING |
 | INVENTREE_DB_LOGGING | db_logging | Enable logging of database messages | False |
 | INVENTREE_TIMEZONE | timezone | Server timezone | UTC |
-| ADMIN_ENABLED | admin_enabled | Enable the [django administrator interface](https://docs.djangoproject.com/en/4.2/ref/contrib/admin/) | True |
-| ADMIN_URL | admin_url | URL for accessing [admin interface](../settings/admin.md) | admin |
+| INVENTREE_ADMIN_ENABLED | admin_enabled | Enable the [django administrator interface](https://docs.djangoproject.com/en/4.2/ref/contrib/admin/) | True |
+| INVENTREE_ADMIN_URL | admin_url | URL for accessing [admin interface](../settings/admin.md) | admin |
 | INVENTREE_LANGUAGE | language | Default language | en-us |
 | INVENTREE_BASE_URL | base_url | Server base URL | *Not specified* |
+
+### Admin Site
+
+Django provides a powerful [administrator interface](https://docs.djangoproject.com/en/4.2/ref/contrib/admin/) which can be used to manage the InvenTree database. This interface is enabled by default, but can be disabled by setting `INVENTREE_ADMIN_ENABLED` to `False`.
+
+#### Custom Admin URL
+
+By default, the admin interface is available at the `/admin/` URL. This can be changed by setting the `INVENTREE_ADMIN_URL` environment variable.
+
+!!! warning "Security"
+    Changing the admin URL is a simple way to improve security, but it is not a substitute for proper security practices.
 
 ### Base URL Configuration
 

--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -55,6 +55,7 @@ The following basic options are available:
 | INVENTREE_LOG_LEVEL | log_level | Set level of logging to terminal | WARNING |
 | INVENTREE_DB_LOGGING | db_logging | Enable logging of database messages | False |
 | INVENTREE_TIMEZONE | timezone | Server timezone | UTC |
+| ADMIN_ENABLED | admin_enabled | Enable the [django administrator interface](https://docs.djangoproject.com/en/4.2/ref/contrib/admin/) | True |
 | ADMIN_URL | admin_url | URL for accessing [admin interface](../settings/admin.md) | admin |
 | INVENTREE_LANGUAGE | language | Default language | en-us |
 | INVENTREE_BASE_URL | base_url | Server base URL | *Not specified* |


### PR DESCRIPTION
The custom admin URL feature has been broken for a little while, when we refactored the urlpatterns to:

- Allow new frontend code
- Improve plugin support

This PR fixes the custom admin URL functionality, and also provides a way to disable the admin site entirely if required.