### PR TITLE
Fix issues with running under Python 3.12

### DIFF
--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -7,6 +7,7 @@ import pathlib
 import pkgutil
 import sysconfig
 import traceback
+from importlib.util import module_from_spec
 from importlib.metadata import entry_points
 
 from django import template
@@ -156,9 +157,9 @@ def get_modules(pkg, path=None):
     elif type(path) is not list:
         path = [path]
 
-    for loader, name, _ in pkgutil.walk_packages(path):
+    for finder, name, _ in pkgutil.walk_packages(path):
         try:
-            module = loader.find_module(name).load_module(name)
+            module = module_from_spec(finder.find_spec(name))
             pkg_names = getattr(module, '__all__', None)
             for k, v in vars(module).items():
                 if not k.startswith('_') and (pkg_names is None or k in pkg_names):

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -102,7 +102,7 @@ def handle_error(error, do_raise: bool = True, do_log: bool = True, log_name: st
 
 def get_entrypoints():
     """Returns list for entrypoints for InvenTree plugins."""
-    return entry_points().get('inventree_plugins', [])
+    return entry_points(group='inventree_plugins')
 # endregion
 
 

--- a/InvenTree/plugin/helpers.py
+++ b/InvenTree/plugin/helpers.py
@@ -7,8 +7,8 @@ import pathlib
 import pkgutil
 import sysconfig
 import traceback
-from importlib.util import module_from_spec
 from importlib.metadata import entry_points
+from importlib.util import module_from_spec
 
 from django import template
 from django.conf import settings

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -5,8 +5,8 @@
 """
 
 import importlib
-import importlib.util
 import importlib.machinery
+import importlib.util
 import logging
 import os
 import time

--- a/InvenTree/plugin/registry.py
+++ b/InvenTree/plugin/registry.py
@@ -4,8 +4,9 @@
 - Manages setup and teardown of plugin class instances
 """
 
-import imp
 import importlib
+import importlib.util
+import importlib.machinery
 import logging
 import os
 import time
@@ -354,7 +355,7 @@ class PluginsRegistry:
 
             # Gather Modules
             if parent_path:
-                raw_module = imp.load_source(plugin, str(parent_obj.joinpath('__init__.py')))
+                raw_module = _load_source(plugin, str(parent_obj.joinpath('__init__.py')))
             else:
                 raw_module = importlib.import_module(plugin)
             modules = get_plugins(raw_module, InvenTreePlugin, path=parent_path)
@@ -724,3 +725,18 @@ registry: PluginsRegistry = PluginsRegistry()
 def call_function(plugin_name, function_name, *args, **kwargs):
     """Global helper function to call a specific member function of a plugin."""
     return registry.call_plugin_function(plugin_name, function_name, *args, **kwargs)
+
+
+def _load_source(modname, filename):
+    """Helper function to replace deprecated & removed imp.load_source.
+
+    See https://docs.python.org/3/whatsnew/3.12.html#imp
+    """
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module


### PR DESCRIPTION
These two commit address issues encountered when running with Python 3.12.0. Notably, the changes remove the use of deprecated APIs related to import machinery.

(This is my first PR to this repo, my feelings won't be hurt if this doesn't get accepted or if you decide to make significant changes)