### PR TITLE
Check minimum python version before launching

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -26,9 +26,11 @@ from dotenv import load_dotenv
 
 from InvenTree.config import get_boolean_setting, get_custom_file, get_setting
 from InvenTree.sentry import default_sentry_dsn, init_sentry
-from InvenTree.version import inventreeApiVersion
+from InvenTree.version import checkMinPythonVersion, inventreeApiVersion
 
 from . import config
+
+checkMinPythonVersion()
 
 INVENTREE_NEWS_URL = 'https://inventree.org/news/feed.atom'
 

--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import platform
 import re
+import sys
 from datetime import datetime as dt
 from datetime import timedelta as td
 
@@ -26,6 +27,22 @@ try:
     main_commit = main_repo[main_repo.head()]
 except (NotGitRepository, FileNotFoundError):
     main_commit = None
+
+
+def checkMinPythonVersion():
+    """Check that the Python version is at least 3.9"""
+
+    version = sys.version.split(" ")[0]
+
+    msg = f"InvenTree requires Python 3.9 or above - you are running version {version}.\nRefer to the InvenTree documentation for more information."
+
+    if sys.version_info.major < 3:
+        raise RuntimeError(msg)
+
+    if sys.version_info.major == 3 and sys.version_info.minor < 9:
+        raise RuntimeError(msg)
+
+    print(f"Python version {version} - {sys.executable}")
 
 
 def inventreeInstanceName():

--- a/InvenTree/InvenTree/version.py
+++ b/InvenTree/InvenTree/version.py
@@ -33,8 +33,13 @@ def checkMinPythonVersion():
     """Check that the Python version is at least 3.9"""
 
     version = sys.version.split(" ")[0]
+    docs = "https://docs.inventree.org/en/stable/start/intro/#python-requirements"
 
-    msg = f"InvenTree requires Python 3.9 or above - you are running version {version}.\nRefer to the InvenTree documentation for more information."
+    msg = f"""
+    InvenTree requires Python 3.9 or above - you are running version {version}.
+    - Refer to the InvenTree documentation for more information:
+    - {docs}
+    """
 
     if sys.version_info.major < 3:
         raise RuntimeError(msg)


### PR DESCRIPTION
We have been getting a lot of "error reports" from users running python below minimum version. This PR runs a python version check at the first entrypoint, to ensure that the correct python version is running