### PR TITLE
Improve deletion behaviour for InvenTreeTree model

### DIFF
--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -580,6 +580,8 @@ class InvenTreeTree(MPTTModel):
         parent: The item immediately above this one. An item with a null parent is a top-level item
     """
 
+    # How items (not nodes) are hooked into the tree
+    # e.g. for StockLocation, this value is 'location'
     ITEM_PARENT_KEY = None
 
     class Meta:

--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -678,7 +678,7 @@ class InvenTreeTree(MPTTModel):
 
         # Case C: Delete all child items, but keep all child nodes
         # - Remove all items directly associated with this node
-        # - Move any direct child notes up one level
+        # - Move any direct child nodes up one level
         elif not delete_children and delete_items:
             self.get_items(cascade=False).delete()
             self.get_children().update(parent=self.parent)

--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models.signals import post_save, pre_delete
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -580,6 +580,8 @@ class InvenTreeTree(MPTTModel):
         parent: The item immediately above this one. An item with a null parent is a top-level item
     """
 
+    ITEM_PARENT_KEY = None
+
     class Meta:
         """Metaclass defines extra model properties."""
         abstract = True
@@ -587,6 +589,100 @@ class InvenTreeTree(MPTTModel):
     class MPTTMeta:
         """Set insert order."""
         order_insertion_by = ['name']
+
+    def delete(self, delete_children=False, delete_items=False):
+        """Handle the deletion of a tree node.
+
+        1. Update nodes and items under the current node
+        2. Delete this node
+        3. Rebuild the model tree
+        4. Rebuild the path for any remaining lower nodes
+        """
+
+        tree_id = self.tree_id if self.parent else None
+
+        # Cache node ID values for lower nodes, before we delete this one
+        lower_nodes = list(self.get_descendants(include_self=False).values_list('pk', flat=True))
+
+        # 1. Update nodes and items under the current node
+        self.handle_tree_delete(delete_children=delete_children, delete_items=delete_items)
+
+        # 2. Delete *this* node
+        super().delete()
+
+        # 3. Update the tree structure
+        if tree_id:
+            self.__class__.objects.partial_rebuild(self.tree_id)
+        else:
+            self.__class__.objects.rebuild()
+
+        # 4. Rebuild the path for any remaining lower nodes
+        nodes = self.__class__.objects.filter(pk__in=lower_nodes)
+
+        nodes_to_update = []
+
+        for node in nodes:
+            new_path = node.construct_pathstring()
+
+            if new_path != node.pathstring:
+                node.pathstring = new_path
+                nodes_to_update.append(node)
+
+        if len(nodes_to_update) > 0:
+            self.__class__.objects.bulk_update(nodes_to_update, ['pathstring'])
+
+    def handle_tree_delete(self, delete_children=False, delete_items=False):
+        """Delete a single instance of the tree, based on provided kwargs.
+
+        Removing a tree "node" from the database must be considered carefully,
+        based on what the user intends for any items which exist *under* that node.
+
+        - "children" are any nodes which exist *under* this node (e.g. PartCategory)
+        - "items" are any items which exist *under* this node (e.g. Part)
+
+        Arguments:
+            delete_children: If True, delete all child items
+            delete_items: If True, delete all items associated with this node
+
+        There are multiple scenarios we can consider here:
+
+        A) delete_children = True and delete_items = True
+        B) delete_children = True and delete_items = False
+        C) delete_children = False and delete_items = True
+        D) delete_children = False and delete_items = False
+        """
+
+        # Case A: Delete all child items, and all child nodes.
+        # - Delete all items at any lower level
+        # - Delete all descendant nodes
+        if delete_children and delete_items:
+            self.get_items(cascade=True).delete()
+            self.get_descendants(include_self=False).delete()
+
+        # Case B: Delete all child nodes, but move all child items up to the parent
+        # - Move all items at any lower level to the parent of this item
+        # - Delete all descendant nodes
+        elif delete_children and not delete_items:
+            self.get_items(cascade=True).update(**{
+                self.ITEM_PARENT_KEY: self.parent
+            })
+            self.get_descendants(include_self=False).delete()
+
+        # Case C: Delete all child items, but keep all child nodes
+        # - Remove all items directly associated with this node
+        # - Move any direct child notes up one level
+        elif not delete_children and delete_items:
+            self.get_items(cascade=False).delete()
+            self.get_children().update(parent=self.parent)
+
+        # Case D: Keep all child items, and keep all child nodes
+        # - Move all items directly associated with this node up one level
+        # - Move any direct child nodes up one level
+        elif not delete_children and not delete_items:
+            self.get_items(cascade=False).update(**{
+                self.ITEM_PARENT_KEY: self.parent
+            })
+            self.get_children().update(parent=self.parent)
 
     def validate_unique(self, exclude=None):
         """Validate that this tree instance satisfies our uniqueness requirements.
@@ -614,6 +710,12 @@ class InvenTreeTree(MPTTModel):
             }
         }
 
+    def construct_pathstring(self):
+        """Construct the pathstring for this tree node"""
+        return InvenTree.helpers.constructPathString(
+            [item.name for item in self.path]
+        )
+
     def save(self, *args, **kwargs):
         """Custom save method for InvenTreeTree abstract model"""
         try:
@@ -625,9 +727,7 @@ class InvenTreeTree(MPTTModel):
             })
 
         # Re-calculate the 'pathstring' field
-        pathstring = InvenTree.helpers.constructPathString(
-            [item.name for item in self.path]
-        )
+        pathstring = self.construct_pathstring()
 
         if pathstring != self.pathstring:
 
@@ -673,16 +773,15 @@ class InvenTreeTree(MPTTModel):
         help_text=_('Path')
     )
 
-    @property
-    def item_count(self):
-        """Return the number of items which exist *under* this node in the tree.
+    def getItems(self, cascade=False):
+        """Return a queryset of items which exist *under* this node in the tree.
 
-        Here an 'item' is considered to be the 'leaf' at the end of each branch,
-        and the exact nature here will depend on the class implementation.
+        - For a StockLocation instance, this would be a queryset of StockItem objects
+        - For a PartCategory instance, this would be a queryset of Part objects
 
-        The default implementation returns zero
+        The default implementation returns an empty list
         """
-        return 0
+        raise NotImplementedError(f"items() method not implemented for {type(self)}")
 
     def getUniqueParents(self):
         """Return a flat set of all parent items that exist above this node.
@@ -876,18 +975,6 @@ class InvenTreeBarcodeMixin(models.Model):
         self.barcode_hash = ''
 
         self.save()
-
-
-@receiver(pre_delete, sender=InvenTreeTree, dispatch_uid='tree_pre_delete_log')
-def before_delete_tree_item(sender, instance, using, **kwargs):
-    """Receives pre_delete signal from InvenTreeTree object.
-
-    Before an item is deleted, update each child object to point to the parent of the object being deleted.
-    """
-    # Update each tree item below this one
-    for child in instance.children.all():
-        child.parent = instance.parent
-        child.save()
 
 
 @receiver(post_save, sender=Error, dispatch_uid='error_post_save_notification')

--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -775,7 +775,7 @@ class InvenTreeTree(MPTTModel):
         help_text=_('Path')
     )
 
-    def getItems(self, cascade=False):
+    def get_items(self, cascade=False):
         """Return a queryset of items which exist *under* this node in the tree.
 
         - For a StockLocation instance, this would be a queryset of StockItem objects

--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -606,8 +606,8 @@ class InvenTreeTree(MPTTModel):
         try:
             self.refresh_from_db()
         except self.__class__.DoesNotExist:
-            # If the object no longer exists, we can just return
-            logger.exception("Object %s of type %s no longer exists", str(self), str(self.__class__))
+            # If the object no longer exists, raise a ValidationError
+            raise ValidationError("Object %s of type %s no longer exists", str(self), str(self.__class__))
 
         # Cache node ID values for lower nodes, before we delete this one
         lower_nodes = list(self.get_descendants(include_self=False).values_list('pk', flat=True))

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -157,7 +157,7 @@ class PartCategory(MetadataMixin, InvenTreeTree):
         """Return the number of parts contained in this PartCategory"""
         return self.partcount()
 
-    def getItems(self, cascade=False):
+    def get_items(self, cascade=False):
         """Return a queryset containing the parts which exist in this category"""
         return self.get_parts(cascade=cascade)
 

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -72,55 +72,23 @@ class PartCategory(MetadataMixin, InvenTreeTree):
         default_keywords: Default keywords for parts created in this category
     """
 
+    ITEM_PARENT_KEY = 'category'
+
     class Meta:
         """Metaclass defines extra model properties"""
         verbose_name = _("Part Category")
         verbose_name_plural = _("Part Categories")
-
-    def delete_recursive(self, *args, **kwargs):
-        """This function handles the recursive deletion of subcategories depending on kwargs contents"""
-        delete_parts = kwargs.get('delete_parts', False)
-        parent_category = kwargs.get('parent_category', None)
-
-        if parent_category is None:
-            # First iteration, (no part_category kwargs passed)
-            parent_category = self.parent
-
-        for child_part in self.parts.all():
-            if delete_parts:
-                child_part.delete()
-            else:
-                child_part.category = parent_category
-                child_part.save()
-
-        for child_category in self.children.all():
-            if kwargs.get('delete_child_categories', False):
-                child_category.delete_recursive(**{
-                    "delete_child_categories": True,
-                    "delete_parts": delete_parts,
-                    "parent_category": parent_category})
-            else:
-                child_category.parent = parent_category
-                child_category.save()
-
-        super().delete(*args, **{})
 
     def delete(self, *args, **kwargs):
         """Custom model deletion routine, which updates any child categories or parts.
 
         This must be handled within a transaction.atomic(), otherwise the tree structure is damaged
         """
-        with transaction.atomic():
-            self.delete_recursive(**{
-                "delete_parts": kwargs.get('delete_parts', False),
-                "delete_child_categories": kwargs.get('delete_child_categories', False),
-                "parent_category": self.parent})
 
-            if self.parent is not None:
-                # Partially rebuild the tree (cheaper than a complete rebuild)
-                PartCategory.objects.partial_rebuild(self.tree_id)
-            else:
-                PartCategory.objects.rebuild()
+        super().delete(
+            delete_children=kwargs.get('delete_child_categories', False),
+            delete_items=kwargs.get('delete_parts', False),
+        )
 
     default_location = TreeForeignKey(
         'stock.StockLocation', related_name="default_categories",
@@ -188,6 +156,10 @@ class PartCategory(MetadataMixin, InvenTreeTree):
     def item_count(self):
         """Return the number of parts contained in this PartCategory"""
         return self.partcount()
+
+    def getItems(self, cascade=False):
+        """Return a queryset containing the parts which exist in this category"""
+        return self.get_parts(cascade=cascade)
 
     def partcount(self, cascade=True, active=False):
         """Return the total part count under this category (including children of child categories)."""

--- a/InvenTree/part/test_bom_import.py
+++ b/InvenTree/part/test_bom_import.py
@@ -237,9 +237,9 @@ class BomUploadTest(InvenTreeAPITestCase):
 
         components = Part.objects.filter(component=True)
 
-        for idx, _ in enumerate(components):
+        for component in components:
             dataset.append([
-                f"Component {idx}",
+                component.name,
                 10,
             ])
 
@@ -266,9 +266,9 @@ class BomUploadTest(InvenTreeAPITestCase):
 
         dataset.headers = ['part_ipn', 'quantity']
 
-        for idx, _ in enumerate(components):
+        for component in components:
             dataset.append([
-                f"CMP_{idx}",
+                component.IPN,
                 10,
             ])
 

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -1418,13 +1418,19 @@ class LocationDetail(CustomRetrieveUpdateDestroyAPI):
 
     def destroy(self, request, *args, **kwargs):
         """Delete a Stock location instance via the API"""
-        delete_stock_items = 'delete_stock_items' in request.data and request.data['delete_stock_items'] == '1'
-        delete_sub_locations = 'delete_sub_locations' in request.data and request.data['delete_sub_locations'] == '1'
-        return super().destroy(request,
-                               *args,
-                               **dict(kwargs,
-                                      delete_sub_locations=delete_sub_locations,
-                                      delete_stock_items=delete_stock_items))
+
+        delete_stock_items = str(request.data.get('delete_stock_items', 0)) == '1'
+        delete_sub_locations = str(request.data.get('delete_sub_locations', 0)) == '1'
+
+        return super().destroy(
+            request,
+            *args,
+            **dict(
+                kwargs,
+                delete_sub_locations=delete_sub_locations,
+                delete_stock_items=delete_stock_items
+            )
+        )
 
 
 stock_api_urls = [

--- a/docs/docs/extend/plugins/urls.md
+++ b/docs/docs/extend/plugins/urls.md
@@ -32,7 +32,7 @@ Rendering templated views is also supported. Templated HTML files should be plac
 Placed here, the template can be called using the file name (ex: `render(request, 'test.html', context)`)
 
 ### Implementing a Page Base
-Some plugins require a page with a navbar, sidebar, and content. 
+Some plugins require a page with a navbar, sidebar, and content.
 This can be done within a templated HTML file. Extend the file "page_base.html". This can be done by placing the following line at the top of the file.
 ``` HTML
 {% extends "page_base.html" %}


### PR DESCRIPTION
This PR solves a long-running bug which I have only now tracked down, which can occur when deleting a tree element (such as stock location, or part category). Additionally it provides a significant improvement in behaviour, removing recursive function calls and running bulk database queries to reduce the O() number of database operations required

This means that updating a complex part or stock tree will be much faster when there is a significant number of descendant nodes

The "bug" being fixed here is that the recursive order of operations, combined with atomic transactions, means that the database records are not always updated in the right sequence, and can result in a thrown `IntegrityError`

- Remove recursive call to function
- Handle database operations as bulk queries
- Ensure child nodes have their pathstring updated correctly
- Remove old `receiver` hook
- Refactor StockLocation.delete method
- Refactor PartCategory.delete method
- Atomic transactions potentially problematic here

Existing unit tests cover tree element deletion, and should be mostly sufficient here, with some small tweaks