### PR TITLE
Build part change fix

### DIFF
--- a/InvenTree/InvenTree/mixins.py
+++ b/InvenTree/InvenTree/mixins.py
@@ -56,6 +56,11 @@ class DiffMixin:
 
         return deltas
 
+    def has_field_changed(self, field_name):
+        """Determine if a particular field has changed."""
+
+        return field_name in self.get_field_deltas()
+
 
 class CleanMixin():
     """Model mixin class which cleans inputs using the Mozilla bleach tools."""

--- a/InvenTree/InvenTree/mixins.py
+++ b/InvenTree/InvenTree/mixins.py
@@ -9,6 +9,54 @@ from InvenTree.fields import InvenTreeNotesField
 from InvenTree.helpers import remove_non_printable_characters, strip_html_tags
 
 
+class DiffMixin:
+    """Mixin which can be used to determine which fields have changed, compared to the instance saved to the database."""
+
+    def get_db_instance(self):
+        """Return the instance of the object saved in the database.
+
+        Returns:
+            object: Instance of the object saved in the database
+        """
+
+        if self.pk:
+            try:
+                return self.__class__.objects.get(pk=self.pk)
+            except self.__class__.DoesNotExist:
+                pass
+
+        return None
+
+    def get_field_deltas(self):
+        """Return a dict of field deltas.
+
+        Compares the current instance with the instance saved in the database,
+        and returns a dict of fields which have changed.
+
+        Returns:
+            dict: Dict of field deltas
+        """
+
+        db_instance = self.get_db_instance()
+
+        if db_instance is None:
+            return {}
+
+        deltas = {}
+
+        for field in self._meta.fields:
+            if field.name == 'id':
+                continue
+
+            if getattr(self, field.name) != getattr(db_instance, field.name):
+                deltas[field.name] = {
+                    'old': getattr(db_instance, field.name),
+                    'new': getattr(self, field.name),
+                }
+
+        return deltas
+
+
 class CleanMixin():
     """Model mixin class which cleans inputs using the Mozilla bleach tools."""
 

--- a/InvenTree/build/test_build.py
+++ b/InvenTree/build/test_build.py
@@ -471,6 +471,28 @@ class BuildTest(BuildTestBase):
         # Check that the "consumed_by" item count has increased
         self.assertEqual(StockItem.objects.filter(consumed_by=self.build).count(), n + 8)
 
+    def test_change_part(self):
+        """Try to change target part after creating a build"""
+
+        bo = Build.objects.create(
+            reference='BO-9999',
+            title='Some new build',
+            part=self.assembly,
+            quantity=5,
+            issued_by=get_user_model().objects.get(pk=1),
+        )
+
+        assembly_2 = Part.objects.create(
+            name="Another assembly",
+            description="A different assembly",
+            assembly=True,
+        )
+
+        # Should not be able to change the part after the Build is saved
+        with self.assertRaises(ValidationError):
+            bo.part = assembly_2
+            bo.save()
+
     def test_cancel(self):
         """Test cancellation of the build"""
         # TODO

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -130,6 +130,9 @@ function editBuildOrder(pk) {
 
     var fields = buildFormFields();
 
+    // Cannot edit "part" field after creation
+    delete fields['part'];
+
     constructForm(`{% url "api-build-list" %}${pk}/`, {
         fields: fields,
         reload: true,


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/5611

Prevents build order target part from being changed after the order is saved.

Also provides a new `DiffMixin` class, which may be useful in general for tracking field deltas:

- https://github.com/inventree/InvenTree/issues/4468
- https://github.com/inventree/InvenTree/issues/2058