### PR TITLE
Bump django_money version back to 3.2.0, Fix #5825

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,7 +20,7 @@ on:
   push:
     branches:
       - 'master'
-  pull_request:
+  # pull_request:
   #   branches:
   #     - 'master'
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,7 +20,7 @@ on:
   push:
     branches:
       - 'master'
-  # pull_request:
+  pull_request:
   #   branches:
   #     - 'master'
 

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ django-ical                             # iCal export for calendar views
 django-import-export>=3.3.1             # Data import / export for admin interface
 django-maintenance-mode                 # Shut down application while reloading etc.
 django-markdownify                      # Markdown rendering
-django-money>=3.0.0                     # Django app for currency management
+django-money>=3.0.0,<3.3.0              # Django app for currency management # FIXED 2023-10-31 3.3.0 breaks due to https://github.com/django-money/django-money/issues/731
 django-mptt==0.11.0                     # Modified Preorder Tree Traversal
 django-redis>=5.0.0                     # Redis integration
 django-q2                               # Background task scheduling

--- a/requirements.txt
+++ b/requirements.txt
@@ -113,7 +113,7 @@ django-maintenance-mode==0.19.0
     # via -r requirements.in
 django-markdownify==0.9.3
     # via -r requirements.in
-django-money==3.3.0
+django-money==3.2.0
     # via -r requirements.in
 django-mptt==0.11.0
     # via -r requirements.in


### PR DESCRIPTION
`makemigrations` didn't cause any changes, so I guess the migrations are fine after all? Can we somehow test this works with the docker builds without merging this @SchrodingersGat ?

Edit: This fixes #5825