### PR TITLE
Prevent settings from writing to the database during import

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -494,6 +494,14 @@ class BaseInvenTreeSetting(models.Model):
         # Unless otherwise specified, attempt to create the setting
         create = kwargs.pop('create', True)
 
+        # Prevent saving to the database during data import
+        if InvenTree.ready.isImportingData():
+            create = False
+
+        # Prevent saving to the database during migrations
+        if InvenTree.ready.isRunningMigrations():
+            create = False
+
         # Perform cache lookup by default
         do_cache = kwargs.pop('cache', True)
 


### PR DESCRIPTION
- Fixes conflicts which can occur due to importing duplicate settings from a data file