### PR TITLE
[PUI] Added pricing settings

### DIFF
--- a/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
+++ b/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
@@ -21,6 +21,7 @@ import {
 } from '@tabler/icons-react';
 import { useMemo } from 'react';
 
+import { PlaceholderPill } from '../../../components/items/Placeholder';
 import { PanelGroup, PanelType } from '../../../components/nav/PanelGroup';
 import { SettingsHeader } from '../../../components/nav/SettingsHeader';
 import { GlobalSettingList } from '../../../components/settings/SettingList';
@@ -123,7 +124,37 @@ export default function SystemSettings() {
       {
         name: 'pricing',
         label: t`Pricing`,
-        icon: <IconCurrencyDollar />
+        icon: <IconCurrencyDollar />,
+        content: (
+          <>
+            <GlobalSettingList
+              keys={[
+                'INVENTREE_DEFAULT_CURRENCY',
+                'PART_INTERNAL_PRICE',
+                'PART_BOM_USE_INTERNAL_PRICE',
+                'PRICING_DECIMAL_PLACES_MIN',
+                'PRICING_DECIMAL_PLACES',
+                'PRICING_UPDATE_DAYS'
+              ]}
+            />
+            <br />
+            <GlobalSettingList
+              keys={[
+                'PRICING_USE_SUPPLIER_PRICING',
+                'PRICING_PURCHASE_HISTORY_OVERRIDES_SUPPLIER',
+                'PRICING_USE_STOCK_PRICING',
+                'PRICING_STOCK_ITEM_AGE_DAYS',
+                'PRICING_USE_VARIANT_PRICING',
+                'PRICING_ACTIVE_VARIANTS'
+              ]}
+            />
+            <br />
+            <GlobalSettingList
+              keys={['CURRENCY_UPDATE_PLUGIN', 'CURRENCY_UPDATE_INTERVAL']}
+            />
+            <PlaceholderPill />
+          </>
+        )
       },
       {
         name: 'labels',


### PR DESCRIPTION
This PR adds the settings part of the system settings pricing section. The current exchange rates and action buttons from CUI are still TBD.

I filed this mainly because I needed the pricing settings in other developments and wanted to stop switching to CUI to change them.