### PR TITLE
Bumped docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # - Runs InvenTree web server under django development server
 # - Monitors source files for any changes, and live-reloads server
 
-FROM python:3.10-alpine3.18 as inventree_base
+FROM python:3.11-alpine3.18 as inventree_base
 
 # Build arguments for this image
 ARG commit_hash=""


### PR DESCRIPTION
Bumps Python from 3.10 to 3.11 - which brought a few performance improvements with it