### PR TITLE
Report image rendering fix

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,15 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 150
+INVENTREE_API_VERSION = 151
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v151 -> 2023-11-13 : https://github.com/inventree/InvenTree/pull/5906
+    - Allow user list API to be filtered by user active status
+    - Allow owner list API to be filtered by user active status
+
 v150 -> 2023-11-07: https://github.com/inventree/InvenTree/pull/5875
     - Extended user API endpoints to enable ordering
     - Extended user API endpoints to enable user role changes

--- a/InvenTree/label/tests.py
+++ b/InvenTree/label/tests.py
@@ -154,8 +154,6 @@ class LabelTest(InvenTreeAPITestCase):
         self.assertIn(f"part: {part_pk} - {part_name}", content)
         self.assertIn(f'data: {{"part": {part_pk}}}', content)
         self.assertIn(f'http://testserver/part/{part_pk}/', content)
-        self.assertIn("img/blank_image.png", content)
-        self.assertIn("img/inventree.png", content)
 
     def test_metadata(self):
         """Unit tests for the metadata field."""

--- a/InvenTree/label/tests.py
+++ b/InvenTree/label/tests.py
@@ -106,7 +106,7 @@ class LabelTest(InvenTreeAPITestCase):
         <!-- Test InvenTree URL -->
         url: {{ qr_url|safe }}
         <!-- Test image URL generation -->
-        image: {% part_image part %}
+        image: {% part_image part width=128 %}
         <!-- Test InvenTree logo -->
         logo: {% logo_image %}
         </html>
@@ -154,6 +154,9 @@ class LabelTest(InvenTreeAPITestCase):
         self.assertIn(f"part: {part_pk} - {part_name}", content)
         self.assertIn(f'data: {{"part": {part_pk}}}', content)
         self.assertIn(f'http://testserver/part/{part_pk}/', content)
+
+        # Check that a encoded image has been generated
+        self.assertIn('data:image/png;charset=utf-8;base64,', content)
 
     def test_metadata(self):
         """Unit tests for the metadata field."""

--- a/InvenTree/report/helpers.py
+++ b/InvenTree/report/helpers.py
@@ -1,5 +1,7 @@
 """Helper functions for report generation."""
 
+import base64
+import io
 import logging
 
 from django.utils.translation import gettext_lazy as _
@@ -48,3 +50,22 @@ def report_page_size_default():
         page_size = 'A4'
 
     return page_size
+
+
+def encode_image_base64(image, format: str = 'PNG'):
+    """Return a base-64 encoded image which can be rendered in an <img> tag
+
+    Arguments:
+        image {Image} -- Image object
+        format {str} -- Image format (e.g. 'PNG')
+
+    Returns:
+        str -- Base64 encoded image data e.g. 'data:image/png;base64,xxxxxxxxx'
+    """
+
+    buffered = io.BytesIO()
+    image.save(buffered, format.lower())
+
+    img_str = base64.b64encode(buffered.getvalue())
+
+    return f"data:image/{format};charset=utf-8;base64," + img_str.decode()

--- a/InvenTree/report/helpers.py
+++ b/InvenTree/report/helpers.py
@@ -63,9 +63,11 @@ def encode_image_base64(image, format: str = 'PNG'):
         str -- Base64 encoded image data e.g. 'data:image/png;base64,xxxxxxxxx'
     """
 
+    fmt = format.lower()
+
     buffered = io.BytesIO()
-    image.save(buffered, format.lower())
+    image.save(buffered, fmt)
 
     img_str = base64.b64encode(buffered.getvalue())
 
-    return f"data:image/{format};charset=utf-8;base64," + img_str.decode()
+    return f"data:image/{fmt};charset=utf-8;base64," + img_str.decode()

--- a/InvenTree/report/templates/report/inventree_bill_of_materials_report.html
+++ b/InvenTree/report/templates/report/inventree_bill_of_materials_report.html
@@ -123,7 +123,7 @@ table td.expand {
             </td>
             <td>
                 <div class='part-logo'>
-                    <img src='{% part_image part %}' alt='{% trans "Image" %}' class='part-logo'>
+                    <img src='{% part_image part height=480 %}' alt='{% trans "Image" %}' class='part-logo'>
                 </div>
             </td>
         </tr>
@@ -145,7 +145,7 @@ table td.expand {
         <tr>
             <td>
                 <div class='thumb-container'>
-                    <img src='{% part_image line.sub_part %}' alt='{% trans "Image" %}' class='part-thumb'>
+                    <img src='{% part_image line.sub_part height=240 %}' alt='{% trans "Image" %}' class='part-thumb'>
                 </div>
                 <div class='part-text'>
                     {{ line.sub_part.full_name }}

--- a/InvenTree/report/templates/report/inventree_build_order_base.html
+++ b/InvenTree/report/templates/report/inventree_build_order_base.html
@@ -95,7 +95,7 @@ content: "v{{ report_revision }} - {{ date.isoformat }}";
 
 <div class='details'>
     <div class='details-image'>
-        <img class='part-image' alt="{% trans 'Part image' %}" src="{% part_image part %}">
+        <img class='part-image' alt="{% trans 'Part image' %}" src="{% part_image part height=480 %}">
     </div>
 
     <div class='details-container'>

--- a/InvenTree/report/templates/report/inventree_po_report_base.html
+++ b/InvenTree/report/templates/report/inventree_po_report_base.html
@@ -37,7 +37,7 @@
         <tr>
             <td>
                 <div class='thumb-container'>
-                    <img src='{% part_image line.part.part %}' class='part-thumb' alt="{% trans 'Part image' %}">
+                    <img src='{% part_image line.part.part height=240 %}' class='part-thumb' alt="{% trans 'Part image' %}">
                 </div>
                 <div class='part-text'>
                     {{ line.part.part.full_name }}

--- a/InvenTree/report/templates/report/inventree_return_order_report_base.html
+++ b/InvenTree/report/templates/report/inventree_return_order_report_base.html
@@ -32,7 +32,7 @@
         <tr>
             <td>
                 <div class='thumb-container'>
-                    <img src='{% part_image line.item.part %}' alt='{% trans "Image" %}' class='part-thumb'>
+                    <img src='{% part_image line.item.part height=240 %}' alt='{% trans "Image" %}' class='part-thumb'>
                 </div>
                 <div class='part-text'>
                     {{ line.item.part.full_name }}

--- a/InvenTree/report/templates/report/inventree_so_report_base.html
+++ b/InvenTree/report/templates/report/inventree_so_report_base.html
@@ -37,7 +37,7 @@
         <tr>
             <td>
                 <div class='thumb-container'>
-                    <img src='{% part_image line.part %}' alt='{% trans "Part image" %}' class='part-thumb'>
+                    <img src='{% part_image line.part height=240 %}' alt='{% trans "Part image" %}' class='part-thumb'>
                 </div>
                 <div class='part-text'>
                     {{ line.part.full_name }}

--- a/InvenTree/report/templates/report/inventree_test_report_base.html
+++ b/InvenTree/report/templates/report/inventree_test_report_base.html
@@ -81,7 +81,7 @@ content: "{% trans 'Stock Item Test Report' %}";
         <p><em>Stock Item ID: {{ stock_item.pk }}</em></p>
     </div>
     <div class='img-right'>
-        <img class='part-img' alt='{% trans "Part image" %}' src="{% part_image part preview=True %}">
+        <img class='part-img' alt='{% trans "Part image" %}' src="{% part_image part height=256 %}">
         <hr>
         <h4>
             {% if stock_item.is_serialized %}

--- a/InvenTree/report/templates/report/inventree_test_report_base.html
+++ b/InvenTree/report/templates/report/inventree_test_report_base.html
@@ -81,7 +81,7 @@ content: "{% trans 'Stock Item Test Report' %}";
         <p><em>Stock Item ID: {{ stock_item.pk }}</em></p>
     </div>
     <div class='img-right'>
-        <img class='part-img' alt='{% trans "Part image" %}' src="{% part_image part height=256 %}">
+        <img class='part-img' alt='{% trans "Part image" %}' src="{% part_image part height=480 %}">
         <hr>
         <h4>
             {% if stock_item.is_serialized %}
@@ -160,7 +160,7 @@ content: "{% trans 'Stock Item Test Report' %}";
     {% for sub_item in installed_items %}
         <tr>
             <td>
-                <img src='{% part_image sub_item.part %}' class='part-img' alt='{% trans "Part image" %}' style='max-width: 24px; max-height: 24px;'>
+                <img src='{% part_image sub_item.part height=240 %}' class='part-img' alt='{% trans "Part image" %}' style='max-width: 24px; max-height: 24px;'>
                 {{ sub_item.part.full_name }}
             </td>
             <td>

--- a/InvenTree/report/templates/report/inventree_test_report_base.html
+++ b/InvenTree/report/templates/report/inventree_test_report_base.html
@@ -81,7 +81,7 @@ content: "{% trans 'Stock Item Test Report' %}";
         <p><em>Stock Item ID: {{ stock_item.pk }}</em></p>
     </div>
     <div class='img-right'>
-        <img class='part-img' alt='{% trans "Part image" %}' src="{% part_image part %}">
+        <img class='part-img' alt='{% trans "Part image" %}' src="{% part_image part preview=True %}">
         <hr>
         <h4>
             {% if stock_item.is_serialized %}

--- a/InvenTree/report/templatetags/barcode.py
+++ b/InvenTree/report/templatetags/barcode.py
@@ -1,12 +1,11 @@
 """Template tags for rendering various barcodes."""
 
-import base64
-from io import BytesIO
-
 from django import template
 
 import barcode as python_barcode
 import qrcode as python_qrcode
+
+import report.helpers
 
 register = template.Library()
 
@@ -16,12 +15,8 @@ def image_data(img, fmt='PNG'):
 
     Returns a string ``data:image/FMT;base64,xxxxxxxxx`` which can be rendered to an <img> tag
     """
-    buffered = BytesIO()
-    img.save(buffered, format=fmt)
 
-    img_str = base64.b64encode(buffered.getvalue())
-
-    return f"data:image/{fmt.lower()};charset=utf-8;base64," + img_str.decode()
+    return report.helpers.encode_image_base64(img, fmt)
 
 
 @register.simple_tag()

--- a/InvenTree/report/templatetags/report.py
+++ b/InvenTree/report/templatetags/report.py
@@ -7,6 +7,7 @@ import os
 from django import template
 from django.conf import settings
 from django.utils.safestring import SafeString, mark_safe
+from django.utils.translation import gettext_lazy as _
 
 from PIL import Image
 
@@ -91,7 +92,7 @@ def asset(filename):
     full_path = settings.MEDIA_ROOT.joinpath('report', 'assets', filename).resolve()
 
     if not full_path.exists() or not full_path.is_file():
-        raise FileNotFoundError(f"Asset file '{filename}' does not exist")
+        raise FileNotFoundError(_("Asset file does not exist") + f": '{filename}'")
 
     if debug_mode:
         return os.path.join(settings.MEDIA_URL, 'report', 'assets', filename)
@@ -140,7 +141,7 @@ def uploaded_image(filename, replace_missing=True, replacement_file='blank_image
         exists = False
 
     if not exists and not replace_missing:
-        raise FileNotFoundError(f"Image file '{filename}' not found")
+        raise FileNotFoundError(_("Image file not found") + f": '{filename}'")
 
     if debug_mode:
         # In debug mode, return a web path (rather than an encoded image blob)
@@ -205,7 +206,7 @@ def encode_svg_image(filename):
             exists = False
 
     if not exists:
-        raise FileNotFoundError(f"Image file '{filename}' not found")
+        raise FileNotFoundError(_("Image file not found") + f": '{filename}'")
 
     # Read the file data
     with open(full_path, 'rb') as f:
@@ -226,7 +227,7 @@ def part_image(part: Part, preview=False, thumbnail=False, **kwargs):
         TypeError if provided part is not a Part instance
     """
     if type(part) is not Part:
-        raise TypeError("part_image tag requires a Part instance")
+        raise TypeError(_("part_image tag requires a Part instance"))
 
     if preview:
         img = part.image.preview.name
@@ -265,7 +266,7 @@ def company_image(company, preview=False, thumbnail=False, **kwargs):
         TypeError if provided company is not a Company instance
     """
     if type(company) is not Company:
-        raise TypeError("company_image tag requires a Company instance")
+        raise TypeError(_("company_image tag requires a Company instance"))
 
     if preview:
         img = company.image.preview.name

--- a/InvenTree/report/templatetags/report.py
+++ b/InvenTree/report/templatetags/report.py
@@ -220,7 +220,7 @@ def part_parameter(part: Part, parameter_name: str):
 
 
 @register.simple_tag()
-def company_image(company, **kwargs):
+def company_image(company, preview=False, thumbnail=False, **kwargs):
     """Return a fully-qualified path for a company image.
 
     Arguments:
@@ -229,10 +229,15 @@ def company_image(company, **kwargs):
     Raises:
         TypeError if provided company is not a Company instance
     """
-    if type(company) is Company:
-        img = company.image.name
-    else:
+    if type(company) is not Company:
         raise TypeError("company_image tag requires a Company instance")
+
+    if preview:
+        img = company.image.preview.name
+    elif thumbnail:
+        img = company.image.thumbnail.name
+    else:
+        img = company.image.name
 
     return uploaded_image(img, **kwargs)
 

--- a/InvenTree/report/templatetags/report.py
+++ b/InvenTree/report/templatetags/report.py
@@ -152,7 +152,11 @@ def uploaded_image(filename, replace_missing=True, replacement_file='blank_image
         full_path = settings.STATIC_ROOT.joinpath('img', replacement_file).resolve()
 
     # Load the image, check that it is valid
-    img = Image.open(full_path)
+    if full_path.exists() and full_path.is_file():
+        img = Image.open(full_path)
+    else:
+        # A placeholder image showing that the image is missing
+        img = Image.new('RGB', (64, 64), color='red')
 
     width = kwargs.get('width', None)
     height = kwargs.get('height', None)

--- a/InvenTree/report/templatetags/report.py
+++ b/InvenTree/report/templatetags/report.py
@@ -175,7 +175,7 @@ def encode_svg_image(filename):
 
 
 @register.simple_tag()
-def part_image(part: Part):
+def part_image(part: Part, preview=False, thumbnail=False, **kwargs):
     """Return a fully-qualified path for a part image.
 
     Arguments:
@@ -184,13 +184,17 @@ def part_image(part: Part):
     Raises:
         TypeError if provided part is not a Part instance
     """
-    if type(part) is Part:
-        img = part.image.name
-
-    else:
+    if type(part) is not Part:
         raise TypeError("part_image tag requires a Part instance")
 
-    return uploaded_image(img)
+    if preview:
+        img = part.image.preview.name
+    elif thumbnail:
+        img = part.image.thumbnail.name
+    else:
+        img = part.image.name
+
+    return uploaded_image(img, **kwargs)
 
 
 @register.simple_tag()
@@ -210,7 +214,7 @@ def part_parameter(part: Part, parameter_name: str):
 
 
 @register.simple_tag()
-def company_image(company):
+def company_image(company, **kwargs):
     """Return a fully-qualified path for a company image.
 
     Arguments:
@@ -224,7 +228,7 @@ def company_image(company):
     else:
         raise TypeError("company_image tag requires a Company instance")
 
-    return uploaded_image(img)
+    return uploaded_image(img, **kwargs)
 
 
 @register.simple_tag()

--- a/InvenTree/report/templatetags/report.py
+++ b/InvenTree/report/templatetags/report.py
@@ -163,17 +163,17 @@ def uploaded_image(filename, replace_missing=True, replacement_file='blank_image
 
     if width is not None and height is not None:
         # Resize the image, width *and* height are provided
-        img = img.resize((width, height), Image.ANTIALIAS)
+        img = img.resize((width, height))
     elif width is not None:
         # Resize the image, width only
         wpercent = (width / float(img.size[0]))
         hsize = int((float(img.size[1]) * float(wpercent)))
-        img = img.resize((width, hsize), Image.ANTIALIAS)
+        img = img.resize((width, hsize))
     elif height is not None:
         # Resize the image, height only
         hpercent = (height / float(img.size[1]))
         wsize = int((float(img.size[0]) * float(hpercent)))
-        img = img.resize((wsize, height), Image.ANTIALIAS)
+        img = img.resize((wsize, height))
 
     # Optionally rotate the image
     rotate = kwargs.get('rotate', None)

--- a/InvenTree/report/templatetags/report.py
+++ b/InvenTree/report/templatetags/report.py
@@ -96,7 +96,7 @@ def asset(filename):
 
 
 @register.simple_tag()
-def uploaded_image(filename, replace_missing=True, replacement_file='blank_image.png', validate=True):
+def uploaded_image(filename, replace_missing=True, replacement_file='blank_image.png', validate=True, **kwargs):
     """Return a fully-qualified path for an 'uploaded' image.
 
     Arguments:
@@ -104,8 +104,14 @@ def uploaded_image(filename, replace_missing=True, replacement_file='blank_image
         replace_missing: Optionally return a placeholder image if the provided filename does not exist
         validate: Optionally validate that the file is a valid image file (default = True)
 
+    kwargs:
+        Extra keyword arguments which can augment the image rendering (e.g. width, height) : Not yet implemented
+
     Returns:
         A fully qualified path to the image
+
+    Raises:
+        FileNotFoundError if the file does not exist
     """
     if type(filename) is SafeString:
         # Prepend an empty string to enforce 'stringiness'

--- a/InvenTree/report/templatetags/report.py
+++ b/InvenTree/report/templatetags/report.py
@@ -146,8 +146,10 @@ def uploaded_image(filename, replace_missing=True, replacement_file='blank_image
         # In debug mode, return a web path (rather than an encoded image blob)
         if exists:
             return os.path.join(settings.MEDIA_URL, filename)
-
         return os.path.join(settings.STATIC_URL, 'img', replacement_file)
+
+    elif not exists:
+        full_path = settings.STATIC_ROOT.joinpath('img', replacement_file).resolve()
 
     # Load the image, check that it is valid
     img = Image.open(full_path)

--- a/InvenTree/report/tests.py
+++ b/InvenTree/report/tests.py
@@ -337,12 +337,7 @@ class TestReportTest(ReportTest):
         # Now print with a valid StockItem
         item = StockItem.objects.first()
 
-        response = self.get(url, {'item': item.pk})
-        print("============= RESPONSE =============")
-        print(response.data)
-        print(response.status_code)
-
-        raise ValueError("Exception!")
+        response = self.get(url, {'item': item.pk}, expected_code=200)
 
         # Response should be a StreamingHttpResponse (PDF file)
         self.assertEqual(type(response), StreamingHttpResponse)

--- a/InvenTree/report/tests.py
+++ b/InvenTree/report/tests.py
@@ -125,10 +125,10 @@ class ReportTagTest(TestCase):
 
         self.debug_mode(False)
         img = report_tags.uploaded_image('part/images/test.jpg')
-        self.assertEqual(img, f'file://{img_path.joinpath("test.jpg")}')
+        self.assertTrue(img.startswith('data:image/png;charset=utf-8;base64,'))
 
         img = report_tags.uploaded_image(SafeString('part/images/test.jpg'))
-        self.assertEqual(img, f'file://{img_path.joinpath("test.jpg")}')
+        self.assertTrue(img.startswith('data:image/png;charset=utf-8;base64,'))
 
     def test_part_image(self):
         """Unit tests for the 'part_image' tag"""

--- a/InvenTree/report/tests.py
+++ b/InvenTree/report/tests.py
@@ -91,8 +91,12 @@ class ReportTagTest(TestCase):
             with self.assertRaises(FileNotFoundError):
                 report_tags.uploaded_image('/part/something/test.png', replace_missing=False)
 
-            img = report_tags.uploaded_image('/part/something/other.png')
-            self.assertTrue('blank_image.png' in img)
+            img = str(report_tags.uploaded_image('/part/something/other.png'))
+
+            if b:
+                self.assertIn('blank_image.png', img)
+            else:
+                self.assertIn('data:image/png;charset=utf-8;base64,', img)
 
         # Create a dummy image
         img_path = 'part/images/'

--- a/InvenTree/report/tests.py
+++ b/InvenTree/report/tests.py
@@ -337,7 +337,12 @@ class TestReportTest(ReportTest):
         # Now print with a valid StockItem
         item = StockItem.objects.first()
 
-        response = self.get(url, {'item': item.pk}, expected_code=200)
+        response = self.get(url, {'item': item.pk})
+        print("============= RESPONSE =============")
+        print(response.data)
+        print(response.status_code)
+
+        raise ValueError("Exception!")
 
         # Response should be a StreamingHttpResponse (PDF file)
         self.assertEqual(type(response), StreamingHttpResponse)

--- a/docs/docs/report/helpers.md
+++ b/docs/docs/report/helpers.md
@@ -138,7 +138,7 @@ You can access an uploaded image file if you know the *path* of the image, relat
 {% raw %}
 <!-- Load the report helper functions -->
 {% load report %}
-<img src='{% uploaded_image "subdir/my_image.png" %}'/>
+<img src='{% uploaded_image "subdir/my_image.png" width=480 rotate=45 %}'/>
 {% endraw %}
 ```
 
@@ -147,6 +147,16 @@ You can access an uploaded image file if you know the *path* of the image, relat
 
 !!! warning "Invalid Image"
     If the supplied file is not a valid image, it will be replaced with a placeholder image file
+
+#### Image Manipulation
+
+The `{% raw %}{% uploaded_image %}{% endraw %}` tag supports some optional parameters for image manipulation. These can be used to adjust or resize the image - to reduce the size of the generated report file, for example.
+
+```html
+{% raw %}
+{% load report %}
+<img src='{% uploaded_image "image_file.png" width=500 rotate=45 %}'>
+{% endraw %}```
 
 
 ### SVG Images
@@ -172,6 +182,10 @@ A shortcut function is provided for rendering an image associated with a Part in
 <img src='{% part_image part %}'/>
 {% endraw %}
 ```
+
+#### Image Arguments
+
+Any optional arguments which can be used in the [uploaded_image tag](#uploaded-images) can be used here too.
 
 #### Image Variations
 

--- a/docs/docs/report/helpers.md
+++ b/docs/docs/report/helpers.md
@@ -173,6 +173,22 @@ A shortcut function is provided for rendering an image associated with a Part in
 {% endraw %}
 ```
 
+#### Image Variations
+
+The *Part* model supports *preview* (256 x 256) and *thumbnail* (128 x 128) versions of the uploaded image. These variations can be used in the generated reports (e.g. to reduce generated file size):
+
+```html
+{% raw %}
+{% load report %}
+<!-- Render the "preview" image variation -->
+<img src='{% part_image part preview=True %}'>
+
+<!-- Render the "thumbnail" image variation -->
+<img src='{% part_image part thumbnail=True %}'>
+{% endraw %}
+```
+
+
 ### Company Images
 
 A shortcut function is provided for rendering an image associated with a Company instance. You can render the image of the company using the `{% raw %}{% company_image ... %}{% endraw %}` template tag:
@@ -184,6 +200,10 @@ A shortcut function is provided for rendering an image associated with a Company
 <img src='{% company_image company %}'/>
 {% endraw %}
 ```
+
+#### Image Variations
+
+*Preview* and *thumbnail* image variations can be rendered for the `company_image` tag, in a similar manner to [part image variations](#image-variations)
 
 ## InvenTree Logo
 


### PR DESCRIPTION
Adds ability to specify which image variation to use when rendering a "part_image" in a report.

If an uploaded image is very large this can cause the report size to bloat out.

- Can use "preview" image e.g. `{% part_image my_part preview=True %}`
- Can use "thumbnail" image  e.g. `{% part_image my_part thumbnail=True %}`
- Can also specify image width / height parameters