### PR TITLE
Fix some issues with supplier barcode plugins

### DIFF
--- a/InvenTree/plugin/base/barcodes/api.py
+++ b/InvenTree/plugin/base/barcodes/api.py
@@ -76,7 +76,7 @@ class BarcodeScan(APIView):
 
             if "error" in result:
                 logger.info("%s.scan(...) returned an error: %s",
-                            current_plugin.__name__, result["error"])
+                            current_plugin.__class__.__name__, result["error"])
                 if not response:
                     plugin = current_plugin
                     response = result
@@ -317,7 +317,7 @@ class BarcodePOReceive(APIView):
 
             if "error" in result:
                 logger.info("%s.scan_receive_item(...) returned an error: %s",
-                            current_plugin.__name__, result["error"])
+                            current_plugin.__class__.__name__, result["error"])
                 if not response:
                     plugin = current_plugin
                     response = result

--- a/InvenTree/plugin/base/barcodes/api.py
+++ b/InvenTree/plugin/base/barcodes/api.py
@@ -75,7 +75,8 @@ class BarcodeScan(APIView):
                 continue
 
             if "error" in result:
-                logger.info("%s.scan(...) returned an error: %s", plugin.__name__, result["error"])
+                logger.info("%s.scan(...) returned an error: %s",
+                            current_plugin.__name__, result["error"])
                 if not response:
                     plugin = current_plugin
                     response = result
@@ -315,7 +316,8 @@ class BarcodePOReceive(APIView):
                 continue
 
             if "error" in result:
-                logger.info("%s.scan_receive_item(...) returned an error: %s", plugin.__name__, result["error"])
+                logger.info("%s.scan_receive_item(...) returned an error: %s",
+                            current_plugin.__name__, result["error"])
                 if not response:
                     plugin = current_plugin
                     response = result

--- a/InvenTree/plugin/base/barcodes/mixins.py
+++ b/InvenTree/plugin/base/barcodes/mixins.py
@@ -130,7 +130,7 @@ class BarcodeMixin:
                 return supplier_parts
 
         if mpn:
-            supplier_parts = SupplierPart.objects.filter(manufacturer_part__MPN__iexact=mpn)
+            supplier_parts = supplier_parts.filter(manufacturer_part__MPN__iexact=mpn)
             if len(supplier_parts) == 1:
                 return supplier_parts
 

--- a/InvenTree/plugin/builtin/suppliers/digikey.py
+++ b/InvenTree/plugin/builtin/suppliers/digikey.py
@@ -37,6 +37,10 @@ class DigiKeyPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):
         if not (barcode_fields := self.parse_ecia_barcode2d(barcode_data)):
             return None
 
+        # digikey barcodes should always contain a SKU
+        if "supplier_part_number" not in barcode_fields:
+            return None
+
         return SupplierBarcodeData(
             SKU=barcode_fields.get("supplier_part_number"),
             MPN=barcode_fields.get("manufacturer_part_number"),

--- a/InvenTree/plugin/builtin/suppliers/digikey.py
+++ b/InvenTree/plugin/builtin/suppliers/digikey.py
@@ -3,15 +3,11 @@
 This plugin can currently only match DigiKey barcodes to supplier parts.
 """
 
-import logging
-
 from django.utils.translation import gettext_lazy as _
 
 from plugin import InvenTreePlugin
 from plugin.base.barcodes.mixins import SupplierBarcodeData
 from plugin.mixins import SettingsMixin, SupplierBarcodeMixin
-
-logger = logging.getLogger('inventree')
 
 
 class DigiKeyPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):

--- a/InvenTree/plugin/builtin/suppliers/lcsc.py
+++ b/InvenTree/plugin/builtin/suppliers/lcsc.py
@@ -3,7 +3,6 @@
 This plugin can currently only match LCSC barcodes to supplier parts.
 """
 
-import logging
 import re
 
 from django.utils.translation import gettext_lazy as _
@@ -11,8 +10,6 @@ from django.utils.translation import gettext_lazy as _
 from plugin import InvenTreePlugin
 from plugin.base.barcodes.mixins import SupplierBarcodeData
 from plugin.mixins import SettingsMixin, SupplierBarcodeMixin
-
-logger = logging.getLogger('inventree')
 
 
 class LCSCPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):

--- a/InvenTree/plugin/builtin/suppliers/mouser.py
+++ b/InvenTree/plugin/builtin/suppliers/mouser.py
@@ -3,15 +3,11 @@
 This plugin currently only match Mouser barcodes to supplier parts.
 """
 
-import logging
-
 from django.utils.translation import gettext_lazy as _
 
 from plugin import InvenTreePlugin
 from plugin.base.barcodes.mixins import SupplierBarcodeData
 from plugin.mixins import SettingsMixin, SupplierBarcodeMixin
-
-logger = logging.getLogger('inventree')
 
 
 class MouserPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):

--- a/InvenTree/plugin/builtin/suppliers/tme.py
+++ b/InvenTree/plugin/builtin/suppliers/tme.py
@@ -3,7 +3,6 @@
 This plugin can currently only match TME barcodes to supplier parts.
 """
 
-import logging
 import re
 
 from django.utils.translation import gettext_lazy as _
@@ -11,8 +10,6 @@ from django.utils.translation import gettext_lazy as _
 from plugin import InvenTreePlugin
 from plugin.base.barcodes.mixins import SupplierBarcodeData
 from plugin.mixins import SettingsMixin, SupplierBarcodeMixin
-
-logger = logging.getLogger('inventree')
 
 
 class TMEPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):


### PR DESCRIPTION
I went through a bunch of parts with the new barcode scanning functionality again and noticed some bugs / possible improvements:

1. the most obvious one is in `get_supplier_parts(...)` in `mixins.py` (accidentally doing a fresh query there instead of reusing the existing one)
2. the digikey plugin should only handle barcodes which contain a SKU (the issue here is that digikey/mouser barcodes look identical, so for mouser barcodes, the digikey plugin tries to parse the barcode and calls `get_supplier_parts(...)`, makes a bunch of queries and fails, **then** the mouser one gets called and does the same queries again)
3. if any plugin finds more than one valid `SupplierPart` via `get_supplier_parts` I return an error response, which leads to that error being directly returned to the end user. i think the better behavior would be to let the other plugins run first and **only** return the error if all of them fail (don't return a result) aswell. alternatively we could just get rid of said error response and return `None` instead
4. unused imports for `logging` in all supplier plugins (forgot to remove these apparently)