### PR TITLE
Only run sposnor action if on upstream repo

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'Inventree'
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
The title says it all - currently the action is going to run on every fork till disabled.