### PR TITLE
Refactor existing barcode API endpoints

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -349,7 +349,7 @@ def MakeBarcode(cls_name, object_pk: int, object_data=None, **kwargs):
         object_data['id'] = object_pk
         data[cls_name] = object_data
 
-    return json.dumps(data, sort_keys=True)
+    return str(json.dumps(data, sort_keys=True))
 
 
 def GetExportFormats():

--- a/InvenTree/InvenTree/helpers_model.py
+++ b/InvenTree/InvenTree/helpers_model.py
@@ -228,7 +228,11 @@ def getModelsWithMixin(mixin_class) -> list:
     """
     from django.contrib.contenttypes.models import ContentType
 
-    db_models = [x.model_class() for x in ContentType.objects.all() if x is not None]
+    try:
+        db_models = [x.model_class() for x in ContentType.objects.all() if x is not None]
+    except (OperationalError, ProgrammingError):
+        # Database is likely not yet ready
+        db_models = []
 
     return [x for x in db_models if x is not None and issubclass(x, mixin_class)]
 

--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -963,11 +963,13 @@ class InvenTreeBarcodeMixin(models.Model):
 
     def format_barcode(self, **kwargs):
         """Return a JSON string for formatting a QR code for this model instance."""
-        return InvenTree.helpers.MakeBarcode(
+        barcode = InvenTree.helpers.MakeBarcode(
             self.__class__.barcode_model_type(),
             self.pk,
             **kwargs
         )
+
+        return str(barcode)
 
     @property
     def barcode(self):

--- a/InvenTree/InvenTree/models.py
+++ b/InvenTree/InvenTree/models.py
@@ -963,13 +963,11 @@ class InvenTreeBarcodeMixin(models.Model):
 
     def format_barcode(self, **kwargs):
         """Return a JSON string for formatting a QR code for this model instance."""
-        barcode = InvenTree.helpers.MakeBarcode(
+        return InvenTree.helpers.MakeBarcode(
             self.__class__.barcode_model_type(),
             self.pk,
             **kwargs
         )
-
-        return str(barcode)
 
     @property
     def barcode(self):

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -522,7 +522,7 @@ class PurchaseOrder(TotalPriceMixin, Order):
     @property
     def is_pending(self):
         """Return True if the PurchaseOrder is 'pending'"""
-        return self.status == PurchaseOrderStatus.PENDING
+        return self.status == PurchaseOrderStatus.PENDING.value
 
     @property
     def is_open(self):
@@ -536,8 +536,8 @@ class PurchaseOrder(TotalPriceMixin, Order):
         - Status is PENDING
         """
         return self.status in [
-            PurchaseOrderStatus.PLACED,
-            PurchaseOrderStatus.PENDING
+            PurchaseOrderStatus.PLACED.value,
+            PurchaseOrderStatus.PENDING.value
         ]
 
     @transaction.atomic

--- a/InvenTree/plugin/base/barcodes/serializers.py
+++ b/InvenTree/plugin/base/barcodes/serializers.py
@@ -32,7 +32,7 @@ class BarcodeAssignMixin(serializers.Serializer):
         super().__init__(*args, **kwargs)
 
         for model in InvenTreeInternalBarcodePlugin.get_supported_barcode_models():
-            self.fields[model._meta.model_name] = serializers.PrimaryKeyRelatedField(
+            self.fields[model.barcode_model_type()] = serializers.PrimaryKeyRelatedField(
                 queryset=model.objects.all(),
                 required=False, allow_null=True,
                 label=model._meta.verbose_name,
@@ -42,7 +42,7 @@ class BarcodeAssignMixin(serializers.Serializer):
     def get_model_fields():
         """Return a list of model fields"""
         fields = [
-            model._meta.model_name for model in InvenTreeInternalBarcodePlugin.get_supported_barcode_models()
+            model.barcode_model_type() for model in InvenTreeInternalBarcodePlugin.get_supported_barcode_models()
         ]
 
         return fields

--- a/InvenTree/plugin/base/barcodes/serializers.py
+++ b/InvenTree/plugin/base/barcodes/serializers.py
@@ -1,0 +1,107 @@
+"""DRF serializers for barcode scanning API"""
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import serializers
+
+import order.models
+import stock.models
+from InvenTree.status_codes import PurchaseOrderStatus
+from plugin.builtin.barcodes.inventree_barcode import \
+    InvenTreeInternalBarcodePlugin
+
+
+class BarcodeSerializer(serializers.Serializer):
+    """Generic serializer for receiving barcode data"""
+
+    MAX_BARCODE_LENGTH = 4095
+
+    barcode = serializers.CharField(
+        required=True, help_text=_('Scanned barcode data'),
+        max_length=MAX_BARCODE_LENGTH,
+    )
+
+
+class BarcodeAssignMixin(serializers.Serializer):
+    """Serializer for linking and unlinking barcode to an internal class"""
+
+    def __init__(self, *args, **kwargs):
+        """Generate serializer fields for each supported model type"""
+
+        super().__init__(*args, **kwargs)
+
+        for model in InvenTreeInternalBarcodePlugin.get_supported_barcode_models():
+            self.fields[model._meta.model_name] = serializers.PrimaryKeyRelatedField(
+                queryset=model.objects.all(),
+                required=False, allow_null=True,
+                label=model._meta.verbose_name,
+            )
+
+    @staticmethod
+    def get_model_fields():
+        """Return a list of model fields"""
+        fields = [
+            model._meta.model_name for model in InvenTreeInternalBarcodePlugin.get_supported_barcode_models()
+        ]
+
+        return fields
+
+
+class BarcodeAssignSerializer(BarcodeAssignMixin, BarcodeSerializer):
+    """Serializer class for linking a barcode to an internal model"""
+
+    class Meta:
+        """Meta class for BarcodeAssignSerializer"""
+
+        fields = [
+            'barcode',
+            *BarcodeAssignMixin.get_model_fields()
+        ]
+
+
+class BarcodeUnassignSerializer(BarcodeAssignMixin):
+    """Serializer class for unlinking a barcode from an internal model"""
+
+    class Meta:
+        """Meta class for BarcodeUnlinkSerializer"""
+
+        fields = BarcodeAssignMixin.get_model_fields()
+
+
+class BarcodePOReceiveSerializer(BarcodeSerializer):
+    """Serializer for receiving items against a purchase order.
+
+    The following additional fields may be specified:
+
+    - purchase_order: PurchaseOrder object to receive items against
+    - location: Location to receive items into
+    """
+
+    purchase_order = serializers.PrimaryKeyRelatedField(
+        queryset=order.models.PurchaseOrder.objects.all(),
+        required=False,
+        help_text=_('PurchaseOrder to receive items against'),
+    )
+
+    def validate_purchase_order(self, order: order.models.PurchaseOrder):
+        """Validate the provided order"""
+
+        if order.status != PurchaseOrderStatus.PLACED.value:
+            raise ValidationError(_("Purchase order has not been placed"))
+
+        return order
+
+    location = serializers.PrimaryKeyRelatedField(
+        queryset=stock.models.StockLocation.objects.all(),
+        required=False,
+        help_text=_('Location to receive items into'),
+    )
+
+    def validate_location(self, location: stock.models.StockLocation):
+        """Validate the provided location"""
+
+        if location.structural:
+            raise ValidationError(_("Cannot select a structural location"))
+
+        return location

--- a/InvenTree/plugin/base/barcodes/test_barcode.py
+++ b/InvenTree/plugin/base/barcodes/test_barcode.py
@@ -2,9 +2,8 @@
 
 from django.urls import reverse
 
-from rest_framework import status
-
 from InvenTree.unit_test import InvenTreeAPITestCase
+from part.models import Part
 from stock.models import StockItem
 
 
@@ -24,150 +23,128 @@ class BarcodeAPITest(InvenTreeAPITestCase):
 
         self.scan_url = reverse('api-barcode-scan')
         self.assign_url = reverse('api-barcode-link')
+        self.unassign_url = reverse('api-barcode-unlink')
 
-    def postBarcode(self, url, barcode):
+    def postBarcode(self, url, barcode, expected_code=None):
         """Post barcode and return results."""
-        return self.client.post(url, format='json', data={'barcode': str(barcode)})
+        return self.post(url, format='json', data={'barcode': str(barcode)}, expected_code=expected_code)
 
     def test_invalid(self):
         """Test that invalid requests fail."""
         # test scan url
-        response = self.client.post(self.scan_url, format='json', data={})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.post(self.scan_url, format='json', data={}, expected_code=400)
 
         # test wrong assign urls
-        response = self.client.post(self.assign_url, format='json', data={})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        response = self.client.post(self.assign_url, format='json', data={'barcode': '123'})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        response = self.client.post(self.assign_url, format='json', data={'barcode': '123', 'stockitem': '123'})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.post(self.assign_url, format='json', data={}, expected_code=400)
+        self.post(self.assign_url, format='json', data={'barcode': '123'}, expected_code=400)
+        self.post(self.assign_url, format='json', data={'barcode': '123', 'stockitem': '123'}, expected_code=400)
 
     def test_empty(self):
         """Test an empty barcode scan.
 
-        Ensure that all required data is in the respomse.
+        Ensure that all required data is in the response.
         """
-        response = self.postBarcode(self.scan_url, '')
-
-        self.assertEqual(response.status_code, 400)
+        response = self.postBarcode(self.scan_url, '', expected_code=400)
 
         data = response.data
         self.assertIn('barcode', data)
-        self.assertIn('Missing barcode data', str(response.data['barcode']))
+
+        self.assertIn('This field may not be blank', str(response.data['barcode']))
 
     def test_find_part(self):
         """Test that we can lookup a part based on ID."""
-        response = self.client.post(
+
+        part = Part.objects.first()
+
+        response = self.post(
             self.scan_url,
             {
-                'barcode': {
-                    'part': 1,
-                },
+                'barcode': f'{{"part": {part.pk}}}',
             },
-            format='json',
+            expected_code=200
         )
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('part', response.data)
         self.assertIn('barcode_data', response.data)
-        self.assertEqual(response.data['part']['pk'], 1)
+        self.assertEqual(response.data['part']['pk'], part.pk)
 
     def test_invalid_part(self):
         """Test response for invalid part."""
-        response = self.client.post(
+        response = self.post(
             self.scan_url,
             {
-                'barcode': {
-                    'part': 999999999,
-                }
+                'barcode': '{"part": 999999999}'
             },
-            format='json'
+            expected_code=400
         )
 
-        self.assertEqual(response.status_code, 400)
         self.assertIn('error', response.data)
 
     def test_find_stock_item(self):
         """Test that we can lookup a stock item based on ID."""
-        response = self.client.post(
+
+        item = StockItem.objects.first()
+
+        response = self.post(
             self.scan_url,
             {
-                'barcode': {
-                    'stockitem': 1,
-                }
+                'barcode': item.format_barcode(),
             },
-            format='json',
+            expected_code=200
         )
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('stockitem', response.data)
         self.assertIn('barcode_data', response.data)
-        self.assertEqual(response.data['stockitem']['pk'], 1)
+        self.assertEqual(response.data['stockitem']['pk'], item.pk)
 
     def test_invalid_item(self):
         """Test response for invalid stock item."""
-        response = self.client.post(
+        response = self.post(
             self.scan_url,
             {
-                'barcode': {
-                    'stockitem': 999999999,
-                }
+                'barcode': '{"stockitem": 999999999}'
             },
-            format='json'
+            expected_code=400
         )
 
-        self.assertEqual(response.status_code, 400)
         self.assertIn('error', response.data)
 
     def test_find_location(self):
         """Test that we can lookup a stock location based on ID."""
-        response = self.client.post(
+        response = self.post(
             self.scan_url,
             {
-                'barcode': {
-                    'stocklocation': 1,
-                },
+                'barcode': '{"stocklocation": 1}',
             },
-            format='json'
+            expected_code=200
         )
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('stocklocation', response.data)
         self.assertIn('barcode_data', response.data)
         self.assertEqual(response.data['stocklocation']['pk'], 1)
 
     def test_invalid_location(self):
         """Test response for an invalid location."""
-        response = self.client.post(
+        response = self.post(
             self.scan_url,
             {
-                'barcode': {
-                    'stocklocation': 999999999,
-                }
+                'barcode': '{"stocklocation": 999999999}'
             },
-            format='json'
+            expected_code=400
         )
 
-        self.assertEqual(response.status_code, 400)
         self.assertIn('error', response.data)
 
     def test_integer_barcode(self):
         """Test scan of an integer barcode."""
-        response = self.postBarcode(self.scan_url, '123456789')
-
-        self.assertEqual(response.status_code, 400)
+        response = self.postBarcode(self.scan_url, '123456789', expected_code=400)
 
         data = response.data
         self.assertIn('error', data)
 
     def test_array_barcode(self):
         """Test scan of barcode with string encoded array."""
-        response = self.postBarcode(self.scan_url, "['foo', 'bar']")
-
-        self.assertEqual(response.status_code, 400)
+        response = self.postBarcode(self.scan_url, "['foo', 'bar']", expected_code=400)
 
         data = response.data
         self.assertIn('error', data)
@@ -176,10 +153,8 @@ class BarcodeAPITest(InvenTreeAPITestCase):
         """Test that a barcode is generated with a scan."""
         item = StockItem.objects.get(pk=522)
 
-        response = self.postBarcode(self.scan_url, item.format_barcode())
+        response = self.postBarcode(self.scan_url, item.format_barcode(), expected_code=200)
         data = response.data
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertIn('stockitem', data)
 
@@ -197,37 +172,88 @@ class BarcodeAPITest(InvenTreeAPITestCase):
 
         barcode_data = 'A-TEST-BARCODE-STRING'
 
-        response = self.client.post(
+        response = self.post(
             self.assign_url, format='json',
             data={
                 'barcode': barcode_data,
                 'stockitem': item.pk
-            }
+            },
+            expected_code=200
         )
 
         data = response.data
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertIn('success', data)
 
         result_hash = data['barcode_hash']
 
         # Read the item out from the database again
-        item = StockItem.objects.get(pk=522)
+        item.refresh_from_db()
 
+        self.assertEqual(item.barcode_data, barcode_data)
         self.assertEqual(result_hash, item.barcode_hash)
 
         # Ensure that the same barcode hash cannot be assigned to a different stock item!
-        response = self.client.post(
+        response = self.post(
             self.assign_url, format='json',
             data={
                 'barcode': barcode_data,
                 'stockitem': 521
-            }
+            },
+            expected_code=400
         )
 
-        data = response.data
+        self.assertIn('error', response.data)
+        self.assertNotIn('success', response.data)
 
-        self.assertIn('error', data)
-        self.assertNotIn('success', data)
+        # Check that we can now unassign a barcode
+        response = self.post(
+            self.unassign_url,
+            {
+                'stockitem': item.pk,
+            },
+            expected_code=200
+        )
+
+        item.refresh_from_db()
+        self.assertEqual(item.barcode_data, '')
+
+        # Check that the 'unassign' endpoint fails if the stockitem is invalid
+        response = self.post(
+            self.unassign_url,
+            {
+                'stockitem': 999999999,
+            },
+            expected_code=400
+        )
+
+    def test_unassign_endpoint(self):
+        """Test that the unassign endpoint works as expected"""
+
+        invalid_keys = ['cat', 'dog', 'fish']
+
+        # Invalid key should fail
+        for k in invalid_keys:
+            response = self.post(
+                self.unassign_url,
+                {
+                    k: 123
+                },
+                expected_code=400
+            )
+
+            self.assertIn("Missing data: Provide one of", str(response.data['error']))
+
+        valid_keys = ['build', 'salesorder', 'part']
+
+        # Valid key but invalid pk should fail
+        for k in valid_keys:
+            response = self.post(
+                self.unassign_url,
+                {
+                    k: 999999999
+                },
+                expected_code=400
+            )
+
+            self.assertIn("object does not exist", str(response.data[k]))

--- a/InvenTree/plugin/builtin/barcodes/inventree_barcode.py
+++ b/InvenTree/plugin/builtin/barcodes/inventree_barcode.py
@@ -63,8 +63,6 @@ class InvenTreeInternalBarcodePlugin(BarcodeMixin, InvenTreePlugin):
 
         Here we are looking for a dict object which contains a reference to a particular InvenTree database object
         """
-        # Create hash from raw barcode data
-        barcode_hash = hash_barcode(barcode_data)
 
         # Attempt to coerce the barcode data into a dict object
         # This is the internal barcode representation that InvenTree uses
@@ -78,9 +76,11 @@ class InvenTreeInternalBarcodePlugin(BarcodeMixin, InvenTreePlugin):
             except json.JSONDecodeError:
                 pass
 
+        supported_models = self.get_supported_barcode_models()
+
         if barcode_dict is not None and type(barcode_dict) is dict:
             # Look for various matches. First good match will be returned
-            for model in self.get_supported_barcode_models():
+            for model in supported_models:
                 label = model.barcode_model_type()
 
                 if label in barcode_dict:
@@ -91,8 +91,11 @@ class InvenTreeInternalBarcodePlugin(BarcodeMixin, InvenTreePlugin):
                     except (ValueError, model.DoesNotExist):
                         pass
 
+        # Create hash from raw barcode data
+        barcode_hash = hash_barcode(barcode_data)
+
         # If no "direct" hits are found, look for assigned third-party barcodes
-        for model in self.get_supported_barcode_models():
+        for model in supported_models:
             label = model.barcode_model_type()
 
             instance = model.lookup_barcode(barcode_hash)

--- a/InvenTree/plugin/builtin/barcodes/test_inventree_barcode.py
+++ b/InvenTree/plugin/builtin/barcodes/test_inventree_barcode.py
@@ -80,8 +80,8 @@ class TestInvenTreeBarcode(InvenTreeAPITestCase):
         # Fail with too many fields provided
         response = self.unassign(
             {
-                'stockitem': 'abcde',
-                'part': 'abcde',
+                'stockitem': stock.models.StockItem.objects.first().pk,
+                'part': part.models.Part.objects.first().pk,
             },
             expected_code=400,
         )
@@ -96,17 +96,17 @@ class TestInvenTreeBarcode(InvenTreeAPITestCase):
             expected_code=400,
         )
 
-        self.assertIn('No match found', str(response.data['stockitem']))
+        self.assertIn('Incorrect type', str(response.data['stockitem']))
 
         # Fail with an invalid Part instance
         response = self.unassign(
             {
-                'part': 'invalid',
+                'part': 99999999999,
             },
             expected_code=400,
         )
 
-        self.assertIn('No match found', str(response.data['part']))
+        self.assertIn('object does not exist', str(response.data['part']))
 
     def test_assign_to_stock_item(self):
         """Test that we can assign a unique barcode to a StockItem object"""
@@ -216,7 +216,7 @@ class TestInvenTreeBarcode(InvenTreeAPITestCase):
             expected_code=400,
         )
 
-        self.assertIn('No matching part instance found in database', str(response.data))
+        self.assertIn('object does not exist', str(response.data['part']))
 
         # Test assigning to a valid part (should pass)
         response = self.assign(


### PR DESCRIPTION
- Expose fields using proper DRF serializers
- API endpoints are now self documenting
- Validation is handled by serializer models
- Serializers and endpoints are extensible
- Extended existing unit tests

@matmair this is a refactor of the existing barcode API endpoints to make use of the DRF serializers, for self-documenting endpoints. The functionality should be unchanged, however field validation is now handled by the serializer class(es) rather than being hidden inside the particular endpoint implementation.