### PR TITLE
Add Platform UI to doc nav

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Getting started: develop/starting.md
       - Contributing: develop/contributing.md
       - Devcontainer: develop/devcontainer.md
+      - Platform UI: develop/react-frontend.md
     - Credits: credits.md
     - Privacy: privacy.md
     - Release Notes: releases/release_notes.md


### PR DESCRIPTION
I forgot to add PUI docs to the navigation of the docs, so it's only searchable atm...
The PR adds a new entry to the "Development" category for the new page