### PR TITLE
LDAP group membership support

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -307,7 +307,7 @@ AUTHENTICATION_BACKENDS = CONFIG.get('authentication_backends', [
 LDAP_AUTH = get_boolean_setting("INVENTREE_LDAP_ENABLED", "ldap.enabled", False)
 if LDAP_AUTH:
     import ldap
-    from django_auth_ldap.config import LDAPSearch
+    from django_auth_ldap.config import LDAPSearch, GroupOfUniqueNames
 
     AUTHENTICATION_BACKENDS.append("django_auth_ldap.backend.LDAPBackend")
 
@@ -359,6 +359,17 @@ if LDAP_AUTH:
     }, dict)
     AUTH_LDAP_ALWAYS_UPDATE_USER = get_boolean_setting("INVENTREE_LDAP_ALWAYS_UPDATE_USER", "ldap.always_update_user", True)
     AUTH_LDAP_CACHE_TIMEOUT = get_setting("INVENTREE_LDAP_CACHE_TIMEOUT", "ldap.cache_timeout", 3600, int)
+    
+    AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
+        get_setting("INVENTREE_LDAP_GROUP_SEARCH", "ldap.group_search"),
+        ldap.SCOPE_SUBTREE,
+        "(objectClass=groupOfUniqueNames)",
+    )
+    AUTH_LDAP_GROUP_TYPE = GroupOfUniqueNamesType(name_attr="cn")
+    AUTH_LDAP_REQUIRE_GROUP = get_setting("INVENTREE_LDAP_REQUIRE_GROUP", "ldap.require_group")
+    AUTH_LDAP_DENY_GROUP = get_setting("INVENTREE_LDAP_DENY_GROUP", "ldap.deny_group")
+    AUTH_LDAP_USER_FLAGS_BY_GROUP = get_setting("INVENTREE_LDAP_USER_FLAGS_BY_GROUP", "ldap.user_flags_by_group", {}, dict)
+    AUTH_LDAP_FIND_GROUP_PERMS = True
 
 DEBUG_TOOLBAR_ENABLED = DEBUG and get_setting('INVENTREE_DEBUG_TOOLBAR', 'debug_toolbar', False)
 

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -359,7 +359,7 @@ if LDAP_AUTH:
     }, dict)
     AUTH_LDAP_ALWAYS_UPDATE_USER = get_boolean_setting("INVENTREE_LDAP_ALWAYS_UPDATE_USER", "ldap.always_update_user", True)
     AUTH_LDAP_CACHE_TIMEOUT = get_setting("INVENTREE_LDAP_CACHE_TIMEOUT", "ldap.cache_timeout", 3600, int)
-    
+
     AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
         get_setting("INVENTREE_LDAP_GROUP_SEARCH", "ldap.group_search"),
         ldap.SCOPE_SUBTREE,

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -307,7 +307,7 @@ AUTHENTICATION_BACKENDS = CONFIG.get('authentication_backends', [
 LDAP_AUTH = get_boolean_setting("INVENTREE_LDAP_ENABLED", "ldap.enabled", False)
 if LDAP_AUTH:
     import ldap
-    from django_auth_ldap.config import LDAPSearch, GroupOfUniqueNames
+    from django_auth_ldap.config import LDAPSearch, GroupOfUniqueNamesType
 
     AUTHENTICATION_BACKENDS.append("django_auth_ldap.backend.LDAPBackend")
 

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -307,7 +307,7 @@ AUTHENTICATION_BACKENDS = CONFIG.get('authentication_backends', [
 LDAP_AUTH = get_boolean_setting("INVENTREE_LDAP_ENABLED", "ldap.enabled", False)
 if LDAP_AUTH:
     import ldap
-    from django_auth_ldap.config import LDAPSearch, GroupOfUniqueNamesType
+    from django_auth_ldap.config import GroupOfUniqueNamesType, LDAPSearch
 
     AUTHENTICATION_BACKENDS.append("django_auth_ldap.backend.LDAPBackend")
 

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -278,6 +278,15 @@ remote_login_header: HTTP_REMOTE_USER
 #   # cache timeout to reduce traffic with LDAP server, default: 3600 (1h)
 #   # cache_timeout: 3600
 
+#   # LDAP group support
+#   # group_search: ou=groups,dc=example,dc=com
+#   # require_group: cn=inventree_allow,ou=groups,dc=example,dc=com
+#   # deny_group: cn=inventree_deny,ou=groups,dc=example,dc=com
+#   # Set staff/superuser flag based on LDAP group membership
+#   # user_flags_by_group:
+#   #   is_staff: cn=inventree_staff,ou=groups,dc=example,dc=com
+#   #   is_superuser: cn=inventree_superuser,ou=groups,dc=example,dc=com
+
 # Customization options
 # Add custom messages to the login page or main interface navbar or exchange the logo
 # Use environment variable INVENTREE_CUSTOMIZE or INVENTREE_CUSTOM_LOGO

--- a/docs/docs/start/advanced.md
+++ b/docs/docs/start/advanced.md
@@ -71,4 +71,3 @@ Next you can start configuring the connection. Either use the config file or set
 | `ldap.require_group` | `INVENTREE_LDAP_REQUIRE_GROUP` | If set, users _must_ be in this group to log in to InvenTree |
 | `ldap.deny_group` | `INVENTREE_LDAP_DENY_GROUP` | If set, users _must not_ be in this group to log in to InvenTree |
 | `ldap.user_flags_by_group` | `INVENTREE_LDAP_USER_FLAGS_BY_GROUP` | LDAP group to InvenTree user flag map, can be json if used as env, in yml directly specify the object. See config template for example, default: `{}` |
-

--- a/docs/docs/start/advanced.md
+++ b/docs/docs/start/advanced.md
@@ -70,5 +70,5 @@ Next you can start configuring the connection. Either use the config file or set
 | `ldap.group_search` | `INVENTREE_LDAP_GROUP_SEARCH` | Base LDAP DN for group searching; required to enable group features |
 | `ldap.require_group` | `INVENTREE_LDAP_REQUIRE_GROUP` | If set, users _must_ be in this group to log in to InvenTree |
 | `ldap.deny_group` | `INVENTREE_LDAP_DENY_GROUP` | If set, users _must not_ be in this group to log in to InvenTree |
-| `ldap.user_flags_by_group` | `INVENTREE_LDAP_USER_FLAGS_BY_GROUP` | LDAP group to InvenTree user flag map, can be json if used as env, in yml directly specify the object. See config template for example, default :`{}` |
+| `ldap.user_flags_by_group` | `INVENTREE_LDAP_USER_FLAGS_BY_GROUP` | LDAP group to InvenTree user flag map, can be json if used as env, in yml directly specify the object. See config template for example, default: `{}` |
 

--- a/docs/docs/start/advanced.md
+++ b/docs/docs/start/advanced.md
@@ -67,3 +67,8 @@ Next you can start configuring the connection. Either use the config file or set
 | `ldap.user_attr_map` | `INVENTREE_LDAP_USER_ATTR_MAP` | LDAP <-> Inventree user attribute map, can be json if used as env, in yml directly specify the object. default: `{"first_name": "givenName", "last_name": "sn", "email": "mail"}` |
 | `ldap.always_update_user` | `INVENTREE_LDAP_ALWAYS_UPDATE_USER` | Always update the user on each login, default: `true` |
 | `ldap.cache_timeout` | `INVENTREE_LDAP_CACHE_TIMEOUT` | cache timeout to reduce traffic with LDAP server, default: `3600` (1h) |
+| `ldap.group_search` | `INVENTREE_LDAP_GROUP_SEARCH` | Base LDAP DN for group searching; required to enable group features |
+| `ldap.require_group` | `INVENTREE_LDAP_REQUIRE_GROUP` | If set, users _must_ be in this group to log in to InvenTree |
+| `ldap.deny_group` | `INVENTREE_LDAP_DENY_GROUP` | If set, users _must not_ be in this group to log in to InvenTree |
+| `ldap.user_flags_by_group` | `INVENTREE_LDAP_USER_FLAGS_BY_GROUP` | LDAP group to InvenTree user flag map, can be json if used as env, in yml directly specify the object. See config template for example, default :`{}` |
+


### PR DESCRIPTION
This PR adds support for LDAP group membership. Specifically, the following features are enabled:

* `ldap.require_group` to allowlist users based on group membership. Users must be in this group to log in to InvenTree.
* `ldap.deny_group` to blocklist users based on group membership. Users in this group are _not_ allowed to log in to InvenTree, regardless of other circumstances.
* `ldap.user_flags_by_group` to enable automatic provisioning of `staff`/`superuser` accounts based on LDAP group membership.

Together, these features enhance the existing LDAP component to make InvenTree more robust in medium/large organisations, and simplify initial onboarding in these organisations by not requiring the manual creation of a superuser account via the CLI.