### PR TITLE
[PUI] Allow rendering of custom states

### DIFF
--- a/src/frontend/src/components/render/StatusRenderer.tsx
+++ b/src/frontend/src/components/render/StatusRenderer.tsx
@@ -69,7 +69,7 @@ export const StatusRenderer = ({
   options
 }: {
   status: string;
-  type: ModelType;
+  type: ModelType | string;
   options?: renderStatusLabelOptionsInterface;
 }) => {
   const statusCodeList = useServerApiState.getState().status;

--- a/src/frontend/src/states/ApiState.tsx
+++ b/src/frontend/src/states/ApiState.tsx
@@ -9,7 +9,7 @@ import { ApiPaths } from '../enums/ApiEndpoints';
 import { ModelType } from '../enums/ModelType';
 import { ServerAPIProps } from './states';
 
-type StatusLookup = Record<ModelType, StatusCodeListInterface>;
+type StatusLookup = Record<ModelType | string, StatusCodeListInterface>;
 
 interface ServerApiStateProps {
   server: ServerAPIProps;
@@ -35,7 +35,8 @@ export const useServerApiState = create<ServerApiStateProps>()(
         await api.get(apiUrl(ApiPaths.global_status)).then((response) => {
           const newStatusLookup: StatusLookup = {} as StatusLookup;
           for (const key in response.data) {
-            newStatusLookup[statusCodeList[key]] = response.data[key].values;
+            newStatusLookup[statusCodeList[key] || key] =
+              response.data[key].values;
           }
           set({ status: newStatusLookup });
         });


### PR DESCRIPTION
This PR makes StatusRenderer and the Zustand it relies on less strict to allow usage of custom states that are defined using the generic StatusCode.

The lookup is now possible either via ModelType or a string. That string has to match the class name of the StatusCode enum that should be used; if no matching state is defined the renderer returns an empty node.
Provides full support for colors, keys, names and translated labels for custom states out of the box.