### PR TITLE
[PUI] Enable passing of string urls to apiUrl

### DIFF
--- a/src/frontend/src/components/forms/ApiForm.tsx
+++ b/src/frontend/src/components/forms/ApiForm.tsx
@@ -60,7 +60,7 @@ export interface ApiFormAction {
  * @param onFormError : A callback function to call when the form is submitted with errors.
  */
 export interface ApiFormProps {
-  url: ApiPaths;
+  url: ApiPaths | string;
   pk?: number | string | undefined;
   pathParams?: PathParams;
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';

--- a/src/frontend/src/functions/forms.tsx
+++ b/src/frontend/src/functions/forms.tsx
@@ -19,7 +19,7 @@ import { generateUniqueId } from './uid';
  * Construct an API url from the provided ApiFormProps object
  */
 export function constructFormUrl(
-  url: ApiPaths,
+  url: ApiPaths | string,
   pk?: string | number,
   pathParams?: PathParams
 ): string {

--- a/src/frontend/src/states/ApiState.tsx
+++ b/src/frontend/src/states/ApiState.tsx
@@ -195,11 +195,14 @@ export type PathParams = Record<string, string | number>;
  * Construct an API URL with an endpoint and (optional) pk value
  */
 export function apiUrl(
-  path: ApiPaths,
+  path: ApiPaths | string,
   pk?: any,
   pathParams?: PathParams
 ): string {
-  let _url = apiEndpoint(path);
+  let _url = path;
+  if (Object.values(ApiPaths).includes(path as ApiPaths)) {
+    _url = apiEndpoint(path as ApiPaths);
+  }
 
   // If the URL does not start with a '/', add the API prefix
   if (!_url.startsWith('/')) {


### PR DESCRIPTION
This PR enables passing strings (preferably URLs) to API forms so they can be used with custom URLs / in plugins.