### PR TITLE
Give the people what they want

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ dummy_image.*
 _tmp.csv
 InvenTree/label.pdf
 InvenTree/label.png
+InvenTree/part_image_123abc.png
 label.pdf
 label.png
 InvenTree/my_special*

--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -2,10 +2,13 @@
 
 
 # InvenTree API version
-INVENTREE_API_VERSION = 156
+INVENTREE_API_VERSION = 157
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v157 -> 2023-12-02 : https://github.com/inventree/InvenTree/pull/6021
+    - Add write-only "existing_image" field to Part API serializer
 
 v156 -> 2023-11-26 : https://github.com/inventree/InvenTree/pull/5982
     - Add POST endpoint for report and label creation

--- a/InvenTree/InvenTree/serializers.py
+++ b/InvenTree/InvenTree/serializers.py
@@ -864,7 +864,7 @@ class RemoteImageMixin(metaclass=serializers.SerializerMetaclass):
         required=False,
         allow_blank=False,
         write_only=True,
-        label=_("URL"),
+        label=_("Remote Image"),
         help_text=_("URL of remote image file"),
     )
 

--- a/InvenTree/part/helpers.py
+++ b/InvenTree/part/helpers.py
@@ -84,9 +84,13 @@ def get_part_image_directory() -> str:
     TODO: Future work may be needed here to support other storage backends, such as S3
     """
 
-    part_image_directory = os.path.join(
+    part_image_directory = os.path.abspath(os.path.join(
         settings.MEDIA_ROOT,
         PART_IMAGE_DIR,
-    )
+    ))
 
-    return os.path.abspath(part_image_directory)
+    # Create the directory if it does not exist
+    if not os.path.exists(part_image_directory):
+        os.makedirs(part_image_directory)
+
+    return part_image_directory

--- a/InvenTree/part/helpers.py
+++ b/InvenTree/part/helpers.py
@@ -1,6 +1,9 @@
 """Various helper functions for the part app"""
 
 import logging
+import os
+
+from django.conf import settings
 
 from jinja2 import Environment
 
@@ -66,3 +69,24 @@ def render_part_full_name(part) -> str:
     # Fallback to the default format
     elements = [el for el in [part.IPN, part.name, part.revision] if el]
     return ' | '.join(elements)
+
+
+# Subdirectory for storing part images
+PART_IMAGE_DIR = "part_images"
+
+
+def get_part_image_directory() -> str:
+    """Return the directory where part images are stored.
+
+    Returns:
+        str: Directory where part images are stored
+
+    TODO: Future work may be needed here to support other storage backends, such as S3
+    """
+
+    part_image_directory = os.path.join(
+        settings.MEDIA_ROOT,
+        PART_IMAGE_DIR,
+    )
+
+    return os.path.abspath(part_image_directory)

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -293,7 +293,8 @@ def rename_part_image(instance, filename):
     Returns:
         Cleaned filename in format part_<n>_img
     """
-    base = 'part_images'
+
+    base = part_helpers.PART_IMAGE_DIR
     fname = os.path.basename(filename)
 
     return os.path.join(base, fname)

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -611,7 +611,8 @@ class PartSerializer(InvenTree.serializers.RemoteImageMixin, InvenTree.serialize
             'duplicate',
             'initial_stock',
             'initial_supplier',
-            'copy_category_parameters'
+            'copy_category_parameters',
+            'existing_image',
         ]
 
         return fields
@@ -767,7 +768,7 @@ class PartSerializer(InvenTree.serializers.RemoteImageMixin, InvenTree.serialize
     # Allow selection of an existing part image file
     existing_image = serializers.CharField(
         label=_('Existing Image'),
-        help_text=_('Select an existing image file for this part'),
+        help_text=_('Filename of an existing part image'),
         write_only=True,
         required=False,
         allow_blank=False,
@@ -901,8 +902,7 @@ class PartSerializer(InvenTree.serializers.RemoteImageMixin, InvenTree.serialize
         part = self.instance
         data = self.validated_data
 
-        # Check if an existing part image was selected
-        existing_image = data.get('existing_image', None)
+        existing_image = data.pop('existing_image', None)
 
         if existing_image:
             img_path = os.path.join(

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -27,6 +27,7 @@ import InvenTree.helpers
 import InvenTree.serializers
 import InvenTree.status
 import part.filters
+import part.helpers
 import part.stocktake
 import part.tasks
 import stock.models
@@ -523,6 +524,7 @@ class PartSerializer(InvenTree.serializers.RemoteImageMixin, InvenTree.serialize
             'pk',
             'purchaseable',
             'remote_image',
+            'existing_image',
             'revision',
             'salable',
             'starred',
@@ -759,6 +761,16 @@ class PartSerializer(InvenTree.serializers.RemoteImageMixin, InvenTree.serialize
         default=True, required=False,
         label=_('Copy Category Parameters'),
         help_text=_('Copy parameter templates from selected part category'),
+    )
+
+    # Allow selection of an existing part image file
+    existing_image = serializers.FilePathField(
+        path=part.helpers.get_part_image_directory(),
+        recursive=False,
+        allow_files=True,
+        allow_folders=False,
+        required=False,
+        write_only=True,
     )
 
     @transaction.atomic

--- a/InvenTree/part/views.py
+++ b/InvenTree/part/views.py
@@ -17,6 +17,7 @@ from common.views import FileManagementAjaxView, FileManagementFormView
 from company.models import SupplierPart
 from InvenTree.helpers import str2bool, str2int
 from InvenTree.views import AjaxUpdateView, AjaxView, InvenTreeRoleMixin
+from part.helpers import PART_IMAGE_DIR
 from plugin.views import InvenTreePluginViewMixin
 from stock.models import StockItem, StockLocation
 
@@ -398,12 +399,12 @@ class PartImageSelect(AjaxUpdateView):
         data = {}
 
         if img:
-            img_path = settings.MEDIA_ROOT.joinpath('part_images', img)
+            img_path = settings.MEDIA_ROOT.joinpath(PART_IMAGE_DIR, img)
 
             # Ensure that the image already exists
             if os.path.exists(img_path):
 
-                part.image = os.path.join('part_images', img)
+                part.image = os.path.join(PART_IMAGE_DIR, img)
                 part.save()
 
                 data['success'] = _('Updated part image')


### PR DESCRIPTION
Implements a `existing_image` field for the `Part` serializer - allowing a new (or existing) Part instance to reference an image already used by a different part.

- Closes https://github.com/inventree/InvenTree/issues/6019
- Closes https://github.com/inventree/InvenTree/issues/5532