### PR TITLE
Fix validation for Build model

### DIFF
--- a/InvenTree/build/models.py
+++ b/InvenTree/build/models.py
@@ -109,17 +109,22 @@ class Build(MPTTModel, InvenTree.mixins.DiffMixin, InvenTree.models.InvenTreeBar
         self.validate_reference_field(self.reference)
         self.reference_int = self.rebuild_reference_field(self.reference)
 
-        # Prevent changing target part after creation
-        if self.has_field_changed('part'):
-            raise ValidationError({
-                'part': _('Build order part cannot be changed')
-            })
-
         try:
             super().save(*args, **kwargs)
         except InvalidMove:
             raise ValidationError({
                 'parent': _('Invalid choice for parent build'),
+            })
+
+    def clean(self):
+        """Validate the BuildOrder model"""
+
+        super().clean()
+
+        # Prevent changing target part after creation
+        if self.has_field_changed('part'):
+            raise ValidationError({
+                'part': _('Build order part cannot be changed')
             })
 
     @staticmethod

--- a/InvenTree/build/test_build.py
+++ b/InvenTree/build/test_build.py
@@ -491,7 +491,7 @@ class BuildTest(BuildTestBase):
         # Should not be able to change the part after the Build is saved
         with self.assertRaises(ValidationError):
             bo.part = assembly_2
-            bo.save()
+            bo.clean()
 
     def test_cancel(self):
         """Test cancellation of the build"""


### PR DESCRIPTION
- Move checks into clean() method
- Allows errors to be handled cleanly when editing from the admin interface