### PR TITLE
Url validation

### DIFF
--- a/InvenTree/InvenTree/tests.py
+++ b/InvenTree/InvenTree/tests.py
@@ -203,6 +203,37 @@ class ValidatorTest(TestCase):
         with self.assertRaises(django_exceptions.ValidationError):
             validate_overage("aaaa")
 
+    def test_url_validation(self):
+        """Test for AllowedURLValidator"""
+
+        from common.models import InvenTreeSetting
+        from part.models import Part, PartCategory
+
+        # Without strict URL validation
+        InvenTreeSetting.set_setting('INVENTREE_STRICT_URLS', False, None)
+
+        n = Part.objects.count()
+        cat = PartCategory.objects.first()
+
+        # Should pass, even without a schema
+        Part.objects.create(
+            name=f'Part {n}',
+            description='Link without schema',
+            category=cat,
+            link='www.google.com',
+        )
+
+        # With strict URL validation
+        InvenTreeSetting.set_setting('INVENTREE_STRICT_URLS', True, None)
+
+        with self.assertRaises(ValidationError):
+            Part.objects.create(
+                name=f'Part {n + 1}',
+                description='Link without schema',
+                category=cat,
+                link='www.google.com',
+            )
+
 
 class FormatTest(TestCase):
     """Unit tests for custom string formatting functionality"""

--- a/InvenTree/InvenTree/validators.py
+++ b/InvenTree/InvenTree/validators.py
@@ -60,9 +60,23 @@ def allowable_url_schemes():
 
 class AllowedURLValidator(validators.URLValidator):
     """Custom URL validator to allow for custom schemes."""
+
     def __call__(self, value):
         """Validate the URL."""
+
+        import common.models
+
         self.schemes = allowable_url_schemes()
+
+        # Determine if 'strict' URL validation is required (i.e. if the URL must have a schema prefix)
+        strict_urls = common.models.InvenTreeSetting.get_setting('INVENTREE_STRICT_URLS', True, cache=False)
+
+        if not strict_urls:
+            # Allow URLs which do not have a provided schema
+            if '://' not in value:
+                # Validate as if it were http
+                value = 'http://' + value
+
         super().__call__(value)
 
 

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1175,6 +1175,13 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'default': '',
         },
 
+        'INVENTREE_STRICT_URLS': {
+            'name': _('Strict URL Validation'),
+            'description': _('Require schema specification when validating URLs'),
+            'validator': bool,
+            'default': True,
+        },
+
         'INVENTREE_REQUIRE_CONFIRM': {
             'name': _('Require confirm'),
             'description': _('Require explicit user confirmation for certain action.'),

--- a/InvenTree/templates/InvenTree/settings/global.html
+++ b/InvenTree/templates/InvenTree/settings/global.html
@@ -24,6 +24,7 @@
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DOWNLOAD_IMAGE_MAX_SIZE" icon="fa-server" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_DOWNLOAD_FROM_URL_USER_AGENT" icon="fa-server" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_REQUIRE_CONFIRM" icon="fa-check" %}
+        {% include "InvenTree/settings/setting.html" with key="INVENTREE_STRICT_URLS" icon="fa-link" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_TREE_DEPTH" icon="fa-sitemap" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_BACKUP_ENABLE" icon="fa-hdd" %}
         {% include "InvenTree/settings/setting.html" with key="INVENTREE_BACKUP_DAYS" icon="fa-calendar-alt" %}


### PR DESCRIPTION
Closes https://github.com/inventree/InvenTree/issues/5493

Allows URLs to be provided without an explicit schema (if setting is configured)