### PR TITLE
Disable part prefetch on stock item save

### DIFF
--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -779,6 +779,7 @@ class StockList(APIDownloadMixin, ListCreateDestroyAPIView):
             })
 
         try:
+            Part.objects.prefetch_related(None)
             part = Part.objects.get(pk=data.get('part', None))
         except (ValueError, Part.DoesNotExist):
             raise ValidationError({


### PR DESCRIPTION
As mentioned in the #6013 when saving the stock items the part pulls out all the stock items from the database due to the prefetch. As no related objects of the part is used in the stock items save I disabled the prefetch. 