### PR TITLE
[PUI] Fix Build Router

### DIFF
--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -130,7 +130,7 @@ export const routes = (
       </Route>
       <Route path="build/">
         <Route index element={<BuildIndex />} />
-        <Route path=":id/" element={<BuildDetail />} />
+        <Route path=":id/*" element={<BuildDetail />} />
       </Route>
       <Route path="purchasing/">
         <Route index element={<Navigate to="index/" />} />


### PR DESCRIPTION
Build entry of router.tsx is missing a `*` at the end, preventing sub-URLs from rendering.

Added a `*` at the build routing entry.