### PR TITLE
fix(SSO): log error message when EMAIL_HOST is empty

### DIFF
--- a/InvenTree/InvenTree/forms.py
+++ b/InvenTree/InvenTree/forms.py
@@ -228,7 +228,12 @@ class CustomSignupForm(SignupForm):
 
 def registration_enabled():
     """Determine whether user registration is enabled."""
-    return settings.EMAIL_HOST and (InvenTreeSetting.get_setting('LOGIN_ENABLE_REG') or InvenTreeSetting.get_setting('LOGIN_ENABLE_SSO_REG'))
+    if InvenTreeSetting.get_setting('LOGIN_ENABLE_REG') or InvenTreeSetting.get_setting('LOGIN_ENABLE_SSO_REG'):
+        if settings.EMAIL_HOST:
+            return True
+        else:
+            logger.error("Registration cannot be enabled, because EMAIL_HOST is not configured.")
+    return False
 
 
 class RegistratonMixin:


### PR DESCRIPTION
fixes #4553. Actually the settings page already includes a warning stating there might be issue without the email host being configured, but I still think an error message should be printed as this is clearly a misconfiguration of the server admin and only happens after the user successfully signed in to their IdP.