### PR TITLE
Allow plugin loading when calling 'showmigrations'

### DIFF
--- a/InvenTree/InvenTree/ready.py
+++ b/InvenTree/InvenTree/ready.py
@@ -49,7 +49,6 @@ def canAppAccessDatabase(allow_test: bool = False, allow_plugins: bool = False, 
         'prerender',
         'rebuild_models',
         'rebuild_thumbnails',
-        'showmigrations',
         'makemessages',
         'compilemessages',
         'backup',
@@ -70,6 +69,7 @@ def canAppAccessDatabase(allow_test: bool = False, allow_plugins: bool = False, 
     if not allow_plugins:
         excluded_commands.extend([
             'makemigrations',
+            'showmigrations',
             'migrate',
             'collectstatic',
         ])


### PR DESCRIPTION
- Otherwise cannot see what migrations have been run for a plugin