### PR TITLE
Remove --no-frontend option from installer

### DIFF
--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -236,7 +236,7 @@ function update_or_install() {
   # Run update as app user
   echo "# Updating InvenTree"
   sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && pip install wheel"
-  sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && invoke update --no-frontend | sed -e 's/^/# inv update| /;'"
+  sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && invoke update | sed -e 's/^/# inv update| /;'"
 
   # Make sure permissions are correct again
   echo "# Set permissions for data dir and media: ${DATA_DIR}"


### PR DESCRIPTION
- This swtich is no longer present in `invoke update`
- Frontend installation is off by default
- Fixes https://github.com/inventree/InvenTree/discussions/6109