### PR TITLE
Fix to clear SO Allocations on receipt of Return Order Line Item

### DIFF
--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -1926,7 +1926,7 @@ class ReturnOrder(TotalPriceMixin, Order):
         stock_item.customer = None
         stock_item.sales_order = None
         stock_item.save(add_note=False)
-	stock_item.clearAllocations()
+        stock_item.clearAllocations()
 
         # Add a tracking entry to the StockItem
         stock_item.add_tracking_entry(

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -1926,6 +1926,7 @@ class ReturnOrder(TotalPriceMixin, Order):
         stock_item.customer = None
         stock_item.sales_order = None
         stock_item.save(add_note=False)
+	stock_item.clearAllocations()
 
         # Add a tracking entry to the StockItem
         stock_item.add_tracking_entry(


### PR DESCRIPTION
Added stock_item.clearAllocations() to order/models.py ReturnOrder.receive_line_item
Fixes issue #6092 