### PR TITLE
[PUI] Move UI rendering out of App.tsx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,9 @@ attrs==23.1.0
 babel==2.13.1
     # via py-moneyed
 bleach[css]==6.1.0
-    # via django-markdownify
+    # via
+    #   bleach
+    #   django-markdownify
 brotli==1.1.0
     # via fonttools
 certifi==2023.7.22
@@ -162,7 +164,9 @@ et-xmlfile==1.1.0
 feedparser==6.0.10
     # via -r requirements.in
 fonttools[woff]==4.44.0
-    # via weasyprint
+    # via
+    #   fonttools
+    #   weasyprint
 gunicorn==21.2.0
     # via -r requirements.in
 html5lib==1.1
@@ -221,6 +225,7 @@ pyjwt[crypto]==2.8.0
     # via
     #   django-allauth
     #   djangorestframework-simplejwt
+    #   pyjwt
 pyphen==0.14.0
     # via weasyprint
 pypng==0.20220715.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,7 @@ attrs==23.1.0
 babel==2.13.1
     # via py-moneyed
 bleach[css]==6.1.0
-    # via
-    #   bleach
-    #   django-markdownify
+    # via django-markdownify
 brotli==1.1.0
     # via fonttools
 certifi==2023.7.22
@@ -164,9 +162,7 @@ et-xmlfile==1.1.0
 feedparser==6.0.10
     # via -r requirements.in
 fonttools[woff]==4.44.0
-    # via
-    #   fonttools
-    #   weasyprint
+    # via weasyprint
 gunicorn==21.2.0
     # via -r requirements.in
 html5lib==1.1
@@ -225,7 +221,6 @@ pyjwt[crypto]==2.8.0
     # via
     #   django-allauth
     #   djangorestframework-simplejwt
-    #   pyjwt
 pyphen==0.14.0
     # via weasyprint
 pypng==0.20220715.0

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,9 +1,6 @@
-import { useViewportSize } from '@mantine/hooks';
 import { QueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import { lazy } from 'react';
 
-import { Loadable } from './functions/loading';
 import { useLocalState } from './states/LocalState';
 import { useSessionState } from './states/SessionState';
 
@@ -18,23 +15,3 @@ export function setApiDefaults() {
   api.defaults.headers.common['Authorization'] = `Token ${token}`;
 }
 export const queryClient = new QueryClient();
-
-function checkMobile() {
-  const { height, width } = useViewportSize();
-  if (width < 425 || height < 425) return true;
-  return false;
-}
-
-const MobileAppView = Loadable(lazy(() => import('./views/MobileAppView')));
-const DesktopAppView = Loadable(lazy(() => import('./views/DesktopAppView')));
-
-// Main App
-export default function App() {
-  // Check if mobile
-  if (checkMobile()) {
-    return <MobileAppView />;
-  }
-
-  // Main App component
-  return <DesktopAppView />;
-}

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -4,8 +4,8 @@ import ReactDOM from 'react-dom/client';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 
-import App from './App';
 import { HostList } from './states/states';
+import MainView from './views/MainView';
 
 // define settings
 declare global {
@@ -71,7 +71,7 @@ export const base_url = window.INVENTREE_SETTINGS.base_url || 'platform';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <MainView />
   </React.StrictMode>
 );
 

--- a/src/frontend/src/views/MainView.tsx
+++ b/src/frontend/src/views/MainView.tsx
@@ -1,0 +1,24 @@
+import { useViewportSize } from '@mantine/hooks';
+import { lazy } from 'react';
+
+import { Loadable } from '../functions/loading';
+
+function checkMobile() {
+  const { height, width } = useViewportSize();
+  if (width < 425 || height < 425) return true;
+  return false;
+}
+
+const MobileAppView = Loadable(lazy(() => import('./MobileAppView')));
+const DesktopAppView = Loadable(lazy(() => import('./DesktopAppView')));
+
+// Main App
+export default function MainView() {
+  // Check if mobile
+  if (checkMobile()) {
+    return <MobileAppView />;
+  }
+
+  // Main App component
+  return <DesktopAppView />;
+}


### PR DESCRIPTION
This makes keeping bundles that just use API components (eg. to render out PUI settings controls for inclusion CUI) smaller much easier as the exporter `api` is used nearly everywhere.
Before the individual views were not lazy loaded in the main context of the `App` file so that was no issue. A bug fix in the last bit changed that so now bundles that only use 1-2 components still get the views bundled up so artifacts are larger than need be.