### PR TITLE
Fix supplier barcode order numbers

### DIFF
--- a/InvenTree/plugin/base/barcodes/mixins.py
+++ b/InvenTree/plugin/base/barcodes/mixins.py
@@ -351,10 +351,11 @@ class SupplierBarcodeMixin(BarcodeMixin):
         supplier_reference_filter = Q(supplier_reference__iexact=supplier_order_number)
 
         orders_union = orders.filter(reference_filter | supplier_reference_filter)
-        if orders_union.count() == 1:
+        orders_intersection = orders.filter(reference_filter & supplier_reference_filter)
+        if orders_union.count() == 1 or not orders_intersection:
             return orders_union
-
-        return orders.filter(reference_filter & supplier_reference_filter)
+        else:
+            return orders_intersection
 
     @staticmethod
     def get_supplier_parts(sku: str = None, supplier: Company = None, mpn: str = None):

--- a/InvenTree/plugin/base/barcodes/mixins.py
+++ b/InvenTree/plugin/base/barcodes/mixins.py
@@ -6,7 +6,7 @@ import logging
 from decimal import Decimal, InvalidOperation
 
 from django.contrib.auth.models import User
-from django.db.models import F
+from django.db.models import F, Q
 from django.utils.translation import gettext_lazy as _
 
 from company.models import Company, SupplierPart
@@ -347,12 +347,14 @@ class SupplierBarcodeMixin(BarcodeMixin):
         if supplier:
             orders = orders.filter(supplier=supplier)
 
-        if customer_order_number:
-            orders = orders.filter(reference__iexact=customer_order_number)
-        elif supplier_order_number:
-            orders = orders.filter(supplier_reference__iexact=supplier_order_number)
+        reference_filter = Q(reference__iexact=customer_order_number)
+        supplier_reference_filter = Q(supplier_reference__iexact=supplier_order_number)
 
-        return orders
+        orders_union = orders.filter(reference_filter | supplier_reference_filter)
+        if orders_union.count() == 1:
+            return orders_union
+
+        return orders.filter(reference_filter & supplier_reference_filter)
 
     @staticmethod
     def get_supplier_parts(sku: str = None, supplier: Company = None, mpn: str = None):

--- a/InvenTree/plugin/base/barcodes/mixins.py
+++ b/InvenTree/plugin/base/barcodes/mixins.py
@@ -347,15 +347,17 @@ class SupplierBarcodeMixin(BarcodeMixin):
         if supplier:
             orders = orders.filter(supplier=supplier)
 
+        # this works because reference and supplier_reference are not nullable, so if
+        # customer_order_number or supplier_order_number is None, the query won't return anything
         reference_filter = Q(reference__iexact=customer_order_number)
         supplier_reference_filter = Q(supplier_reference__iexact=supplier_order_number)
 
         orders_union = orders.filter(reference_filter | supplier_reference_filter)
-        orders_intersection = orders.filter(reference_filter & supplier_reference_filter)
-        if orders_union.count() == 1 or not orders_intersection:
+        if orders_union.count() == 1:
             return orders_union
         else:
-            return orders_intersection
+            orders_intersection = orders.filter(reference_filter & supplier_reference_filter)
+            return orders_intersection if orders_intersection else orders_union
 
     @staticmethod
     def get_supplier_parts(sku: str = None, supplier: Company = None, mpn: str = None):

--- a/InvenTree/plugin/builtin/suppliers/lcsc.py
+++ b/InvenTree/plugin/builtin/suppliers/lcsc.py
@@ -36,7 +36,7 @@ class LCSCPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):
         "pm": SupplierBarcodeMixin.MANUFACTURER_PART_NUMBER,
         "pc": SupplierBarcodeMixin.SUPPLIER_PART_NUMBER,
         "qty": SupplierBarcodeMixin.QUANTITY,
-        "on": SupplierBarcodeMixin.CUSTOMER_ORDER_NUMBER,
+        "on": SupplierBarcodeMixin.SUPPLIER_ORDER_NUMBER,
     }
 
     def extract_barcode_fields(self, barcode_data: str) -> dict[str, str]:

--- a/InvenTree/plugin/builtin/suppliers/mouser.py
+++ b/InvenTree/plugin/builtin/suppliers/mouser.py
@@ -30,4 +30,11 @@ class MouserPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):
     def extract_barcode_fields(self, barcode_data: str) -> dict[str, str]:
         """Get supplier_part and barcode_fields from Mouser DataMatrix-Code."""
 
-        return self.parse_ecia_barcode2d(barcode_data)
+        barcode_fields = self.parse_ecia_barcode2d(barcode_data)
+
+        # Mouser uses the custom order number ('K') field of the 2D barcode for both,
+        # the order number and the customer order number
+        if order_number := barcode_fields.get(self.CUSTOMER_ORDER_NUMBER):
+            barcode_fields.setdefault(self.SUPPLIER_ORDER_NUMBER, order_number)
+
+        return barcode_fields

--- a/InvenTree/plugin/builtin/suppliers/tme.py
+++ b/InvenTree/plugin/builtin/suppliers/tme.py
@@ -35,7 +35,8 @@ class TMEPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):
     # Custom field mapping
     TME_QRCODE_FIELDS = {
         "PN": SupplierBarcodeMixin.SUPPLIER_PART_NUMBER,
-        "PO": SupplierBarcodeMixin.CUSTOMER_ORDER_NUMBER,
+        "CPO": SupplierBarcodeMixin.CUSTOMER_ORDER_NUMBER,
+        "PO": SupplierBarcodeMixin.SUPPLIER_ORDER_NUMBER,
         "MPN": SupplierBarcodeMixin.MANUFACTURER_PART_NUMBER,
         "QTY": SupplierBarcodeMixin.QUANTITY,
     }


### PR DESCRIPTION
Seems like the logic for retrieving a purchase order from an order number from a supplier barcode got broken when refactoring. This fixes the logic and also some supplier specific details.