### PR TITLE
[BUG] Fixed depreceated is_ajax

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -845,3 +845,8 @@ def inheritors(cls):
                 subcls.add(child)
                 work.append(child)
     return subcls
+
+
+def is_ajax(request):
+    """Check if the current request is an AJAX request."""
+    return request.headers.get('x-requested-with') == 'XMLHttpRequest'

--- a/InvenTree/InvenTree/views.py
+++ b/InvenTree/InvenTree/views.py
@@ -31,7 +31,7 @@ from part.models import PartCategory
 from users.models import RuleSet, check_user_role
 
 from .forms import EditUserForm, SetPasswordForm
-from .helpers import remove_non_printable_characters, strip_html_tags
+from .helpers import is_ajax, remove_non_printable_characters, strip_html_tags
 
 
 def auth_request(request):
@@ -256,7 +256,7 @@ class AjaxMixin(InvenTreeRoleMixin):
         if not data:
             data = {}
 
-        if not request.is_ajax():
+        if not is_ajax(request):
             return HttpResponseRedirect('/')
 
         if context is None:

--- a/InvenTree/part/api.py
+++ b/InvenTree/part/api.py
@@ -33,6 +33,7 @@ from InvenTree.filters import (
 from InvenTree.helpers import (
     DownloadFile,
     increment_serial_number,
+    is_ajax,
     isNull,
     str2bool,
     str2int,
@@ -1123,7 +1124,7 @@ class PartList(PartMixin, APIDownloadMixin, ListCreateAPI):
         """
         if page is not None:
             return self.get_paginated_response(data)
-        elif request.is_ajax():
+        elif is_ajax(request):
             return JsonResponse(data, safe=False)
         return Response(data)
 
@@ -1774,7 +1775,7 @@ class BomList(BomMixin, ListCreateDestroyAPIView):
         """
         if page is not None:
             return self.get_paginated_response(data)
-        elif request.is_ajax():
+        elif is_ajax(request):
             return JsonResponse(data, safe=False)
         return Response(data)
 

--- a/InvenTree/stock/api.py
+++ b/InvenTree/stock/api.py
@@ -38,6 +38,7 @@ from InvenTree.filters import (
 from InvenTree.helpers import (
     DownloadFile,
     extract_serial_numbers,
+    is_ajax,
     isNull,
     str2bool,
     str2int,
@@ -1025,7 +1026,7 @@ class StockList(APIDownloadMixin, ListCreateDestroyAPIView):
 
         if page is not None:
             return self.get_paginated_response(data)
-        elif request.is_ajax():
+        elif is_ajax(request):
             return JsonResponse(data, safe=False)
         return Response(data)
 
@@ -1396,7 +1397,7 @@ class StockTrackingList(ListAPI):
 
         if page is not None:
             return self.get_paginated_response(data)
-        if request.is_ajax():
+        if is_ajax(request):
             return JsonResponse(data, safe=False)
         return Response(data)
 


### PR DESCRIPTION
is_ajax was depreceated with 3.1 - see [here](https://docs.djangoproject.com/en/3.1/releases/3.1/#id2). This PR fixes the few usages.