### PR TITLE
Add new setting PURCHASEORDER_AUTO_COMPLETE

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -1752,6 +1752,14 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'default': False,
             'validator': bool,
         },
+        'PURCHASEORDER_AUTO_COMPLETE': {
+            'name': _('Auto Complete Purchase Orders'),
+            'description': _(
+                'Automatically mark purchase orders as complete when all line items are received'
+            ),
+            'default': True,
+            'validator': bool,
+        },
         # login / SSO
         'LOGIN_ENABLE_PWD_FORGOT': {
             'name': _('Enable password forgot'),

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -779,8 +779,11 @@ class PurchaseOrder(TotalPriceMixin, Order):
 
         # Has this order been completed?
         if len(self.pending_line_items()) == 0:
-            self.received_by = user
-            self.complete_order()  # This will save the model
+            if common_models.InvenTreeSetting.get_setting(
+                'PURCHASEORDER_AUTO_COMPLETE', True
+            ):
+                self.received_by = user
+                self.complete_order()  # This will save the model
 
         # Issue a notification to interested parties, that this order has been "updated"
         notify_responsible(

--- a/InvenTree/templates/InvenTree/settings/po.html
+++ b/InvenTree/templates/InvenTree/settings/po.html
@@ -12,6 +12,7 @@
     <tbody>
         {% include "InvenTree/settings/setting.html" with key="PURCHASEORDER_REFERENCE_PATTERN" %}
         {% include "InvenTree/settings/setting.html" with key="PURCHASEORDER_EDIT_COMPLETED_ORDERS" icon='fa-edit' %}
+        {% include "InvenTree/settings/setting.html" with key="PURCHASEORDER_AUTO_COMPLETE" icon='fa-check-circle' %}
     </tbody>
 </table>
 {% endblock content %}

--- a/src/frontend/src/components/settings/SettingItem.tsx
+++ b/src/frontend/src/components/settings/SettingItem.tsx
@@ -172,8 +172,8 @@ export function SettingItem({
 
   return (
     <Paper style={style}>
-      <Group position="apart" p="10">
-        <Stack spacing="2">
+      <Group position="apart" p="3">
+        <Stack spacing="2" p="4px">
           <Text>{setting.name}</Text>
           <Text size="xs">{setting.description}</Text>
         </Stack>

--- a/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
+++ b/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
@@ -238,7 +238,8 @@ export default function SystemSettings() {
           <GlobalSettingList
             keys={[
               'PURCHASEORDER_REFERENCE_PATTERN',
-              'PURCHASEORDER_EDIT_COMPLETED_ORDERS'
+              'PURCHASEORDER_EDIT_COMPLETED_ORDERS',
+              'PURCHASEORDER_AUTO_COMPLETE'
             ]}
           />
         )


### PR DESCRIPTION
- Controls whether purchase orders are automatically closed
- Default to True (preserve current behaviour)