### PR TITLE
Import data fix

### DIFF
--- a/InvenTree/InvenTree/apps.py
+++ b/InvenTree/InvenTree/apps.py
@@ -1,4 +1,4 @@
-"""AppConfig for inventree app."""
+"""AppConfig for InvenTree app."""
 
 import logging
 from importlib import import_module

--- a/tasks.py
+++ b/tasks.py
@@ -469,7 +469,7 @@ def export_records(
         allow_sso=include_sso,
     )
 
-    cmd = f"dumpdata --indent 2 --output '{tmpfile}' {excludes}"
+    cmd = f"dumpdata --natural-foreign --indent 2 --output '{tmpfile}' {excludes}"
 
     # Dump data to temporary file
     manage(c, cmd, pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -540,7 +540,7 @@ def import_records(
     authfile = f'{filename}.auth.json'
 
     # Pre-process the data, to remove any "permissions" specified for a user or group
-    datafile = f'{filename}.tmp.json'
+    datafile = f'{filename}.data.json'
 
     with open(filename, 'r') as f_in:
         try:


### PR DESCRIPTION
Crucial fixes for the dataset import / export process (i.e. `invoke import-records` and `invoke export-records`)

### Data Export

By specifing `--natural-foreign` in the export step, we ensure that any `ContentType` foreign key entries use the *name* of the referenced model, and not the *primary key* (which can change)

**Old Export File**

```json
  {
    "model": "users.owner",
    "pk": 1,
    "fields": {
      "owner_type": 84,
      "owner_id": 1
    }
  },
```

**New Export File**

```json
  {
    "model": "users.owner",
    "pk": 1,
    "fields": {
      "owner_type": [
        "auth",
        "group"
      ],
      "owner_id": 1
    }
  },
```

### Data Import

We split the data import process into two parts:

1. Import `auth.user` and `auth.group`
2. Import the rest of the data (including `users.owner` which was causing problems)

### References

- https://github.com/inventree/InvenTree/issues/6127
- https://github.com/inventree/InvenTree/pull/6244