### PR TITLE
Report copy fix

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -790,6 +790,11 @@ def hash_barcode(barcode_data):
     return str(hash.hexdigest())
 
 
+def hash_file(filename: str):
+    """Return the MD5 hash of a file."""
+    return hashlib.md5(open(filename, 'rb').read()).hexdigest()
+
+
 def get_objectreference(
     obj, type_ref: str = 'content_type', object_ref: str = 'object_id'
 ):

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -394,10 +394,12 @@ def DownloadFile(
         length = len(bytes(data, response.charset))
     response['Content-Length'] = length
 
-    disposition = 'inline' if inline else 'attachment'
+    if inline:
+        disposition = f'inline; filename={filename}'
+    else:
+        disposition = f'attachment; filename={filename}'
 
-    response['Content-Disposition'] = f'{disposition}; filename={filename}'
-
+    response['Content-Disposition'] = disposition
     return response
 
 

--- a/InvenTree/label/apps.py
+++ b/InvenTree/label/apps.py
@@ -12,20 +12,10 @@ from django.conf import settings
 from django.core.exceptions import AppRegistryNotReady
 from django.db.utils import IntegrityError, OperationalError, ProgrammingError
 
+import InvenTree.helpers
 import InvenTree.ready
 
 logger = logging.getLogger('inventree')
-
-
-def hashFile(filename):
-    """Calculate the MD5 hash of a file."""
-    md5 = hashlib.md5()
-
-    with open(filename, 'rb') as f:
-        data = f.read()
-        md5.update(data)
-
-    return md5.hexdigest()
 
 
 class LabelConfig(AppConfig):
@@ -167,7 +157,9 @@ class LabelConfig(AppConfig):
         if dst_file.exists():
             # File already exists - let's see if it is the "same"
 
-            if hashFile(dst_file) != hashFile(src_file):  # pragma: no cover
+            if InvenTree.helpers.hash_file(dst_file) != InvenTree.helpers.hash_file(
+                src_file
+            ):  # pragma: no cover
                 logger.info("Hash differs for '%s'", filename)
                 to_copy = True
 

--- a/InvenTree/report/apps.py
+++ b/InvenTree/report/apps.py
@@ -11,6 +11,8 @@ from django.conf import settings
 from django.core.exceptions import AppRegistryNotReady
 from django.db.utils import IntegrityError, OperationalError, ProgrammingError
 
+import InvenTree.helpers
+
 logger = logging.getLogger('inventree')
 
 
@@ -83,7 +85,21 @@ class ReportConfig(AppConfig):
             src_file = src_dir.joinpath(report['file'])
             dst_file = settings.MEDIA_ROOT.joinpath(filename)
 
+            do_copy = False
+
             if not dst_file.exists():
+                logger.info("Report template '%s' is not present", filename)
+                do_copy = True
+            else:
+                # Check if the file contents are different
+                src_hash = InvenTree.helpers.hash_file(src_file)
+                dst_hash = InvenTree.helpers.hash_file(dst_file)
+
+                if src_hash != dst_hash:
+                    logger.info("Hash differs for '%s'", filename)
+                    do_copy = True
+
+            if do_copy:
                 logger.info("Copying test report template '%s'", dst_file)
                 shutil.copyfile(src_file, dst_file)
 


### PR DESCRIPTION
Ensure that report templates are updated correctly when the base template changes. Use file hashes (like we already are doing for the label templates)