### PR TITLE
Import Fix (#6274)

### DIFF
--- a/InvenTree/InvenTree/admin.py
+++ b/InvenTree/InvenTree/admin.py
@@ -1,6 +1,7 @@
 """Admin classes"""
 
 from django.contrib import admin
+from django.db.models.fields import CharField
 from django.http.request import HttpRequest
 
 from djmoney.contrib.exchange.admin import RateAdmin
@@ -83,7 +84,16 @@ class InvenTreeResource(ModelResource):
         return [f for f in fields if f.column_name not in fields_to_exclude]
 
     def before_import_row(self, row, row_number=None, **kwargs):
-        """Run custom code before importing each row"""
+        """Run custom code before importing each row.
+
+        - Convert any null fields to empty strings, for fields which do not support null values
+        """
+        # We can automatically determine which fields might need such a conversion
+        for field in self.Meta.model._meta.fields:
+            if isinstance(field, CharField):
+                if field.blank and not field.null:
+                    if field.name not in self.CONVERT_NULL_FIELDS:
+                        self.CONVERT_NULL_FIELDS.append(field.name)
 
         for field in self.CONVERT_NULL_FIELDS:
             if field in row and row[field] is None:

--- a/InvenTree/order/admin.py
+++ b/InvenTree/order/admin.py
@@ -237,7 +237,7 @@ class SalesOrderLineItemResource(PriceResourceMixin, InvenTreeResource):
         Ref: https://github.com/inventree/InvenTree/issues/2207
         """
         if item.sale_price:
-            return str(item.sale_price)
+            return item.sale_price.amount
         return ''
 
 

--- a/InvenTree/order/models.py
+++ b/InvenTree/order/models.py
@@ -1385,7 +1385,12 @@ class SalesOrderLineItem(OrderLineItem):
 
     def fulfilled_quantity(self):
         """Return the total stock quantity fulfilled against this line item."""
-        query = self.order.stock_items.filter(part=self.part).aggregate(fulfilled=Coalesce(Sum('quantity'), Decimal(0)))
+        if not self.pk:
+            return 0
+
+        query = self.order.stock_items.filter(part=self.part).aggregate(
+            fulfilled=Coalesce(Sum('quantity'), Decimal(0))
+        )
 
         return query['fulfilled']
 
@@ -1394,7 +1399,12 @@ class SalesOrderLineItem(OrderLineItem):
 
         This is a summation of the quantity of each attached StockItem
         """
-        query = self.allocations.aggregate(allocated=Coalesce(Sum('quantity'), Decimal(0)))
+        if not self.pk:
+            return 0
+
+        query = self.allocations.aggregate(
+            allocated=Coalesce(Sum('quantity'), Decimal(0))
+        )
 
         return query['allocated']
 


### PR DESCRIPTION
* Fix export price field for SalesOrderLineItem

* Automatically detect which non-nullable fields need conversion

* Fix bug during import

- fulfilled_quantity and allocated_quantity must have a pk
- Cannot work before imported!