### PR TITLE
Remove {% jstrans %} tag

### DIFF
--- a/InvenTree/InvenTree/templatetags/i18n.py
+++ b/InvenTree/InvenTree/templatetags/i18n.py
@@ -123,18 +123,6 @@ def do_translate(parser, token, escape=False):
     )
 
 
-@register.tag('jstrans')
-def do_jstrans(parser, token):
-    """Custom translation function for javascript strings.
-
-    - Usage: {% jstrans "String to translate" %}
-    - Performs the same function as the 'trans' tag, but also escapes the translated string.
-    - Explicitly required for javascript code within a .html template
-    - Note: Any {% trans %} tag is automatically escaped in a .js file
-    """
-    return do_translate(parser, token, escape=True)
-
-
 # Re-register tags which we have not explicitly overridden
 register.tag('blocktrans', django.templatetags.i18n.do_block_translate)
 register.tag('blocktranslate', django.templatetags.i18n.do_block_translate)

--- a/InvenTree/InvenTree/templatetags/i18n.py
+++ b/InvenTree/InvenTree/templatetags/i18n.py
@@ -110,6 +110,9 @@ def do_translate(parser, token, escape=False):
                     "No argument provided to the '%s' tag for the as option." % bits[0]
                 )
             asvar = value
+        elif option == 'escape':
+            # Allow extra argument for 'escape' option
+            pass
         else:
             raise TemplateSyntaxError(
                 "Unknown argument for '%s' tag: '%s'. The only options "

--- a/InvenTree/InvenTree/templatetags/i18n.py
+++ b/InvenTree/InvenTree/templatetags/i18n.py
@@ -62,7 +62,7 @@ class CustomTranslateNode(TranslateNode):
 
 @register.tag('translate')
 @register.tag('trans')
-def do_translate(parser, token, escape=False):
+def do_translate(parser, token):
     """Custom translation function.
 
     - Lifted from https://github.com/django/django/blob/main/django/templatetags/i18n.py.
@@ -74,6 +74,7 @@ def do_translate(parser, token, escape=False):
     message_string = parser.compile_filter(bits[1])
     remaining = bits[2:]
 
+    escape = False
     noop = False
     asvar = None
     message_context = None
@@ -111,8 +112,7 @@ def do_translate(parser, token, escape=False):
                 )
             asvar = value
         elif option == 'escape':
-            # Allow extra argument for 'escape' option
-            pass
+            escape = True
         else:
             raise TemplateSyntaxError(
                 "Unknown argument for '%s' tag: '%s'. The only options "

--- a/InvenTree/build/templates/build/build_base.html
+++ b/InvenTree/build/templates/build/build_base.html
@@ -270,7 +270,7 @@ src="{% static 'img/blank_image.png' %}"
             '{% url "api-build-detail" build.pk %}',
             {
                 method: 'DELETE',
-                title: '{% jstrans "Delete Build Order" %}',
+                title: '{% trans "Delete Build Order" escape=True %}',
                 redirect: "{% url 'build-index' %}",
             }
         );
@@ -280,7 +280,7 @@ src="{% static 'img/blank_image.png' %}"
     <!-- Barcode functionality callbacks -->
     $('#show-qr-code').click(function() {
         showQRDialog(
-            '{% jstrans "Build Order QR Code" %}',
+            '{% trans "Build Order QR Code" escape=True %}',
             '{"build": {{ build.pk }} }'
         );
     });
@@ -292,7 +292,7 @@ src="{% static 'img/blank_image.png' %}"
                 build: {{ build.pk }},
             },
             {
-                title: '{% jstrans "Link Barcode to Build Order" %}',
+                title: '{% trans "Link Barcode to Build Order" escape=True %}',
             }
         );
     });

--- a/InvenTree/build/templates/build/build_base.html
+++ b/InvenTree/build/templates/build/build_base.html
@@ -270,7 +270,7 @@ src="{% static 'img/blank_image.png' %}"
             '{% url "api-build-detail" build.pk %}',
             {
                 method: 'DELETE',
-                title: '{% trans "Delete Build Order" escape=True %}',
+                title: '{% trans "Delete Build Order" escape %}',
                 redirect: "{% url 'build-index' %}",
             }
         );
@@ -280,7 +280,7 @@ src="{% static 'img/blank_image.png' %}"
     <!-- Barcode functionality callbacks -->
     $('#show-qr-code').click(function() {
         showQRDialog(
-            '{% trans "Build Order QR Code" escape=True %}',
+            '{% trans "Build Order QR Code" escape %}',
             '{"build": {{ build.pk }} }'
         );
     });
@@ -292,7 +292,7 @@ src="{% static 'img/blank_image.png' %}"
                 build: {{ build.pk }},
             },
             {
-                title: '{% trans "Link Barcode to Build Order" escape=True %}',
+                title: '{% trans "Link Barcode to Build Order" escape %}',
             }
         );
     });

--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -419,8 +419,8 @@ function allocateSelectedLines() {
 
     if (unallocated_lines.length == 0) {
         showAlertDialog(
-            '{% jstrans "Allocation Complete" %}',
-            '{% jstrans "All lines have been fully allocated" %}',
+            '{% trans "Allocation Complete" escape=True %}',
+            '{% trans "All lines have been fully allocated" escape=True %}',
         );
     } else {
 

--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -419,8 +419,8 @@ function allocateSelectedLines() {
 
     if (unallocated_lines.length == 0) {
         showAlertDialog(
-            '{% trans "Allocation Complete" escape=True %}',
-            '{% trans "All lines have been fully allocated" escape=True %}',
+            '{% trans "Allocation Complete" escape %}',
+            '{% trans "All lines have been fully allocated" escape %}',
         );
     } else {
 

--- a/InvenTree/company/templates/company/company_base.html
+++ b/InvenTree/company/templates/company/company_base.html
@@ -159,7 +159,7 @@
     $('#company-delete').click(function() {
         constructForm('{% url "api-company-detail" company.pk %}', {
             method: 'DELETE',
-            title: '{% trans "Delete Company" escape=True %}',
+            title: '{% trans "Delete Company" escape %}',
             redirect: '{% url "company-index" %}',
         });
     });
@@ -202,10 +202,10 @@
     $('#company-image-delete').click(function(event) {
         event.stopPropagation();
         showQuestionDialog(
-            '{% trans "Remove Image" escape=True %}',
-            '{% trans "Remove associated image from this company" escape=True %}',
+            '{% trans "Remove Image" escape %}',
+            '{% trans "Remove associated image from this company" escape %}',
             {
-                accept_text: '{% trans "Remove" escape=True %}',
+                accept_text: '{% trans "Remove" escape %}',
                 submitClass: 'danger',
                 accept: function() {
                     inventreePut(
@@ -234,7 +234,7 @@
                 fields: {
                     image: {},
                 },
-                title: '{% trans "Upload Image" escape=True %}',
+                title: '{% trans "Upload Image" escape %}',
                 onSuccess: function(data) {
                     reloadImage(data);
                 }
@@ -249,7 +249,7 @@
                 '{% url "api-company-detail" company.pk %}',
                 {
                     method: 'PATCH',
-                    title: '{% trans "Download Image" escape=True %}',
+                    title: '{% trans "Download Image" escape %}',
                     fields: {
                         remote_image: {},
                     },

--- a/InvenTree/company/templates/company/company_base.html
+++ b/InvenTree/company/templates/company/company_base.html
@@ -159,7 +159,7 @@
     $('#company-delete').click(function() {
         constructForm('{% url "api-company-detail" company.pk %}', {
             method: 'DELETE',
-            title: '{% jstrans "Delete Company" %}',
+            title: '{% trans "Delete Company" escape=True %}',
             redirect: '{% url "company-index" %}',
         });
     });
@@ -202,10 +202,10 @@
     $('#company-image-delete').click(function(event) {
         event.stopPropagation();
         showQuestionDialog(
-            '{% jstrans "Remove Image" %}',
-            '{% jstrans "Remove associated image from this company" %}',
+            '{% trans "Remove Image" escape=True %}',
+            '{% trans "Remove associated image from this company" escape=True %}',
             {
-                accept_text: '{% jstrans "Remove" %}',
+                accept_text: '{% trans "Remove" escape=True %}',
                 submitClass: 'danger',
                 accept: function() {
                     inventreePut(
@@ -234,7 +234,7 @@
                 fields: {
                     image: {},
                 },
-                title: '{% jstrans "Upload Image" %}',
+                title: '{% trans "Upload Image" escape=True %}',
                 onSuccess: function(data) {
                     reloadImage(data);
                 }
@@ -249,7 +249,7 @@
                 '{% url "api-company-detail" company.pk %}',
                 {
                     method: 'PATCH',
-                    title: '{% jstrans "Download Image" %}',
+                    title: '{% trans "Download Image" escape=True %}',
                     fields: {
                         remote_image: {},
                     },

--- a/InvenTree/company/templates/company/manufacturer_part.html
+++ b/InvenTree/company/templates/company/manufacturer_part.html
@@ -203,7 +203,7 @@ $('#parameter-create').click(function() {
                 hidden: true,
             }
         },
-        title: '{% trans "Add Parameter" escape=True %}',
+        title: '{% trans "Add Parameter" escape %}',
         refreshTable: '#parameter-table',
     });
 });

--- a/InvenTree/company/templates/company/manufacturer_part.html
+++ b/InvenTree/company/templates/company/manufacturer_part.html
@@ -203,7 +203,7 @@ $('#parameter-create').click(function() {
                 hidden: true,
             }
         },
-        title: '{% jstrans "Add Parameter" %}',
+        title: '{% trans "Add Parameter" escape=True %}',
         refreshTable: '#parameter-table',
     });
 });

--- a/InvenTree/company/templates/company/supplier_part.html
+++ b/InvenTree/company/templates/company/supplier_part.html
@@ -273,7 +273,7 @@ src="{% static 'img/blank_image.png' %}"
 
 $("#show-qr-code").click(function() {
     showQRDialog(
-        '{% jstrans "Supplier Part QR Code" %}',
+        '{% trans "Supplier Part QR Code" escape=True %}',
         '{"supplierpart": {{ part.pk }} }'
     );
 });
@@ -284,7 +284,7 @@ $("#barcode-link").click(function() {
             supplierpart: {{ part.pk }},
         },
         {
-            title: '{% jstrans "Link Barcode to Supplier Part" %}',
+            title: '{% trans "Link Barcode to Supplier Part" escape=True %}',
         }
     );
 });
@@ -356,7 +356,7 @@ $('#update-part-availability').click(function() {
         fields: {
             available: {},
         },
-        title: '{% jstrans "Update Part Availability" %}',
+        title: '{% trans "Update Part Availability" escape=True %}',
         onSuccess: function() {
             location.reload();
         }

--- a/InvenTree/company/templates/company/supplier_part.html
+++ b/InvenTree/company/templates/company/supplier_part.html
@@ -273,7 +273,7 @@ src="{% static 'img/blank_image.png' %}"
 
 $("#show-qr-code").click(function() {
     showQRDialog(
-        '{% trans "Supplier Part QR Code" escape=True %}',
+        '{% trans "Supplier Part QR Code" escape %}',
         '{"supplierpart": {{ part.pk }} }'
     );
 });
@@ -284,7 +284,7 @@ $("#barcode-link").click(function() {
             supplierpart: {{ part.pk }},
         },
         {
-            title: '{% trans "Link Barcode to Supplier Part" escape=True %}',
+            title: '{% trans "Link Barcode to Supplier Part" escape %}',
         }
     );
 });
@@ -356,7 +356,7 @@ $('#update-part-availability').click(function() {
         fields: {
             available: {},
         },
-        title: '{% trans "Update Part Availability" escape=True %}',
+        title: '{% trans "Update Part Availability" escape %}',
         onSuccess: function() {
             location.reload();
         }

--- a/InvenTree/order/templates/order/order_base.html
+++ b/InvenTree/order/templates/order/order_base.html
@@ -315,7 +315,7 @@ $("#export-order").click(function() {
 <!-- Barcode functionality callbacks -->
 $('#show-qr-code').click(function() {
     showQRDialog(
-        '{% trans "Purchase Order QR Code" escape=True %}',
+        '{% trans "Purchase Order QR Code" escape %}',
         '{"purchaseorder": {{ order.pk }} }'
     );
 });
@@ -327,7 +327,7 @@ $("#barcode-link").click(function() {
             purchaseorder: {{ order.pk }},
         },
         {
-            title: '{% trans "Link Barcode to Purchase Order" escape=True %}',
+            title: '{% trans "Link Barcode to Purchase Order" escape %}',
         }
     );
 });

--- a/InvenTree/order/templates/order/order_base.html
+++ b/InvenTree/order/templates/order/order_base.html
@@ -315,7 +315,7 @@ $("#export-order").click(function() {
 <!-- Barcode functionality callbacks -->
 $('#show-qr-code').click(function() {
     showQRDialog(
-        '{% jstrans "Purchase Order QR Code" %}',
+        '{% trans "Purchase Order QR Code" escape=True %}',
         '{"purchaseorder": {{ order.pk }} }'
     );
 });
@@ -327,7 +327,7 @@ $("#barcode-link").click(function() {
             purchaseorder: {{ order.pk }},
         },
         {
-            title: '{% jstrans "Link Barcode to Purchase Order" %}',
+            title: '{% trans "Link Barcode to Purchase Order" escape=True %}',
         }
     );
 });

--- a/InvenTree/order/templates/order/return_order_base.html
+++ b/InvenTree/order/templates/order/return_order_base.html
@@ -260,7 +260,7 @@ $('#print-order-report').click(function() {
 <!-- Barcode functionality callbacks -->
 $('#show-qr-code').click(function() {
     showQRDialog(
-        '{% trans "Return Order QR Code" escape=True %}',
+        '{% trans "Return Order QR Code" escape %}',
         '{"returnorder": {{ order.pk }} }'
     );
 });
@@ -272,7 +272,7 @@ $("#barcode-link").click(function() {
             returnorder: {{ order.pk }},
         },
         {
-            title: '{% trans "Link Barcode to Return Order" escape=True %}',
+            title: '{% trans "Link Barcode to Return Order" escape %}',
         }
     );
 });

--- a/InvenTree/order/templates/order/return_order_base.html
+++ b/InvenTree/order/templates/order/return_order_base.html
@@ -260,7 +260,7 @@ $('#print-order-report').click(function() {
 <!-- Barcode functionality callbacks -->
 $('#show-qr-code').click(function() {
     showQRDialog(
-        '{% jstrans "Return Order QR Code" %}',
+        '{% trans "Return Order QR Code" escape=True %}',
         '{"returnorder": {{ order.pk }} }'
     );
 });
@@ -272,7 +272,7 @@ $("#barcode-link").click(function() {
             returnorder: {{ order.pk }},
         },
         {
-            title: '{% jstrans "Link Barcode to Return Order" %}',
+            title: '{% trans "Link Barcode to Return Order" escape=True %}',
         }
     );
 });

--- a/InvenTree/order/templates/order/sales_order_base.html
+++ b/InvenTree/order/templates/order/sales_order_base.html
@@ -309,7 +309,7 @@ $('#print-order-report').click(function() {
 <!-- Barcode functionality callbacks -->
 $('#show-qr-code').click(function() {
     showQRDialog(
-        '{% trans "Sales Order QR Code" escape=True %}',
+        '{% trans "Sales Order QR Code" escape %}',
         '{"salesorder": {{ order.pk }} }'
     );
 });
@@ -321,7 +321,7 @@ $("#barcode-link").click(function() {
             salesorder: {{ order.pk }},
         },
         {
-            title: '{% trans "Link Barcode to Sales Order" escape=True %}',
+            title: '{% trans "Link Barcode to Sales Order" escape %}',
         }
     );
 });

--- a/InvenTree/order/templates/order/sales_order_base.html
+++ b/InvenTree/order/templates/order/sales_order_base.html
@@ -309,7 +309,7 @@ $('#print-order-report').click(function() {
 <!-- Barcode functionality callbacks -->
 $('#show-qr-code').click(function() {
     showQRDialog(
-        '{% jstrans "Sales Order QR Code" %}',
+        '{% trans "Sales Order QR Code" escape=True %}',
         '{"salesorder": {{ order.pk }} }'
     );
 });
@@ -321,7 +321,7 @@ $("#barcode-link").click(function() {
             salesorder: {{ order.pk }},
         },
         {
-            title: '{% jstrans "Link Barcode to Sales Order" %}',
+            title: '{% trans "Link Barcode to Sales Order" escape=True %}',
         }
     );
 });

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -656,7 +656,7 @@
                         value: {{ part.pk }},
                     },
                     part_2: {
-                        label: '{% trans "Related Part" escape=True %}',
+                        label: '{% trans "Related Part" escape %}',
                         filters: {
                             exclude_id: {{ part.pk }},
                             exclude_related: {{ part.pk }},
@@ -664,7 +664,7 @@
                     }
                 },
                 focus: 'part_2',
-                title: '{% trans "Add Related Part" escape=True %}',
+                title: '{% trans "Add Related Part" escape %}',
                 refreshTable: '#related-parts-table',
             });
         });
@@ -749,7 +749,7 @@
                 fields: partTestTemplateFields({
                     part: {{ part.pk }}
                 }),
-                title: '{% trans "Add Test Result Template" escape=True %}',
+                title: '{% trans "Add Test Result Template" escape %}',
                 refreshTable: '#test-template-table',
             });
         });

--- a/InvenTree/part/templates/part/detail.html
+++ b/InvenTree/part/templates/part/detail.html
@@ -656,7 +656,7 @@
                         value: {{ part.pk }},
                     },
                     part_2: {
-                        label: '{% jstrans "Related Part" %}',
+                        label: '{% trans "Related Part" escape=True %}',
                         filters: {
                             exclude_id: {{ part.pk }},
                             exclude_related: {{ part.pk }},
@@ -664,7 +664,7 @@
                     }
                 },
                 focus: 'part_2',
-                title: '{% jstrans "Add Related Part" %}',
+                title: '{% trans "Add Related Part" escape=True %}',
                 refreshTable: '#related-parts-table',
             });
         });
@@ -749,7 +749,7 @@
                 fields: partTestTemplateFields({
                     part: {{ part.pk }}
                 }),
-                title: '{% jstrans "Add Test Result Template" %}',
+                title: '{% trans "Add Test Result Template" escape=True %}',
                 refreshTable: '#test-template-table',
             });
         });

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -441,7 +441,7 @@
     {% if barcodes %}
     $("#show-qr-code").click(function() {
         showQRDialog(
-            '{% jstrans "Part QR Code" %}',
+            '{% trans "Part QR Code" escape=True %}',
             '{"part": {{ part.pk }} }',
         );
     });
@@ -458,7 +458,7 @@
                 part: {{ part.pk }},
             },
             {
-                title: '{% jstrans "Link Barcode to Part" %}',
+                title: '{% trans "Link Barcode to Part" escape=True %}',
             }
         );
     });
@@ -509,7 +509,7 @@
         launchModalForm(
             "{% url 'part-pricing' part.id %}",
             {
-                submit_text: '{% jstrans "Calculate" %}',
+                submit_text: '{% trans "Calculate" escape=True %}',
                 hideErrorMessage: true,
             }
         );
@@ -525,10 +525,10 @@
     $('#part-image-delete').click(function(event) {
         event.stopPropagation();
         showQuestionDialog(
-            '{% jstrans "Remove Image" %}',
-            '{% jstrans "Remove associated image from this part" %}',
+            '{% trans "Remove Image" escape=True %}',
+            '{% trans "Remove associated image from this part" escape=True %}',
             {
-                accept_text: '{% jstrans "Remove" %}',
+                accept_text: '{% trans "Remove" escape=True %}',
                 submitClass: 'danger',
                 accept: function() {
                     inventreePut(
@@ -557,7 +557,7 @@
                 fields: {
                     image: {},
                 },
-                title: '{% jstrans "Upload Image" %}',
+                title: '{% trans "Upload Image" escape=True %}',
                 onSuccess: function(data) {
                     reloadImage(data);
                 }
@@ -577,7 +577,7 @@
             sidePagination: 'server',
             singleSelect: true,
             formatNoMatches: function() {
-                return '{% jstrans "No matching images found" %}';
+                return '{% trans "No matching images found" escape=True %}';
             },
             columns: [
                 {
@@ -611,7 +611,7 @@
                 '{% url "api-part-detail" part.pk %}',
                 {
                     method: 'PATCH',
-                    title: '{% jstrans "Download Image" %}',
+                    title: '{% trans "Download Image" escape=True %}',
                     fields: {
                         remote_image: {},
                     },
@@ -673,13 +673,13 @@
 
     // Callback function when the "part details" panel is shown
     $('#collapse-part-details').on('show.bs.collapse', function() {
-        $('#toggle-details-button').html('{% jstrans "Hide Part Details" %}');
+        $('#toggle-details-button').html('{% trans "Hide Part Details" escape=True %}');
         inventreeSave('show-part-details', true);
     });
 
     // Callback function when the "part details" panel is hidden
     $('#collapse-part-details').on('hide.bs.collapse', function() {
-        $('#toggle-details-button').html('{% jstrans "Show Part Details" %}');
+        $('#toggle-details-button').html('{% trans "Show Part Details" escape=True %}');
         inventreeSave('show-part-details', false);
     });
 

--- a/InvenTree/part/templates/part/part_base.html
+++ b/InvenTree/part/templates/part/part_base.html
@@ -441,7 +441,7 @@
     {% if barcodes %}
     $("#show-qr-code").click(function() {
         showQRDialog(
-            '{% trans "Part QR Code" escape=True %}',
+            '{% trans "Part QR Code" escape %}',
             '{"part": {{ part.pk }} }',
         );
     });
@@ -458,7 +458,7 @@
                 part: {{ part.pk }},
             },
             {
-                title: '{% trans "Link Barcode to Part" escape=True %}',
+                title: '{% trans "Link Barcode to Part" escape %}',
             }
         );
     });
@@ -509,7 +509,7 @@
         launchModalForm(
             "{% url 'part-pricing' part.id %}",
             {
-                submit_text: '{% trans "Calculate" escape=True %}',
+                submit_text: '{% trans "Calculate" escape %}',
                 hideErrorMessage: true,
             }
         );
@@ -525,10 +525,10 @@
     $('#part-image-delete').click(function(event) {
         event.stopPropagation();
         showQuestionDialog(
-            '{% trans "Remove Image" escape=True %}',
-            '{% trans "Remove associated image from this part" escape=True %}',
+            '{% trans "Remove Image" escape %}',
+            '{% trans "Remove associated image from this part" escape %}',
             {
-                accept_text: '{% trans "Remove" escape=True %}',
+                accept_text: '{% trans "Remove" escape %}',
                 submitClass: 'danger',
                 accept: function() {
                     inventreePut(
@@ -557,7 +557,7 @@
                 fields: {
                     image: {},
                 },
-                title: '{% trans "Upload Image" escape=True %}',
+                title: '{% trans "Upload Image" escape %}',
                 onSuccess: function(data) {
                     reloadImage(data);
                 }
@@ -577,7 +577,7 @@
             sidePagination: 'server',
             singleSelect: true,
             formatNoMatches: function() {
-                return '{% trans "No matching images found" escape=True %}';
+                return '{% trans "No matching images found" escape %}';
             },
             columns: [
                 {
@@ -611,7 +611,7 @@
                 '{% url "api-part-detail" part.pk %}',
                 {
                     method: 'PATCH',
-                    title: '{% trans "Download Image" escape=True %}',
+                    title: '{% trans "Download Image" escape %}',
                     fields: {
                         remote_image: {},
                     },
@@ -673,13 +673,13 @@
 
     // Callback function when the "part details" panel is shown
     $('#collapse-part-details').on('show.bs.collapse', function() {
-        $('#toggle-details-button').html('{% trans "Hide Part Details" escape=True %}');
+        $('#toggle-details-button').html('{% trans "Hide Part Details" escape %}');
         inventreeSave('show-part-details', true);
     });
 
     // Callback function when the "part details" panel is hidden
     $('#collapse-part-details').on('hide.bs.collapse', function() {
-        $('#toggle-details-button').html('{% trans "Show Part Details" escape=True %}');
+        $('#toggle-details-button').html('{% trans "Show Part Details" escape %}');
         inventreeSave('show-part-details', false);
     });
 

--- a/InvenTree/part/templates/part/pricing_javascript.html
+++ b/InvenTree/part/templates/part/pricing_javascript.html
@@ -21,7 +21,7 @@ $('#part-pricing-refresh').click(function() {
 
 $('#part-pricing-edit').click(function() {
     constructForm('{% url "api-part-pricing" part.pk %}', {
-        title: '{% trans "Update Pricing" escape=True %}',
+        title: '{% trans "Update Pricing" escape %}',
         fields: {
             override_min: {},
             override_min_currency: {},

--- a/InvenTree/part/templates/part/pricing_javascript.html
+++ b/InvenTree/part/templates/part/pricing_javascript.html
@@ -21,7 +21,7 @@ $('#part-pricing-refresh').click(function() {
 
 $('#part-pricing-edit').click(function() {
     constructForm('{% url "api-part-pricing" part.pk %}', {
-        title: '{% jstrans "Update Pricing" %}',
+        title: '{% trans "Update Pricing" escape=True %}',
         fields: {
             override_min: {},
             override_min_currency: {},

--- a/InvenTree/stock/templates/stock/item.html
+++ b/InvenTree/stock/templates/stock/item.html
@@ -276,7 +276,7 @@
                         },
                         multi_delete: true,
                         method: 'DELETE',
-                        title: '{% jstrans "Delete Test Data" %}',
+                        title: '{% trans "Delete Test Data" escape=True %}',
                         preFormContent: html,
                         refreshTable: '#test-result-table',
                     });
@@ -293,7 +293,7 @@
             fields: stockItemTestResultFields({
                 stock_item: {{ item.pk }},
             }),
-            title: '{% jstrans "Add Test Result" %}',
+            title: '{% trans "Add Test Result" escape=True %}',
             refreshTable: '#test-result-table',
         });
     });

--- a/InvenTree/stock/templates/stock/item.html
+++ b/InvenTree/stock/templates/stock/item.html
@@ -276,7 +276,7 @@
                         },
                         multi_delete: true,
                         method: 'DELETE',
-                        title: '{% trans "Delete Test Data" escape=True %}',
+                        title: '{% trans "Delete Test Data" escape %}',
                         preFormContent: html,
                         refreshTable: '#test-result-table',
                     });
@@ -293,7 +293,7 @@
             fields: stockItemTestResultFields({
                 stock_item: {{ item.pk }},
             }),
-            title: '{% trans "Add Test Result" escape=True %}',
+            title: '{% trans "Add Test Result" escape %}',
             refreshTable: '#test-result-table',
         });
     });

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -504,7 +504,7 @@ $("#stock-test-report").click(function() {
 $("#print-label").click(function() {
     printLabels({
         items: [{{ item.pk }}],
-        singular_name: '{% jstrans "stock item" %}',
+        singular_name: '{% trans "stock item" escape=True %}',
         url: '{% url "api-stockitem-label-list" %}',
         key: 'item',
     });
@@ -529,7 +529,7 @@ $('#stock-edit-status').click(function () {
             status: {},
         },
         reload: true,
-        title: '{% jstrans "Edit Stock Status" %}',
+        title: '{% trans "Edit Stock Status" escape=True %}',
     });
 });
 
@@ -538,7 +538,7 @@ $('#stock-edit-status').click(function () {
 {% if barcodes %}
 $("#show-qr-code").click(function() {
     showQRDialog(
-        '{% jstrans "Stock Item QR Code" %}',
+        '{% trans "Stock Item QR Code" escape=True %}',
         '{"stockitem": {{ item.pk }} }',
     );
 });
@@ -549,7 +549,7 @@ $("#barcode-link").click(function() {
             stockitem: {{ item.pk }},
         },
         {
-            title: '{% jstrans "Link Barcode to Stock Item" %}',
+            title: '{% trans "Link Barcode to Stock Item" escape=True %}',
         }
     );
 });
@@ -625,7 +625,7 @@ $("#stock-convert").click(function() {
         '{% url "api-stock-item-convert" item.pk %}',
         {
             method: 'POST',
-            title: '{% jstrans "Convert Stock Item" %}',
+            title: '{% trans "Convert Stock Item" escape=True %}',
             preFormContent: html,
             reload: true,
             fields: {
@@ -659,7 +659,7 @@ $("#stock-return-from-customer").click(function() {
             },
         },
         method: 'POST',
-        title: '{% jstrans "Return to Stock" %}',
+        title: '{% trans "Return to Stock" escape=True %}',
         reload: true,
     });
 

--- a/InvenTree/stock/templates/stock/item_base.html
+++ b/InvenTree/stock/templates/stock/item_base.html
@@ -504,7 +504,7 @@ $("#stock-test-report").click(function() {
 $("#print-label").click(function() {
     printLabels({
         items: [{{ item.pk }}],
-        singular_name: '{% trans "stock item" escape=True %}',
+        singular_name: '{% trans "stock item" escape %}',
         url: '{% url "api-stockitem-label-list" %}',
         key: 'item',
     });
@@ -529,7 +529,7 @@ $('#stock-edit-status').click(function () {
             status: {},
         },
         reload: true,
-        title: '{% trans "Edit Stock Status" escape=True %}',
+        title: '{% trans "Edit Stock Status" escape %}',
     });
 });
 
@@ -538,7 +538,7 @@ $('#stock-edit-status').click(function () {
 {% if barcodes %}
 $("#show-qr-code").click(function() {
     showQRDialog(
-        '{% trans "Stock Item QR Code" escape=True %}',
+        '{% trans "Stock Item QR Code" escape %}',
         '{"stockitem": {{ item.pk }} }',
     );
 });
@@ -549,7 +549,7 @@ $("#barcode-link").click(function() {
             stockitem: {{ item.pk }},
         },
         {
-            title: '{% trans "Link Barcode to Stock Item" escape=True %}',
+            title: '{% trans "Link Barcode to Stock Item" escape %}',
         }
     );
 });
@@ -625,7 +625,7 @@ $("#stock-convert").click(function() {
         '{% url "api-stock-item-convert" item.pk %}',
         {
             method: 'POST',
-            title: '{% trans "Convert Stock Item" escape=True %}',
+            title: '{% trans "Convert Stock Item" escape %}',
             preFormContent: html,
             reload: true,
             fields: {
@@ -659,7 +659,7 @@ $("#stock-return-from-customer").click(function() {
             },
         },
         method: 'POST',
-        title: '{% trans "Return to Stock" escape=True %}',
+        title: '{% trans "Return to Stock" escape %}',
         reload: true,
     });
 

--- a/InvenTree/stock/templates/stock/location.html
+++ b/InvenTree/stock/templates/stock/location.html
@@ -286,7 +286,7 @@
 
         printLabels({
             items: locs,
-            singular_name: '{% jstrans "stock location" %}',
+            singular_name: '{% trans "stock location" escape=True %}',
             key: 'location',
             url: '{% url "api-stocklocation-label-list" %}',
         });
@@ -314,7 +314,7 @@
             {
                 onSuccess: function() {
                     showMessage(
-                        '{% jstrans "Scanned stock container into this location" %}',
+                        '{% trans "Scanned stock container into this location" escape=True %}',
                         {
                             style: 'success',
                         }
@@ -387,7 +387,7 @@
     {% if barcodes %}
     $('#show-qr-code').click(function() {
         showQRDialog(
-            '{% jstrans "Stock Location QR Code" %}',
+            '{% trans "Stock Location QR Code" escape=True %}',
             '{"stocklocation": {{ location.pk }} }'
         );
     });
@@ -398,7 +398,7 @@
                 stocklocation: {{ location.pk }},
             },
             {
-                title: '{% jstrans "Link Barcode to Stock Location" %}',
+                title: '{% trans "Link Barcode to Stock Location" escape=True %}',
             }
         );
     });

--- a/InvenTree/stock/templates/stock/location.html
+++ b/InvenTree/stock/templates/stock/location.html
@@ -286,7 +286,7 @@
 
         printLabels({
             items: locs,
-            singular_name: '{% trans "stock location" escape=True %}',
+            singular_name: '{% trans "stock location" escape %}',
             key: 'location',
             url: '{% url "api-stocklocation-label-list" %}',
         });
@@ -314,7 +314,7 @@
             {
                 onSuccess: function() {
                     showMessage(
-                        '{% trans "Scanned stock container into this location" escape=True %}',
+                        '{% trans "Scanned stock container into this location" escape %}',
                         {
                             style: 'success',
                         }
@@ -387,7 +387,7 @@
     {% if barcodes %}
     $('#show-qr-code').click(function() {
         showQRDialog(
-            '{% trans "Stock Location QR Code" escape=True %}',
+            '{% trans "Stock Location QR Code" escape %}',
             '{"stocklocation": {{ location.pk }} }'
         );
     });
@@ -398,7 +398,7 @@
                 stocklocation: {{ location.pk }},
             },
             {
-                title: '{% trans "Link Barcode to Stock Location" escape=True %}',
+                title: '{% trans "Link Barcode to Stock Location" escape %}',
             }
         );
     });

--- a/InvenTree/templates/InvenTree/index.html
+++ b/InvenTree/templates/InvenTree/index.html
@@ -33,10 +33,10 @@
 {% to_list setting_part_starred setting_part_latest setting_bom_validation as settings_list_part %}
 
 {% if roles.part.view and True in settings_list_part %}
-addHeaderTitle('{% trans "Parts" escape=True %}');
+addHeaderTitle('{% trans "Parts" escape %}');
 
 {% if setting_part_starred %}
-addHeaderAction('starred-parts', '{% trans "Subscribed Parts" escape=True %}', 'fa-bell');
+addHeaderAction('starred-parts', '{% trans "Subscribed Parts" escape %}', 'fa-bell');
 loadSimplePartTable("#table-starred-parts", "{% url 'api-part-list' %}", {
     name: 'starred-parts',
     params: {
@@ -49,7 +49,7 @@ loadSimplePartTable("#table-starred-parts", "{% url 'api-part-list' %}", {
 {% endif %}
 
 {% if setting_category_starred %}
-addHeaderAction('starred-categories', '{% trans "Subscribed Categories" escape=True %}', 'fa-bell');
+addHeaderAction('starred-categories', '{% trans "Subscribed Categories" escape %}', 'fa-bell');
 loadPartCategoryTable($('#table-starred-categories'), {
     params: {
         starred: true,
@@ -59,7 +59,7 @@ loadPartCategoryTable($('#table-starred-categories'), {
 {% endif %}
 
 {% if setting_part_latest %}
-addHeaderAction('latest-parts', '{% trans "Latest Parts" escape=True %}', 'fa-newspaper');
+addHeaderAction('latest-parts', '{% trans "Latest Parts" escape %}', 'fa-newspaper');
 loadSimplePartTable("#table-latest-parts", "{% url 'api-part-list' %}", {
     name: 'latest-parts',
     params: {
@@ -74,7 +74,7 @@ loadSimplePartTable("#table-latest-parts", "{% url 'api-part-list' %}", {
 {% endif %}
 
 {% if setting_bom_validation %}
-addHeaderAction('bom-validation', '{% trans "BOM Waiting Validation" escape=True %}', 'fa-times-circle');
+addHeaderAction('bom-validation', '{% trans "BOM Waiting Validation" escape %}', 'fa-times-circle');
 loadSimplePartTable("#table-bom-validation", "{% url 'api-part-list' %}", {
     name: 'parts-invalid-bom',
     params: {
@@ -103,7 +103,7 @@ loadSimplePartTable("#table-bom-validation", "{% url 'api-part-list' %}", {
 
 {% if roles.stock.view %}
 {% if setting_stock_recent %}
-addHeaderAction('recently-updated-stock', '{% trans "Recently Updated" escape=True %}', 'fa-clock');
+addHeaderAction('recently-updated-stock', '{% trans "Recently Updated" escape %}', 'fa-clock');
 loadStockTable($('#table-recently-updated-stock'), {
     disableFilters: true,
     params: {
@@ -117,7 +117,7 @@ loadStockTable($('#table-recently-updated-stock'), {
 {% endif %}
 
 {% if setting_stock_low %}
-addHeaderAction('low-stock', '{% trans "Low Stock" escape=True %}', 'fa-flag');
+addHeaderAction('low-stock', '{% trans "Low Stock" escape %}', 'fa-flag');
 loadSimplePartTable("#table-low-stock", "{% url 'api-part-list' %}", {
     name: 'parts-low-stock',
     params: {
@@ -131,7 +131,7 @@ loadSimplePartTable("#table-low-stock", "{% url 'api-part-list' %}", {
 {% endif %}
 
 {% if setting_stock_depleted %}
-addHeaderAction('depleted-stock', '{% trans "Depleted Stock" escape=True %}', 'fa-times');
+addHeaderAction('depleted-stock', '{% trans "Depleted Stock" escape %}', 'fa-times');
 loadSimplePartTable("#table-depleted-stock", "{% url 'api-part-list' %}", {
     name: 'parts-depleted-stock',
     params: {
@@ -145,7 +145,7 @@ loadSimplePartTable("#table-depleted-stock", "{% url 'api-part-list' %}", {
 {% endif %}
 
 {% if setting_stock_needed %}
-addHeaderAction('stock-to-build', '{% trans "Required for Build Orders" escape=True %}', 'fa-bullhorn');
+addHeaderAction('stock-to-build', '{% trans "Required for Build Orders" escape %}', 'fa-bullhorn');
 
 loadRequiredForBuildsPartsTable("#table-stock-to-build", {});
 {% endif %}
@@ -153,7 +153,7 @@ loadRequiredForBuildsPartsTable("#table-stock-to-build", {});
 {% if expiry %}
 
 {% if setting_stock_expired %}
-addHeaderAction('expired-stock', '{% trans "Expired Stock" escape=True %}', 'fa-calendar-times');
+addHeaderAction('expired-stock', '{% trans "Expired Stock" escape %}', 'fa-calendar-times');
 loadStockTable($("#table-expired-stock"), {
     disableFilters: true,
     params: {
@@ -169,7 +169,7 @@ loadStockTable($("#table-expired-stock"), {
 {% endif %}
 
 {% if setting_stock_stale %}
-addHeaderAction('stale-stock', '{% trans "Stale Stock" escape=True %}', 'fa-stopwatch');
+addHeaderAction('stale-stock', '{% trans "Stale Stock" escape %}', 'fa-stopwatch');
 loadStockTable($("#table-stale-stock"), {
     disableFilters: true,
     params: {
@@ -193,10 +193,10 @@ loadStockTable($("#table-stale-stock"), {
 {% to_list setting_build_pending setting_build_overdue as settings_list_build %}
 
 {% if roles.build.view and True in settings_list_build %}
-addHeaderTitle('{% trans "Build Orders" escape=True %}');
+addHeaderTitle('{% trans "Build Orders" escape %}');
 
 {% if setting_build_pending %}
-addHeaderAction('build-pending', '{% trans "Build Orders In Progress" escape=True %}', 'fa-cogs');
+addHeaderAction('build-pending', '{% trans "Build Orders In Progress" escape %}', 'fa-cogs');
 loadBuildTable("#table-build-pending", {
     locale: '{{ request.LANGUAGE_CODE }}',
     params: {
@@ -207,7 +207,7 @@ loadBuildTable("#table-build-pending", {
 {% endif %}
 
 {% if setting_build_overdue %}
-addHeaderAction('build-overdue', '{% trans "Overdue Build Orders" escape=True %}', 'fa-calendar-times');
+addHeaderAction('build-overdue', '{% trans "Overdue Build Orders" escape %}', 'fa-calendar-times');
 loadBuildTable("#table-build-overdue", {
     locale: '{{ request.LANGUAGE_CODE }}',
     params: {
@@ -224,10 +224,10 @@ loadBuildTable("#table-build-overdue", {
 {% to_list setting_po_outstanding setting_po_overdue as settings_list_po %}
 
 {% if roles.purchase_order.view and True in settings_list_po %}
-addHeaderTitle('{% trans "Purchase Orders" escape=True %}');
+addHeaderTitle('{% trans "Purchase Orders" escape %}');
 
 {% if setting_po_outstanding %}
-addHeaderAction('po-outstanding', '{% trans "Outstanding Purchase Orders" escape=True %}', 'fa-sign-in-alt');
+addHeaderAction('po-outstanding', '{% trans "Outstanding Purchase Orders" escape %}', 'fa-sign-in-alt');
 loadPurchaseOrderTable("#table-po-outstanding", {
     url: "{% url 'api-po-list' %}",
     params: {
@@ -238,7 +238,7 @@ loadPurchaseOrderTable("#table-po-outstanding", {
 {% endif %}
 
 {% if setting_po_overdue %}
-addHeaderAction('po-overdue', '{% trans "Overdue Purchase Orders" escape=True %}', 'fa-calendar-times');
+addHeaderAction('po-overdue', '{% trans "Overdue Purchase Orders" escape %}', 'fa-calendar-times');
 loadPurchaseOrderTable("#table-po-overdue", {
     url: "{% url 'api-po-list' %}",
     params: {
@@ -256,10 +256,10 @@ loadPurchaseOrderTable("#table-po-overdue", {
 {% to_list setting_so_outstanding setting_so_overdue setting_so_shipments_pending as settings_list_so %}
 
 {% if roles.sales_order.view and True in settings_list_so %}
-addHeaderTitle('{% trans "Sales Orders" escape=True %}');
+addHeaderTitle('{% trans "Sales Orders" escape %}');
 
 {% if setting_so_outstanding %}
-addHeaderAction('so-outstanding', '{% trans "Outstanding Sales Orders" escape=True %}', 'fa-sign-out-alt');
+addHeaderAction('so-outstanding', '{% trans "Outstanding Sales Orders" escape %}', 'fa-sign-out-alt');
 loadSalesOrderTable("#table-so-outstanding", {
     url: "{% url 'api-so-list' %}",
     params: {
@@ -270,7 +270,7 @@ loadSalesOrderTable("#table-so-outstanding", {
 {% endif %}
 
 {% if setting_so_overdue %}
-addHeaderAction('so-overdue', '{% trans "Overdue Sales Orders" escape=True %}', 'fa-calendar-times');
+addHeaderAction('so-overdue', '{% trans "Overdue Sales Orders" escape %}', 'fa-calendar-times');
 loadSalesOrderTable("#table-so-overdue", {
     url: "{% url 'api-so-list' %}",
     params: {
@@ -281,7 +281,7 @@ loadSalesOrderTable("#table-so-overdue", {
 {% endif %}
 
 {% if setting_so_shipments_pending %}
-addHeaderAction('so-shipments', '{% trans "Pending Shipments" escape=True %}', 'fa-truck-loading');
+addHeaderAction('so-shipments', '{% trans "Pending Shipments" escape %}', 'fa-truck-loading');
 loadSalesOrderShipmentTable("#table-so-shipments", {
     url: "{% url 'api-so-shipment-list' %}",
     params: {
@@ -296,9 +296,9 @@ loadSalesOrderShipmentTable("#table-so-shipments", {
 {% settings_value 'HOMEPAGE_NEWS' user=request.user as setting_news %}
 {% if setting_news and user.is_staff %}
 
-addHeaderTitle('{% trans "InvenTree News" escape=True %}');
+addHeaderTitle('{% trans "InvenTree News" escape %}');
 
-addHeaderAction('news', '{% trans "Current News" escape=True %}', 'fa-newspaper');
+addHeaderAction('news', '{% trans "Current News" escape %}', 'fa-newspaper');
 loadNewsFeedTable("#table-news", {
     url: "{% url 'api-news-list' %}",
 });

--- a/InvenTree/templates/InvenTree/index.html
+++ b/InvenTree/templates/InvenTree/index.html
@@ -33,10 +33,10 @@
 {% to_list setting_part_starred setting_part_latest setting_bom_validation as settings_list_part %}
 
 {% if roles.part.view and True in settings_list_part %}
-addHeaderTitle('{% jstrans "Parts" %}');
+addHeaderTitle('{% trans "Parts" escape=True %}');
 
 {% if setting_part_starred %}
-addHeaderAction('starred-parts', '{% jstrans "Subscribed Parts" %}', 'fa-bell');
+addHeaderAction('starred-parts', '{% trans "Subscribed Parts" escape=True %}', 'fa-bell');
 loadSimplePartTable("#table-starred-parts", "{% url 'api-part-list' %}", {
     name: 'starred-parts',
     params: {
@@ -49,7 +49,7 @@ loadSimplePartTable("#table-starred-parts", "{% url 'api-part-list' %}", {
 {% endif %}
 
 {% if setting_category_starred %}
-addHeaderAction('starred-categories', '{% jstrans "Subscribed Categories" %}', 'fa-bell');
+addHeaderAction('starred-categories', '{% trans "Subscribed Categories" escape=True %}', 'fa-bell');
 loadPartCategoryTable($('#table-starred-categories'), {
     params: {
         starred: true,
@@ -59,7 +59,7 @@ loadPartCategoryTable($('#table-starred-categories'), {
 {% endif %}
 
 {% if setting_part_latest %}
-addHeaderAction('latest-parts', '{% jstrans "Latest Parts" %}', 'fa-newspaper');
+addHeaderAction('latest-parts', '{% trans "Latest Parts" escape=True %}', 'fa-newspaper');
 loadSimplePartTable("#table-latest-parts", "{% url 'api-part-list' %}", {
     name: 'latest-parts',
     params: {
@@ -74,7 +74,7 @@ loadSimplePartTable("#table-latest-parts", "{% url 'api-part-list' %}", {
 {% endif %}
 
 {% if setting_bom_validation %}
-addHeaderAction('bom-validation', '{% jstrans "BOM Waiting Validation" %}', 'fa-times-circle');
+addHeaderAction('bom-validation', '{% trans "BOM Waiting Validation" escape=True %}', 'fa-times-circle');
 loadSimplePartTable("#table-bom-validation", "{% url 'api-part-list' %}", {
     name: 'parts-invalid-bom',
     params: {
@@ -103,7 +103,7 @@ loadSimplePartTable("#table-bom-validation", "{% url 'api-part-list' %}", {
 
 {% if roles.stock.view %}
 {% if setting_stock_recent %}
-addHeaderAction('recently-updated-stock', '{% jstrans "Recently Updated" %}', 'fa-clock');
+addHeaderAction('recently-updated-stock', '{% trans "Recently Updated" escape=True %}', 'fa-clock');
 loadStockTable($('#table-recently-updated-stock'), {
     disableFilters: true,
     params: {
@@ -117,7 +117,7 @@ loadStockTable($('#table-recently-updated-stock'), {
 {% endif %}
 
 {% if setting_stock_low %}
-addHeaderAction('low-stock', '{% jstrans "Low Stock" %}', 'fa-flag');
+addHeaderAction('low-stock', '{% trans "Low Stock" escape=True %}', 'fa-flag');
 loadSimplePartTable("#table-low-stock", "{% url 'api-part-list' %}", {
     name: 'parts-low-stock',
     params: {
@@ -131,7 +131,7 @@ loadSimplePartTable("#table-low-stock", "{% url 'api-part-list' %}", {
 {% endif %}
 
 {% if setting_stock_depleted %}
-addHeaderAction('depleted-stock', '{% jstrans "Depleted Stock" %}', 'fa-times');
+addHeaderAction('depleted-stock', '{% trans "Depleted Stock" escape=True %}', 'fa-times');
 loadSimplePartTable("#table-depleted-stock", "{% url 'api-part-list' %}", {
     name: 'parts-depleted-stock',
     params: {
@@ -145,7 +145,7 @@ loadSimplePartTable("#table-depleted-stock", "{% url 'api-part-list' %}", {
 {% endif %}
 
 {% if setting_stock_needed %}
-addHeaderAction('stock-to-build', '{% jstrans "Required for Build Orders" %}', 'fa-bullhorn');
+addHeaderAction('stock-to-build', '{% trans "Required for Build Orders" escape=True %}', 'fa-bullhorn');
 
 loadRequiredForBuildsPartsTable("#table-stock-to-build", {});
 {% endif %}
@@ -153,7 +153,7 @@ loadRequiredForBuildsPartsTable("#table-stock-to-build", {});
 {% if expiry %}
 
 {% if setting_stock_expired %}
-addHeaderAction('expired-stock', '{% jstrans "Expired Stock" %}', 'fa-calendar-times');
+addHeaderAction('expired-stock', '{% trans "Expired Stock" escape=True %}', 'fa-calendar-times');
 loadStockTable($("#table-expired-stock"), {
     disableFilters: true,
     params: {
@@ -169,7 +169,7 @@ loadStockTable($("#table-expired-stock"), {
 {% endif %}
 
 {% if setting_stock_stale %}
-addHeaderAction('stale-stock', '{% jstrans "Stale Stock" %}', 'fa-stopwatch');
+addHeaderAction('stale-stock', '{% trans "Stale Stock" escape=True %}', 'fa-stopwatch');
 loadStockTable($("#table-stale-stock"), {
     disableFilters: true,
     params: {
@@ -193,10 +193,10 @@ loadStockTable($("#table-stale-stock"), {
 {% to_list setting_build_pending setting_build_overdue as settings_list_build %}
 
 {% if roles.build.view and True in settings_list_build %}
-addHeaderTitle('{% jstrans "Build Orders" %}');
+addHeaderTitle('{% trans "Build Orders" escape=True %}');
 
 {% if setting_build_pending %}
-addHeaderAction('build-pending', '{% jstrans "Build Orders In Progress" %}', 'fa-cogs');
+addHeaderAction('build-pending', '{% trans "Build Orders In Progress" escape=True %}', 'fa-cogs');
 loadBuildTable("#table-build-pending", {
     locale: '{{ request.LANGUAGE_CODE }}',
     params: {
@@ -207,7 +207,7 @@ loadBuildTable("#table-build-pending", {
 {% endif %}
 
 {% if setting_build_overdue %}
-addHeaderAction('build-overdue', '{% jstrans "Overdue Build Orders" %}', 'fa-calendar-times');
+addHeaderAction('build-overdue', '{% trans "Overdue Build Orders" escape=True %}', 'fa-calendar-times');
 loadBuildTable("#table-build-overdue", {
     locale: '{{ request.LANGUAGE_CODE }}',
     params: {
@@ -224,10 +224,10 @@ loadBuildTable("#table-build-overdue", {
 {% to_list setting_po_outstanding setting_po_overdue as settings_list_po %}
 
 {% if roles.purchase_order.view and True in settings_list_po %}
-addHeaderTitle('{% jstrans "Purchase Orders" %}');
+addHeaderTitle('{% trans "Purchase Orders" escape=True %}');
 
 {% if setting_po_outstanding %}
-addHeaderAction('po-outstanding', '{% jstrans "Outstanding Purchase Orders" %}', 'fa-sign-in-alt');
+addHeaderAction('po-outstanding', '{% trans "Outstanding Purchase Orders" escape=True %}', 'fa-sign-in-alt');
 loadPurchaseOrderTable("#table-po-outstanding", {
     url: "{% url 'api-po-list' %}",
     params: {
@@ -238,7 +238,7 @@ loadPurchaseOrderTable("#table-po-outstanding", {
 {% endif %}
 
 {% if setting_po_overdue %}
-addHeaderAction('po-overdue', '{% jstrans "Overdue Purchase Orders" %}', 'fa-calendar-times');
+addHeaderAction('po-overdue', '{% trans "Overdue Purchase Orders" escape=True %}', 'fa-calendar-times');
 loadPurchaseOrderTable("#table-po-overdue", {
     url: "{% url 'api-po-list' %}",
     params: {
@@ -256,10 +256,10 @@ loadPurchaseOrderTable("#table-po-overdue", {
 {% to_list setting_so_outstanding setting_so_overdue setting_so_shipments_pending as settings_list_so %}
 
 {% if roles.sales_order.view and True in settings_list_so %}
-addHeaderTitle('{% jstrans "Sales Orders" %}');
+addHeaderTitle('{% trans "Sales Orders" escape=True %}');
 
 {% if setting_so_outstanding %}
-addHeaderAction('so-outstanding', '{% jstrans "Outstanding Sales Orders" %}', 'fa-sign-out-alt');
+addHeaderAction('so-outstanding', '{% trans "Outstanding Sales Orders" escape=True %}', 'fa-sign-out-alt');
 loadSalesOrderTable("#table-so-outstanding", {
     url: "{% url 'api-so-list' %}",
     params: {
@@ -270,7 +270,7 @@ loadSalesOrderTable("#table-so-outstanding", {
 {% endif %}
 
 {% if setting_so_overdue %}
-addHeaderAction('so-overdue', '{% jstrans "Overdue Sales Orders" %}', 'fa-calendar-times');
+addHeaderAction('so-overdue', '{% trans "Overdue Sales Orders" escape=True %}', 'fa-calendar-times');
 loadSalesOrderTable("#table-so-overdue", {
     url: "{% url 'api-so-list' %}",
     params: {
@@ -281,7 +281,7 @@ loadSalesOrderTable("#table-so-overdue", {
 {% endif %}
 
 {% if setting_so_shipments_pending %}
-addHeaderAction('so-shipments', '{% jstrans "Pending Shipments" %}', 'fa-truck-loading');
+addHeaderAction('so-shipments', '{% trans "Pending Shipments" escape=True %}', 'fa-truck-loading');
 loadSalesOrderShipmentTable("#table-so-shipments", {
     url: "{% url 'api-so-shipment-list' %}",
     params: {
@@ -296,9 +296,9 @@ loadSalesOrderShipmentTable("#table-so-shipments", {
 {% settings_value 'HOMEPAGE_NEWS' user=request.user as setting_news %}
 {% if setting_news and user.is_staff %}
 
-addHeaderTitle('{% jstrans "InvenTree News" %}');
+addHeaderTitle('{% trans "InvenTree News" escape=True %}');
 
-addHeaderAction('news', '{% jstrans "Current News" %}', 'fa-newspaper');
+addHeaderAction('news', '{% trans "Current News" escape=True %}', 'fa-newspaper');
 loadNewsFeedTable("#table-news", {
     url: "{% url 'api-news-list' %}",
 });

--- a/InvenTree/templates/InvenTree/notifications/notifications.html
+++ b/InvenTree/templates/InvenTree/notifications/notifications.html
@@ -35,7 +35,7 @@ loadNotificationTable("#inbox-table", {
     params: {
         read: false,
     },
-    no_matches: function() { return '{% jstrans "No unread notifications found" %}'; },
+    no_matches: function() { return '{% trans "No unread notifications found" escape=True %}'; },
 });
 
 $("#mark-all").on('click', function() {
@@ -55,7 +55,7 @@ $("#mark-all").on('click', function() {
 loadNotificationTable("#history-table", {
     name: 'history',
     url: '{% url 'api-notifications-list' %}',
-    no_matches: function() { return '{% jstrans "No notification history found" %}'; },
+    no_matches: function() { return '{% trans "No notification history found" escape=True %}'; },
 }, true);
 
 $('#history-delete').click(function() {
@@ -72,7 +72,7 @@ $('#history-delete').click(function() {
             method: 'DELETE',
             multi_delete: true,
             preFormContent: html,
-            title: '{% jstrans "Delete Notifications" %}',
+            title: '{% trans "Delete Notifications" escape=True %}',
             refreshTable: '#history-table',
             form_data: {
                 filters: {
@@ -86,7 +86,7 @@ $('#history-delete').click(function() {
 $("#history-table").on('click', '.notification-delete', function() {
     constructForm(`{% url "api-notifications-list" %}${$(this).attr('pk')}/`, {
         method: 'DELETE',
-        title: '{% jstrans "Delete Notification" %}',
+        title: '{% trans "Delete Notification" escape=True %}',
         onSuccess: function(data) {
             updateNotificationTables();
         }

--- a/InvenTree/templates/InvenTree/notifications/notifications.html
+++ b/InvenTree/templates/InvenTree/notifications/notifications.html
@@ -35,7 +35,7 @@ loadNotificationTable("#inbox-table", {
     params: {
         read: false,
     },
-    no_matches: function() { return '{% trans "No unread notifications found" escape=True %}'; },
+    no_matches: function() { return '{% trans "No unread notifications found" escape %}'; },
 });
 
 $("#mark-all").on('click', function() {
@@ -55,7 +55,7 @@ $("#mark-all").on('click', function() {
 loadNotificationTable("#history-table", {
     name: 'history',
     url: '{% url 'api-notifications-list' %}',
-    no_matches: function() { return '{% trans "No notification history found" escape=True %}'; },
+    no_matches: function() { return '{% trans "No notification history found" escape %}'; },
 }, true);
 
 $('#history-delete').click(function() {
@@ -72,7 +72,7 @@ $('#history-delete').click(function() {
             method: 'DELETE',
             multi_delete: true,
             preFormContent: html,
-            title: '{% trans "Delete Notifications" escape=True %}',
+            title: '{% trans "Delete Notifications" escape %}',
             refreshTable: '#history-table',
             form_data: {
                 filters: {
@@ -86,7 +86,7 @@ $('#history-delete').click(function() {
 $("#history-table").on('click', '.notification-delete', function() {
     constructForm(`{% url "api-notifications-list" %}${$(this).attr('pk')}/`, {
         method: 'DELETE',
-        title: '{% trans "Delete Notification" escape=True %}',
+        title: '{% trans "Delete Notification" escape %}',
         onSuccess: function(data) {
             updateNotificationTables();
         }

--- a/InvenTree/templates/InvenTree/search.html
+++ b/InvenTree/templates/InvenTree/search.html
@@ -79,9 +79,9 @@
     }
 
     {% if roles.part.view %}
-    addItemTitle('{% trans "Part" escape=True %}');
+    addItemTitle('{% trans "Part" escape %}');
 
-    addItem('part', '{% trans "Parts" escape=True %}', 'fa-shapes');
+    addItem('part', '{% trans "Parts" escape %}', 'fa-shapes');
 
     loadPartTable("#table-part",
         "{% url 'api-part-list' %}",
@@ -94,7 +94,7 @@
         }
     );
 
-    addItem('category', '{% trans "Part Categories" escape=True %}', 'fa-sitemap');
+    addItem('category', '{% trans "Part Categories" escape %}', 'fa-sitemap');
 
     loadPartCategoryTable($("#table-category"), {
         params: {
@@ -102,7 +102,7 @@
         }
     });
 
-    addItem('manufacturer-part', '{% trans "Manufacturer Parts" escape=True %}', 'fa-toolbox');
+    addItem('manufacturer-part', '{% trans "Manufacturer Parts" escape %}', 'fa-toolbox');
 
     loadManufacturerPartTable(
         "#table-manufacturer-part",
@@ -117,7 +117,7 @@
         }
     );
 
-    addItem('supplier-part', '{% trans "Supplier Parts" escape=True %}', 'fa-pallet');
+    addItem('supplier-part', '{% trans "Supplier Parts" escape %}', 'fa-pallet');
 
     loadSupplierPartTable(
         "#table-supplier-part",
@@ -136,9 +136,9 @@
 
     {% if roles.build.view %}
 
-    addItemTitle('{% trans "Build" escape=True %}');
+    addItemTitle('{% trans "Build" escape %}');
 
-    addItem('build-order', '{% trans "Build Orders" escape=True %}', 'fa-tools');
+    addItem('build-order', '{% trans "Build Orders" escape %}', 'fa-tools');
 
     loadBuildTable('#table-build-order', {
         locale: '{{ request.LANGUAGE_CODE }}',
@@ -150,9 +150,9 @@
     {% endif %}
 
     {% if roles.stock.view %}
-    addItemTitle('{% trans "Stock" escape=True %}');
+    addItemTitle('{% trans "Stock" escape %}');
 
-    addItem('stock', '{% trans "Stock Items" escape=True %}', 'fa-boxes');
+    addItem('stock', '{% trans "Stock Items" escape %}', 'fa-boxes');
 
     loadStockTable($('#table-stock'), {
         filterKey: 'stocksearch',
@@ -163,7 +163,7 @@
         }
     });
 
-    addItem('location', '{% trans "Stock Locations" escape=True %}', 'fa-map-marker-alt');
+    addItem('location', '{% trans "Stock Locations" escape %}', 'fa-map-marker-alt');
 
     loadStockLocationTable($("#table-location"), {
         filterKey: 'locationsearch',
@@ -175,9 +175,9 @@
     {% endif %}
 
     {% if roles.purchase_order.view or roles.sales_order.view %}
-    addItemTitle('{% trans "Company" escape=True %}');
+    addItemTitle('{% trans "Company" escape %}');
 
-    addItem('manufacturer', '{% trans "Manufacturers" escape=True %}', 'fa-industry');
+    addItem('manufacturer', '{% trans "Manufacturers" escape %}', 'fa-industry');
 
     loadCompanyTable('#table-manufacturer', "{% url 'api-company-list' %}", {
         params: {
@@ -187,7 +187,7 @@
     });
 
     {% if roles.purchase_order.view %}
-    addItem('supplier', '{% trans "Suppliers" escape=True %}', 'fa-building');
+    addItem('supplier', '{% trans "Suppliers" escape %}', 'fa-building');
 
     loadCompanyTable('#table-supplier', "{% url 'api-company-list' %}", {
         params: {
@@ -196,7 +196,7 @@
         }
     });
 
-    addItem('purchase-order', '{% trans "Purchase Orders" escape=True %}', 'fa-shopping-cart');
+    addItem('purchase-order', '{% trans "Purchase Orders" escape %}', 'fa-shopping-cart');
 
     loadPurchaseOrderTable('#table-purchase-order', {
         params: {
@@ -207,7 +207,7 @@
     {% endif %}
 
     {% if roles.sales_order.view %}
-    addItem('customer', '{% trans "Customers" escape=True %}', 'fa-user-tie');
+    addItem('customer', '{% trans "Customers" escape %}', 'fa-user-tie');
 
     loadCompanyTable('#table-customer', "{% url 'api-company-list' %}", {
         params: {
@@ -216,7 +216,7 @@
         }
     });
 
-    addItem('sales-orders', '{% trans "Sales Orders" escape=True %}', 'fa-truck');
+    addItem('sales-orders', '{% trans "Sales Orders" escape %}', 'fa-truck');
 
     loadSalesOrderTable('#table-sales-orders', {
         params: {

--- a/InvenTree/templates/InvenTree/search.html
+++ b/InvenTree/templates/InvenTree/search.html
@@ -79,9 +79,9 @@
     }
 
     {% if roles.part.view %}
-    addItemTitle('{% jstrans "Part" %}');
+    addItemTitle('{% trans "Part" escape=True %}');
 
-    addItem('part', '{% jstrans "Parts" %}', 'fa-shapes');
+    addItem('part', '{% trans "Parts" escape=True %}', 'fa-shapes');
 
     loadPartTable("#table-part",
         "{% url 'api-part-list' %}",
@@ -94,7 +94,7 @@
         }
     );
 
-    addItem('category', '{% jstrans "Part Categories" %}', 'fa-sitemap');
+    addItem('category', '{% trans "Part Categories" escape=True %}', 'fa-sitemap');
 
     loadPartCategoryTable($("#table-category"), {
         params: {
@@ -102,7 +102,7 @@
         }
     });
 
-    addItem('manufacturer-part', '{% jstrans "Manufacturer Parts" %}', 'fa-toolbox');
+    addItem('manufacturer-part', '{% trans "Manufacturer Parts" escape=True %}', 'fa-toolbox');
 
     loadManufacturerPartTable(
         "#table-manufacturer-part",
@@ -117,7 +117,7 @@
         }
     );
 
-    addItem('supplier-part', '{% jstrans "Supplier Parts" %}', 'fa-pallet');
+    addItem('supplier-part', '{% trans "Supplier Parts" escape=True %}', 'fa-pallet');
 
     loadSupplierPartTable(
         "#table-supplier-part",
@@ -136,9 +136,9 @@
 
     {% if roles.build.view %}
 
-    addItemTitle('{% jstrans "Build" %}');
+    addItemTitle('{% trans "Build" escape=True %}');
 
-    addItem('build-order', '{% jstrans "Build Orders" %}', 'fa-tools');
+    addItem('build-order', '{% trans "Build Orders" escape=True %}', 'fa-tools');
 
     loadBuildTable('#table-build-order', {
         locale: '{{ request.LANGUAGE_CODE }}',
@@ -150,9 +150,9 @@
     {% endif %}
 
     {% if roles.stock.view %}
-    addItemTitle('{% jstrans "Stock" %}');
+    addItemTitle('{% trans "Stock" escape=True %}');
 
-    addItem('stock', '{% jstrans "Stock Items" %}', 'fa-boxes');
+    addItem('stock', '{% trans "Stock Items" escape=True %}', 'fa-boxes');
 
     loadStockTable($('#table-stock'), {
         filterKey: 'stocksearch',
@@ -163,7 +163,7 @@
         }
     });
 
-    addItem('location', '{% jstrans "Stock Locations" %}', 'fa-map-marker-alt');
+    addItem('location', '{% trans "Stock Locations" escape=True %}', 'fa-map-marker-alt');
 
     loadStockLocationTable($("#table-location"), {
         filterKey: 'locationsearch',
@@ -175,9 +175,9 @@
     {% endif %}
 
     {% if roles.purchase_order.view or roles.sales_order.view %}
-    addItemTitle('{% jstrans "Company" %}');
+    addItemTitle('{% trans "Company" escape=True %}');
 
-    addItem('manufacturer', '{% jstrans "Manufacturers" %}', 'fa-industry');
+    addItem('manufacturer', '{% trans "Manufacturers" escape=True %}', 'fa-industry');
 
     loadCompanyTable('#table-manufacturer', "{% url 'api-company-list' %}", {
         params: {
@@ -187,7 +187,7 @@
     });
 
     {% if roles.purchase_order.view %}
-    addItem('supplier', '{% jstrans "Suppliers" %}', 'fa-building');
+    addItem('supplier', '{% trans "Suppliers" escape=True %}', 'fa-building');
 
     loadCompanyTable('#table-supplier', "{% url 'api-company-list' %}", {
         params: {
@@ -196,7 +196,7 @@
         }
     });
 
-    addItem('purchase-order', '{% jstrans "Purchase Orders" %}', 'fa-shopping-cart');
+    addItem('purchase-order', '{% trans "Purchase Orders" escape=True %}', 'fa-shopping-cart');
 
     loadPurchaseOrderTable('#table-purchase-order', {
         params: {
@@ -207,7 +207,7 @@
     {% endif %}
 
     {% if roles.sales_order.view %}
-    addItem('customer', '{% jstrans "Customers" %}', 'fa-user-tie');
+    addItem('customer', '{% trans "Customers" escape=True %}', 'fa-user-tie');
 
     loadCompanyTable('#table-customer', "{% url 'api-company-list' %}", {
         params: {
@@ -216,7 +216,7 @@
         }
     });
 
-    addItem('sales-orders', '{% jstrans "Sales Orders" %}', 'fa-truck');
+    addItem('sales-orders', '{% trans "Sales Orders" escape=True %}', 'fa-truck');
 
     loadSalesOrderTable('#table-sales-orders', {
         params: {

--- a/InvenTree/templates/InvenTree/settings/settings_js.html
+++ b/InvenTree/templates/InvenTree/settings/settings_js.html
@@ -55,14 +55,14 @@ $('table').find('.btn-edit-setting').click(function() {
     var title = '';
 
     if (plugin != null) {
-        title = '{% trans "Edit Plugin Setting" escape=True %}';
+        title = '{% trans "Edit Plugin Setting" escape %}';
     } else if (notification) {
-        title = '{% trans "Edit Notification Setting" escape=True %}';
+        title = '{% trans "Edit Notification Setting" escape %}';
         setting = $(this).attr('pk');
     } else if (is_global) {
-        title = '{% trans "Edit Global Setting" escape=True %}';
+        title = '{% trans "Edit Global Setting" escape %}';
     } else {
-        title = '{% trans "Edit User Setting" escape=True %}';
+        title = '{% trans "Edit User Setting" escape %}';
     }
 
     editSetting(setting, {

--- a/InvenTree/templates/InvenTree/settings/settings_js.html
+++ b/InvenTree/templates/InvenTree/settings/settings_js.html
@@ -55,14 +55,14 @@ $('table').find('.btn-edit-setting').click(function() {
     var title = '';
 
     if (plugin != null) {
-        title = '{% jstrans "Edit Plugin Setting" %}';
+        title = '{% trans "Edit Plugin Setting" escape=True %}';
     } else if (notification) {
-        title = '{% jstrans "Edit Notification Setting" %}';
+        title = '{% trans "Edit Notification Setting" escape=True %}';
         setting = $(this).attr('pk');
     } else if (is_global) {
-        title = '{% jstrans "Edit Global Setting" %}';
+        title = '{% trans "Edit Global Setting" escape=True %}';
     } else {
-        title = '{% jstrans "Edit User Setting" %}';
+        title = '{% trans "Edit User Setting" escape=True %}';
     }
 
     editSetting(setting, {

--- a/InvenTree/templates/InvenTree/settings/settings_staff_js.html
+++ b/InvenTree/templates/InvenTree/settings/settings_staff_js.html
@@ -41,12 +41,12 @@ onPanelLoad('pricing', function() {
             {
                 field: 'currency',
                 sortable: true,
-                title: '{% trans "Currency" escape=True %}',
+                title: '{% trans "Currency" escape %}',
             },
             {
                 field: 'rate',
                 sortable: true,
-                title: '{% trans "Rate" escape=True %}',
+                title: '{% trans "Rate" escape %}',
             }
         ]
     });
@@ -64,21 +64,21 @@ onPanelLoad('units', function() {
         columns: [
             {
                 field: 'name',
-                title: '{% trans "Name" escape=True %}',
+                title: '{% trans "Name" escape %}',
             },
             {
                 field: 'definition',
-                title: '{% trans "Definition" escape=True %}',
+                title: '{% trans "Definition" escape %}',
             },
             {
                 field: 'symbol',
-                title: '{% trans "Symbol" escape=True %}',
+                title: '{% trans "Symbol" escape %}',
                 formatter: function(value, row) {
                     let html = value;
                     let buttons = '';
 
-                    buttons += makeEditButton('button-units-edit', row.pk, '{% trans "Edit" escape=True %}');
-                    buttons += makeDeleteButton('button-units-delete', row.pk, '{% trans "Delete" escape=True %}');
+                    buttons += makeEditButton('button-units-edit', row.pk, '{% trans "Edit" escape %}');
+                    buttons += makeDeleteButton('button-units-delete', row.pk, '{% trans "Delete" escape %}');
 
                     html += wrapButtons(buttons);
                     return html;
@@ -92,7 +92,7 @@ onPanelLoad('units', function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-custom-unit-list" %}${pk}/`, {
-            title: '{% trans "Edit Custom Unit" escape=True %}',
+            title: '{% trans "Edit Custom Unit" escape %}',
             fields: {
                 name: {},
                 definition: {},
@@ -107,7 +107,7 @@ onPanelLoad('units', function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-custom-unit-list" %}${pk}/`, {
-            title: '{% trans "Delete Custom Unit" escape=True %}',
+            title: '{% trans "Delete Custom Unit" escape %}',
             method: 'DELETE',
             refreshTable: '#physical-units-table',
         });
@@ -121,7 +121,7 @@ onPanelLoad('units', function() {
                 definition: {},
                 symbol: {},
             },
-            title: '{% trans "New Custom Unit" escape=True %}',
+            title: '{% trans "New Custom Unit" escape %}',
             method: 'POST',
             refreshTable: '#physical-units-table',
         });
@@ -137,17 +137,17 @@ onPanelLoad('project-codes', function() {
         search: true,
         sortable: true,
         formatNoMatches: function() {
-            return '{% trans "No project codes found" escape=True %}';
+            return '{% trans "No project codes found" escape %}';
         },
         columns: [
             {
                 field: 'code',
                 sortable: true,
-                title: '{% trans "Project Code" escape=True %}',
+                title: '{% trans "Project Code" escape %}',
             },
             {
                 field: 'responsible',
-                title: '{% trans "Responsible" escape=True %}',
+                title: '{% trans "Responsible" escape %}',
                 formatter: function(value, row) {
                     if (!row.responsible_detail) {
                         return '-';
@@ -155,7 +155,7 @@ onPanelLoad('project-codes', function() {
 
                     var html = row.responsible_detail.name;
 
-                    if (row.responsible_detail.label == '{% trans "group" escape=True %}') {
+                    if (row.responsible_detail.label == '{% trans "group" escape %}') {
                         html += `<span class='float-right fas fa-users'></span>`;
                     } else {
                         html += `<span class='float-right fas fa-user'></span>`;
@@ -167,13 +167,13 @@ onPanelLoad('project-codes', function() {
             {
                 field: 'description',
                 sortable: false,
-                title: '{% trans "Description" escape=True %}',
+                title: '{% trans "Description" escape %}',
                 formatter: function(value, row) {
                     let html = value;
                     let buttons = '';
 
-                    buttons += makeEditButton('button-project-code-edit', row.pk, '{% trans "Edit Project Code" escape=True %}');
-                    buttons += makeDeleteButton('button-project-code-delete', row.pk, '{% trans "Delete Project Code" escape=True %}');
+                    buttons += makeEditButton('button-project-code-edit', row.pk, '{% trans "Edit Project Code" escape %}');
+                    buttons += makeDeleteButton('button-project-code-delete', row.pk, '{% trans "Delete Project Code" escape %}');
 
                     html += wrapButtons(buttons);
                     return html;
@@ -186,7 +186,7 @@ onPanelLoad('project-codes', function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-project-code-list" %}${pk}/`, {
-            title: '{% trans "Edit Project Code" escape=True %}',
+            title: '{% trans "Edit Project Code" escape %}',
             fields: {
                 code: {},
                 description: {},
@@ -200,7 +200,7 @@ onPanelLoad('project-codes', function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-project-code-list" %}${pk}/`, {
-            title: '{% trans "Delete Project Code" escape=True %}',
+            title: '{% trans "Delete Project Code" escape %}',
             method: 'DELETE',
             refreshTable: '#project-code-table',
         });
@@ -213,7 +213,7 @@ onPanelLoad('project-codes', function() {
                 code: {},
                 description: {},
             },
-            title: '{% trans "New Project Code" escape=True %}',
+            title: '{% trans "New Project Code" escape %}',
             method: 'POST',
             refreshTable: '#project-code-table',
         });
@@ -282,7 +282,7 @@ onPanelLoad('category', function() {
     });
 
     $('#cat-param-table').inventreeTable({
-        formatNoMatches: function() { return '{% trans "No category parameter templates found" escape=True %}'; },
+        formatNoMatches: function() { return '{% trans "No category parameter templates found" escape %}'; },
         columns: [
             {
                 field: 'pk',
@@ -292,21 +292,21 @@ onPanelLoad('category', function() {
             },
             {
                 field: 'parameter_template_detail.name',
-                title: '{% trans "Parameter Template" escape=True %}',
+                title: '{% trans "Parameter Template" escape %}',
                 sortable: 'true',
             },
             {
                 field: 'category_detail.pathstring',
-                title: '{% trans "Category" escape=True %}',
+                title: '{% trans "Category" escape %}',
             },
             {
                 field: 'default_value',
-                title: '{% trans "Default Value" escape=True %}',
+                title: '{% trans "Default Value" escape %}',
                 sortable: 'true',
                 formatter: function(value, row, index, field) {
                     let buttons = '';
-                    buttons += makeEditButton('template-edit', row.pk, '{% trans "Edit Template" escape=True %}');
-                    buttons += makeDeleteButton('template-delete', row.pk, '{% trans "Delete Template" escape=True %}');
+                    buttons += makeEditButton('template-edit', row.pk, '{% trans "Edit Template" escape %}');
+                    buttons += makeDeleteButton('template-delete', row.pk, '{% trans "Delete Template" escape %}');
 
                     let html = value
                     html += wrapButtons(buttons);
@@ -323,7 +323,7 @@ onPanelLoad('category', function() {
         var pk = $(this).attr('pk');
 
         constructForm(`/api/part/category/parameters/${pk}/`, {
-            title: '{% trans "Edit Category Parameter Template" escape=True %}',
+            title: '{% trans "Edit Category Parameter Template" escape %}',
             fields: {
                 parameter_template: {},
                 category: {
@@ -350,7 +350,7 @@ onPanelLoad('category', function() {
 
         constructForm(`/api/part/category/parameters/${pk}/`, {
             method: 'DELETE',
-            title: '{% trans "Delete Category Parameter Template" escape=True %}',
+            title: '{% trans "Delete Category Parameter Template" escape %}',
             onSuccess: function() {
                 loadTemplateTable(pk);
             }
@@ -385,7 +385,7 @@ onPanelLoad('category', function() {
         var pk = $('#category-select').val();
 
         constructForm('{% url "api-part-category-parameter-list" %}', {
-            title: '{% trans "Create Category Parameter Template" escape=True %}',
+            title: '{% trans "Create Category Parameter Template" escape %}',
             method: 'POST',
             fields: {
                 parameter_template: {},
@@ -415,7 +415,7 @@ onPanelLoad('part-parameters', function() {
         constructForm('{% url "api-part-parameter-template-list" %}', {
             fields: partParameterTemplateFields(),
             method: 'POST',
-            title: '{% trans "Create Part Parameter Template" escape=True %}',
+            title: '{% trans "Create Part Parameter Template" escape %}',
             refreshTable: '#param-table',
         });
     });
@@ -437,34 +437,34 @@ onPanelLoad("stock", function() {
         search: true,
         sortable: true,
         formatNoMatches: function() {
-            return '{% trans "No stock location types found" escape=True %}';
+            return '{% trans "No stock location types found" escape %}';
         },
         columns: [
             {
                 field: 'name',
                 sortable: true,
-                title: '{% trans "Name" escape=True %}',
+                title: '{% trans "Name" escape %}',
             },
             {
                 field: 'description',
                 sortable: false,
-                title: '{% trans "Description" escape=True %}',
+                title: '{% trans "Description" escape %}',
             },
             {
                 field: 'icon',
                 sortable: true,
-                title: '{% trans "Icon" escape=True %}',
+                title: '{% trans "Icon" escape %}',
             },
             {
                 field: 'location_count',
                 sortable: true,
-                title: '{% trans "Location count" escape=True %}',
+                title: '{% trans "Location count" escape %}',
                 formatter: function(value, row) {
                     let html = value;
                     let buttons = '';
 
-                    buttons += makeEditButton('button-location-type-edit', row.pk, '{% trans "Edit Location Type" escape=True %}');
-                    buttons += makeDeleteButton('button-location-type-delete', row.pk, '{% trans "Delete Location type" escape=True %}');
+                    buttons += makeEditButton('button-location-type-edit', row.pk, '{% trans "Edit Location Type" escape %}');
+                    buttons += makeDeleteButton('button-location-type-delete', row.pk, '{% trans "Delete Location type" escape %}');
 
                     html += wrapButtons(buttons);
                     return html;
@@ -477,7 +477,7 @@ onPanelLoad("stock", function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-location-type-list" %}${pk}/`, {
-            title: '{% trans "Edit Location Type" escape=True %}',
+            title: '{% trans "Edit Location Type" escape %}',
             fields: stockLocationTypeFields(),
             refreshTable: '#location-type-table',
         });
@@ -487,7 +487,7 @@ onPanelLoad("stock", function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-location-type-list" %}${pk}/`, {
-            title: '{% trans "Delete Location Type" escape=True %}',
+            title: '{% trans "Delete Location Type" escape %}',
             method: 'DELETE',
             refreshTable: '#location-type-table',
         });
@@ -497,7 +497,7 @@ onPanelLoad("stock", function() {
         // Construct a new location type
         constructForm('{% url "api-location-type-list" %}', {
             fields: stockLocationTypeFields(),
-            title: '{% trans "New Location Type" escape=True %}',
+            title: '{% trans "New Location Type" escape %}',
             method: 'POST',
             refreshTable: '#location-type-table',
         });
@@ -526,18 +526,18 @@ onPanelLoad('stocktake', function() {
         columns: [
             {
                 field: 'report',
-                title: '{% trans "Report" escape=True %}',
+                title: '{% trans "Report" escape %}',
                 formatter: function(value, row) {
                     return attachmentLink(value);
                 }
             },
             {
                 field: 'part_count',
-                title: '{% trans "Part Count" escape=True %}',
+                title: '{% trans "Part Count" escape %}',
             },
             {
                 field: 'date',
-                title: '{% trans "Date" escape=True %}',
+                title: '{% trans "Date" escape %}',
                 sortable: true,
                 formatter: function(value, row) {
                     let html = renderDate(value);

--- a/InvenTree/templates/InvenTree/settings/settings_staff_js.html
+++ b/InvenTree/templates/InvenTree/settings/settings_staff_js.html
@@ -41,12 +41,12 @@ onPanelLoad('pricing', function() {
             {
                 field: 'currency',
                 sortable: true,
-                title: '{% jstrans "Currency" %}',
+                title: '{% trans "Currency" escape=True %}',
             },
             {
                 field: 'rate',
                 sortable: true,
-                title: '{% jstrans "Rate" %}',
+                title: '{% trans "Rate" escape=True %}',
             }
         ]
     });
@@ -64,21 +64,21 @@ onPanelLoad('units', function() {
         columns: [
             {
                 field: 'name',
-                title: '{% jstrans "Name" %}',
+                title: '{% trans "Name" escape=True %}',
             },
             {
                 field: 'definition',
-                title: '{% jstrans "Definition" %}',
+                title: '{% trans "Definition" escape=True %}',
             },
             {
                 field: 'symbol',
-                title: '{% jstrans "Symbol" %}',
+                title: '{% trans "Symbol" escape=True %}',
                 formatter: function(value, row) {
                     let html = value;
                     let buttons = '';
 
-                    buttons += makeEditButton('button-units-edit', row.pk, '{% jstrans "Edit" %}');
-                    buttons += makeDeleteButton('button-units-delete', row.pk, '{% jstrans "Delete" %}');
+                    buttons += makeEditButton('button-units-edit', row.pk, '{% trans "Edit" escape=True %}');
+                    buttons += makeDeleteButton('button-units-delete', row.pk, '{% trans "Delete" escape=True %}');
 
                     html += wrapButtons(buttons);
                     return html;
@@ -92,7 +92,7 @@ onPanelLoad('units', function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-custom-unit-list" %}${pk}/`, {
-            title: '{% jstrans "Edit Custom Unit" %}',
+            title: '{% trans "Edit Custom Unit" escape=True %}',
             fields: {
                 name: {},
                 definition: {},
@@ -107,7 +107,7 @@ onPanelLoad('units', function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-custom-unit-list" %}${pk}/`, {
-            title: '{% jstrans "Delete Custom Unit" %}',
+            title: '{% trans "Delete Custom Unit" escape=True %}',
             method: 'DELETE',
             refreshTable: '#physical-units-table',
         });
@@ -121,7 +121,7 @@ onPanelLoad('units', function() {
                 definition: {},
                 symbol: {},
             },
-            title: '{% jstrans "New Custom Unit" %}',
+            title: '{% trans "New Custom Unit" escape=True %}',
             method: 'POST',
             refreshTable: '#physical-units-table',
         });
@@ -137,17 +137,17 @@ onPanelLoad('project-codes', function() {
         search: true,
         sortable: true,
         formatNoMatches: function() {
-            return '{% jstrans "No project codes found" %}';
+            return '{% trans "No project codes found" escape=True %}';
         },
         columns: [
             {
                 field: 'code',
                 sortable: true,
-                title: '{% jstrans "Project Code" %}',
+                title: '{% trans "Project Code" escape=True %}',
             },
             {
                 field: 'responsible',
-                title: '{% jstrans "Responsible" %}',
+                title: '{% trans "Responsible" escape=True %}',
                 formatter: function(value, row) {
                     if (!row.responsible_detail) {
                         return '-';
@@ -155,7 +155,7 @@ onPanelLoad('project-codes', function() {
 
                     var html = row.responsible_detail.name;
 
-                    if (row.responsible_detail.label == '{% jstrans "group" %}') {
+                    if (row.responsible_detail.label == '{% trans "group" escape=True %}') {
                         html += `<span class='float-right fas fa-users'></span>`;
                     } else {
                         html += `<span class='float-right fas fa-user'></span>`;
@@ -167,13 +167,13 @@ onPanelLoad('project-codes', function() {
             {
                 field: 'description',
                 sortable: false,
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" escape=True %}',
                 formatter: function(value, row) {
                     let html = value;
                     let buttons = '';
 
-                    buttons += makeEditButton('button-project-code-edit', row.pk, '{% jstrans "Edit Project Code" %}');
-                    buttons += makeDeleteButton('button-project-code-delete', row.pk, '{% jstrans "Delete Project Code" %}');
+                    buttons += makeEditButton('button-project-code-edit', row.pk, '{% trans "Edit Project Code" escape=True %}');
+                    buttons += makeDeleteButton('button-project-code-delete', row.pk, '{% trans "Delete Project Code" escape=True %}');
 
                     html += wrapButtons(buttons);
                     return html;
@@ -186,7 +186,7 @@ onPanelLoad('project-codes', function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-project-code-list" %}${pk}/`, {
-            title: '{% jstrans "Edit Project Code" %}',
+            title: '{% trans "Edit Project Code" escape=True %}',
             fields: {
                 code: {},
                 description: {},
@@ -200,7 +200,7 @@ onPanelLoad('project-codes', function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-project-code-list" %}${pk}/`, {
-            title: '{% jstrans "Delete Project Code" %}',
+            title: '{% trans "Delete Project Code" escape=True %}',
             method: 'DELETE',
             refreshTable: '#project-code-table',
         });
@@ -213,7 +213,7 @@ onPanelLoad('project-codes', function() {
                 code: {},
                 description: {},
             },
-            title: '{% jstrans "New Project Code" %}',
+            title: '{% trans "New Project Code" escape=True %}',
             method: 'POST',
             refreshTable: '#project-code-table',
         });
@@ -282,7 +282,7 @@ onPanelLoad('category', function() {
     });
 
     $('#cat-param-table').inventreeTable({
-        formatNoMatches: function() { return '{% jstrans "No category parameter templates found" %}'; },
+        formatNoMatches: function() { return '{% trans "No category parameter templates found" escape=True %}'; },
         columns: [
             {
                 field: 'pk',
@@ -292,21 +292,21 @@ onPanelLoad('category', function() {
             },
             {
                 field: 'parameter_template_detail.name',
-                title: '{% jstrans "Parameter Template" %}',
+                title: '{% trans "Parameter Template" escape=True %}',
                 sortable: 'true',
             },
             {
                 field: 'category_detail.pathstring',
-                title: '{% jstrans "Category" %}',
+                title: '{% trans "Category" escape=True %}',
             },
             {
                 field: 'default_value',
-                title: '{% jstrans "Default Value" %}',
+                title: '{% trans "Default Value" escape=True %}',
                 sortable: 'true',
                 formatter: function(value, row, index, field) {
                     let buttons = '';
-                    buttons += makeEditButton('template-edit', row.pk, '{% jstrans "Edit Template" %}');
-                    buttons += makeDeleteButton('template-delete', row.pk, '{% jstrans "Delete Template" %}');
+                    buttons += makeEditButton('template-edit', row.pk, '{% trans "Edit Template" escape=True %}');
+                    buttons += makeDeleteButton('template-delete', row.pk, '{% trans "Delete Template" escape=True %}');
 
                     let html = value
                     html += wrapButtons(buttons);
@@ -323,7 +323,7 @@ onPanelLoad('category', function() {
         var pk = $(this).attr('pk');
 
         constructForm(`/api/part/category/parameters/${pk}/`, {
-            title: '{% jstrans "Edit Category Parameter Template" %}',
+            title: '{% trans "Edit Category Parameter Template" escape=True %}',
             fields: {
                 parameter_template: {},
                 category: {
@@ -350,7 +350,7 @@ onPanelLoad('category', function() {
 
         constructForm(`/api/part/category/parameters/${pk}/`, {
             method: 'DELETE',
-            title: '{% jstrans "Delete Category Parameter Template" %}',
+            title: '{% trans "Delete Category Parameter Template" escape=True %}',
             onSuccess: function() {
                 loadTemplateTable(pk);
             }
@@ -385,7 +385,7 @@ onPanelLoad('category', function() {
         var pk = $('#category-select').val();
 
         constructForm('{% url "api-part-category-parameter-list" %}', {
-            title: '{% jstrans "Create Category Parameter Template" %}',
+            title: '{% trans "Create Category Parameter Template" escape=True %}',
             method: 'POST',
             fields: {
                 parameter_template: {},
@@ -415,7 +415,7 @@ onPanelLoad('part-parameters', function() {
         constructForm('{% url "api-part-parameter-template-list" %}', {
             fields: partParameterTemplateFields(),
             method: 'POST',
-            title: '{% jstrans "Create Part Parameter Template" %}',
+            title: '{% trans "Create Part Parameter Template" escape=True %}',
             refreshTable: '#param-table',
         });
     });
@@ -437,34 +437,34 @@ onPanelLoad("stock", function() {
         search: true,
         sortable: true,
         formatNoMatches: function() {
-            return '{% jstrans "No stock location types found" %}';
+            return '{% trans "No stock location types found" escape=True %}';
         },
         columns: [
             {
                 field: 'name',
                 sortable: true,
-                title: '{% jstrans "Name" %}',
+                title: '{% trans "Name" escape=True %}',
             },
             {
                 field: 'description',
                 sortable: false,
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" escape=True %}',
             },
             {
                 field: 'icon',
                 sortable: true,
-                title: '{% jstrans "Icon" %}',
+                title: '{% trans "Icon" escape=True %}',
             },
             {
                 field: 'location_count',
                 sortable: true,
-                title: '{% jstrans "Location count" %}',
+                title: '{% trans "Location count" escape=True %}',
                 formatter: function(value, row) {
                     let html = value;
                     let buttons = '';
 
-                    buttons += makeEditButton('button-location-type-edit', row.pk, '{% jstrans "Edit Location Type" %}');
-                    buttons += makeDeleteButton('button-location-type-delete', row.pk, '{% jstrans "Delete Location type" %}');
+                    buttons += makeEditButton('button-location-type-edit', row.pk, '{% trans "Edit Location Type" escape=True %}');
+                    buttons += makeDeleteButton('button-location-type-delete', row.pk, '{% trans "Delete Location type" escape=True %}');
 
                     html += wrapButtons(buttons);
                     return html;
@@ -477,7 +477,7 @@ onPanelLoad("stock", function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-location-type-list" %}${pk}/`, {
-            title: '{% jstrans "Edit Location Type" %}',
+            title: '{% trans "Edit Location Type" escape=True %}',
             fields: stockLocationTypeFields(),
             refreshTable: '#location-type-table',
         });
@@ -487,7 +487,7 @@ onPanelLoad("stock", function() {
         let pk = $(this).attr('pk');
 
         constructForm(`{% url "api-location-type-list" %}${pk}/`, {
-            title: '{% jstrans "Delete Location Type" %}',
+            title: '{% trans "Delete Location Type" escape=True %}',
             method: 'DELETE',
             refreshTable: '#location-type-table',
         });
@@ -497,7 +497,7 @@ onPanelLoad("stock", function() {
         // Construct a new location type
         constructForm('{% url "api-location-type-list" %}', {
             fields: stockLocationTypeFields(),
-            title: '{% jstrans "New Location Type" %}',
+            title: '{% trans "New Location Type" escape=True %}',
             method: 'POST',
             refreshTable: '#location-type-table',
         });
@@ -526,18 +526,18 @@ onPanelLoad('stocktake', function() {
         columns: [
             {
                 field: 'report',
-                title: '{% jstrans "Report" %}',
+                title: '{% trans "Report" escape=True %}',
                 formatter: function(value, row) {
                     return attachmentLink(value);
                 }
             },
             {
                 field: 'part_count',
-                title: '{% jstrans "Part Count" %}',
+                title: '{% trans "Part Count" escape=True %}',
             },
             {
                 field: 'date',
-                title: '{% jstrans "Date" %}',
+                title: '{% trans "Date" escape=True %}',
                 sortable: true,
                 formatter: function(value, row) {
                     let html = renderDate(value);

--- a/InvenTree/templates/InvenTree/settings/user.html
+++ b/InvenTree/templates/InvenTree/settings/user.html
@@ -215,7 +215,7 @@
 
 {% block js_ready %}
 (function() {
-var message = '{% trans "Do you really want to remove the selected email address?" escape=True %}';
+var message = '{% trans "Do you really want to remove the selected email address?" escape %}';
 var actions = document.getElementsByName('action_remove');
 if (actions.length) {
 actions[0].addEventListener("click", function(e) {

--- a/InvenTree/templates/InvenTree/settings/user.html
+++ b/InvenTree/templates/InvenTree/settings/user.html
@@ -215,7 +215,7 @@
 
 {% block js_ready %}
 (function() {
-var message = "{% jstrans 'Do you really want to remove the selected email address?' %}";
+var message = '{% trans "Do you really want to remove the selected email address?" escape=True %}';
 var actions = document.getElementsByName('action_remove');
 if (actions.length) {
 actions[0].addEventListener("click", function(e) {

--- a/InvenTree/templates/js/translated/api.js
+++ b/InvenTree/templates/js/translated/api.js
@@ -222,48 +222,48 @@ function showApiError(xhr, url) {
     switch (xhr.status || 0) {
     // No response
     case 0:
-        title = '{% jstrans "No Response" %}';
-        message = '{% jstrans "No response from the InvenTree server" %}';
+        title = '{% trans "No Response" %}';
+        message = '{% trans "No response from the InvenTree server" %}';
         break;
     // Bad request
     case 400:
         // Note: Normally error code 400 is handled separately,
         //       and should now be shown here!
-        title = '{% jstrans "Error 400: Bad request" %}';
-        message = '{% jstrans "API request returned error code 400" %}';
+        title = '{% trans "Error 400: Bad request" %}';
+        message = '{% trans "API request returned error code 400" %}';
         break;
     // Not authenticated
     case 401:
-        title = '{% jstrans "Error 401: Not Authenticated" %}';
-        message = '{% jstrans "Authentication credentials not supplied" %}';
+        title = '{% trans "Error 401: Not Authenticated" %}';
+        message = '{% trans "Authentication credentials not supplied" %}';
         break;
     // Permission denied
     case 403:
-        title = '{% jstrans "Error 403: Permission Denied" %}';
-        message = '{% jstrans "You do not have the required permissions to access this function" %}';
+        title = '{% trans "Error 403: Permission Denied" %}';
+        message = '{% trans "You do not have the required permissions to access this function" %}';
         break;
     // Resource not found
     case 404:
-        title = '{% jstrans "Error 404: Resource Not Found" %}';
-        message = '{% jstrans "The requested resource could not be located on the server" %}';
+        title = '{% trans "Error 404: Resource Not Found" %}';
+        message = '{% trans "The requested resource could not be located on the server" %}';
         break;
     // Method not allowed
     case 405:
-        title = '{% jstrans "Error 405: Method Not Allowed" %}';
-        message = '{% jstrans "HTTP method not allowed at URL" %}';
+        title = '{% trans "Error 405: Method Not Allowed" %}';
+        message = '{% trans "HTTP method not allowed at URL" %}';
         break;
     // Timeout
     case 408:
-        title = '{% jstrans "Error 408: Timeout" %}';
-        message = '{% jstrans "Connection timeout while requesting data from server" %}';
+        title = '{% trans "Error 408: Timeout" %}';
+        message = '{% trans "Connection timeout while requesting data from server" %}';
         break;
     case 503:
-        title = '{% jstrans "Error 503: Service Unavailable" %}';
-        message = '{% jstrans "The server is currently unavailable" %}';
+        title = '{% trans "Error 503: Service Unavailable" %}';
+        message = '{% trans "The server is currently unavailable" %}';
         break;
     default:
-        title = '{% jstrans "Unhandled Error Code" %}';
-        message = `{% jstrans "Error code" %}: ${xhr.status}`;
+        title = '{% trans "Unhandled Error Code" %}';
+        message = `{% trans "Error code" %}: ${xhr.status}`;
 
         var response = xhr.responseJSON;
 

--- a/InvenTree/templates/js/translated/attachment.js
+++ b/InvenTree/templates/js/translated/attachment.js
@@ -45,7 +45,7 @@ function addAttachmentButtonCallbacks(url, fields={}) {
             fields: file_fields,
             method: 'POST',
             refreshTable: '#attachment-table',
-            title: '{% jstrans "Add Attachment" %}',
+            title: '{% trans "Add Attachment" %}',
         });
     });
 
@@ -67,7 +67,7 @@ function addAttachmentButtonCallbacks(url, fields={}) {
             fields: link_fields,
             method: 'POST',
             refreshTable: '#attachment-table',
-            title: '{% jstrans "Add Link" %}',
+            title: '{% trans "Add Link" %}',
         });
     });
 }
@@ -111,13 +111,13 @@ function deleteAttachments(attachments, url, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "All selected attachments will be deleted" %}
+    {% trans "All selected attachments will be deleted" %}
     </div>
     <table class='table table-striped table-condensed'>
     <tr>
         <th></th>
-        <th>{% jstrans "Attachment" %}</th>
-        <th>{% jstrans "Comment" %}</th>
+        <th>{% trans "Attachment" %}</th>
+        <th>{% trans "Comment" %}</th>
     </tr>
     ${rows}
     </table>
@@ -126,7 +126,7 @@ function deleteAttachments(attachments, url, options={}) {
     constructForm(url, {
         method: 'DELETE',
         multi_delete: true,
-        title: '{% jstrans "Delete Attachments" %}',
+        title: '{% trans "Delete Attachments" %}',
         preFormContent: html,
         form_data: {
             items: ids,
@@ -202,7 +202,7 @@ function makeAttachmentActions(permissions, options) {
         actions.push({
             label: 'delete',
             icon: 'fa-trash-alt icon-red',
-            title: '{% jstrans "Delete attachments" %}',
+            title: '{% trans "Delete attachments" %}',
             callback: options.callback,
         });
     }
@@ -250,7 +250,7 @@ function loadAttachmentTable(url, options) {
             {
                 label: 'attachments',
                 icon: 'fa-tools',
-                title: '{% jstrans "Attachment actions" %}',
+                title: '{% trans "Attachment actions" %}',
                 actions: makeAttachmentActions(permissions, {
                     callback: function(attachments) {
                         deleteAttachments(attachments, url, options);
@@ -272,7 +272,7 @@ function loadAttachmentTable(url, options) {
         url: url,
         name: options.name || 'attachments',
         formatNoMatches: function() {
-            return '{% jstrans "No attachments found" %}';
+            return '{% trans "No attachments found" %}';
         },
         sortable: true,
         search: true,
@@ -312,7 +312,7 @@ function loadAttachmentTable(url, options) {
                             }
                         },
                         refreshTable: '#attachment-table',
-                        title: '{% jstrans "Edit Attachment" %}',
+                        title: '{% trans "Edit Attachment" %}',
                     });
                 });
             }
@@ -323,7 +323,7 @@ function loadAttachmentTable(url, options) {
             },
             {
                 field: 'attachment',
-                title: '{% jstrans "Attachment" %}',
+                title: '{% trans "Attachment" %}',
                 formatter: function(value, row) {
 
                     if (row.attachment) {
@@ -338,12 +338,12 @@ function loadAttachmentTable(url, options) {
             },
             {
                 field: 'comment',
-                title: '{% jstrans "Comment" %}',
+                title: '{% trans "Comment" %}',
             },
             {
                 field: 'upload_date',
                 sortable: true,
-                title: '{% jstrans "Upload Date" %}',
+                title: '{% trans "Upload Date" %}',
                 formatter: function(value, row) {
                     var html = renderDate(value);
 
@@ -363,7 +363,7 @@ function loadAttachmentTable(url, options) {
                         buttons += makeEditButton(
                             'button-attachment-edit',
                             row.pk,
-                            '{% jstrans "Edit attachment" %}',
+                            '{% trans "Edit attachment" %}',
                         );
                     }
 
@@ -371,7 +371,7 @@ function loadAttachmentTable(url, options) {
                         buttons += makeDeleteButton(
                             'button-attachment-delete',
                             row.pk,
-                            '{% jstrans "Delete attachment" %}',
+                            '{% trans "Delete attachment" %}',
                         );
                     }
 

--- a/InvenTree/templates/js/translated/barcode.js
+++ b/InvenTree/templates/js/translated/barcode.js
@@ -40,23 +40,23 @@ var barcodeInputTimer = null;
  */
 function makeBarcodeInput(placeholderText='', hintText='') {
 
-    placeholderText = placeholderText || '{% jstrans "Scan barcode data here using barcode scanner" %}';
+    placeholderText = placeholderText || '{% trans "Scan barcode data here using barcode scanner" %}';
 
-    hintText = hintText || '{% jstrans "Enter barcode data" %}';
+    hintText = hintText || '{% trans "Enter barcode data" %}';
 
     var html = `
     <div id='barcode_scan_video_container' class="mx-auto" style='width: 100%; max-width: 240px; display: none;'>
         <div id="barcode_scan_video"></div>
     </div>
     <div class='form-group'>
-        <label class='control-label' for='barcode'>{% jstrans "Barcode" %}</label>
+        <label class='control-label' for='barcode'>{% trans "Barcode" %}</label>
         <div class='controls'>
             <div class='input-group'>
                 <span class='input-group-text'>
                     ${makeIcon('fa-qrcode')}
                 </span>
                 <input id='barcode' class='textinput textInput form-control' type='text' name='barcode' placeholder='${placeholderText}'>
-                <button title='{% jstrans "Scan barcode using connected webcam" %}' id='barcode_scan_btn' type='button' class='btn btn-secondary' onclick='onBarcodeScanClicked()' style='display: none;'>
+                <button title='{% trans "Scan barcode using connected webcam" %}' id='barcode_scan_btn' type='button' class='btn btn-secondary' onclick='onBarcodeScanClicked()' style='display: none;'>
                     ${makeIcon('fa-camera')}
                 </button>
             </div>
@@ -135,12 +135,12 @@ function onBarcodeScanCompleted(result, options) {
  */
 function makeNotesField(options={}) {
 
-    var tooltip = options.tooltip || '{% jstrans "Enter optional notes for stock transfer" %}';
-    var placeholder = options.placeholder || '{% jstrans "Enter notes" %}';
+    var tooltip = options.tooltip || '{% trans "Enter optional notes for stock transfer" %}';
+    var placeholder = options.placeholder || '{% trans "Enter notes" %}';
 
     return `
     <div class='form-group'>
-        <label class='control-label' for='notes'>{% jstrans "Notes" %}</label>
+        <label class='control-label' for='notes'>{% trans "Notes" %}</label>
         <div class='controls'>
             <div class='input-group'>
                 <span class='input-group-text'>
@@ -185,7 +185,7 @@ function postBarcodeData(barcode_data, options={}) {
                     } else {
                         console.error(xhr);
                         data = xhr.responseJSON || {};
-                        showBarcodeMessage(modal, data.error || '{% jstrans "Server error" %}');
+                        showBarcodeMessage(modal, data.error || '{% trans "Server error" %}');
                     }
                     break;
                 default:
@@ -214,7 +214,7 @@ function postBarcodeData(barcode_data, options={}) {
                     } else {
                         showBarcodeMessage(
                             modal,
-                            '{% jstrans "Unknown response from server" %}',
+                            '{% trans "Unknown response from server" %}',
                             'warning'
                         );
                     }
@@ -249,7 +249,7 @@ function showBarcodeMessage(modal, message, style='danger') {
 function showInvalidResponseError(modal, response, status) {
     showBarcodeMessage(
         modal,
-        `{% jstrans "Invalid server response" %}<br>{% jstrans "Status" %}: '${status}'`
+        `{% trans "Invalid server response" %}<br>{% trans "Status" %}: '${status}'`
     );
 }
 
@@ -369,7 +369,7 @@ function barcodeDialog(title, options={}) {
         modalShowSubmitButton(modal, false);
     }
 
-    var details = options.details || '{% jstrans "Scan barcode data" %}';
+    var details = options.details || '{% trans "Scan barcode data" %}';
 
     var content = '';
 
@@ -417,7 +417,7 @@ function barcodeDialog(title, options={}) {
 function barcodeScanDialog(options={}) {
 
     let modal = options.modal || createNewModal();
-    let title = options.title || '{% jstrans "Scan Barcode" %}';
+    let title = options.title || '{% trans "Scan Barcode" %}';
 
     const matching_models = [
         'build',
@@ -455,7 +455,7 @@ function barcodeScanDialog(options={}) {
                     // No match
                     showBarcodeMessage(
                         modal,
-                        '{% jstrans "No URL in response" %}',
+                        '{% trans "No URL in response" %}',
                         'warning'
                     );
                 }
@@ -493,15 +493,15 @@ function linkBarcodeDialog(data, options={}) {
  */
 function unlinkBarcode(data, options={}) {
 
-    var html = `<b>{% jstrans "Unlink Barcode" %}</b><br>`;
+    var html = `<b>{% trans "Unlink Barcode" %}</b><br>`;
 
-    html += '{% jstrans "This will remove the link to the associated barcode" %}';
+    html += '{% trans "This will remove the link to the associated barcode" %}';
 
     showQuestionDialog(
-        '{% jstrans "Unlink Barcode" %}',
+        '{% trans "Unlink Barcode" %}',
         html,
         {
-            accept_text: '{% jstrans "Unlink" %}',
+            accept_text: '{% trans "Unlink" %}',
             accept: function() {
                 inventreePut(
                     '{% url "api-barcode-unlink" %}',
@@ -543,9 +543,9 @@ function barcodeCheckInStockItems(location_id, options={}) {
         <table class='table table-condensed table-striped' id='items-table'>
             <thead>
                 <tr>
-                    <th>{% jstrans "Part" %}</th>
-                    <th>{% jstrans "Location" %}</th>
-                    <th>{% jstrans "Quantity" %}</th>
+                    <th>{% trans "Part" %}</th>
+                    <th>{% trans "Location" %}</th>
+                    <th>{% trans "Quantity" %}</th>
                     <th></th>
                 </tr>
             </thead>
@@ -564,7 +564,7 @@ function barcodeCheckInStockItems(location_id, options={}) {
                 <td>${imageHoverIcon(item.part_detail.thumbnail)} ${item.part_detail.name}</td>
                 <td>${location_info}</td>
                 <td>${item.quantity}</td>
-                <td>${makeRemoveButton('button-item-remove', item.pk, '{% jstrans "Remove stock item" %}')}</td>
+                <td>${makeRemoveButton('button-item-remove', item.pk, '{% trans "Remove stock item" %}')}</td>
             </tr>`;
         });
 
@@ -607,12 +607,12 @@ function barcodeCheckInStockItems(location_id, options={}) {
     var extra = makeNotesField();
 
     barcodeDialog(
-        '{% jstrans "Scan Stock Items Into Location" %}',
+        '{% trans "Scan Stock Items Into Location" %}',
         {
-            details: '{% jstrans "Scan stock item barcode to check in to this location" %}',
+            details: '{% trans "Scan stock item barcode to check in to this location" %}',
             headerContent: table,
             preShow: function() {
-                modalSetSubmitText(modal, '{% jstrans "Check In" %}');
+                modalSetSubmitText(modal, '{% trans "Check In" %}');
                 modalEnable(modal, false);
                 reloadTable();
             },
@@ -644,7 +644,7 @@ function barcodeCheckInStockItems(location_id, options={}) {
 
                 // Prevent submission without any entries
                 if (entries.length == 0) {
-                    showBarcodeMessage(modal, '{% jstrans "No barcode provided" %}', 'warning');
+                    showBarcodeMessage(modal, '{% trans "No barcode provided" %}', 'warning');
                     return;
                 }
 
@@ -684,18 +684,18 @@ function barcodeCheckInStockItems(location_id, options={}) {
                                 });
 
                                 if (duplicate) {
-                                    showBarcodeMessage(modal, '{% jstrans "Stock Item already scanned" %}', 'warning');
+                                    showBarcodeMessage(modal, '{% trans "Stock Item already scanned" %}', 'warning');
                                 } else {
 
                                     if (stockitem.location == location_id) {
-                                        showBarcodeMessage(modal, '{% jstrans "Stock Item already in this location" %}');
+                                        showBarcodeMessage(modal, '{% trans "Stock Item already in this location" %}');
                                         return;
                                     }
 
                                     // Add this stock item to the list
                                     items.push(stockitem);
 
-                                    showBarcodeMessage(modal, '{% jstrans "Added stock item" %}', 'success');
+                                    showBarcodeMessage(modal, '{% trans "Added stock item" %}', 'success');
 
                                     reloadTable();
                                 }
@@ -704,7 +704,7 @@ function barcodeCheckInStockItems(location_id, options={}) {
                     );
                 } else {
                     // Barcode does not match a stock item
-                    showBarcodeMessage(modal, '{% jstrans "Barcode does not match valid stock item" %}', 'warning');
+                    showBarcodeMessage(modal, '{% trans "Barcode does not match valid stock item" %}', 'warning');
                 }
             },
         }
@@ -723,9 +723,9 @@ function barcodeCheckInStockLocations(location_id, options={}) {
     var header = '';
 
     barcodeDialog(
-        '{% jstrans "Scan Stock Container Into Location" %}',
+        '{% trans "Scan Stock Container Into Location" %}',
         {
-            details: '{% jstrans "Scan stock container barcode to check in to this location" %}',
+            details: '{% trans "Scan stock container barcode to check in to this location" %}',
             headerContent: header,
             preShow: function() {
                 modalEnable(modal, false);
@@ -759,7 +759,7 @@ function barcodeCheckInStockLocations(location_id, options={}) {
                     );
                 } else {
                     // Barcode does not match a valid stock location
-                    showBarcodeMessage(modal, '{% jstrans "Barcode does not match valid stock location" %}', 'warning');
+                    showBarcodeMessage(modal, '{% trans "Barcode does not match valid stock location" %}', 'warning');
                 }
             }
         }
@@ -792,7 +792,7 @@ function scanItemsIntoLocation(item_list, options={}) {
         if (location && location.pk) {
             div.html(`
             <div class='alert alert-block alert-info'>
-            <b>{% jstrans "Location" %}</b></br>
+            <b>{% trans "Location" %}</b></br>
             ${location.name}<br>
             <i>${location.description}</i>
             </div>
@@ -803,13 +803,13 @@ function scanItemsIntoLocation(item_list, options={}) {
     }
 
     barcodeDialog(
-        '{% jstrans "Check Into Location" %}',
+        '{% trans "Check Into Location" %}',
         {
             headerContent: header,
             extraFields: extra,
             modal: modal,
             preShow: function() {
-                modalSetSubmitText(modal, '{% jstrans "Check In" %}');
+                modalSetSubmitText(modal, '{% trans "Check In" %}');
                 modalEnable(modal, false);
             },
             onShow: function() {
@@ -872,7 +872,7 @@ function scanItemsIntoLocation(item_list, options={}) {
                             // Barcode does *NOT* correspond to a StockLocation
                             showBarcodeMessage(
                                 modal,
-                                '{% jstrans "Barcode does not match a valid location" %}',
+                                '{% trans "Barcode does not match a valid location" %}',
                                 'warning',
                             );
                         }
@@ -881,7 +881,7 @@ function scanItemsIntoLocation(item_list, options={}) {
                     // Barcode does *NOT* correspond to a StockLocation
                     showBarcodeMessage(
                         modal,
-                        '{% jstrans "Barcode does not match a valid location" %}',
+                        '{% trans "Barcode does not match a valid location" %}',
                         'warning',
                     );
                 }

--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -75,7 +75,7 @@ function addBomItem(part_id, options={}) {
     constructForm('{% url "api-bom-list" %}', {
         fields: fields,
         method: 'POST',
-        title: '{% jstrans "Create BOM Item" %}',
+        title: '{% trans "Create BOM Item" %}',
         focus: 'sub_part',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
@@ -129,8 +129,8 @@ function constructBomUploadTable(data, options={}) {
 
         let buttons = '';
 
-        buttons += makeInfoButton('button-row-data', idx, '{% jstrans "Display row data" %}');
-        buttons += makeRemoveButton('button-row-remove', idx, '{% jstrans "Remove row" %}');
+        buttons += makeInfoButton('button-row-data', idx, '{% trans "Display row data" %}');
+        buttons += makeRemoveButton('button-row-remove', idx, '{% trans "Remove row" %}');
 
         buttons = wrapButtons(buttons);
 
@@ -185,8 +185,8 @@ function constructBomUploadTable(data, options={}) {
         $(`#button-row-data-${idx}`).click(function() {
 
             var modal = createNewModal({
-                title: '{% jstrans "Row Data" %}',
-                closeText: '{% jstrans "Close" %}',
+                title: '{% trans "Row Data" %}',
+                closeText: '{% trans "Close" %}',
                 hideSubmitButton: true
             });
 
@@ -303,11 +303,11 @@ function downloadBomTemplate(options={}) {
     }
 
     constructFormBody({}, {
-        title: '{% jstrans "Download BOM Template" %}',
+        title: '{% trans "Download BOM Template" %}',
         fields: {
             format: {
-                label: '{% jstrans "Format" %}',
-                help_text: '{% jstrans "Select file format" %}',
+                label: '{% trans "Format" %}',
+                help_text: '{% trans "Select file format" %}',
                 required: true,
                 type: 'choice',
                 value: format,
@@ -337,63 +337,63 @@ function downloadBomTemplate(options={}) {
 function exportBom(part_id, options={}) {
 
     constructFormBody({}, {
-        title: '{% jstrans "Export BOM" %}',
+        title: '{% trans "Export BOM" %}',
         fields: {
             format: {
-                label: '{% jstrans "Format" %}',
-                help_text: '{% jstrans "Select file format" %}',
+                label: '{% trans "Format" %}',
+                help_text: '{% trans "Select file format" %}',
                 required: true,
                 type: 'choice',
                 value: inventreeLoad('bom-export-format', 'csv'),
                 choices: exportFormatOptions(),
             },
             cascade: {
-                label: '{% jstrans "Multi Level BOM" %}',
-                help_text: '{% jstrans "Include BOM data for subassemblies" %}',
+                label: '{% trans "Multi Level BOM" %}',
+                help_text: '{% trans "Include BOM data for subassemblies" %}',
                 type: 'boolean',
                 value: inventreeLoad('bom-export-cascading', true),
             },
             levels: {
-                label: '{% jstrans "Levels" %}',
-                help_text: '{% jstrans "Select maximum number of BOM levels to export (0 = all levels)" %}',
+                label: '{% trans "Levels" %}',
+                help_text: '{% trans "Select maximum number of BOM levels to export (0 = all levels)" %}',
                 type: 'integer',
                 value: 0,
                 required: true,
                 min_value: 0,
             },
             substitute_part_data: {
-                label: '{% jstrans "Include Alternative Parts" %}',
-                help_text: '{% jstrans "Include alternative parts in exported BOM" %}',
+                label: '{% trans "Include Alternative Parts" %}',
+                help_text: '{% trans "Include alternative parts in exported BOM" %}',
                 type: 'boolean',
                 value: inventreeLoad('bom-export-substitute_part_data', false),
             },
             parameter_data: {
-                label: '{% jstrans "Include Parameter Data" %}',
-                help_text: '{% jstrans "Include part parameter data in exported BOM" %}',
+                label: '{% trans "Include Parameter Data" %}',
+                help_text: '{% trans "Include part parameter data in exported BOM" %}',
                 type: 'boolean',
                 value: inventreeLoad('bom-export-parameter_data', false),
             },
             stock_data: {
-                label: '{% jstrans "Include Stock Data" %}',
-                help_text: '{% jstrans "Include part stock data in exported BOM" %}',
+                label: '{% trans "Include Stock Data" %}',
+                help_text: '{% trans "Include part stock data in exported BOM" %}',
                 type: 'boolean',
                 value: inventreeLoad('bom-export-stock_data', false),
             },
             manufacturer_data: {
-                label: '{% jstrans "Include Manufacturer Data" %}',
-                help_text: '{% jstrans "Include part manufacturer data in exported BOM" %}',
+                label: '{% trans "Include Manufacturer Data" %}',
+                help_text: '{% trans "Include part manufacturer data in exported BOM" %}',
                 type: 'boolean',
                 value: inventreeLoad('bom-export-manufacturer_data', false),
             },
             supplier_data: {
-                label: '{% jstrans "Include Supplier Data" %}',
-                help_text: '{% jstrans "Include part supplier data in exported BOM" %}',
+                label: '{% trans "Include Supplier Data" %}',
+                help_text: '{% trans "Include part supplier data in exported BOM" %}',
                 type: 'boolean',
                 value: inventreeLoad('bom-export-supplier_data', false),
             },
             pricing_data: {
-                label: '{% jstrans "Include Pricing Data" %}',
-                help_text: '{% jstrans "Include part pricing data in exported BOM" %}',
+                label: '{% trans "Include Pricing Data" %}',
+                help_text: '{% trans "Include part pricing data in exported BOM" %}',
                 type: 'boolean',
                 value: inventreeLoad('bom-export-pricing_data', false),
             }
@@ -441,7 +441,7 @@ function bomItemFields() {
         sub_part: {
             icon: 'fa-shapes',
             secondary: {
-                title: '{% jstrans "New Part" %}',
+                title: '{% trans "New Part" %}',
                 fields: function() {
                     var fields = partFields();
 
@@ -588,7 +588,7 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
 
         var buttons = '';
 
-        buttons += makeRemoveButton('button-row-remove', pk, '{% jstrans "Remove substitute part" %}');
+        buttons += makeRemoveButton('button-row-remove', pk, '{% trans "Remove substitute part" %}');
 
         // Render a single row
         var html = `
@@ -619,7 +619,7 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
 
     var html = `
     <div class='alert alert-block'>
-    <strong>{% jstrans "Base Part" %}</strong><hr>
+    <strong>{% trans "Base Part" %}</strong><hr>
     ${part_thumb} ${part_name} - <em>${part_desc}</em>
     </div>
     `;
@@ -629,8 +629,8 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
     <table class='table table-striped table-condensed' id='substitute-table'>
         <thead>
             <tr>
-                <th>{% jstrans "Part" %}</th>
-                <th>{% jstrans "Description" %}</th>
+                <th>{% trans "Part" %}</th>
+                <th>{% trans "Description" %}</th>
                 <th><!-- Actions --></th>
             </tr>
         </thead>
@@ -642,7 +642,7 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
 
     html += `
     <div class='alert alert-success alert-block'>
-        {% jstrans "Select and add a new substitute part using the input below" %}
+        {% trans "Select and add a new substitute part using the input below" %}
     </div>
     `;
 
@@ -653,13 +653,13 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
 
             var pre = `
             <div class='alert alert-block alert-warning'>
-            {% jstrans "Are you sure you wish to remove this substitute part link?" %}
+            {% trans "Are you sure you wish to remove this substitute part link?" %}
             </div>
             `;
 
             constructForm(`{% url "api-bom-substitute-list" %}${pk}/`, {
                 method: 'DELETE',
-                title: '{% jstrans "Remove Substitute Part" %}',
+                title: '{% trans "Remove Substitute Part" %}',
                 preFormContent: pre,
                 confirm: true,
                 onSuccess: function() {
@@ -697,9 +697,9 @@ function bomSubstitutesDialog(bom_item_id, substitutes, options={}) {
             },
         },
         preFormContent: html,
-        closeText: '{% jstrans "Close" %}',
-        submitText: '{% jstrans "Add Substitute" %}',
-        title: '{% jstrans "Edit BOM Item Substitutes" %}',
+        closeText: '{% trans "Close" %}',
+        submitText: '{% trans "Add Substitute" %}',
+        title: '{% trans "Edit BOM Item Substitutes" %}',
         afterRender: function(fields, opts) {
             addRemoveCallback(opts.modal, '.button-row-remove');
         },
@@ -761,14 +761,14 @@ function deleteBomItems(items, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "All selected BOM items will be deleted" %}
+    {% trans "All selected BOM items will be deleted" %}
     </div>
 
     <table class='table table-striped table-condensed'>
         <tr>
-            <th>{% jstrans "Part" %}</th>
-            <th>{% jstrans "Reference" %}</th>
-            <th>{% jstrans "Quantity" %}</th>
+            <th>{% trans "Part" %}</th>
+            <th>{% trans "Reference" %}</th>
+            <th>{% trans "Quantity" %}</th>
         </tr>
         ${rows}
     </table>
@@ -777,7 +777,7 @@ function deleteBomItems(items, options={}) {
     constructForm('{% url "api-bom-list"  %}', {
         method: 'DELETE',
         multi_delete: true,
-        title: '{% jstrans "Delete selected BOM items?" %}',
+        title: '{% trans "Delete selected BOM items?" %}',
         form_data: {
             items: ids,
         },
@@ -823,7 +823,7 @@ function loadBomTable(table, options={}) {
             label: 'actions',
             actions: [{
                 label: 'delete',
-                title: '{% jstrans "Delete items" %}',
+                title: '{% trans "Delete items" %}',
                 icon: 'fa-trash-alt icon-red',
                 permission: 'part.change',
                 callback: function(data) {
@@ -902,7 +902,7 @@ function loadBomTable(table, options={}) {
     cols.push(
         {
             field: 'sub_part',
-            title: '{% jstrans "Part" %}',
+            title: '{% trans "Part" %}',
             sortable: true,
             switchable: false,
             sorter: function(_valA, _valB, rowA, rowB) {
@@ -933,7 +933,7 @@ function loadBomTable(table, options={}) {
                     } else {
                         html += `
                             <a href='#' pk='${row.pk}' class='load-sub-assembly' id='load-sub-assembly-${row.pk}'>
-                                <span class='fas fa-sync-alt' title='{% jstrans "Load BOM for subassembly" %}'></span>
+                                <span class='fas fa-sync-alt' title='{% trans "Load BOM for subassembly" %}'></span>
                             </a> `;
                     }
                 }
@@ -943,11 +943,11 @@ function loadBomTable(table, options={}) {
                 html += makePartIcons(sub_part);
 
                 if (row.substitutes && row.substitutes.length > 0) {
-                    html += makeIconBadge('fa-exchange-alt', '{% jstrans "Substitutes Available" %}');
+                    html += makeIconBadge('fa-exchange-alt', '{% trans "Substitutes Available" %}');
                 }
 
                 if (row.allow_variants) {
-                    html += makeIconBadge('fa-sitemap', '{% jstrans "Variant stock allowed" %}');
+                    html += makeIconBadge('fa-sitemap', '{% trans "Variant stock allowed" %}');
                 }
 
                 return html;
@@ -960,7 +960,7 @@ function loadBomTable(table, options={}) {
     cols.push(
         {
             field: 'sub_part_detail.description',
-            title: '{% jstrans "Description" %}',
+            title: '{% trans "Description" %}',
             formatter: function(value) {
                 return withTitle(shortenString(value), value);
             }
@@ -970,7 +970,7 @@ function loadBomTable(table, options={}) {
     // Part reference
     cols.push({
         field: 'reference',
-        title: '{% jstrans "Reference" %}',
+        title: '{% trans "Reference" %}',
         searchable: true,
         sortable: true,
     });
@@ -978,7 +978,7 @@ function loadBomTable(table, options={}) {
     // Part quantity
     cols.push({
         field: 'quantity',
-        title: '{% jstrans "Quantity" %}',
+        title: '{% trans "Quantity" %}',
         searchable: false,
         sortable: true,
         switchable: false,
@@ -994,11 +994,11 @@ function loadBomTable(table, options={}) {
             }
 
             if (row.consumable) {
-                text += ` <small>({% jstrans "Consumable" %})</small>`;
+                text += ` <small>({% trans "Consumable" %})</small>`;
             }
 
             if (row.optional) {
-                text += ' <small>({% jstrans "Optional" %})</small>';
+                text += ' <small>({% trans "Optional" %})</small>';
             }
 
             if (row.overage) {
@@ -1011,7 +1011,7 @@ function loadBomTable(table, options={}) {
 
     cols.push({
         field: 'substitutes',
-        title: '{% jstrans "Substitutes" %}',
+        title: '{% trans "Substitutes" %}',
         searchable: false,
         sortable: true,
         formatter: function(value, row) {
@@ -1025,7 +1025,7 @@ function loadBomTable(table, options={}) {
 
     cols.push({
         field: 'optional',
-        title: '{% jstrans "Optional" %}',
+        title: '{% trans "Optional" %}',
         searchable: false,
         formatter: function(value) {
             return yesNoLabel(value);
@@ -1034,7 +1034,7 @@ function loadBomTable(table, options={}) {
 
     cols.push({
         field: 'consumable',
-        title: '{% jstrans "Consumable" %}',
+        title: '{% trans "Consumable" %}',
         searchable: false,
         formatter: function(value) {
             return yesNoLabel(value);
@@ -1043,7 +1043,7 @@ function loadBomTable(table, options={}) {
 
     cols.push({
         field: 'allow_variants',
-        title: '{% jstrans "Allow Variants" %}',
+        title: '{% trans "Allow Variants" %}',
         formatter: function(value) {
             return yesNoLabel(value);
         }
@@ -1051,7 +1051,7 @@ function loadBomTable(table, options={}) {
 
     cols.push({
         field: 'inherited',
-        title: '{% jstrans "Gets inherited" %}',
+        title: '{% trans "Gets inherited" %}',
         searchable: false,
         formatter: function(value, row) {
             // This BOM item *is* inheritable, but is defined for this BOM
@@ -1068,7 +1068,7 @@ function loadBomTable(table, options={}) {
 
     cols.push({
         field: 'pricing',
-        title: '{% jstrans "Price Range" %}',
+        title: '{% trans "Price Range" %}',
         sortable: true,
         sorter: function(valA, valB, rowA, rowB) {
             var a = rowA.pricing_min || rowA.pricing_max;
@@ -1136,19 +1136,19 @@ function loadBomTable(table, options={}) {
                 if (complete_pricing) {
                     html += makeIconBadge(
                         'fa-check-circle icon-green',
-                        '{% jstrans "BOM pricing is complete" %}',
+                        '{% trans "BOM pricing is complete" %}',
                     );
                 } else {
                     html += makeIconBadge(
                         'fa-exclamation-circle icon-yellow',
-                        '{% jstrans "BOM pricing is incomplete" %}',
+                        '{% trans "BOM pricing is incomplete" %}',
                     );
                 }
 
                 return html;
 
             } else {
-                let html = '<em>{% jstrans "No pricing available" %}</em>';
+                let html = '<em>{% trans "No pricing available" %}</em>';
                 html += makeIconBadge('fa-times-circle icon-red');
 
                 return html;
@@ -1159,7 +1159,7 @@ function loadBomTable(table, options={}) {
 
     cols.push({
         field: 'available_stock',
-        title: '{% jstrans "Available" %}',
+        title: '{% trans "Available" %}',
         searchable: false,
         sortable: true,
         formatter: function(value, row) {
@@ -1179,16 +1179,16 @@ function loadBomTable(table, options={}) {
             }
 
             if (available_stock <= 0) {
-                text += makeIconBadge('fa-times-circle icon-red', '{% jstrans "No Stock Available" %}');
+                text += makeIconBadge('fa-times-circle icon-red', '{% trans "No Stock Available" %}');
             } else {
                 var extra = '';
 
                 if ((substitute_stock > 0) && (variant_stock > 0)) {
-                    extra = '{% jstrans "Includes variant and substitute stock" %}';
+                    extra = '{% trans "Includes variant and substitute stock" %}';
                 } else if (variant_stock > 0) {
-                    extra = '{% jstrans "Includes variant stock" %}';
+                    extra = '{% trans "Includes variant stock" %}';
                 } else if (substitute_stock > 0) {
-                    extra = '{% jstrans "Includes substitute stock" %}';
+                    extra = '{% trans "Includes substitute stock" %}';
                 }
 
                 if (extra) {
@@ -1199,7 +1199,7 @@ function loadBomTable(table, options={}) {
             if (row.on_order && row.on_order > 0) {
                 text += makeIconBadge(
                     'fa-shopping-cart',
-                    `{% jstrans "On Order" %}: ${row.on_order}`,
+                    `{% trans "On Order" %}: ${row.on_order}`,
                 );
             }
 
@@ -1210,13 +1210,13 @@ function loadBomTable(table, options={}) {
     cols.push(
         {
             field: 'can_build',
-            title: '{% jstrans "Can Build" %}',
+            title: '{% trans "Can Build" %}',
             sortable: true,
             formatter: function(value, row) {
 
                 // "Consumable" parts are not tracked in the build
                 if (row.consumable) {
-                    return `<em>{% jstrans "Consumable item" %}</em>`;
+                    return `<em>{% trans "Consumable item" %}</em>`;
                 }
 
                 var can_build = canBuildQuantity(row);
@@ -1256,7 +1256,7 @@ function loadBomTable(table, options={}) {
     cols.push(
         {
             field: 'note',
-            title: '{% jstrans "Notes" %}',
+            title: '{% trans "Notes" %}',
             searchable: true,
             sortable: true,
             formatter: function(value) {
@@ -1268,7 +1268,7 @@ function loadBomTable(table, options={}) {
     if (options.editable) {
 
         cols.push({
-            title: '{% jstrans "Actions" %}',
+            title: '{% trans "Actions" %}',
             switchable: false,
             field: 'pk',
             visible: true,
@@ -1276,15 +1276,15 @@ function loadBomTable(table, options={}) {
 
                 if (row.part == options.parent_id) {
 
-                    var bValidate = makeIconButton('fa-check-circle icon-green', 'bom-validate-button', row.pk, '{% jstrans "Validate BOM Item" %}');
+                    var bValidate = makeIconButton('fa-check-circle icon-green', 'bom-validate-button', row.pk, '{% trans "Validate BOM Item" %}');
 
-                    var bValid = makeIconButton('fa-check-double icon-green', 'bom-valid-button', row.pk, '{% jstrans "This line has been validated" %}', {disabled: true});
+                    var bValid = makeIconButton('fa-check-double icon-green', 'bom-valid-button', row.pk, '{% trans "This line has been validated" %}', {disabled: true});
 
-                    var bSubs = makeIconButton('fa-exchange-alt icon-blue', 'bom-substitutes-button', row.pk, '{% jstrans "Edit substitute parts" %}');
+                    var bSubs = makeIconButton('fa-exchange-alt icon-blue', 'bom-substitutes-button', row.pk, '{% trans "Edit substitute parts" %}');
 
-                    var bEdit = makeEditButton('bom-edit-button', row.pk, '{% jstrans "Edit BOM Item" %}');
+                    var bEdit = makeEditButton('bom-edit-button', row.pk, '{% trans "Edit BOM Item" %}');
 
-                    var bDelt = makeDeleteButton('bom-delete-button', row.pk, '{% jstrans "Delete BOM Item" %}');
+                    var bDelt = makeDeleteButton('bom-delete-button', row.pk, '{% trans "Delete BOM Item" %}');
 
                     let buttons = '';
 
@@ -1304,15 +1304,15 @@ function loadBomTable(table, options={}) {
                     // Return a link to the external BOM
 
                     return renderLink(
-                        '{% jstrans "View BOM" %}',
+                        '{% trans "View BOM" %}',
                         `/part/${row.part}/bom/`
                     );
                 }
             },
             footerFormatter: function(data) {
                 return `
-                <button class='btn btn-success float-right' type='button' title='{% jstrans "Add BOM Item" %}' id='bom-item-new-footer'>
-                    ${makeIcon('fa-plus-circle')} {% jstrans "Add BOM Item" %}
+                <button class='btn btn-success float-right' type='button' title='{% trans "Add BOM Item" %}' id='bom-item-new-footer'>
+                    ${makeIcon('fa-plus-circle')} {% trans "Add BOM Item" %}
                 </button>
                 `;
             }
@@ -1388,7 +1388,7 @@ function loadBomTable(table, options={}) {
 
         },
         formatNoMatches: function() {
-            return '{% jstrans "No BOM items found" %}';
+            return '{% trans "No BOM items found" %}';
         },
         queryParams: filters,
         original: params,
@@ -1477,7 +1477,7 @@ function loadBomTable(table, options={}) {
 
             constructForm(`{% url "api-bom-list" %}${pk}/`, {
                 fields: fields,
-                title: '{% jstrans "Edit BOM Item" %}',
+                title: '{% trans "Edit BOM Item" %}',
                 focus: 'sub_part',
                 onSuccess: function() {
                     reloadBomTable(table);
@@ -1630,7 +1630,7 @@ function loadUsedInTable(table, part_id, options={}) {
             },
             {
                 field: 'part',
-                title: '{% jstrans "Assembly" %}',
+                title: '{% trans "Assembly" %}',
                 switchable: false,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1648,7 +1648,7 @@ function loadUsedInTable(table, part_id, options={}) {
             },
             {
                 field: 'sub_part',
-                title: '{% jstrans "Required Part" %}',
+                title: '{% trans "Required Part" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     var url = `/part/${value}/`;
@@ -1665,7 +1665,7 @@ function loadUsedInTable(table, part_id, options={}) {
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Required Quantity" %}',
+                title: '{% trans "Required Quantity" %}',
                 formatter: function(value, row) {
                     var html = value;
 
@@ -1674,7 +1674,7 @@ function loadUsedInTable(table, part_id, options={}) {
                     }
 
                     if (row.parent && row.parent != 'top-level-item') {
-                        html += ` <em>({% jstrans "Inherited from parent BOM" %})</em>`;
+                        html += ` <em>({% trans "Inherited from parent BOM" %})</em>`;
                     }
 
                     return html;

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -139,7 +139,7 @@ function editBuildOrder(pk) {
     constructForm(`{% url "api-build-list" %}${pk}/`, {
         fields: fields,
         reload: true,
-        title: '{% jstrans "Edit Build Order" %}',
+        title: '{% trans "Edit Build Order" %}',
     });
 }
 
@@ -182,7 +182,7 @@ function newBuildOrder(options={}) {
         data: options.data,
         follow: true,
         method: 'POST',
-        title: '{% jstrans "Create Build Order" %}',
+        title: '{% trans "Create Build Order" %}',
         onSuccess: options.onSuccess,
     });
 }
@@ -214,7 +214,7 @@ function cancelBuildOrder(build_id, options={}) {
         `{% url "api-build-list" %}${build_id}/cancel/`,
         {
             method: 'POST',
-            title: '{% jstrans "Cancel Build Order" %}',
+            title: '{% trans "Cancel Build Order" %}',
             confirm: true,
             fields: {
                 remove_allocated_stock: {},
@@ -223,20 +223,20 @@ function cancelBuildOrder(build_id, options={}) {
             preFormContent: function(opts) {
                 var html = `
                 <div class='alert alert-block alert-info'>
-                    {% jstrans "Are you sure you wish to cancel this build?" %}
+                    {% trans "Are you sure you wish to cancel this build?" %}
                 </div>`;
 
                 if (opts.context.has_allocated_stock) {
                     html += `
                     <div class='alert alert-block alert-warning'>
-                        {% jstrans "Stock items have been allocated to this build order" %}
+                        {% trans "Stock items have been allocated to this build order" %}
                     </div>`;
                 }
 
                 if (opts.context.incomplete_outputs) {
                     html += `
                     <div class='alert alert-block alert-warning'>
-                        {% jstrans "There are incomplete outputs remaining for this build order" %}
+                        {% trans "There are incomplete outputs remaining for this build order" %}
                     </div>`;
                 }
 
@@ -288,30 +288,30 @@ function completeBuildOrder(build_id, options={}) {
             if (ctx.allocated && ctx.remaining == 0 && ctx.incomplete == 0) {
                 html += `
                 <div class='alert alert-block alert-success'>
-                {% jstrans "Build order is ready to be completed" %}'
+                {% trans "Build order is ready to be completed" %}'
                 </div>`;
             } else {
 
                 if (ctx.incomplete > 0) {
                     html += `
                     <div class='alert alert-block alert-danger'>
-                    <strong>{% jstrans "Build order has incomplete outputs" %}</strong><br>
-                    {% jstrans "This build order cannot be completed as there are incomplete outputs" %}
+                    <strong>{% trans "Build order has incomplete outputs" %}</strong><br>
+                    {% trans "This build order cannot be completed as there are incomplete outputs" %}
                     </div>`;
                 } else {
                     html += `
                     <div class='alert alert-block alert-danger'>
-                    <strong>{% jstrans "Build Order is incomplete" %}</strong>
+                    <strong>{% trans "Build Order is incomplete" %}</strong>
                     </div>
                     `;
                 }
 
                 if (!ctx.allocated) {
-                    html += `<div class='alert alert-block alert-warning'>{% jstrans "Required stock has not been fully allocated" %}</div>`;
+                    html += `<div class='alert alert-block alert-warning'>{% trans "Required stock has not been fully allocated" %}</div>`;
                 }
 
                 if (ctx.remaining > 0) {
-                    html += `<div class='alert alert-block alert-warning'>{% jstrans "Required build quantity has not been completed" %}</div>`;
+                    html += `<div class='alert alert-block alert-warning'>{% trans "Required build quantity has not been completed" %}</div>`;
                 }
             }
 
@@ -319,7 +319,7 @@ function completeBuildOrder(build_id, options={}) {
         },
         reload: true,
         confirm: true,
-        title: '{% jstrans "Complete Build Order" %}',
+        title: '{% trans "Complete Build Order" %}',
         method: 'POST',
     });
 }
@@ -360,9 +360,9 @@ function createBuildOutput(build_id, options) {
                 inventreeGet(`{% url "api-part-list" %}${build.part}/serial-numbers/`, {}, {
                     success: function(data) {
                         if (data.next) {
-                            fields.serial_numbers.placeholder = `{% jstrans "Next available serial number" %}: ${data.next}`;
+                            fields.serial_numbers.placeholder = `{% trans "Next available serial number" %}: ${data.next}`;
                         } else if (data.latest) {
-                            fields.serial_numbers.placeholder = `{% jstrans "Latest serial number" %}: ${data.latest}`;
+                            fields.serial_numbers.placeholder = `{% trans "Latest serial number" %}: ${data.latest}`;
                         }
                     },
                     async: false,
@@ -371,8 +371,8 @@ function createBuildOutput(build_id, options) {
                 if (options.trackable_parts) {
                     html += `
                     <div class='alert alert-block alert-info'>
-                        {% jstrans "The Bill of Materials contains trackable parts" %}.<br>
-                        {% jstrans "Build outputs must be generated individually" %}.
+                        {% trans "The Bill of Materials contains trackable parts" %}.<br>
+                        {% trans "Build outputs must be generated individually" %}.
                     </div>
                     `;
                 }
@@ -380,15 +380,15 @@ function createBuildOutput(build_id, options) {
                 if (trackable) {
                     html += `
                     <div class='alert alert-block alert-info'>
-                        {% jstrans "Trackable parts can have serial numbers specified" %}<br>
-                        {% jstrans "Enter serial numbers to generate multiple single build outputs" %}
+                        {% trans "Trackable parts can have serial numbers specified" %}<br>
+                        {% trans "Enter serial numbers to generate multiple single build outputs" %}
                     </div>
                     `;
                 }
 
                 constructForm(`{% url "api-build-list" %}${build_id}/create-output/`, {
                     method: 'POST',
-                    title: '{% jstrans "Create Build Output" %}',
+                    title: '{% trans "Create Build Output" %}',
                     confirm: true,
                     fields: fields,
                     preFormContent: html,
@@ -419,7 +419,7 @@ function makeBuildOutputButtons(output_id, build_info, options={}) {
             'fa-sign-in-alt icon-blue',
             'button-output-allocate',
             output_id,
-            '{% jstrans "Allocate stock items to this build output" %}',
+            '{% trans "Allocate stock items to this build output" %}',
         );
 
         // Add a button to deallocate stock from this build output
@@ -427,7 +427,7 @@ function makeBuildOutputButtons(output_id, build_info, options={}) {
             'fa-minus-circle icon-red',
             'button-output-deallocate',
             output_id,
-            '{% jstrans "Deallocate stock from build output" %}',
+            '{% trans "Deallocate stock from build output" %}',
         );
     }
 
@@ -436,7 +436,7 @@ function makeBuildOutputButtons(output_id, build_info, options={}) {
         'fa-check-circle icon-green',
         'button-output-complete',
         output_id,
-        '{% jstrans "Complete build output" %}',
+        '{% trans "Complete build output" %}',
     );
 
     // Add a button to "scrap" the build output
@@ -444,14 +444,14 @@ function makeBuildOutputButtons(output_id, build_info, options={}) {
         'fa-times-circle icon-red',
         'button-output-scrap',
         output_id,
-        '{% jstrans "Scrap build output" %}',
+        '{% trans "Scrap build output" %}',
     );
 
     // Add a button to "remove" this build output
     html += makeDeleteButton(
         'button-output-remove',
         output_id,
-        '{% jstrans "Delete build output" %}',
+        '{% trans "Delete build output" %}',
     );
 
     return wrapButtons(html);
@@ -471,7 +471,7 @@ function deallocateStock(build_id, options={}) {
 
     var html = `
     <div class='alert alert-block alert-warning'>
-    {% jstrans "Are you sure you wish to deallocate the selected stock items from this build?" %}
+    {% trans "Are you sure you wish to deallocate the selected stock items from this build?" %}
     </dvi>
     `;
 
@@ -489,7 +489,7 @@ function deallocateStock(build_id, options={}) {
                 value: options.build_line,
             },
         },
-        title: '{% jstrans "Deallocate Stock Items" %}',
+        title: '{% trans "Deallocate Stock Items" %}',
         onSuccess: function(response, opts) {
             if (options.onSuccess) {
                 options.onSuccess(response, opts);
@@ -511,9 +511,9 @@ function renderBuildOutput(output, options={}) {
     let output_html = imageHoverIcon(output.part_detail.thumbnail);
 
     if (output.quantity == 1 && output.serial) {
-        output_html += `{% jstrans "Serial Number" %}: ${output.serial}`;
+        output_html += `{% trans "Serial Number" %}: ${output.serial}`;
     } else {
-        output_html += `{% jstrans "Quantity" %}: ${output.quantity}`;
+        output_html += `{% trans "Quantity" %}: ${output.quantity}`;
         if (output.part_detail && output.part_detail.units) {
             output_html += ` ${output.part_detail.units}  `;
         }
@@ -521,7 +521,7 @@ function renderBuildOutput(output, options={}) {
 
     let buttons = `<div class='btn-group float-right' role='group'>`;
 
-    buttons += makeRemoveButton('button-row-remove', pk, '{% jstrans "Remove row" %}');
+    buttons += makeRemoveButton('button-row-remove', pk, '{% trans "Remove row" %}');
 
     buttons += '</div>';
 
@@ -575,8 +575,8 @@ function completeBuildOutputs(build_id, outputs, options={}) {
 
     if (outputs.length == 0) {
         showAlertDialog(
-            '{% jstrans "Select Build Outputs" %}',
-            '{% jstrans "At least one build output must be selected" %}',
+            '{% trans "Select Build Outputs" %}',
+            '{% trans "At least one build output must be selected" %}',
         );
         return;
     }
@@ -590,11 +590,11 @@ function completeBuildOutputs(build_id, outputs, options={}) {
 
     var html = `
     <div class='alert alert-block alert-success'>
-    {% jstrans "Selected build outputs will be marked as complete" %}
+    {% trans "Selected build outputs will be marked as complete" %}
     </div>
     <table class='table table-striped table-condensed' id='build-complete-table'>
         <thead>
-            <th colspan='2'>{% jstrans "Output" %}</th>
+            <th colspan='2'>{% trans "Output" %}</th>
             <th><!-- Actions --></th>
         </thead>
         <tbody>
@@ -622,7 +622,7 @@ function completeBuildOutputs(build_id, outputs, options={}) {
             accept_incomplete_allocation: {},
         },
         confirm: true,
-        title: '{% jstrans "Complete Build Outputs" %}',
+        title: '{% trans "Complete Build Outputs" %}',
         afterRender: function(fields, opts) {
             // Setup callbacks to remove outputs
             $(opts.modal).find('.button-row-remove').click(function() {
@@ -703,8 +703,8 @@ function scrapBuildOutputs(build_id, outputs, options={}) {
 
     if (outputs.length == 0) {
         showAlertDialog(
-            '{% jstrans "Select Build Outputs" %}',
-            '{% jstrans "At least one build output must be selected" %}',
+            '{% trans "Select Build Outputs" %}',
+            '{% trans "At least one build output must be selected" %}',
         );
         return;
     }
@@ -719,17 +719,17 @@ function scrapBuildOutputs(build_id, outputs, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "Selected build outputs will be marked as scrapped" %}
+    {% trans "Selected build outputs will be marked as scrapped" %}
     <ul>
-        <li>{% jstrans "Scrapped output are marked as rejected" %}</li>
-        <li>{% jstrans "Allocated stock items will no longer be available" %}</li>
-        <li>{% jstrans "The completion status of the build order will not be adjusted" %}</li>
+        <li>{% trans "Scrapped output are marked as rejected" %}</li>
+        <li>{% trans "Allocated stock items will no longer be available" %}</li>
+        <li>{% trans "The completion status of the build order will not be adjusted" %}</li>
     </ul>
     </div>
     <table class='table table-striped table-condensed' id='build-scrap-table'>
         <thead>
-            <th colspan='2'>{% jstrans "Output" %}</th>
-            <th>{% jstrans "Quantity" %}</th>
+            <th colspan='2'>{% trans "Output" %}</th>
+            <th>{% trans "Quantity" %}</th>
             <th><!-- Actions --></th>
         </thead>
         <tbody>
@@ -754,7 +754,7 @@ function scrapBuildOutputs(build_id, outputs, options={}) {
             discard_allocations: {},
         },
         confirm: true,
-        title: '{% jstrans "Scrap Build Outputs" %}',
+        title: '{% trans "Scrap Build Outputs" %}',
         afterRender: function(fields, opts) {
             // Setup callbacks to remove outputs
             $(opts.modal).find('.button-row-remove').click(function() {
@@ -829,8 +829,8 @@ function deleteBuildOutputs(build_id, outputs, options={}) {
 
     if (outputs.length == 0) {
         showAlertDialog(
-            '{% jstrans "Select Build Outputs" %}',
-            '{% jstrans "At least one build output must be selected" %}',
+            '{% trans "Select Build Outputs" %}',
+            '{% trans "At least one build output must be selected" %}',
         );
         return;
     }
@@ -844,15 +844,15 @@ function deleteBuildOutputs(build_id, outputs, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "Selected build outputs will be deleted" %}
+    {% trans "Selected build outputs will be deleted" %}
     <ul>
-    <li>{% jstrans "Build output data will be permanently deleted" %}</li>
-    <li>{% jstrans "Allocated stock items will be returned to stock" %}</li>
+    <li>{% trans "Build output data will be permanently deleted" %}</li>
+    <li>{% trans "Allocated stock items will be returned to stock" %}</li>
     </ul>
     </div>
     <table class='table table-striped table-condensed' id='build-complete-table'>
         <thead>
-            <th colspan='2'>{% jstrans "Output" %}</th>
+            <th colspan='2'>{% trans "Output" %}</th>
             <th><!-- Actions --></th>
         </thead>
         <tbody>
@@ -865,7 +865,7 @@ function deleteBuildOutputs(build_id, outputs, options={}) {
         preFormContent: html,
         fields: {},
         confirm: true,
-        title: '{% jstrans "Delete Build Outputs" %}',
+        title: '{% trans "Delete Build Outputs" %}',
         afterRender: function(fields, opts) {
             // Setup callbacks to remove outputs
             $(opts.modal).find('.button-row-remove').click(function() {
@@ -952,7 +952,7 @@ function loadBuildOrderAllocationTable(table, options={}) {
         paginationVAlign: 'bottom',
         original: options.params,
         formatNoMatches: function() {
-            return '{% jstrans "No build order allocations found" %}';
+            return '{% trans "No build order allocations found" %}';
         },
         columns: [
             {
@@ -964,7 +964,7 @@ function loadBuildOrderAllocationTable(table, options={}) {
                 field: 'build',
                 sortable: true,
                 switchable: false,
-                title: '{% jstrans "Build Order" %}',
+                title: '{% trans "Build Order" %}',
                 formatter: function(value, row) {
                     let ref = `${row.build_detail.reference}`;
                     let html = renderLink(ref, `/build/${row.build}/`);
@@ -981,7 +981,7 @@ function loadBuildOrderAllocationTable(table, options={}) {
             {
                 field: 'quantity',
                 sortable: true,
-                title: '{% jstrans "Allocated Quantity" %}',
+                title: '{% trans "Allocated Quantity" %}',
                 formatter: function(value, row) {
                     let link = `/stock/item/${row.stock_item}/`;
                     let text = formatDecimal(value);
@@ -991,11 +991,11 @@ function loadBuildOrderAllocationTable(table, options={}) {
             },
             {
                 field: 'location_detail',
-                title: '{% jstrans "Location" %}',
+                title: '{% trans "Location" %}',
                 formatter: function(value, row) {
 
                     if (!value) {
-                        return '{% jstrans "Location not specified" %}';
+                        return '{% trans "Location not specified" %}';
                     }
 
                     let item = row.stock_item_detail;
@@ -1017,7 +1017,7 @@ function makeBuildOutputActions(build_info) {
     return [
         {
             label: 'complete',
-            title: '{% jstrans "Complete outputs" %}',
+            title: '{% trans "Complete outputs" %}',
             icon: 'fa-check-circle icon-green',
             permission: 'build.add',
             callback: function(data) {
@@ -1035,7 +1035,7 @@ function makeBuildOutputActions(build_info) {
         },
         {
             label: 'scrap',
-            title: '{% jstrans "Scrap outputs" %}',
+            title: '{% trans "Scrap outputs" %}',
             icon: 'fa-times-circle icon-red',
             permission: 'build.change',
             callback: function(data) {
@@ -1053,7 +1053,7 @@ function makeBuildOutputActions(build_info) {
         },
         {
             label: 'delete',
-            title: '{% jstrans "Delete outputs" %}',
+            title: '{% trans "Delete outputs" %}',
             icon: 'fa-trash-alt icon-red',
             permission: 'build.delete',
             callback: function(data) {
@@ -1107,12 +1107,12 @@ function loadBuildOutputTable(build_info, options={}) {
             url: '{% url "api-stockitem-label-list" %}',
             key: 'item',
         },
-        singular_name: '{% jstrans "build output" %}',
-        plural_name: '{% jstrans "build outputs" %}',
+        singular_name: '{% trans "build output" %}',
+        plural_name: '{% trans "build outputs" %}',
         custom_actions: [{
             label: 'buildoutput',
             icon: 'fa-tools',
-            title: '{% jstrans "Build output actions" %}',
+            title: '{% trans "Build output actions" %}',
             actions: makeBuildOutputActions(build_info),
         }]
     });
@@ -1281,7 +1281,7 @@ function loadBuildOutputTable(build_info, options={}) {
             return constructOutputSubTable(index, row, element);
         },
         formatNoMatches: function() {
-            return '{% jstrans "No active build outputs found" %}';
+            return '{% trans "No active build outputs found" %}';
         },
         onLoadSuccess: function() {
             reloadOutputAllocations();
@@ -1296,7 +1296,7 @@ function loadBuildOutputTable(build_info, options={}) {
             },
             {
                 field: 'part',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 switchable: false,
                 formatter: function(value, row) {
                     return imageHoverIcon(row.part_detail.thumbnail) +
@@ -1306,7 +1306,7 @@ function loadBuildOutputTable(build_info, options={}) {
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Build Output" %}',
+                title: '{% trans "Build Output" %}',
                 switchable: false,
                 sortable: true,
                 sorter: function(fieldA, fieldB, rowA, rowB) {
@@ -1351,9 +1351,9 @@ function loadBuildOutputTable(build_info, options={}) {
                     let text = '';
 
                     if (row.serial && row.quantity == 1) {
-                        text = `{% jstrans "Serial Number" %}: ${row.serial}`;
+                        text = `{% trans "Serial Number" %}: ${row.serial}`;
                     } else {
-                        text = `{% jstrans "Quantity" %}: ${row.quantity}`;
+                        text = `{% trans "Quantity" %}: ${row.quantity}`;
 
                     }
 
@@ -1364,7 +1364,7 @@ function loadBuildOutputTable(build_info, options={}) {
                     }
 
                     if (row.batch) {
-                        text += ` <small>({% jstrans "Batch" %}: ${row.batch})</small>`;
+                        text += ` <small>({% trans "Batch" %}: ${row.batch})</small>`;
                     }
 
                     text += stockStatusDisplay(row.status, {classes: 'float-right'});
@@ -1374,7 +1374,7 @@ function loadBuildOutputTable(build_info, options={}) {
             },
             {
                 field: 'fully_allocated',
-                title: '{% jstrans "Allocated Lines" %}',
+                title: '{% trans "Allocated Lines" %}',
                 visible: false,
                 sortable: true,
                 switchable: false,
@@ -1388,7 +1388,7 @@ function loadBuildOutputTable(build_info, options={}) {
             },
             {
                 field: 'tests',
-                title: '{% jstrans "Required Tests" %}',
+                title: '{% trans "Required Tests" %}',
                 visible: test_templates.length > 0,
                 switchable: true,
                 sortable: true,
@@ -1560,8 +1560,8 @@ function allocateStockToBuild(build_id, line_items, options={}) {
     if (line_items.length == 0) {
 
         showAlertDialog(
-            '{% jstrans "Select Parts" %}',
-            '{% jstrans "You must select at least one part to allocate" %}',
+            '{% trans "Select Parts" %}',
+            '{% trans "You must select at least one part to allocate" %}',
         );
 
         return;
@@ -1613,7 +1613,7 @@ function allocateStockToBuild(build_id, line_items, options={}) {
         delete_button += makeRemoveButton(
             'button-row-remove',
             pk,
-            '{% jstrans "Remove row" %}',
+            '{% trans "Remove row" %}',
         );
 
         delete_button += `</div>`;
@@ -1624,7 +1624,7 @@ function allocateStockToBuild(build_id, line_items, options={}) {
                 type: 'decimal',
                 min_value: 0,
                 value: quantity || 0,
-                title: '{% jstrans "Specify stock allocation quantity" %}',
+                title: '{% trans "Specify stock allocation quantity" %}',
                 required: true,
             },
             {
@@ -1701,8 +1701,8 @@ function allocateStockToBuild(build_id, line_items, options={}) {
     if (table_entries.length == 0) {
 
         showAlertDialog(
-            '{% jstrans "All Parts Allocated" %}',
-            '{% jstrans "All selected parts have been fully allocated" %}',
+            '{% trans "All Parts Allocated" %}',
+            '{% trans "All selected parts have been fully allocated" %}',
         );
 
         return;
@@ -1715,8 +1715,8 @@ function allocateStockToBuild(build_id, line_items, options={}) {
         'take_from',
         {
             type: 'related field',
-            label: '{% jstrans "Source Location" %}',
-            help_text: '{% jstrans "Select source location (leave blank to take from all locations)" %}',
+            label: '{% trans "Source Location" %}',
+            help_text: '{% trans "Select source location (leave blank to take from all locations)" %}',
             required: false,
         },
         {},
@@ -1727,10 +1727,10 @@ function allocateStockToBuild(build_id, line_items, options={}) {
     <table class='table table-striped table-condensed' id='stock-allocation-table'>
         <thead>
             <tr>
-                <th>{% jstrans "Part" %}</th>
-                <th>{% jstrans "Allocated" %}</th>
-                <th style='min-width: 250px;'>{% jstrans "Stock Item" %}</th>
-                <th>{% jstrans "Quantity" %}</th>
+                <th>{% trans "Part" %}</th>
+                <th>{% trans "Allocated" %}</th>
+                <th style='min-width: 250px;'>{% trans "Stock Item" %}</th>
+                <th>{% trans "Quantity" %}</th>
                 <th></th>
             </tr>
         </thead>
@@ -1744,7 +1744,7 @@ function allocateStockToBuild(build_id, line_items, options={}) {
         method: 'POST',
         fields: {},
         preFormContent: html,
-        title: '{% jstrans "Allocate Stock Items to Build Order" %}',
+        title: '{% trans "Allocate Stock Items to Build Order" %}',
         afterRender: function(fields, options) {
 
             var take_from_field = {
@@ -1755,7 +1755,7 @@ function allocateStockToBuild(build_id, line_items, options={}) {
                 type: 'related field',
                 value: source_location,
                 noResults: function(query) {
-                    return '{% jstrans "No matching stock locations" %}';
+                    return '{% trans "No matching stock locations" %}';
                 },
             };
 
@@ -1828,7 +1828,7 @@ function allocateStockToBuild(build_id, line_items, options={}) {
                             return filters;
                         },
                         noResults: function(query) {
-                            return '{% jstrans "No matching stock items" %}';
+                            return '{% trans "No matching stock items" %}';
                         }
                     },
                     null,
@@ -1925,12 +1925,12 @@ function autoAllocateStockToBuild(build_id, bom_items=[], options={}) {
 
     var html = `
     <div class='alert alert-block alert-info'>
-    <strong>{% jstrans "Automatic Stock Allocation" %}</strong><br>
-    {% jstrans "Stock items will be automatically allocated to this build order, according to the provided guidelines" %}:
+    <strong>{% trans "Automatic Stock Allocation" %}</strong><br>
+    {% trans "Stock items will be automatically allocated to this build order, according to the provided guidelines" %}:
     <ul>
-        <li>{% jstrans "If a location is specified, stock will only be allocated from that location" %}</li>
-        <li>{% jstrans "If stock is considered interchangeable, it will be allocated from the first location it is found" %}</li>
-        <li>{% jstrans "If substitute stock is allowed, it will be used where stock of the primary part cannot be found" %}</li>
+        <li>{% trans "If a location is specified, stock will only be allocated from that location" %}</li>
+        <li>{% trans "If stock is considered interchangeable, it will be allocated from the first location it is found" %}</li>
+        <li>{% trans "If substitute stock is allowed, it will be used where stock of the primary part cannot be found" %}</li>
     </ul>
     </div>
     `;
@@ -1961,7 +1961,7 @@ function autoAllocateStockToBuild(build_id, bom_items=[], options={}) {
     constructForm(`{% url "api-build-list" %}${build_id}/auto-allocate/`, {
         method: 'POST',
         fields: fields,
-        title: '{% jstrans "Allocate Stock Items" %}',
+        title: '{% trans "Allocate Stock Items" %}',
         confirm: true,
         preFormContent: html,
         onSuccess: function(response) {
@@ -2067,7 +2067,7 @@ function loadBuildTable(table, options) {
     $(table).inventreeTable({
         method: 'get',
         formatNoMatches: function() {
-            return '{% jstrans "No builds matching query" %}';
+            return '{% trans "No builds matching query" %}';
         },
         url: '{% url "api-build-list" %}',
         queryParams: filters,
@@ -2102,13 +2102,13 @@ function loadBuildTable(table, options) {
             },
             {
                 checkbox: true,
-                title: '{% jstrans "Select" %}',
+                title: '{% trans "Select" %}',
                 searchable: false,
                 switchable: false,
             },
             {
                 field: 'reference',
-                title: '{% jstrans "Build" %}',
+                title: '{% trans "Build" %}',
                 sortable: true,
                 switchable: true,
                 formatter: function(value, row) {
@@ -2116,7 +2116,7 @@ function loadBuildTable(table, options) {
                     var html = renderLink(value, '/build/' + row.pk + '/');
 
                     if (row.overdue) {
-                        html += makeIconBadge('fa-calendar-times icon-red', '{% jstrans "Build order is overdue" %}');
+                        html += makeIconBadge('fa-calendar-times icon-red', '{% trans "Build order is overdue" %}');
                     }
 
                     return html;
@@ -2124,12 +2124,12 @@ function loadBuildTable(table, options) {
             },
             {
                 field: 'title',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
                 switchable: true,
             },
             {
                 field: 'project_code',
-                title: '{% jstrans "Project Code" %}',
+                title: '{% trans "Project Code" %}',
                 sortable: true,
                 switchable: global_settings.PROJECT_CODES_ENABLED,
                 visible: global_settings.PROJECT_CODES_ENABLED,
@@ -2141,13 +2141,13 @@ function loadBuildTable(table, options) {
             },
             {
                 field: 'priority',
-                title: '{% jstrans "Priority" %}',
+                title: '{% trans "Priority" %}',
                 switchable: true,
                 sortable: true,
             },
             {
                 field: 'part',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 sortable: true,
                 sortName: 'part__name',
                 formatter: function(value, row) {
@@ -2162,7 +2162,7 @@ function loadBuildTable(table, options) {
             },
             {
                 field: 'completed',
-                title: '{% jstrans "Progress" %}',
+                title: '{% trans "Progress" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     return makeProgressBar(
@@ -2176,7 +2176,7 @@ function loadBuildTable(table, options) {
             },
             {
                 field: 'status',
-                title: '{% jstrans "Status" %}',
+                title: '{% trans "Status" %}',
                 sortable: true,
                 formatter: function(value) {
                     return buildStatusDisplay(value);
@@ -2184,7 +2184,7 @@ function loadBuildTable(table, options) {
             },
             {
                 field: 'creation_date',
-                title: '{% jstrans "Created" %}',
+                title: '{% trans "Created" %}',
                 sortable: true,
                 formatter: function(value) {
                     return renderDate(value);
@@ -2192,19 +2192,19 @@ function loadBuildTable(table, options) {
             },
             {
                 field: 'issued_by',
-                title: '{% jstrans "Issued by" %}',
+                title: '{% trans "Issued by" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     if (value) {
                         return row.issued_by_detail.username;
                     } else {
-                        return `<i>{% jstrans "No user information" %}</i>`;
+                        return `<i>{% trans "No user information" %}</i>`;
                     }
                 }
             },
             {
                 field: 'responsible',
-                title: '{% jstrans "Responsible" %}',
+                title: '{% trans "Responsible" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     if (!row.responsible_detail) {
@@ -2213,7 +2213,7 @@ function loadBuildTable(table, options) {
 
                     var html = row.responsible_detail.name;
 
-                    if (row.responsible_detail.label == '{% jstrans "group" %}') {
+                    if (row.responsible_detail.label == '{% trans "group" %}') {
                         html += `<span class='float-right fas fa-users'></span>`;
                     } else {
                         html += `<span class='float-right fas fa-user'></span>`;
@@ -2224,7 +2224,7 @@ function loadBuildTable(table, options) {
             },
             {
                 field: 'target_date',
-                title: '{% jstrans "Target Date" %}',
+                title: '{% trans "Target Date" %}',
                 sortable: true,
                 formatter: function(value) {
                     return renderDate(value);
@@ -2232,7 +2232,7 @@ function loadBuildTable(table, options) {
             },
             {
                 field: 'completion_date',
-                title: '{% jstrans "Completion Date" %}',
+                title: '{% trans "Completion Date" %}',
                 sortable: true,
                 formatter: function(value) {
                     return renderDate(value);
@@ -2320,7 +2320,7 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
         columns: [
             {
                 field: 'part',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 formatter: function(_value, row) {
                     let html = imageHoverIcon(row.part_detail.thumbnail);
                     html += renderLink(row.part_detail.full_name, `/part/${row.part_detail.pk}/`);
@@ -2329,7 +2329,7 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Allocated Quantity" %}',
+                title: '{% trans "Allocated Quantity" %}',
                 formatter: function(_value, row) {
                     let text = '';
                     let url = '';
@@ -2340,9 +2340,9 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
                     }
 
                     if (serial && row.quantity == 1) {
-                        text = `{% jstrans "Serial Number" %}: ${serial}`;
+                        text = `{% trans "Serial Number" %}: ${serial}`;
                     } else {
-                        text = `{% jstrans "Quantity" %}: ${row.quantity}`;
+                        text = `{% trans "Quantity" %}: ${row.quantity}`;
                         if (row.part_detail && row.part_detail.units) {
                             text += ` <small>${row.part_detail.units}</small>`;
                         }
@@ -2357,7 +2357,7 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
             },
             {
                 field: 'location',
-                title: '{% jstrans "Location" %}',
+                title: '{% trans "Location" %}',
                 formatter: function(value, row) {
                     if (row.location_detail) {
                         let text = shortenString(row.location_detail.pathstring);
@@ -2365,7 +2365,7 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
 
                         return renderLink(text, url);
                     } else {
-                        return '<i>{% jstrans "No location set" %}</i>';
+                        return '<i>{% trans "No location set" %}</i>';
                     }
                 }
             },
@@ -2374,8 +2374,8 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
                 title: '',
                 formatter: function(value, row) {
                     let buttons = '';
-                    buttons += makeEditButton('button-allocation-edit', row.pk, '{% jstrans "Edit stock allocation" %}');
-                    buttons += makeDeleteButton('button-allocation-delete', row.pk, '{% jstrans "Delete stock allocation" %}');
+                    buttons += makeEditButton('button-allocation-edit', row.pk, '{% trans "Edit stock allocation" %}');
+                    buttons += makeDeleteButton('button-allocation-delete', row.pk, '{% trans "Delete stock allocation" %}');
                     return wrapButtons(buttons);
                 }
             }
@@ -2390,7 +2390,7 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
             fields: {
                 quantity: {},
             },
-            title: '{% jstrans "Edit Allocation" %}',
+            title: '{% trans "Edit Allocation" %}',
             onSuccess: function() {
                 $(options.parent_table).bootstrapTable('refresh');
             },
@@ -2402,7 +2402,7 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
 
         constructForm(`{% url "api-build-item-list" %}${pk}/`, {
             method: 'DELETE',
-            title: '{% jstrans "Remove Allocation" %}',
+            title: '{% trans "Remove Allocation" %}',
             onSuccess: function() {
                 $(options.parent_table).bootstrapTable('refresh');
             },
@@ -2443,8 +2443,8 @@ function loadBuildLineTable(table, build_id, options={}) {
                 url: '{% url "api-buildline-label-list" %}',
                 key: 'line',
             },
-            singular_name: '{% jstrans "build line" %}',
-            plural_name: '{% jstrans "build lines" %}',
+            singular_name: '{% trans "build line" %}',
+            plural_name: '{% trans "build lines" %}',
         });
     }
 
@@ -2462,18 +2462,18 @@ function loadBuildLineTable(table, build_id, options={}) {
             });
         },
         formatNoMatches: function() {
-            return '{% jstrans "No build lines found" %}';
+            return '{% trans "No build lines found" %}';
         },
         columns: [
             {
                 checkbox: true,
-                title: '{% jstrans "Select" %}',
+                title: '{% trans "Select" %}',
                 searchable: false,
                 switchable: false,
             },
             {
                 field: 'bom_item',
-                title: '{% jstrans "Required Part" %}',
+                title: '{% trans "Required Part" %}',
                 switchable: false,
                 sortable: true,
                 sortName: 'part',
@@ -2488,11 +2488,11 @@ function loadBuildLineTable(table, build_id, options={}) {
                     html += imageHoverIcon(row.part_detail.thumbnail) + renderLink(row.part_detail.full_name, `/part/${row.part_detail.pk}/`);
 
                     if (row.bom_item_detail.allow_variants) {
-                        html += makeIconBadge('fa-sitemap', '{% jstrans "Variant stock allowed" %}');
+                        html += makeIconBadge('fa-sitemap', '{% trans "Variant stock allowed" %}');
                     }
 
                     if (row.part_detail.trackable) {
-                        html += makeIconBadge('fa-directions', '{% jstrans "Trackable part" %}');
+                        html += makeIconBadge('fa-directions', '{% trans "Trackable part" %}');
                     }
 
                     return html;
@@ -2500,7 +2500,7 @@ function loadBuildLineTable(table, build_id, options={}) {
             },
             {
                 field: 'reference',
-                title: '{% jstrans "Reference" %}',
+                title: '{% trans "Reference" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     return row.bom_item_detail.reference;
@@ -2508,7 +2508,7 @@ function loadBuildLineTable(table, build_id, options={}) {
             },
             {
                 field: 'consumable',
-                title: '{% jstrans "Consumable" %}',
+                title: '{% trans "Consumable" %}',
                 sortable: true,
                 switchable: true,
                 formatter: function(value, row) {
@@ -2517,7 +2517,7 @@ function loadBuildLineTable(table, build_id, options={}) {
             },
             {
                 field: 'optional',
-                title: '{% jstrans "Optional" %}',
+                title: '{% trans "Optional" %}',
                 sortable: true,
                 switchable: true,
                 formatter: function(value, row) {
@@ -2527,7 +2527,7 @@ function loadBuildLineTable(table, build_id, options={}) {
             {
                 field: 'unit_quantity',
                 sortable: true,
-                title: '{% jstrans "Unit Quantity" %}',
+                title: '{% trans "Unit Quantity" %}',
                 formatter: function(value, row) {
                     let text = row.bom_item_detail.quantity;
 
@@ -2544,12 +2544,12 @@ function loadBuildLineTable(table, build_id, options={}) {
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Required Quantity" %}',
+                title: '{% trans "Required Quantity" %}',
                 sortable: true,
             },
             {
                 field: 'available_stock',
-                title: '{% jstrans "Available" %}',
+                title: '{% trans "Available" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     var url = `/part/${row.part_detail.pk}/?display=part-stock`;
@@ -2573,24 +2573,24 @@ function loadBuildLineTable(table, build_id, options={}) {
                     let icons = '';
 
                     if (row.bom_item_detail.consumable) {
-                        icons += `<span class='fas fa-info-circle icon-blue float-right' title='{% jstrans "Consumable item" %}'></span>`;
+                        icons += `<span class='fas fa-info-circle icon-blue float-right' title='{% trans "Consumable item" %}'></span>`;
                     } else {
                         if (available < (row.quantity - row.allocated)) {
-                            icons += makeIconBadge('fa-times-circle icon-red', '{% jstrans "Insufficient stock available" %}');
+                            icons += makeIconBadge('fa-times-circle icon-red', '{% trans "Insufficient stock available" %}');
                         } else {
-                            icons += makeIconBadge('fa-check-circle icon-green', '{% jstrans "Sufficient stock available" %}');
+                            icons += makeIconBadge('fa-check-circle icon-green', '{% trans "Sufficient stock available" %}');
                         }
 
                         if (available <= 0) {
-                            icons += `<span class='badge rounded-pill bg-danger'>{% jstrans "No Stock Available" %}</span>`;
+                            icons += `<span class='badge rounded-pill bg-danger'>{% trans "No Stock Available" %}</span>`;
                         } else {
                             let extra = '';
                             if ((row.available_substitute_stock > 0) && (row.available_variant_stock > 0)) {
-                                extra = '{% jstrans "Includes variant and substitute stock" %}';
+                                extra = '{% trans "Includes variant and substitute stock" %}';
                             } else if (row.available_variant_stock > 0) {
-                                extra = '{% jstrans "Includes variant stock" %}';
+                                extra = '{% trans "Includes variant stock" %}';
                             } else if (row.available_substitute_stock > 0) {
-                                extra = '{% jstrans "Includes substitute stock" %}';
+                                extra = '{% trans "Includes substitute stock" %}';
                             }
 
                             if (extra) {
@@ -2600,7 +2600,7 @@ function loadBuildLineTable(table, build_id, options={}) {
                     }
 
                     if (row.on_order && row.on_order > 0) {
-                        icons += makeIconBadge('fa-shopping-cart', `{% jstrans "On Order" %}: ${formatDecimal(row.on_order)}`);
+                        icons += makeIconBadge('fa-shopping-cart', `{% trans "On Order" %}: ${formatDecimal(row.on_order)}`);
                     }
 
                     return renderLink(text, url) + icons;
@@ -2608,7 +2608,7 @@ function loadBuildLineTable(table, build_id, options={}) {
             },
             {
                 field: 'allocated',
-                title: '{% jstrans "Allocated" %}',
+                title: '{% trans "Allocated" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     return makeProgressBar(row.allocated, row.quantity);
@@ -2625,32 +2625,32 @@ function loadBuildLineTable(table, build_id, options={}) {
 
                     // Consumable items do not need to be allocated
                     if (row.bom_item_detail.consumable) {
-                        return `<em>{% jstrans "Consumable Item" %}</em>`;
+                        return `<em>{% trans "Consumable Item" %}</em>`;
                     }
 
                     if (row.part_detail.trackable && !options.output) {
                         // Tracked parts must be allocated to a specific build output
-                        return `<em>{% jstrans "Tracked item" %}</em>`;
+                        return `<em>{% trans "Tracked item" %}</em>`;
                     }
 
                     if (row.allocated < row.quantity) {
 
                         // Add a button to "build" stock for this line
                         if (row.part_detail.assembly) {
-                            buttons += makeIconButton('fa-tools icon-blue', 'button-build', pk, '{% jstrans "Build stock" %}');
+                            buttons += makeIconButton('fa-tools icon-blue', 'button-build', pk, '{% trans "Build stock" %}');
                         }
 
                         // Add a button to "purchase" stock for this line
                         if (row.part_detail.purchaseable) {
-                            buttons += makeIconButton('fa-shopping-cart icon-blue', 'button-buy', pk, '{% jstrans "Order stock" %}');
+                            buttons += makeIconButton('fa-shopping-cart icon-blue', 'button-buy', pk, '{% trans "Order stock" %}');
                         }
 
                         // Add a button to "allocate" stock for this line
-                        buttons += makeIconButton('fa-sign-in-alt icon-green', 'button-allocate', pk, '{% jstrans "Allocate stock" %}');
+                        buttons += makeIconButton('fa-sign-in-alt icon-green', 'button-allocate', pk, '{% trans "Allocate stock" %}');
                     }
 
                     if (row.allocated > 0) {
-                        buttons += makeRemoveButton('button-unallocate', pk, '{% jstrans "Remove stock allocation" %}');
+                        buttons += makeRemoveButton('button-unallocate', pk, '{% trans "Remove stock allocation" %}');
                     }
 
                     return wrapButtons(buttons);

--- a/InvenTree/templates/js/translated/company.js
+++ b/InvenTree/templates/js/translated/company.js
@@ -95,7 +95,7 @@ function createManufacturerPart(options={}) {
     }
 
     fields.manufacturer.secondary = {
-        title: '{% jstrans "Add Manufacturer" %}',
+        title: '{% trans "Add Manufacturer" %}',
         fields: function() {
             var company_fields = companyFormFields();
 
@@ -108,7 +108,7 @@ function createManufacturerPart(options={}) {
     constructForm('{% url "api-manufacturer-part-list" %}', {
         fields: fields,
         method: 'POST',
-        title: '{% jstrans "Add Manufacturer Part" %}',
+        title: '{% trans "Add Manufacturer Part" %}',
         onSuccess: options.onSuccess
     });
 }
@@ -129,7 +129,7 @@ function editManufacturerPart(part, options={}) {
 
     constructForm(url, {
         fields: fields,
-        title: '{% jstrans "Edit Manufacturer Part" %}',
+        title: '{% trans "Edit Manufacturer Part" %}',
         onSuccess: options.onSuccess
     });
 }
@@ -198,7 +198,7 @@ function createSupplierPart(options={}) {
 
     // Add a secondary modal for the supplier
     fields.supplier.secondary = {
-        title: '{% jstrans "Add Supplier" %}',
+        title: '{% trans "Add Supplier" %}',
         fields: function() {
             var company_fields = companyFormFields();
 
@@ -210,7 +210,7 @@ function createSupplierPart(options={}) {
 
     // Add a secondary modal for the manufacturer part
     fields.manufacturer_part.secondary = {
-        title: '{% jstrans "Add Manufacturer Part" %}',
+        title: '{% trans "Add Manufacturer Part" %}',
         fields: function(data) {
             var mp_fields = manufacturerPartFields();
 
@@ -240,7 +240,7 @@ function createSupplierPart(options={}) {
     constructForm('{% url "api-supplier-part-list" %}', {
         fields: fields,
         method: 'POST',
-        title: '{% jstrans "Add Supplier Part" %}',
+        title: '{% trans "Add Supplier Part" %}',
         onSuccess: options.onSuccess,
         header_html: header,
     });
@@ -266,7 +266,7 @@ function duplicateSupplierPart(part, options={}) {
             constructForm('{% url "api-supplier-part-list" %}', {
                 method: 'POST',
                 fields: fields,
-                title: '{% jstrans "Duplicate Supplier Part" %}',
+                title: '{% trans "Duplicate Supplier Part" %}',
                 data: data,
                 onSuccess: function(response) {
                     handleFormSuccess(response, options);
@@ -291,7 +291,7 @@ function editSupplierPart(part, options={}) {
 
     constructForm(`{% url "api-supplier-part-list" %}${part}/`, {
         fields: fields,
-        title: options.title || '{% jstrans "Edit Supplier Part" %}',
+        title: options.title || '{% trans "Edit Supplier Part" %}',
         onSuccess: options.onSuccess
     });
 }
@@ -341,14 +341,14 @@ function deleteSupplierParts(parts, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "All selected supplier parts will be deleted" %}
+    {% trans "All selected supplier parts will be deleted" %}
     </div>
     <table class='table table-striped table-condensed'>
     <tr>
-        <th>{% jstrans "Part" %}</th>
-        <th>{% jstrans "SKU" %}</th>
-        <th>{% jstrans "Supplier" %}</th>
-        <th>{% jstrans "MPN" %}</th>
+        <th>{% trans "Part" %}</th>
+        <th>{% trans "SKU" %}</th>
+        <th>{% trans "Supplier" %}</th>
+        <th>{% trans "MPN" %}</th>
     </tr>
     ${rows}
     </table>
@@ -357,7 +357,7 @@ function deleteSupplierParts(parts, options={}) {
     constructForm('{% url "api-supplier-part-list" %}', {
         method: 'DELETE',
         multi_delete: true,
-        title: '{% jstrans "Delete Supplier Parts" %}',
+        title: '{% trans "Delete Supplier Parts" %}',
         preFormContent: html,
         form_data: {
             items: ids,
@@ -395,7 +395,7 @@ function createSupplierPartPriceBreak(part_id, options={}) {
     constructForm('{% url "api-part-supplier-price-list" %}', {
         fields: fields,
         method: 'POST',
-        title: '{% jstrans "Add Price Break" %}',
+        title: '{% trans "Add Price Break" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -441,7 +441,7 @@ function editCompany(pk, options={}) {
             method: 'PATCH',
             fields: fields,
             reload: true,
-            title: '{% jstrans "Edit Company" %}',
+            title: '{% trans "Edit Company" %}',
         }
     );
 }
@@ -462,7 +462,7 @@ function createCompany(options={}) {
             method: 'POST',
             fields: fields,
             follow: true,
-            title: '{% jstrans "Add new Company" %}',
+            title: '{% trans "Add new Company" %}',
         }
     );
 }
@@ -492,22 +492,22 @@ function loadCompanyTable(table, url, options={}) {
         },
         {
             field: 'name',
-            title: '{% jstrans "Company" %}',
+            title: '{% trans "Company" %}',
             sortable: true,
             switchable: false,
             formatter: function(value, row) {
                 var html = imageHoverIcon(row.image) + renderLink(value, row.url);
 
                 if (row.is_customer) {
-                    html += `<span title='{% jstrans "Customer" %}' class='fas fa-user-tie float-right'></span>`;
+                    html += `<span title='{% trans "Customer" %}' class='fas fa-user-tie float-right'></span>`;
                 }
 
                 if (row.is_manufacturer) {
-                    html += `<span title='{% jstrans "Manufacturer" %}' class='fas fa-industry float-right'></span>`;
+                    html += `<span title='{% trans "Manufacturer" %}' class='fas fa-industry float-right'></span>`;
                 }
 
                 if (row.is_supplier) {
-                    html += `<span title='{% jstrans "Supplier" %}' class='fas fa-building float-right'></span>`;
+                    html += `<span title='{% trans "Supplier" %}' class='fas fa-building float-right'></span>`;
                 }
 
                 return html;
@@ -515,11 +515,11 @@ function loadCompanyTable(table, url, options={}) {
         },
         {
             field: 'description',
-            title: '{% jstrans "Description" %}',
+            title: '{% trans "Description" %}',
         },
         {
             field: 'website',
-            title: '{% jstrans "Website" %}',
+            title: '{% trans "Website" %}',
             formatter: function(value) {
                 if (value) {
                     return renderLink(value, value);
@@ -533,7 +533,7 @@ function loadCompanyTable(table, url, options={}) {
         columns.push({
             sortable: true,
             field: 'parts_supplied',
-            title: '{% jstrans "Parts Supplied" %}',
+            title: '{% trans "Parts Supplied" %}',
             formatter: function(value, row) {
                 return renderLink(value, `/company/${row.pk}/?display=supplier-parts`);
             }
@@ -542,7 +542,7 @@ function loadCompanyTable(table, url, options={}) {
         columns.push({
             sortable: true,
             field: 'parts_manufactured',
-            title: '{% jstrans "Parts Manufactured" %}',
+            title: '{% trans "Parts Manufactured" %}',
             formatter: function(value, row) {
                 return renderLink(value, `/company/${row.pk}/?display=manufacturer-parts`);
             }
@@ -557,7 +557,7 @@ function loadCompanyTable(table, url, options={}) {
         groupBy: false,
         sidePagination: 'server',
         formatNoMatches: function() {
-            return '{% jstrans "No company information found" %}';
+            return '{% trans "No company information found" %}';
         },
         showColumns: true,
         name: options.pagetype || 'company',
@@ -606,7 +606,7 @@ function createContact(options={}) {
     constructForm('{% url "api-contact-list" %}', {
         method: 'POST',
         fields: fields,
-        title: '{% jstrans "Create New Contact" %}',
+        title: '{% trans "Create New Contact" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -622,7 +622,7 @@ function editContact(pk, options={}) {
 
     constructForm(`{% url "api-contact-list" %}${pk}/`, {
         fields: fields,
-        title: '{% jstrans "Edit Contact" %}',
+        title: '{% trans "Edit Contact" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -659,13 +659,13 @@ function deleteContacts(contacts, options={}) {
     // eslint-disable-next-line no-useless-escape
     let html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "All selected contacts will be deleted" %}
+    {% trans "All selected contacts will be deleted" %}
     </div>
     <table class='table table-striped table-condensed'>
     <tr>
-        <th>{% jstrans "Name" %}</th>
-        <th>{% jstrans "Email" %}</th>
-        <th>{% jstrans "Role" %}</th>
+        <th>{% trans "Name" %}</th>
+        <th>{% trans "Email" %}</th>
+        <th>{% trans "Role" %}</th>
     </tr>
     ${rows}
     </table>`;
@@ -673,7 +673,7 @@ function deleteContacts(contacts, options={}) {
     constructForm('{% url "api-contact-list" %}', {
         method: 'DELETE',
         multi_delete: true,
-        title: '{% jstrans "Delete Contacts" %}',
+        title: '{% trans "Delete Contacts" %}',
         preFormContent: html,
         form_data: {
             items: ids,
@@ -704,32 +704,32 @@ function loadContactTable(table, options={}) {
         uniqueId: 'pk',
         sidePagination: 'server',
         formatNoMatches: function() {
-            return '{% jstrans "No contacts found" %}';
+            return '{% trans "No contacts found" %}';
         },
         showColumns: true,
         name: 'contacts',
         columns: [
             {
                 field: 'name',
-                title: '{% jstrans "Name" %}',
+                title: '{% trans "Name" %}',
                 sortable: true,
                 switchable: false,
             },
             {
                 field: 'phone',
-                title: '{% jstrans "Phone Number" %}',
+                title: '{% trans "Phone Number" %}',
                 sortable: false,
                 switchable: true,
             },
             {
                 field: 'email',
-                title: '{% jstrans "Email Address" %}',
+                title: '{% trans "Email Address" %}',
                 sortable: false,
                 switchable: true,
             },
             {
                 field: 'role',
-                title: '{% jstrans "Role" %}',
+                title: '{% trans "Role" %}',
                 sortable: false,
                 switchable: false,
             },
@@ -745,11 +745,11 @@ function loadContactTable(table, options={}) {
                     let html = '';
 
                     if (options.allow_edit) {
-                        html += makeEditButton('btn-contact-edit', pk, '{% jstrans "Edit Contact" %}');
+                        html += makeEditButton('btn-contact-edit', pk, '{% trans "Edit Contact" %}');
                     }
 
                     if (options.allow_delete) {
-                        html += makeDeleteButton('btn-contact-delete', pk, '{% jstrans "Delete Contact" %}');
+                        html += makeDeleteButton('btn-contact-delete', pk, '{% trans "Delete Contact" %}');
                     }
 
                     return wrapButtons(html);
@@ -846,7 +846,7 @@ function createAddress(options={}) {
     constructForm('{% url "api-address-list" %}', {
         method: 'POST',
         fields: fields,
-        title: '{% jstrans "Create New Address" %}',
+        title: '{% trans "Create New Address" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -861,7 +861,7 @@ function editAddress(pk, options={}) {
 
     constructForm(`{% url "api-address-list" %}${pk}/`, {
         fields: fields,
-        title: '{% jstrans "Edit Address" %}',
+        title: '{% trans "Edit Address" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -896,13 +896,13 @@ function deleteAddress(addresses, options={}) {
 
     let html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "All selected addresses will be deleted" %}
+    {% trans "All selected addresses will be deleted" %}
     </div>
     <table class='table table-striped table-condensed'>
     <tr>
-        <th>{% jstrans "Name" %}</th>
-        <th>{% jstrans "Line 1" %}</th>
-        <th>{% jstrans "Line 2" %}</th>
+        <th>{% trans "Name" %}</th>
+        <th>{% trans "Line 1" %}</th>
+        <th>{% trans "Line 2" %}</th>
     </tr>
     ${rows}
     </table>`;
@@ -910,7 +910,7 @@ function deleteAddress(addresses, options={}) {
     constructForm('{% url "api-address-list" %}', {
         method: 'DELETE',
         multi_delete: true,
-        title: '{% jstrans "Delete Addresses" %}',
+        title: '{% trans "Delete Addresses" %}',
         preFormContent: html,
         form_data: {
             items: ids,
@@ -937,14 +937,14 @@ function loadAddressTable(table, options={}) {
         sidePagination: 'server',
         sortable: true,
         formatNoMatches: function() {
-            return '{% jstrans "No addresses found" %}';
+            return '{% trans "No addresses found" %}';
         },
         showColumns: true,
         name: 'addresses',
         columns: [
             {
                 field: 'primary',
-                title: '{% jstrans "Primary" %}',
+                title: '{% trans "Primary" %}',
                 switchable: false,
                 formatter: function(value) {
                     return yesNoLabel(value);
@@ -952,61 +952,61 @@ function loadAddressTable(table, options={}) {
             },
             {
                 field: 'title',
-                title: '{% jstrans "Title" %}',
+                title: '{% trans "Title" %}',
                 sortable: true,
                 switchable: false,
             },
             {
                 field: 'line1',
-                title: '{% jstrans "Line 1" %}',
+                title: '{% trans "Line 1" %}',
                 sortable: false,
                 switchable: false,
             },
             {
                 field: 'line2',
-                title: '{% jstrans "Line 2" %}',
+                title: '{% trans "Line 2" %}',
                 sortable: false,
                 switchable: false,
             },
             {
                 field: 'postal_code',
-                title: '{% jstrans "Postal code" %}',
+                title: '{% trans "Postal code" %}',
                 sortable: false,
                 switchable: false,
             },
             {
                 field: 'postal_city',
-                title: '{% jstrans "Postal city" %}',
+                title: '{% trans "Postal city" %}',
                 sortable: false,
                 switchable: false,
             },
             {
                 field: 'province',
-                title: '{% jstrans "State/province" %}',
+                title: '{% trans "State/province" %}',
                 sortable: false,
                 switchable: false,
             },
             {
                 field: 'country',
-                title: '{% jstrans "Country" %}',
+                title: '{% trans "Country" %}',
                 sortable: false,
                 switchable: false,
             },
             {
                 field: 'shipping_notes',
-                title: '{% jstrans "Courier notes" %}',
+                title: '{% trans "Courier notes" %}',
                 sortable: false,
                 switchable: true,
             },
             {
                 field: 'internal_shipping_notes',
-                title: '{% jstrans "Internal notes" %}',
+                title: '{% trans "Internal notes" %}',
                 sortable: false,
                 switchable: true,
             },
             {
                 field: 'link',
-                title: '{% jstrans "External Link" %}',
+                title: '{% trans "External Link" %}',
                 sortable: false,
                 switchable: true,
             },
@@ -1022,11 +1022,11 @@ function loadAddressTable(table, options={}) {
                     let html = '';
 
                     if (options.allow_edit) {
-                        html += makeEditButton('btn-address-edit', pk, '{% jstrans "Edit Address" %}');
+                        html += makeEditButton('btn-address-edit', pk, '{% trans "Edit Address" %}');
                     }
 
                     if (options.allow_delete) {
-                        html += makeDeleteButton('btn-address-delete', pk, '{% jstrans "Delete Address" %}');
+                        html += makeDeleteButton('btn-address-delete', pk, '{% trans "Delete Address" %}');
                     }
 
                     return wrapButtons(html);
@@ -1099,13 +1099,13 @@ function deleteManufacturerParts(selections, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "All selected manufacturer parts will be deleted" %}
+    {% trans "All selected manufacturer parts will be deleted" %}
     </div>
     <table class='table table-striped table-condensed'>
     <tr>
-        <th>{% jstrans "Part" %}</th>
-        <th>{% jstrans "MPN" %}</th>
-        <th>{% jstrans "Manufacturer" %}</th>
+        <th>{% trans "Part" %}</th>
+        <th>{% trans "MPN" %}</th>
+        <th>{% trans "Manufacturer" %}</th>
     </tr>
     ${rows}
     </table>
@@ -1114,7 +1114,7 @@ function deleteManufacturerParts(selections, options={}) {
     constructForm('{% url "api-manufacturer-part-list" %}', {
         method: 'DELETE',
         multi_delete: true,
-        title: '{% jstrans "Delete Manufacturer Parts" %}',
+        title: '{% trans "Delete Manufacturer Parts" %}',
         preFormContent: html,
         form_data: {
             items: ids,
@@ -1148,12 +1148,12 @@ function deleteManufacturerPartParameters(selections, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "All selected parameters will be deleted" %}
+    {% trans "All selected parameters will be deleted" %}
     </div>
     <table class='table table-striped table-condensed'>
     <tr>
-        <th>{% jstrans "Name" %}</th>
-        <th>{% jstrans "Value" %}</th>
+        <th>{% trans "Name" %}</th>
+        <th>{% trans "Value" %}</th>
     </tr>
     ${rows}
     </table>
@@ -1162,7 +1162,7 @@ function deleteManufacturerPartParameters(selections, options={}) {
     constructForm('{% url "api-manufacturer-part-parameter-list" %}', {
         method: 'DELETE',
         multi_delete: true,
-        title: '{% jstrans "Delete Parameters" %}',
+        title: '{% trans "Delete Parameters" %}',
         preFormContent: html,
         form_data: {
             items: ids,
@@ -1178,7 +1178,7 @@ function makeManufacturerPartActions(options={}) {
     return [
         {
             label: 'order',
-            title: '{% jstrans "Order parts" %}',
+            title: '{% trans "Order parts" %}',
             icon: 'fa-shopping-cart',
             permission: 'purchase_order.add',
             callback: function(data) {
@@ -1195,7 +1195,7 @@ function makeManufacturerPartActions(options={}) {
         },
         {
             label: 'delete',
-            title: '{% jstrans "Delete manufacturer parts" %}',
+            title: '{% trans "Delete manufacturer parts" %}',
             icon: 'fa-trash-alt icon-red',
             permission: 'purchase_order.delete',
             callback: function(data) {
@@ -1227,7 +1227,7 @@ function loadManufacturerPartTable(table, url, options) {
         custom_actions: [
             {
                 label: 'manufacturer-part',
-                title: '{% jstrans "Manufacturer part actions" %}',
+                title: '{% trans "Manufacturer part actions" %}',
                 icon: 'fa-tools',
                 actions: makeManufacturerPartActions({
                     manufacturer_id: options.params.manufacturer,
@@ -1246,7 +1246,7 @@ function loadManufacturerPartTable(table, url, options) {
         name: 'manufacturerparts',
         groupBy: false,
         formatNoMatches: function() {
-            return '{% jstrans "No manufacturer parts found" %}';
+            return '{% trans "No manufacturer parts found" %}';
         },
         columns: [
             {
@@ -1258,7 +1258,7 @@ function loadManufacturerPartTable(table, url, options) {
                 switchable: params['part_detail'],
                 sortable: true,
                 field: 'part_detail.full_name',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 formatter: function(value, row) {
 
                     var url = `/part/${row.part}/`;
@@ -1266,15 +1266,15 @@ function loadManufacturerPartTable(table, url, options) {
                     var html = imageHoverIcon(row.part_detail.thumbnail) + renderLink(value, url);
 
                     if (row.part_detail.is_template) {
-                        html += makeIconBadge('fa-clone', '{% jstrans "Template part" %}');
+                        html += makeIconBadge('fa-clone', '{% trans "Template part" %}');
                     }
 
                     if (row.part_detail.assembly) {
-                        html += makeIconBadge('fa-tools', '{% jstrans "Assembled part" %}');
+                        html += makeIconBadge('fa-tools', '{% trans "Assembled part" %}');
                     }
 
                     if (!row.part_detail.active) {
-                        html += `<span class='badge badge-right rounded-pill bg-warning'>{% jstrans "Inactive" %}</span>`;
+                        html += `<span class='badge badge-right rounded-pill bg-warning'>{% trans "Inactive" %}</span>`;
                     }
 
                     return html;
@@ -1283,7 +1283,7 @@ function loadManufacturerPartTable(table, url, options) {
             {
                 sortable: true,
                 field: 'manufacturer',
-                title: '{% jstrans "Manufacturer" %}',
+                title: '{% trans "Manufacturer" %}',
                 formatter: function(value, row) {
                     if (value && row.manufacturer_detail) {
                         var name = row.manufacturer_detail.name;
@@ -1299,14 +1299,14 @@ function loadManufacturerPartTable(table, url, options) {
             {
                 sortable: true,
                 field: 'MPN',
-                title: '{% jstrans "MPN" %}',
+                title: '{% trans "MPN" %}',
                 formatter: function(value, row) {
                     return renderClipboard(renderLink(value, `/manufacturer-part/${row.pk}/`));
                 }
             },
             {
                 field: 'link',
-                title: '{% jstrans "Link" %}',
+                title: '{% trans "Link" %}',
                 formatter: function(value) {
                     if (value) {
                         return renderLink(value, value, {external: true});
@@ -1317,7 +1317,7 @@ function loadManufacturerPartTable(table, url, options) {
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
                 sortable: false,
                 switchable: true,
             },
@@ -1330,8 +1330,8 @@ function loadManufacturerPartTable(table, url, options) {
                     let pk = row.pk;
                     let html = '';
 
-                    html += makeEditButton('button-manufacturer-part-edit', pk, '{% jstrans "Edit manufacturer part" %}');
-                    html += makeDeleteButton('button-manufacturer-part-delete', pk, '{% jstrans "Delete manufacturer part" %}');
+                    html += makeEditButton('button-manufacturer-part-edit', pk, '{% trans "Edit manufacturer part" %}');
+                    html += makeDeleteButton('button-manufacturer-part-delete', pk, '{% trans "Delete manufacturer part" %}');
 
                     return wrapButtons(html);
                 }
@@ -1390,7 +1390,7 @@ function loadManufacturerPartParameterTable(table, url, options) {
         name: 'manufacturerpartparameters',
         groupBy: false,
         formatNoMatches: function() {
-            return '{% jstrans "No parameters found" %}';
+            return '{% trans "No parameters found" %}';
         },
         columns: [
             {
@@ -1400,19 +1400,19 @@ function loadManufacturerPartParameterTable(table, url, options) {
             },
             {
                 field: 'name',
-                title: '{% jstrans "Name" %}',
+                title: '{% trans "Name" %}',
                 switchable: false,
                 sortable: true,
             },
             {
                 field: 'value',
-                title: '{% jstrans "Value" %}',
+                title: '{% trans "Value" %}',
                 switchable: false,
                 sortable: true,
             },
             {
                 field: 'units',
-                title: '{% jstrans "Units" %}',
+                title: '{% trans "Units" %}',
                 switchable: true,
                 sortable: true,
             },
@@ -1425,8 +1425,8 @@ function loadManufacturerPartParameterTable(table, url, options) {
                     let pk = row.pk;
                     let html = '';
 
-                    html += makeEditButton('button-parameter-edit', pk, '{% jstrans "Edit parameter" %}');
-                    html += makeDeleteButton('button-parameter-delete', pk, '{% jstrans "Delete parameter" %}');
+                    html += makeEditButton('button-parameter-edit', pk, '{% trans "Edit parameter" %}');
+                    html += makeDeleteButton('button-parameter-delete', pk, '{% trans "Delete parameter" %}');
 
                     return wrapButtons(html);
                 }
@@ -1443,7 +1443,7 @@ function loadManufacturerPartParameterTable(table, url, options) {
                         value: {},
                         units: {},
                     },
-                    title: '{% jstrans "Edit Parameter" %}',
+                    title: '{% trans "Edit Parameter" %}',
                     refreshTable: table,
                 });
             });
@@ -1452,7 +1452,7 @@ function loadManufacturerPartParameterTable(table, url, options) {
 
                 constructForm(`{% url "api-manufacturer-part-parameter-list" %}${pk}/`, {
                     method: 'DELETE',
-                    title: '{% jstrans "Delete Parameter" %}',
+                    title: '{% trans "Delete Parameter" %}',
                     refreshTable: table,
                 });
             });
@@ -1466,7 +1466,7 @@ function makeSupplierPartActions(options={}) {
     return [
         {
             label: 'order',
-            title: '{% jstrans "Order parts" %}',
+            title: '{% trans "Order parts" %}',
             icon: 'fa-shopping-cart',
             permission: 'purchase_order.add',
             callback: function(data) {
@@ -1483,7 +1483,7 @@ function makeSupplierPartActions(options={}) {
         },
         {
             label: 'delete',
-            title: '{% jstrans "Delete supplier parts" %}',
+            title: '{% trans "Delete supplier parts" %}',
             icon: 'fa-trash-alt icon-red',
             permission: 'purchase_order.delete',
             callback: function(data) {
@@ -1513,7 +1513,7 @@ function loadSupplierPartTable(table, url, options) {
         custom_actions: [
             {
                 label: 'supplier-part',
-                title: '{% jstrans "Supplier part actions" %}',
+                title: '{% trans "Supplier part actions" %}',
                 icon: 'fa-tools',
                 actions: makeSupplierPartActions({
                     supplier_id: options.params.supplier,
@@ -1533,7 +1533,7 @@ function loadSupplierPartTable(table, url, options) {
         groupBy: false,
         sortable: true,
         formatNoMatches: function() {
-            return '{% jstrans "No supplier parts found" %}';
+            return '{% trans "No supplier parts found" %}';
         },
         columns: [
             {
@@ -1546,7 +1546,7 @@ function loadSupplierPartTable(table, url, options) {
                 sortable: true,
                 field: 'part_detail.full_name',
                 sortName: 'part',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 formatter: function(value, row) {
 
                     var url = `/part/${row.part}/`;
@@ -1554,15 +1554,15 @@ function loadSupplierPartTable(table, url, options) {
                     var html = imageHoverIcon(row.part_detail.thumbnail) + renderLink(value, url);
 
                     if (row.part_detail.is_template) {
-                        html += makeIconBadge('fa-clone', '{% jstrans "Template part" %}');
+                        html += makeIconBadge('fa-clone', '{% trans "Template part" %}');
                     }
 
                     if (row.part_detail.assembly) {
-                        html += makeIconBadge('fa-tools', '{% jstrans "Assembled part" %}');
+                        html += makeIconBadge('fa-tools', '{% trans "Assembled part" %}');
                     }
 
                     if (!row.part_detail.active) {
-                        html += `<span class='badge badge-right rounded-pill bg-warning'>{% jstrans "Inactive" %}</span>`;
+                        html += `<span class='badge badge-right rounded-pill bg-warning'>{% trans "Inactive" %}</span>`;
                     }
 
                     return html;
@@ -1571,7 +1571,7 @@ function loadSupplierPartTable(table, url, options) {
             {
                 sortable: true,
                 field: 'supplier',
-                title: '{% jstrans "Supplier" %}',
+                title: '{% trans "Supplier" %}',
                 formatter: function(value, row) {
                     if (value) {
                         var name = row.supplier_detail.name;
@@ -1587,7 +1587,7 @@ function loadSupplierPartTable(table, url, options) {
             {
                 sortable: true,
                 field: 'SKU',
-                title: '{% jstrans "Supplier Part" %}',
+                title: '{% trans "Supplier Part" %}',
                 formatter: function(value, row) {
                     return renderClipboard(renderLink(value, `/supplier-part/${row.pk}/`));
                 }
@@ -1598,7 +1598,7 @@ function loadSupplierPartTable(table, url, options) {
                 sortable: true,
                 sortName: 'manufacturer',
                 field: 'manufacturer_detail.name',
-                title: '{% jstrans "Manufacturer" %}',
+                title: '{% trans "Manufacturer" %}',
                 formatter: function(value, row) {
                     if (value && row.manufacturer_detail) {
                         var name = value;
@@ -1617,7 +1617,7 @@ function loadSupplierPartTable(table, url, options) {
                 sortable: true,
                 sortName: 'MPN',
                 field: 'manufacturer_part_detail.MPN',
-                title: '{% jstrans "MPN" %}',
+                title: '{% trans "MPN" %}',
                 formatter: function(value, row) {
                     if (value && row.manufacturer_part) {
                         return renderClipboard(renderLink(value, `/manufacturer-part/${row.manufacturer_part}/`));
@@ -1628,17 +1628,17 @@ function loadSupplierPartTable(table, url, options) {
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
                 sortable: false,
             },
             {
                 field: 'packaging',
-                title: '{% jstrans "Packaging" %}',
+                title: '{% trans "Packaging" %}',
                 sortable: true,
             },
             {
                 field: 'pack_quantity',
-                title: '{% jstrans "Pack Quantity" %}',
+                title: '{% trans "Pack Quantity" %}',
                 sortable: true,
                 formatter: function(value, row) {
 
@@ -1651,7 +1651,7 @@ function loadSupplierPartTable(table, url, options) {
                     }
 
                     if (row.part_detail && row.part_detail.units) {
-                        html += `<span class='fas fa-info-circle float-right' title='{% jstrans "Base Units" %}: ${row.part_detail.units}'></span>`;
+                        html += `<span class='fas fa-info-circle float-right' title='{% trans "Base Units" %}: ${row.part_detail.units}'></span>`;
                     }
 
                     return html;
@@ -1660,7 +1660,7 @@ function loadSupplierPartTable(table, url, options) {
             {
                 field: 'link',
                 sortable: false,
-                title: '{% jstrans "Link" %}',
+                title: '{% trans "Link" %}',
                 formatter: function(value) {
                     if (value) {
                         return renderLink(value, value, {external: true});
@@ -1671,17 +1671,17 @@ function loadSupplierPartTable(table, url, options) {
             },
             {
                 field: 'note',
-                title: '{% jstrans "Notes" %}',
+                title: '{% trans "Notes" %}',
                 sortable: false,
             },
             {
                 field: 'in_stock',
-                title: '{% jstrans "In Stock" %}',
+                title: '{% trans "In Stock" %}',
                 sortable: true,
             },
             {
                 field: 'available',
-                title: '{% jstrans "Availability" %}',
+                title: '{% trans "Availability" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     if (row.availability_updated) {
@@ -1690,7 +1690,7 @@ function loadSupplierPartTable(table, url, options) {
 
                         html += makeIconBadge(
                             'fa-info-circle',
-                            `{% jstrans "Last Updated" %}: ${date}`
+                            `{% trans "Last Updated" %}: ${date}`
                         );
                         return html;
                     } else {
@@ -1700,7 +1700,7 @@ function loadSupplierPartTable(table, url, options) {
             },
             {
                 field: 'updated',
-                title: '{% jstrans "Last Updated" %}',
+                title: '{% trans "Last Updated" %}',
                 sortable: true,
             },
             {
@@ -1712,8 +1712,8 @@ function loadSupplierPartTable(table, url, options) {
                     let pk = row.pk;
                     let html = '';
 
-                    html += makeEditButton('button-supplier-part-edit', pk, '{% jstrans "Edit supplier part" %}');
-                    html += makeDeleteButton('button-supplier-part-delete', pk, '{% jstrans "Delete supplier part" %}');
+                    html += makeEditButton('button-supplier-part-edit', pk, '{% trans "Edit supplier part" %}');
+                    html += makeDeleteButton('button-supplier-part-delete', pk, '{% trans "Delete supplier part" %}');
 
                     return wrapButtons(html);
                 }
@@ -1766,7 +1766,7 @@ function loadSupplierPriceBreakTable(options={}) {
 
             constructForm(`{% url "api-part-supplier-price-list" %}${pk}/`, {
                 method: 'DELETE',
-                title: '{% jstrans "Delete Price Break" %}',
+                title: '{% trans "Delete Price Break" %}',
                 refreshTable: table,
             });
         });
@@ -1776,7 +1776,7 @@ function loadSupplierPriceBreakTable(options={}) {
 
             constructForm(`{% url "api-part-supplier-price-list" %}${pk}/`, {
                 fields: supplierPartPriceBreakFields(),
-                title: '{% jstrans "Edit Price Break" %}',
+                title: '{% trans "Edit Price Break" %}',
                 refreshTable: table,
             });
         });
@@ -1791,7 +1791,7 @@ function loadSupplierPriceBreakTable(options={}) {
             part: options.part,
         },
         formatNoMatches: function() {
-            return '{% jstrans "No price break information found" %}';
+            return '{% trans "No price break information found" %}';
         },
         onPostBody: function() {
             setupCallbacks();
@@ -1805,12 +1805,12 @@ function loadSupplierPriceBreakTable(options={}) {
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Quantity" %}',
+                title: '{% trans "Quantity" %}',
                 sortable: true,
             },
             {
                 field: 'price',
-                title: '{% jstrans "Price" %}',
+                title: '{% trans "Price" %}',
                 sortable: true,
                 formatter: function(value, row, index) {
                     return formatCurrency(value, {
@@ -1820,15 +1820,15 @@ function loadSupplierPriceBreakTable(options={}) {
             },
             {
                 field: 'updated',
-                title: '{% jstrans "Last updated" %}',
+                title: '{% trans "Last updated" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     var html = renderDate(value);
 
                     let buttons = '';
 
-                    buttons += makeEditButton('button-price-break-edit', row.pk, '{% jstrans "Edit price break" %}');
-                    buttons += makeDeleteButton('button-price-break-delete', row.pk, '{% jstrans "Delete price break" %}');
+                    buttons += makeEditButton('button-price-break-edit', row.pk, '{% trans "Edit price break" %}');
+                    buttons += makeDeleteButton('button-price-break-delete', row.pk, '{% trans "Delete price break" %}');
 
                     html += wrapButtons(buttons);
 

--- a/InvenTree/templates/js/translated/filters.js
+++ b/InvenTree/templates/js/translated/filters.js
@@ -183,11 +183,11 @@ function getFilterOptionList(tableKey, filterKey) {
         return {
             '1': {
                 key: '1',
-                value: '{% jstrans "true" %}',
+                value: '{% trans "true" %}',
             },
             '0': {
                 key: '0',
-                value: '{% jstrans "false" %}',
+                value: '{% trans "false" %}',
             },
         };
     } else if (settings.type == 'date') {
@@ -211,7 +211,7 @@ function generateAvailableFilterList(tableKey) {
 
     var html = `<select class='form-control filter-input' id='${id}' name='tag'>`;
 
-    html += `<option value=''>{% jstrans 'Select filter' %}</option>`;
+    html += `<option value=''>{% trans 'Select filter' %}</option>`;
 
     for (var opt in remaining) {
         var title = getFilterTitle(tableKey, opt);
@@ -293,7 +293,7 @@ function makeCustomActionGroup(action_group, table) {
 
     let buttons = [];
     let label = action_group.label || 'actions';
-    let title = action_group.title || '{% jstrans "Actions" %}';
+    let title = action_group.title || '{% trans "Actions" %}';
     let icon = action_group.icon || 'fa-tools';
 
     // Construct the HTML for each button
@@ -332,7 +332,7 @@ function makeBarcodeActions(barcode_actions, table) {
 
     let html = `
     <div class='btn-group' role='group'>
-    <button id='barcode-actions' title='{% jstrans "Barcode actions" %}' class='btn btn-outline-secondary dropdown-toggle' type='button' data-bs-toggle='dropdown'>
+    <button id='barcode-actions' title='{% trans "Barcode actions" %}' class='btn btn-outline-secondary dropdown-toggle' type='button' data-bs-toggle='dropdown'>
         <span class='fas fa-qrcode'></span>
     </button>
     <ul class='dropdown-menu' role='menu'>
@@ -428,17 +428,17 @@ function setupFilterList(tableKey, table, target, options={}) {
     if (report_button || labels_button) {
         let print_buttons = `
         <div class='btn-group' role='group'>
-        <button id='printing-options' title='{% jstrans "Printing actions" %}' class='btn btn-outline-secondary dropdown-toggle' type='button' data-bs-toggle='dropdown'>
+        <button id='printing-options' title='{% trans "Printing actions" %}' class='btn btn-outline-secondary dropdown-toggle' type='button' data-bs-toggle='dropdown'>
             <span class='fas fa-print'></span> <span class='caret'></span>
         </button>
         <ul class='dropdown-menu' role='menu'>`;
 
         if (labels_button) {
-            print_buttons += `<li><a class='dropdown-item' href='#' id='print-labels-${tableKey}'><span class='fas fa-tag'></span> {% jstrans "Print Labels" %}</a></li>`;
+            print_buttons += `<li><a class='dropdown-item' href='#' id='print-labels-${tableKey}'><span class='fas fa-tag'></span> {% trans "Print Labels" %}</a></li>`;
         }
 
         if (report_button) {
-            print_buttons += `<li><a class='dropdown-item' href='#' id='print-report-${tableKey}'><span class='fas fa-file-pdf'></span> {% jstrans "Print Reports" %}</a></li>`;
+            print_buttons += `<li><a class='dropdown-item' href='#' id='print-report-${tableKey}'><span class='fas fa-file-pdf'></span> {% trans "Print Reports" %}</a></li>`;
         }
 
         print_buttons += `</ul></div>`;
@@ -450,14 +450,14 @@ function setupFilterList(tableKey, table, target, options={}) {
     if (options.download) {
         buttons += makeFilterButton({
             id: `download-${tableKey}`,
-            title: '{% jstrans "Download table data" %}',
+            title: '{% trans "Download table data" %}',
             icon: 'fa-download',
         });
     }
 
     buttons += makeFilterButton({
         id: `reload-${tableKey}`,
-        title: '{% jstrans "Reload table data" %}',
+        title: '{% trans "Reload table data" %}',
         icon: 'fa-redo-alt',
     });
 
@@ -466,7 +466,7 @@ function setupFilterList(tableKey, table, target, options={}) {
 
         buttons += makeFilterButton({
             id: add,
-            title: '{% jstrans "Add new filter" %}',
+            title: '{% trans "Add new filter" %}',
             icon: 'fa-filter',
         });
 
@@ -474,7 +474,7 @@ function setupFilterList(tableKey, table, target, options={}) {
         if (Object.keys(filters).length > 0) {
             buttons += makeFilterButton({
                 id: clear,
-                title: '{% jstrans "Clear all filters" %}',
+                title: '{% trans "Clear all filters" %}',
                 icon: 'fa-backspace icon-red',
             });
         }
@@ -579,7 +579,7 @@ function setupFilterList(tableKey, table, target, options={}) {
             html += generateAvailableFilterList(tableKey);
             html += generateFilterInput(tableKey);
 
-            html += `<button title='{% jstrans "Create filter" %}' class='btn btn-outline-secondary filter-button' id='${make}'><span class='fas fa-plus'></span></button>`;
+            html += `<button title='{% trans "Create filter" %}' class='btn btn-outline-secondary filter-button' id='${make}'><span class='fas fa-plus'></span></button>`;
             html += `</div>`;
 
             element.append(html);
@@ -669,8 +669,8 @@ function getFilterOptionValue(tableKey, filterKey, valueKey) {
 
     // Lookup for boolean options
     if (filter.type == 'bool') {
-        if (value == '1') return '{% jstrans "true" %}';
-        if (value == '0') return '{% jstrans "false" %}';
+        if (value == '1') return '{% trans "true" %}';
+        if (value == '0') return '{% trans "false" %}';
 
         return value;
     }

--- a/InvenTree/templates/js/translated/forms.js
+++ b/InvenTree/templates/js/translated/forms.js
@@ -371,9 +371,9 @@ function constructForm(url, options={}) {
                 constructCreateForm(OPTIONS.actions.POST, options);
             } else {
                 // User does not have permission to POST to the endpoint
-                showMessage('{% jstrans "Action Prohibited" %}', {
+                showMessage('{% trans "Action Prohibited" %}', {
                     style: 'danger',
-                    details: '{% jstrans "Create operation not allowed" %}',
+                    details: '{% trans "Create operation not allowed" %}',
                     icon: 'fas fa-user-times',
                 });
 
@@ -386,9 +386,9 @@ function constructForm(url, options={}) {
                 constructChangeForm(OPTIONS.actions.PUT, options);
             } else {
                 // User does not have permission to PUT/PATCH to the endpoint
-                showMessage('{% jstrans "Action Prohibited" %}', {
+                showMessage('{% trans "Action Prohibited" %}', {
                     style: 'danger',
-                    details: '{% jstrans "Update operation not allowed" %}',
+                    details: '{% trans "Update operation not allowed" %}',
                     icon: 'fas fa-user-times',
                 });
 
@@ -400,9 +400,9 @@ function constructForm(url, options={}) {
                 constructDeleteForm(OPTIONS.actions.DELETE, options);
             } else {
                 // User does not have permission to DELETE to the endpoint
-                showMessage('{% jstrans "Action Prohibited" %}', {
+                showMessage('{% trans "Action Prohibited" %}', {
                     style: 'danger',
-                    details: '{% jstrans "Delete operation not allowed" %}',
+                    details: '{% trans "Delete operation not allowed" %}',
                     icon: 'fas fa-user-times',
                 });
 
@@ -414,9 +414,9 @@ function constructForm(url, options={}) {
                 // TODO?
             } else {
                 // User does not have permission to GET to the endpoint
-                showMessage('{% jstrans "Action Prohibited" %}', {
+                showMessage('{% trans "Action Prohibited" %}', {
                     style: 'danger',
-                    details: '{% jstrans "View operation not allowed" %}',
+                    details: '{% trans "View operation not allowed" %}',
                     icon: 'fas fa-user-times',
                 });
 
@@ -540,7 +540,7 @@ function constructFormBody(fields, options) {
         }
 
         if (!('submitText' in options)) {
-            options.submitText = '{% jstrans "Delete" %}';
+            options.submitText = '{% trans "Delete" %}';
         }
     }
 
@@ -767,7 +767,7 @@ function updateForm(options) {
 // The "submit" button will be disabled unless "confirm" is checked
 function insertConfirmButton(options) {
 
-    var message = options.confirmMessage || '{% jstrans "Confirm" %}';
+    var message = options.confirmMessage || '{% trans "Confirm" %}';
 
     var html = `
     <div class="form-check form-switch">
@@ -793,7 +793,7 @@ function insertConfirmButton(options) {
 /* Add a checkbox to select if the modal will stay open after success */
 function insertPersistButton(options) {
 
-    var message = options.persistMessage || '{% jstrans "Keep this form open" %}';
+    var message = options.persistMessage || '{% trans "Keep this form open" %}';
 
     var html = `
     <div class="form-check form-switch">
@@ -896,7 +896,7 @@ function submitFormData(fields, options) {
                 if (!validateFormField(name, options)) {
                     data_valid = false;
 
-                    data_errors[name] = ['{% jstrans "Enter a valid number" %}'];
+                    data_errors[name] = ['{% trans "Enter a valid number" %}'];
                 }
                 break;
             default:
@@ -1466,7 +1466,7 @@ function handleFormErrors(errors, fields={}, options={}) {
     // TODO: Display the JSON error text when hovering over the "info" icon
     non_field_errors.append(
         `<div class='alert alert-block alert-danger'>
-            <b>{% jstrans "Form errors exist" %}</b>
+            <b>{% trans "Form errors exist" %}</b>
             <span id='form-errors-info' class='float-right fas fa-info-circle icon-red'>
             </span>
         </div>`
@@ -1964,7 +1964,7 @@ function initializeRelatedField(field, fields, options={}) {
                 if (field.noResults) {
                     return field.noResults(query);
                 } else {
-                    return '{% jstrans "No results found" %}';
+                    return '{% trans "No results found" %}';
                 }
             }
         },
@@ -2148,11 +2148,11 @@ function initializeRelatedField(field, fields, options={}) {
         button.on("click", () => {
             const tree_id = `${name}_tree`;
 
-            const title = '{% jstrans "Select" %}' + " " + options.actions[name].label;
+            const title = '{% trans "Select" %}' + " " + options.actions[name].label;
             const content = `
                 <div class="mb-1">
                     <div class="input-group mb-2">
-                        <input class="form-control" type="text" id="${name}_tree_search" placeholder="{% jstrans "Search" %} ${options.actions[name].label}..." />
+                        <input class="form-control" type="text" id="${name}_tree_search" placeholder="{% trans "Search" %} ${options.actions[name].label}..." />
                         <button class="input-group-text" id="${name}_tree_search_btn"><i class="fas fa-search"></i></button>
                     </div>
 
@@ -2164,7 +2164,7 @@ function initializeRelatedField(field, fields, options={}) {
                 </div>
             `;
             showQuestionDialog(title, content, {
-                accept_text: '{% jstrans "Select" %}',
+                accept_text: '{% trans "Select" %}',
                 accept: () => {
                     const selectedNode = $(`#${tree_id}`).treeview('getSelected');
                     if(selectedNode.length > 0) {
@@ -2268,7 +2268,7 @@ function initializeChoiceField(field, fields, options) {
 
 // Render a 'no results' element
 function searching() {
-    return `<span>{% jstrans "Searching" %}...</span>`;
+    return `<span>{% trans "Searching" %}...</span>`;
 }
 
 /*
@@ -2482,7 +2482,7 @@ function constructField(name, parameters, options={}) {
 
         if (!parameters.required && !options.hideClearButton) {
             html += `
-            <button class='input-group-text form-clear' id='clear_${field_name}' title='{% jstrans "Clear input" %}'>
+            <button class='input-group-text form-clear' id='clear_${field_name}' title='{% trans "Clear input" %}'>
                 <span class='icon-red fas fa-backspace'></span>
             </button>`;
         }
@@ -3068,7 +3068,7 @@ function selectImportFields(url, data={}, options={}) {
         rows += `<tr><td><em>${field_name}</em></td><td>${choice_input}</td></tr>`;
     }
 
-    var headers = `<tr><th>{% jstrans "File Column" %}</th><th>{% jstrans "Field Name" %}</th></tr>`;
+    var headers = `<tr><th>{% trans "File Column" %}</th><th>{% trans "Field Name" %}</th></tr>`;
 
     var html = '';
 
@@ -3080,7 +3080,7 @@ function selectImportFields(url, data={}, options={}) {
 
     constructForm(url, {
         method: 'POST',
-        title: '{% jstrans "Select Columns" %}',
+        title: '{% trans "Select Columns" %}',
         fields: {},
         preFormContent: html,
         onSubmit: function(fields, opts) {

--- a/InvenTree/templates/js/translated/helpers.js
+++ b/InvenTree/templates/js/translated/helpers.js
@@ -74,10 +74,10 @@ function yesNoLabel(value, options={}) {
     let color = '';
 
     if (toBool(value)) {
-        text = options.pass || '{% jstrans "YES" %}';
+        text = options.pass || '{% trans "YES" %}';
         color = 'bg-success';
     } else {
-        text = options.fail || '{% jstrans "NO" %}';
+        text = options.fail || '{% trans "NO" %}';
         color = 'bg-warning';
     }
 
@@ -90,19 +90,19 @@ function yesNoLabel(value, options={}) {
 
 
 function trueFalseLabel(value, options={}) {
-    options.pass = '{% jstrans "True" %}';
-    options.fail = '{% jstrans "False" %}';
+    options.pass = '{% trans "True" %}';
+    options.fail = '{% trans "False" %}';
 
     return yesNoLabel(value, options);
 }
 
 
-function editButton(url, text='{% jstrans "Edit" %}') {
+function editButton(url, text='{% trans "Edit" %}') {
     return `<button class='btn btn-success edit-button btn-sm' type='button' url='${url}'>${text}</button>`;
 }
 
 
-function deleteButton(url, text='{% jstrans "Delete" %}') {
+function deleteButton(url, text='{% trans "Delete" %}') {
     return `<button class='btn btn-danger delete-button btn-sm' type='button' url='${url}'>${text}</button>`;
 }
 
@@ -582,7 +582,7 @@ function renderClipboard(s, prepend=false) {
         return s;
     }
 
-    let clipString = `<span class="d-none d-xl-inline"><button class="btn clip-btn" type="button" data-bs-toggle='tooltip' title='{% jstrans "copy to clipboard" %}'><em class="fas fa-copy"></em></button></span>`;
+    let clipString = `<span class="d-none d-xl-inline"><button class="btn clip-btn" type="button" data-bs-toggle='tooltip' title='{% trans "copy to clipboard" %}'><em class="fas fa-copy"></em></button></span>`;
 
     if (prepend === true) {
         return `<div class="flex-cell">${clipString+s}</div>`;

--- a/InvenTree/templates/js/translated/index.js
+++ b/InvenTree/templates/js/translated/index.js
@@ -101,12 +101,12 @@ function loadRequiredForBuildsPartsTable(table, options={}) {
         search: false,
         sortable: false,
         formatNoMatches: function() {
-            return '{% jstrans "No parts required for builds" %}';
+            return '{% trans "No parts required for builds" %}';
         },
         columns: [
             {
                 field: 'name',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 formatter: function(value, row) {
                     let name = shortenString(row.full_name);
                     let display= imageHoverIcon(row.thumbnail) + renderLink(name, `/part/${row.pk}/`);
@@ -116,18 +116,18 @@ function loadRequiredForBuildsPartsTable(table, options={}) {
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
             },
             {
                 field: 'total_in_stock',
-                title: '{% jstrans "Available" %}',
+                title: '{% trans "Available" %}',
                 formatter: function(value, row) {
                     return value;
                 }
             },
             {
                 field: 'allocated_to_build_orders',
-                title: '{% jstrans "Allocated Stock" %}',
+                title: '{% trans "Allocated Stock" %}',
                 formatter: function(_value, row) {
                     return makeProgressBar(
                         row.allocated_to_build_orders,

--- a/InvenTree/templates/js/translated/label.js
+++ b/InvenTree/templates/js/translated/label.js
@@ -50,8 +50,8 @@ function printLabels(options) {
 
     if (!options.items || options.items.length == 0) {
         showAlertDialog(
-            '{% jstrans "Select Items" %}',
-            '{% jstrans "No items selected for printing" %}',
+            '{% trans "Select Items" %}',
+            '{% trans "No items selected for printing" %}',
         );
         return;
     }
@@ -69,8 +69,8 @@ function printLabels(options) {
         success: function (response) {
             if (response.length == 0) {
                 showAlertDialog(
-                    '{% jstrans "No Labels Found" %}',
-                    '{% jstrans "No label templates found which match the selected items" %}',
+                    '{% trans "No Labels Found" %}',
+                    '{% trans "No label templates found which match the selected items" %}',
                 );
                 return;
             }
@@ -94,7 +94,7 @@ function printLabels(options) {
     if (options.items.length > 1) {
         header_html += `
             <div class='alert alert-block alert-info'>
-            ${options.items.length} ${options.plural_name} {% jstrans "selected" %}
+            ${options.items.length} ${options.plural_name} {% trans "selected" %}
             </div>
         `;
     }
@@ -130,7 +130,7 @@ function printLabels(options) {
         if (Object.keys(printingOptions).length > 0) {
             formOptions.fields = {
                 ...formOptions.fields,
-                divider: { type: "candy", html: `<hr/><h5>{% jstrans "Printing Options" %}</h5>` },
+                divider: { type: "candy", html: `<hr/><h5>{% trans "Printing Options" %}</h5>` },
                 ...printingOptions,
             };
         }
@@ -145,14 +145,14 @@ function printLabels(options) {
     }
 
     const printingFormOptions = {
-        title: options.items.length === 1 ? `{% jstrans "Print label" %}` : `{% jstrans "Print labels" %}`,
-        submitText: `{% jstrans "Print" %}`,
+        title: options.items.length === 1 ? `{% trans "Print label" %}` : `{% trans "Print labels" %}`,
+        submitText: `{% trans "Print" %}`,
         method: "POST",
         disableSuccessMessage: true,
         header_html,
         fields: {
             _label_template: {
-                label: `{% jstrans "Select label template" %}`,
+                label: `{% trans "Select label template" %}`,
                 type: "choice",
                 localOnly: true,
                 value: defaultLabelTemplates[options.key],
@@ -165,7 +165,7 @@ function printLabels(options) {
                 }
             },
             _plugin: {
-                label: `{% jstrans "Select plugin" %}`,
+                label: `{% trans "Select plugin" %}`,
                 type: "choice",
                 localOnly: true,
                 value: user_settings.LABEL_DEFAULT_PRINTER || plugins[0].key,
@@ -184,7 +184,7 @@ function printLabels(options) {
                 // Download the generated file
                 window.open(response.file);
             } else {
-                showMessage('{% jstrans "Labels sent to printer" %}', {
+                showMessage('{% trans "Labels sent to printer" %}', {
                     style: 'success',
                 });
             }

--- a/InvenTree/templates/js/translated/modals.js
+++ b/InvenTree/templates/js/translated/modals.js
@@ -55,12 +55,12 @@ function createNewModal(options={}) {
 
     // Add in a "close" button
     if (!options.hideCloseButton) {
-        buttons += `<button type='button' class='btn btn-secondary' id='modal-form-close' data-bs-dismiss='modal'>{% jstrans "Cancel" %}</button>`;
+        buttons += `<button type='button' class='btn btn-secondary' id='modal-form-close' data-bs-dismiss='modal'>{% trans "Cancel" %}</button>`;
     }
 
     // Add in a "submit" button
     if (!options.hideSubmitButton) {
-        buttons += `<button type='button' class='btn btn-${submitClass}' id='modal-form-submit'>{% jstrans "Submit" %}</button>`;
+        buttons += `<button type='button' class='btn btn-${submitClass}' id='modal-form-submit'>{% trans "Submit" %}</button>`;
     }
 
     var html = `
@@ -71,7 +71,7 @@ function createNewModal(options={}) {
                     <h4 id='modal-title' class='modal-title'>
                         <!-- Form title to be injected here -->
                     </h4>
-                    <button type='button' class='btn-close' data-bs-dismiss='modal' aria-label='{% jstrans "Close" %}'></button>
+                    <button type='button' class='btn-close' data-bs-dismiss='modal' aria-label='{% trans "Close" %}'></button>
                 </div>
                 <div class='modal-body modal-form-content-wrapper'>
                     <div id='non-field-errors'>
@@ -153,9 +153,9 @@ function createNewModal(options={}) {
     });
 
     // Set labels based on supplied options
-    modalSetTitle(modal_name, options.title || '{% jstrans "Form Title" %}');
-    modalSetSubmitText(modal_name, options.submitText || '{% jstrans "Submit" %}');
-    modalSetCloseText(modal_name, options.closeText || '{% jstrans "Cancel" %}');
+    modalSetTitle(modal_name, options.title || '{% trans "Form Title" %}');
+    modalSetSubmitText(modal_name, options.submitText || '{% trans "Submit" %}');
+    modalSetCloseText(modal_name, options.closeText || '{% trans "Cancel" %}');
 
     // Return the "name" of the modal
     return modal_name;
@@ -442,7 +442,7 @@ function attachBootstrapCheckbox(modal) {
 function loadingMessageContent() {
 
     // TODO - This can be made a lot better
-    return `<span class='glyphicon glyphicon-refresh glyphicon-refresh-animate'></span> {% jstrans 'Waiting for server...' %}`;
+    return `<span class='glyphicon glyphicon-refresh glyphicon-refresh-animate'></span> {% trans 'Waiting for server...' %}`;
 }
 
 
@@ -593,7 +593,7 @@ function renderErrorMessage(xhr) {
         <div class='panel'>
             <div class='panel panel-heading'>
                 <div class='panel-title'>
-                    <a data-bs-toggle='collapse' href="#collapse-error-info">{% jstrans "Show Error Information" %}</a>
+                    <a data-bs-toggle='collapse' href="#collapse-error-info">{% trans "Show Error Information" %}</a>
                 </div>
             </div>
             <div class='panel-collapse collapse' id='collapse-error-info'>
@@ -625,7 +625,7 @@ function showAlertDialog(title, content, options={}) {
 
     var modal = createNewModal({
         title: title,
-        closeText: '{% jstrans "Close" %}',
+        closeText: '{% trans "Close" %}',
         hideSubmitButton: true,
     });
 
@@ -679,8 +679,8 @@ function showQuestionDialog(title, content, options={}) {
      */
 
     options.title = title;
-    options.submitText = options.accept_text || '{% jstrans "Accept" %}';
-    options.closeText = options.cancel_text || '{% jstrans "Cancel" %}';
+    options.submitText = options.accept_text || '{% trans "Accept" %}';
+    options.closeText = options.cancel_text || '{% trans "Cancel" %}';
 
     var modal = createNewModal(options);
 
@@ -737,7 +737,7 @@ function openModal(options) {
     if (options.title) {
         modalSetTitle(modal, options.title);
     } else {
-        modalSetTitle(modal, '{% jstrans "Loading Data" %}...');
+        modalSetTitle(modal, '{% trans "Loading Data" %}...');
     }
 
     // Unless the content is explicitly set, display loading message
@@ -748,8 +748,8 @@ function openModal(options) {
     }
 
     // Default labels for 'Submit' and 'Close' buttons in the form
-    var submit_text = options.submit_text || '{% jstrans "Submit" %}';
-    var close_text = options.close_text || '{% jstrans "Close" %}';
+    var submit_text = options.submit_text || '{% trans "Submit" %}';
+    var close_text = options.close_text || '{% trans "Close" %}';
 
     modalSetButtonText(modal, submit_text, close_text);
 
@@ -1008,7 +1008,7 @@ function handleModalForm(url, options) {
                             }
                         } else {
                             $(modal).modal('hide');
-                            showAlertDialog('{% jstrans "Invalid response from server" %}', '{% jstrans "Form data missing from server response" %}');
+                            showAlertDialog('{% trans "Invalid response from server" %}', '{% trans "Form data missing from server response" %}');
                         }
                     }
                 } else {
@@ -1020,7 +1020,7 @@ function handleModalForm(url, options) {
                 // There was an error submitting form data via POST
 
                 $(modal).modal('hide');
-                showAlertDialog('{% jstrans "Error posting form data" %}', renderErrorMessage(xhr));
+                showAlertDialog('{% trans "Error posting form data" %}', renderErrorMessage(xhr));
             },
             complete: function() {
                 // TODO
@@ -1056,8 +1056,8 @@ function launchModalForm(url, options = {}) {
     var modal = options.modal || '#modal-form';
 
     // Default labels for 'Submit' and 'Close' buttons in the form
-    var submit_text = options.submit_text || '{% jstrans "Submit" %}';
-    var close_text = options.close_text || '{% jstrans "Close" %}';
+    var submit_text = options.submit_text || '{% trans "Submit" %}';
+    var close_text = options.close_text || '{% trans "Close" %}';
 
     // Clean custom action buttons
     $(modal).find('#modal-footer-buttons').html('');
@@ -1117,7 +1117,7 @@ function launchModalForm(url, options = {}) {
 
             } else {
                 $(modal).modal('hide');
-                showAlertDialog('{% jstrans "Invalid server response" %}', '{% jstrans "JSON response missing form data" %}');
+                showAlertDialog('{% trans "Invalid server response" %}', '{% trans "JSON response missing form data" %}');
             }
         },
         error: function(xhr) {
@@ -1127,36 +1127,36 @@ function launchModalForm(url, options = {}) {
             if (xhr.status == 0) {
                 // No response from the server
                 showAlertDialog(
-                    '{% jstrans "No Response" %}',
-                    '{% jstrans "No response from the InvenTree server" %}',
+                    '{% trans "No Response" %}',
+                    '{% trans "No response from the InvenTree server" %}',
                 );
             } else if (xhr.status == 400) {
                 showAlertDialog(
-                    '{% jstrans "Error 400: Bad Request" %}',
-                    '{% jstrans "Server returned error code 400" %}',
+                    '{% trans "Error 400: Bad Request" %}',
+                    '{% trans "Server returned error code 400" %}',
                 );
             } else if (xhr.status == 401) {
                 showAlertDialog(
-                    '{% jstrans "Error 401: Not Authenticated" %}',
-                    '{% jstrans "Authentication credentials not supplied" %}',
+                    '{% trans "Error 401: Not Authenticated" %}',
+                    '{% trans "Authentication credentials not supplied" %}',
                 );
             } else if (xhr.status == 403) {
                 showAlertDialog(
-                    '{% jstrans "Error 403: Permission Denied" %}',
-                    '{% jstrans "You do not have the required permissions to access this function" %}',
+                    '{% trans "Error 403: Permission Denied" %}',
+                    '{% trans "You do not have the required permissions to access this function" %}',
                 );
             } else if (xhr.status == 404) {
                 showAlertDialog(
-                    '{% jstrans "Error 404: Resource Not Found" %}',
-                    '{% jstrans "The requested resource could not be located on the server" %}',
+                    '{% trans "Error 404: Resource Not Found" %}',
+                    '{% trans "The requested resource could not be located on the server" %}',
                 );
             } else if (xhr.status == 408) {
                 showAlertDialog(
-                    '{% jstrans "Error 408: Timeout" %}',
-                    '{% jstrans "Connection timeout while requesting data from server" %}',
+                    '{% trans "Error 408: Timeout" %}',
+                    '{% trans "Connection timeout while requesting data from server" %}',
                 );
             } else {
-                showAlertDialog('{% jstrans "Error requesting form data" %}', renderErrorMessage(xhr));
+                showAlertDialog('{% trans "Error requesting form data" %}', renderErrorMessage(xhr));
             }
 
             console.error('Modal form error: ' + xhr.status);

--- a/InvenTree/templates/js/translated/model_renderers.js
+++ b/InvenTree/templates/js/translated/model_renderers.js
@@ -216,21 +216,21 @@ function renderStockItem(data, parameters={}) {
     }
 
     if (data.quantity == 0) {
-        stock_detail = `<span class='badge rounded-pill bg-danger'>{% jstrans "No Stock"% }</span>`;
+        stock_detail = `<span class='badge rounded-pill bg-danger'>{% trans "No Stock"% }</span>`;
     } else {
         if (data.serial && data.quantity == 1) {
-            stock_detail = `{% jstrans "Serial Number" %}: ${data.serial}`;
+            stock_detail = `{% trans "Serial Number" %}: ${data.serial}`;
         } else {
             if (render_available_quantity) {
                 var available = data.quantity - data.allocated;
-                stock_detail = `{% jstrans "Available" %}: ${available}`;
+                stock_detail = `{% trans "Available" %}: ${available}`;
             } else {
-                stock_detail = `{% jstrans "Quantity" %}: ${data.quantity}`;
+                stock_detail = `{% trans "Quantity" %}: ${data.quantity}`;
             }
         }
 
         if (data.batch) {
-            stock_detail += ` - <small>{% jstrans "Batch" %}: ${data.batch}</small>`;
+            stock_detail += ` - <small>{% trans "Batch" %}: ${data.batch}</small>`;
         }
     }
 
@@ -301,7 +301,7 @@ function renderPart(data, parameters={}) {
         labels = partStockLabel(data);
 
         if (!data.active) {
-            labels += `<span class='badge badge-right rounded-pill bg-danger'>{% jstrans "Inactive" %}</span>`;
+            labels += `<span class='badge badge-right rounded-pill bg-danger'>{% trans "Inactive" %}</span>`;
         }
     }
 
@@ -443,7 +443,7 @@ function renderSalesOrderShipment(data, parameters={}) {
     return renderModel(
         {
             text: data.order_detail.reference,
-            textSecondary: `{% jstrans "Shipment" %} ${data.reference}`,
+            textSecondary: `{% trans "Shipment" %} ${data.reference}`,
         },
         parameters
     );

--- a/InvenTree/templates/js/translated/news.js
+++ b/InvenTree/templates/js/translated/news.js
@@ -30,18 +30,18 @@ function loadNewsFeedTable(table, options={}, enableDelete=false) {
         },
         paginationVAlign: 'bottom',
         formatNoMatches: function() {
-            return '{% jstrans "No news found" %}';
+            return '{% trans "No news found" %}';
         },
         columns: [
             {
                 field: 'pk',
-                title: '{% jstrans "ID" %}',
+                title: '{% trans "ID" %}',
                 visible: false,
                 switchable: false,
             },
             {
                 field: 'title',
-                title: '{% jstrans "Title" %}',
+                title: '{% trans "Title" %}',
                 sortable: 'true',
                 formatter: function(value, row) {
                     return `<a href="` + row.link + `">` + value + `</a>`;
@@ -49,15 +49,15 @@ function loadNewsFeedTable(table, options={}, enableDelete=false) {
             },
             {
                 field: 'summary',
-                title: '{% jstrans "Summary" %}',
+                title: '{% trans "Summary" %}',
             },
             {
                 field: 'author',
-                title: '{% jstrans "Author" %}',
+                title: '{% trans "Author" %}',
             },
             {
                 field: 'published',
-                title: '{% jstrans "Published" %}',
+                title: '{% trans "Published" %}',
                 sortable: 'true',
                 formatter: function(value, row) {
                     var html = renderDate(value);

--- a/InvenTree/templates/js/translated/notification.js
+++ b/InvenTree/templates/js/translated/notification.js
@@ -43,13 +43,13 @@ function loadNotificationTable(table, options={}, enableDelete=false) {
         columns: [
             {
                 field: 'pk',
-                title: '{% jstrans "ID" %}',
+                title: '{% trans "ID" %}',
                 visible: false,
                 switchable: false,
             },
             {
                 field: 'age',
-                title: '{% jstrans "Age" %}',
+                title: '{% trans "Age" %}',
                 sortable: 'true',
                 formatter: function(value, row) {
                     return row.age_human;
@@ -57,12 +57,12 @@ function loadNotificationTable(table, options={}, enableDelete=false) {
             },
             {
                 field: 'category',
-                title: '{% jstrans "Category" %}',
+                title: '{% trans "Category" %}',
                 sortable: 'true',
             },
             {
                 field: 'name',
-                title: '{% jstrans "Notification" %}',
+                title: '{% trans "Notification" %}',
                 formatter: function(value, row) {
                     if (row.target && row.target.link) {
                         return renderLink(value, row.target.link);
@@ -73,7 +73,7 @@ function loadNotificationTable(table, options={}, enableDelete=false) {
             },
             {
                 field: 'message',
-                title: '{% jstrans "Message" %}',
+                title: '{% trans "Message" %}',
             },
             {
                 formatter: function(value, row, index, field) {
@@ -82,7 +82,7 @@ function loadNotificationTable(table, options={}, enableDelete=false) {
                     let bDel = '';
 
                     if (enableDelete) {
-                        bDel = `<button title='{% jstrans "Delete Notification" %}' class='notification-delete btn btn-outline-secondary' type='button' pk='${row.pk}'><span class='fas fa-trash-alt icon-red'></span></button>`;
+                        bDel = `<button title='{% trans "Delete Notification" %}' class='notification-delete btn btn-outline-secondary' type='button' pk='${row.pk}'><span class='fas fa-trash-alt icon-red'></span></button>`;
                     }
 
                     var html = `<div class='btn-group float-right' role='group'>${bRead}${bDel}</div>`;
@@ -221,11 +221,11 @@ function getReadEditButton(pk, state, small=false) {
     let bReadTarget = '';
 
     if (state) {
-        bReadText = '{% jstrans "Mark as unread" %}';
+        bReadText = '{% trans "Mark as unread" %}';
         bReadIcon = 'fas fa-bookmark icon-red';
         bReadTarget = 'unread';
     } else {
-        bReadText = '{% jstrans "Mark as read" %}';
+        bReadText = '{% trans "Mark as read" %}';
         bReadIcon = 'far fa-bookmark icon-green';
         bReadTarget = 'read';
     }
@@ -251,7 +251,7 @@ function openNotificationPanel() {
         {
             success: function(response) {
                 if (response.length == 0) {
-                    html = `<p class='text-muted'><em>{% jstrans "No unread notifications" %}</em><span class='fas fa-check-circle icon-green float-right'></span></p>`;
+                    html = `<p class='text-muted'><em>{% trans "No unread notifications" %}</em><span class='fas fa-check-circle icon-green float-right'></span></p>`;
                 } else {
                     // build up items
                     response.forEach(function(item, index) {
@@ -293,7 +293,7 @@ function openNotificationPanel() {
  * clears the notification panel when closed
  **/
 function closeNotificationPanel() {
-    $('#notification-center').html(`<p class='text-muted'>{% jstrans "Notifications will load here" %}</p>`);
+    $('#notification-center').html(`<p class='text-muted'>{% trans "Notifications will load here" %}</p>`);
 }
 
 /**

--- a/InvenTree/templates/js/translated/order.js
+++ b/InvenTree/templates/js/translated/order.js
@@ -86,7 +86,7 @@ function createExtraLineItem(options={}) {
     constructForm(options.url, {
         fields: fields,
         method: 'POST',
-        title: '{% jstrans "Add Extra Line Item" %}',
+        title: '{% trans "Add Extra Line Item" %}',
         onSuccess: function(response) {
             if (options.table) {
                 reloadBootstrapTable(options.table);
@@ -123,11 +123,11 @@ function exportOrder(redirect_url, options={}) {
     }
 
     constructFormBody({}, {
-        title: '{% jstrans "Export Order" %}',
+        title: '{% trans "Export Order" %}',
         fields: {
             format: {
-                label: '{% jstrans "Format" %}',
-                help_text: '{% jstrans "Select file format" %}',
+                label: '{% trans "Format" %}',
+                help_text: '{% trans "Select file format" %}',
                 required: true,
                 type: 'choice',
                 value: format,
@@ -238,7 +238,7 @@ function loadExtraLineTable(options={}) {
                             method: 'POST',
                             fields: fields,
                             data: data,
-                            title: '{% jstrans "Duplicate Line" %}',
+                            title: '{% trans "Duplicate Line" %}',
                             onSuccess: reloadExtraLineTable,
                         });
                     }
@@ -252,7 +252,7 @@ function loadExtraLineTable(options={}) {
 
                 constructForm(`${options.url}${pk}/`, {
                     fields: extraLineFields(),
-                    title: '{% jstrans "Edit Line" %}',
+                    title: '{% trans "Edit Line" %}',
                     onSuccess: reloadExtraLineTable,
                 });
             });
@@ -265,7 +265,7 @@ function loadExtraLineTable(options={}) {
 
                 constructForm(`${options.url}${pk}/`, {
                     method: 'DELETE',
-                    title: '{% jstrans "Delete Line" %}',
+                    title: '{% trans "Delete Line" %}',
                     onSuccess: reloadExtraLineTable,
                 });
             });
@@ -278,7 +278,7 @@ function loadExtraLineTable(options={}) {
         sidePagination: 'server',
         onPostBody: setupCallbacks,
         formatNoMatches: function() {
-            return '{% jstrans "No line items found" %}';
+            return '{% trans "No line items found" %}';
         },
         queryParams: filters,
         original: options.params,
@@ -288,20 +288,20 @@ function loadExtraLineTable(options={}) {
             {
                 sortable: true,
                 field: 'reference',
-                title: '{% jstrans "Reference" %}',
+                title: '{% trans "Reference" %}',
                 switchable: false,
             },
             {
                 sortable: false,
                 switchable: true,
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
             },
             {
                 sortable: true,
                 switchable: false,
                 field: 'quantity',
-                title: '{% jstrans "Quantity" %}',
+                title: '{% trans "Quantity" %}',
                 footerFormatter: function(data) {
                     return data.map(function(row) {
                         return +row['quantity'];
@@ -313,7 +313,7 @@ function loadExtraLineTable(options={}) {
             {
                 sortable: true,
                 field: 'price',
-                title: '{% jstrans "Unit Price" %}',
+                title: '{% trans "Unit Price" %}',
                 formatter: function(value, row) {
                     return formatCurrency(row.price, {
                         currency: row.price_currency,
@@ -324,7 +324,7 @@ function loadExtraLineTable(options={}) {
                 field: 'total_price',
                 sortable: true,
                 switchable: true,
-                title: '{% jstrans "Total Price" %}',
+                title: '{% trans "Total Price" %}',
                 formatter: function(value, row) {
                     return formatCurrency(row.price * row.quantity, {
                         currency: row.price_currency,
@@ -344,11 +344,11 @@ function loadExtraLineTable(options={}) {
             },
             {
                 field: 'notes',
-                title: '{% jstrans "Notes" %}',
+                title: '{% trans "Notes" %}',
             },
             {
                 field: 'link',
-                title: '{% jstrans "Link" %}',
+                title: '{% trans "Link" %}',
                 formatter: function(value) {
                     if (value) {
                         return renderLink(value, value);
@@ -366,12 +366,12 @@ function loadExtraLineTable(options={}) {
                         var pk = row.pk;
 
                         if (options.allow_edit) {
-                            html += makeCopyButton('button-duplicate', pk, '{% jstrans "Duplicate line" %}');
-                            html += makeEditButton('button-edit', pk, '{% jstrans "Edit line" %}');
+                            html += makeCopyButton('button-duplicate', pk, '{% trans "Duplicate line" %}');
+                            html += makeEditButton('button-edit', pk, '{% trans "Edit line" %}');
                         }
 
                         if (options.allow_delete) {
-                            html += makeDeleteButton('button-delete', pk, '{% jstrans "Delete line" %}', );
+                            html += makeDeleteButton('button-delete', pk, '{% trans "Delete line" %}', );
                         }
                     }
 

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -87,24 +87,24 @@ function partGroups() {
 
     return {
         attributes: {
-            title: '{% jstrans "Part Attributes" %}',
+            title: '{% trans "Part Attributes" %}',
             collapsible: true,
         },
         create: {
-            title: '{% jstrans "Part Creation Options" %}',
+            title: '{% trans "Part Creation Options" %}',
             collapsible: true,
         },
         duplicate: {
-            title: '{% jstrans "Part Duplication Options" %}',
+            title: '{% trans "Part Duplication Options" %}',
             collapsible: true,
         },
         initial_stock: {
-            title: '{% jstrans "Initial Stock" %}',
+            title: '{% trans "Initial Stock" %}',
             collapsible: true,
             hidden: !global_settings.PART_CREATE_INITIAL,
         },
         initial_supplier: {
-            title: '{% jstrans "Initial Supplier Data" %}',
+            title: '{% trans "Initial Supplier Data" %}',
             collapsible: true,
             hidden: !global_settings.PART_CREATE_SUPPLIER,
         },
@@ -118,7 +118,7 @@ function partFields(options={}) {
     var fields = {
         category: {
             secondary: {
-                title: '{% jstrans "Add Part Category" %}',
+                title: '{% trans "Add Part Category" %}',
                 fields: function() {
                     var fields = categoryFields();
 
@@ -305,7 +305,7 @@ function partFields(options={}) {
 function categoryFields(options={}) {
     let fields = {
         parent: {
-            help_text: '{% jstrans "Parent part category" %}',
+            help_text: '{% trans "Parent part category" %}',
             required: false,
             tree_picker: {
                 url: '{% url "api-part-category-tree" %}',
@@ -329,7 +329,7 @@ function categoryFields(options={}) {
         },
         structural: {},
         icon: {
-            help_text: `{% jstrans "Icon (optional) - Explore all available icons on" %} <a href="https://fontawesome.com/v5/search?s=solid" target="_blank" rel="noopener noreferrer">Font Awesome</a>.`,
+            help_text: `{% trans "Icon (optional) - Explore all available icons on" %} <a href="https://fontawesome.com/v5/search?s=solid" target="_blank" rel="noopener noreferrer">Font Awesome</a>.`,
             placeholder: 'fas fa-tag',
         },
     };
@@ -349,11 +349,11 @@ function createPartCategory(options={}) {
     constructForm('{% url "api-part-category-list" %}', {
         fields: fields,
         method: 'POST',
-        title: '{% jstrans "Create Part Category" %}',
+        title: '{% trans "Create Part Category" %}',
         follow: true,
         persist: true,
-        persistMessage: '{% jstrans "Create new category after this one" %}',
-        successMessage: '{% jstrans "Part category created" %}'
+        persistMessage: '{% trans "Create new category after this one" %}',
+        successMessage: '{% trans "Part category created" %}'
     });
 }
 
@@ -367,7 +367,7 @@ function editCategory(pk) {
 
     constructForm(url, {
         fields: fields,
-        title: '{% jstrans "Edit Part Category" %}',
+        title: '{% trans "Edit Part Category" %}',
         reload: true,
     });
 }
@@ -380,30 +380,30 @@ function deletePartCategory(pk, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "Are you sure you want to delete this part category?" %}
+    {% trans "Are you sure you want to delete this part category?" %}
     </div>`;
     var subChoices = [
         {
             value: 0,
-            display_name: '{% jstrans "Move to parent category" %}',
+            display_name: '{% trans "Move to parent category" %}',
         },
         {
             value: 1,
-            display_name: '{% jstrans "Delete" %}',
+            display_name: '{% trans "Delete" %}',
         }
     ];
 
     constructForm(url, {
-        title: '{% jstrans "Delete Part Category" %}',
+        title: '{% trans "Delete Part Category" %}',
         method: 'DELETE',
         fields: {
             'delete_parts': {
-                label: '{% jstrans "Action for parts in this category" %}',
+                label: '{% trans "Action for parts in this category" %}',
                 choices: subChoices,
                 type: 'choice'
             },
             'delete_child_categories': {
-                label: '{% jstrans "Action for child categories" %}',
+                label: '{% trans "Action for child categories" %}',
                 choices: subChoices,
                 type: 'choice'
             },
@@ -427,10 +427,10 @@ function createPart(options={}) {
         method: 'POST',
         fields: partFields(options),
         groups: partGroups(),
-        title: '{% jstrans "Create Part" %}',
+        title: '{% trans "Create Part" %}',
         persist: true,
-        persistMessage: '{% jstrans "Create another part after this one" %}',
-        successMessage: '{% jstrans "Part created successfully" %}',
+        persistMessage: '{% trans "Create another part after this one" %}',
+        successMessage: '{% trans "Part created successfully" %}',
         onSuccess: function(data) {
             // Follow the new part
             location.href = `/part/${data.pk}/`;
@@ -458,9 +458,9 @@ function editPart(pk) {
     constructForm(url, {
         fields: fields,
         groups: groups,
-        title: '{% jstrans "Edit Part" %}',
+        title: '{% trans "Edit Part" %}',
         reload: true,
-        successMessage: '{% jstrans "Part edited" %}',
+        successMessage: '{% trans "Part edited" %}',
     });
 }
 
@@ -468,10 +468,10 @@ function editPart(pk) {
 // Launch form to duplicate a part
 function duplicatePart(pk, options={}) {
 
-    var title = '{% jstrans "Duplicate Part" %}';
+    var title = '{% trans "Duplicate Part" %}';
 
     if (options.variant) {
-        title = '{% jstrans "Create Part Variant" %}';
+        title = '{% trans "Create Part Variant" %}';
     }
 
     // First we need all the part information
@@ -528,8 +528,8 @@ function deletePart(pk, options={}) {
         success: function(part) {
             if (part.active) {
                 showAlertDialog(
-                    '{% jstrans "Active Part" %}',
-                    '{% jstrans "Part cannot be deleted as it is currently active" %}',
+                    '{% trans "Active Part" %}',
+                    '{% trans "Part cannot be deleted as it is currently active" %}',
                     {
                         alert_style: 'danger',
                     }
@@ -543,18 +543,18 @@ function deletePart(pk, options={}) {
             <div class='alert alert-block alert-danger'>
             <p>${thumb} ${part.full_name} - <em>${part.description}</em></p>
 
-            {% jstrans "Deleting this part cannot be reversed" %}
+            {% trans "Deleting this part cannot be reversed" %}
             <ul>
-            <li>{% jstrans "Any stock items for this part will be deleted" %}</li>
-            <li>{% jstrans "This part will be removed from any Bills of Material" %}</li>
-            <li>{% jstrans "All manufacturer and supplier information for this part will be deleted" %}</li>
+            <li>{% trans "Any stock items for this part will be deleted" %}</li>
+            <li>{% trans "This part will be removed from any Bills of Material" %}</li>
+            <li>{% trans "All manufacturer and supplier information for this part will be deleted" %}</li>
             </div>`;
 
             constructForm(
                 `{% url "api-part-list" %}${pk}/`,
                 {
                     method: 'DELETE',
-                    title: '{% jstrans "Delete Part" %}',
+                    title: '{% trans "Delete Part" %}',
                     preFormContent: html,
                     onSuccess: function(response) {
                         handleFormSuccess(response, options);
@@ -590,16 +590,16 @@ function toggleStar(options) {
                     success: function(response) {
                         if (response.starred) {
                             $(options.button).removeClass('fa fa-bell-slash').addClass('fas fa-bell icon-green');
-                            $(options.button).attr('title', '{% jstrans "You are subscribed to notifications for this item" %}');
+                            $(options.button).attr('title', '{% trans "You are subscribed to notifications for this item" %}');
 
-                            showMessage('{% jstrans "You have subscribed to notifications for this item" %}', {
+                            showMessage('{% trans "You have subscribed to notifications for this item" %}', {
                                 style: 'success',
                             });
                         } else {
                             $(options.button).removeClass('fas fa-bell icon-green').addClass('fa fa-bell-slash');
-                            $(options.button).attr('title', '{% jstrans "Subscribe to notifications for this item" %}');
+                            $(options.button).attr('title', '{% trans "Subscribe to notifications for this item" %}');
 
-                            showMessage('{% jstrans "You have unsubscribed to notifications for this item" %}', {
+                            showMessage('{% trans "You have unsubscribed to notifications for this item" %}', {
                                 style: 'warning',
                             });
                         }
@@ -616,7 +616,7 @@ function validateBom(part_id, options={}) {
 
     var html = `
     <div class='alert alert-block alert-success'>
-    {% jstrans "Validating the BOM will mark each line item as valid" %}
+    {% trans "Validating the BOM will mark each line item as valid" %}
     </div>
     `;
 
@@ -626,10 +626,10 @@ function validateBom(part_id, options={}) {
             valid: {},
         },
         preFormContent: html,
-        title: '{% jstrans "Validate Bill of Materials" %}',
+        title: '{% trans "Validate Bill of Materials" %}',
         reload: options.reload,
         onSuccess: function(response) {
-            showMessage('{% jstrans "Validated Bill of Materials" %}');
+            showMessage('{% trans "Validated Bill of Materials" %}');
         }
     });
 }
@@ -654,7 +654,7 @@ function duplicateBom(part_id, options={}) {
             skip_invalid: {},
         },
         confirm: true,
-        title: '{% jstrans "Copy Bill of Materials" %}',
+        title: '{% trans "Copy Bill of Materials" %}',
         onSuccess: function(response) {
             if (options.success) {
                 options.success(response);
@@ -682,36 +682,36 @@ function partStockLabel(part, options={}) {
 
         // Is stock "low" (below the 'minimum_stock' quantity)?
         if ((part.minimum_stock > 0) && (part.minimum_stock > part.total_in_stock)) {
-            elements.push(`{% jstrans "Low stock" %}: ${part.total_in_stock}`);
+            elements.push(`{% trans "Low stock" %}: ${part.total_in_stock}`);
         } else if (part.unallocated_stock <= 0) {
             // There is no available stock at all
-            elements.push(`{% jstrans "No stock available" %}`);
+            elements.push(`{% trans "No stock available" %}`);
         } else if (part.unallocated_stock < part.in_stock) {
             // Unallocated quantity is less than total quantity
             if (options.hideTotalStock) {
-                elements.push(`{% jstrans "Available" %}: ${part.unallocated_stock}`);
+                elements.push(`{% trans "Available" %}: ${part.unallocated_stock}`);
             } else {
-                elements.push(`{% jstrans "Available" %}: ${part.unallocated_stock}/${part.in_stock}`);
+                elements.push(`{% trans "Available" %}: ${part.unallocated_stock}/${part.in_stock}`);
             }
         } else {
             // Stock is completely available
             if (!options.hideTotalStock) {
-                elements.push(`{% jstrans "Available" %}: ${part.unallocated_stock}`);
+                elements.push(`{% trans "Available" %}: ${part.unallocated_stock}`);
             }
         }
     } else {
         // There IS NO stock available for this part
-        elements.push(`{% jstrans "No Stock" %}`);
+        elements.push(`{% trans "No Stock" %}`);
     }
 
     // Check for items on order
     if (part.ordering) {
-        elements.push(`{% jstrans "On Order" %}: ${part.ordering}`);
+        elements.push(`{% trans "On Order" %}: ${part.ordering}`);
     }
 
     // Check for items being built
     if (part.building) {
-        elements.push(`{% jstrans "Building" %}: ${part.building}`);
+        elements.push(`{% trans "Building" %}: ${part.building}`);
     }
 
     // Determine badge color based on overall stock health
@@ -745,7 +745,7 @@ function partStockLabel(part, options={}) {
 
         var demand = (required_build_order_quantity - part.allocated_to_build_orders) + (required_sales_order_quantity - part.allocated_to_sales_orders);
         if (demand) {
-            elements.push(`{% jstrans "Demand" %}: ${demand}`);
+            elements.push(`{% trans "Demand" %}: ${demand}`);
         }
 
         stock_health -= (required_build_order_quantity + required_sales_order_quantity);
@@ -768,7 +768,7 @@ function partStockLabel(part, options={}) {
 
     // Display units next to stock badge
     if (units && !options.no_units) {
-        output += `<span class='badge rounded-pill text-muted bg-muted ${classes}'>{% jstrans "Unit" %}: ${units}</span> `;
+        output += `<span class='badge rounded-pill text-muted bg-muted ${classes}'>{% trans "Unit" %}: ${units}</span> `;
     }
 
     if (elements.length > 0) {
@@ -787,31 +787,31 @@ function makePartIcons(part) {
     var html = '';
 
     if (part.trackable) {
-        html += makeIconBadge('fa-directions', '{% jstrans "Trackable part" %}');
+        html += makeIconBadge('fa-directions', '{% trans "Trackable part" %}');
     }
 
     if (part.virtual) {
-        html += makeIconBadge('fa-ghost', '{% jstrans "Virtual part" %}');
+        html += makeIconBadge('fa-ghost', '{% trans "Virtual part" %}');
     }
 
     if (part.is_template) {
-        html += makeIconBadge('fa-clone', '{% jstrans "Template part" %}');
+        html += makeIconBadge('fa-clone', '{% trans "Template part" %}');
     }
 
     if (part.assembly) {
-        html += makeIconBadge('fa-tools', '{% jstrans "Assembled part" %}');
+        html += makeIconBadge('fa-tools', '{% trans "Assembled part" %}');
     }
 
     if (part.starred) {
-        html += makeIconBadge('fa-bell icon-green', '{% jstrans "Subscribed part" %}');
+        html += makeIconBadge('fa-bell icon-green', '{% trans "Subscribed part" %}');
     }
 
     if (part.salable) {
-        html += makeIconBadge('fa-dollar-sign', '{% jstrans "Salable part" %}');
+        html += makeIconBadge('fa-dollar-sign', '{% trans "Salable part" %}');
     }
 
     if (!part.active) {
-        html += `<span class='badge badge-right rounded-pill bg-warning'>{% jstrans "Inactive" %}</span> `;
+        html += `<span class='badge badge-right rounded-pill bg-warning'>{% trans "Inactive" %}</span> `;
     }
 
     return html;
@@ -886,7 +886,7 @@ function generateStocktakeReport(options={}) {
 
     let content = `
     <div class='alert alert-block alert-info'>
-    {% jstrans "Schedule generation of a new stocktake report." %} {% jstrans "Once complete, the stocktake report will be available for download." %}
+    {% trans "Schedule generation of a new stocktake report." %} {% trans "Once complete, the stocktake report will be available for download." %}
     </div>
     `;
 
@@ -894,11 +894,11 @@ function generateStocktakeReport(options={}) {
         '{% url "api-part-stocktake-report-generate" %}',
         {
             method: 'POST',
-            title: '{% jstrans "Generate Stocktake Report" %}',
+            title: '{% trans "Generate Stocktake Report" %}',
             preFormContent: content,
             fields: fields,
             onSuccess: function(response) {
-                showMessage('{% jstrans "Stocktake report scheduled" %}', {
+                showMessage('{% trans "Stocktake report scheduled" %}', {
                     style: 'success',
                 });
             }
@@ -958,7 +958,7 @@ function loadStocktakeChart(data, options={}) {
     var chart_data = {
         datasets: [
             {
-                label: '{% jstrans "Quantity" %}',
+                label: '{% trans "Quantity" %}',
                 data: quantity_data,
                 backgroundColor: 'rgba(160, 80, 220, 0.75)',
                 borderWidth: 3,
@@ -966,7 +966,7 @@ function loadStocktakeChart(data, options={}) {
                 yAxisID: 'y',
             },
             {
-                label: '{% jstrans "Minimum Cost" %}',
+                label: '{% trans "Minimum Cost" %}',
                 data: cost_min_data,
                 backgroundColor: 'rgba(220, 160, 80, 0.25)',
                 borderWidth: 2,
@@ -976,7 +976,7 @@ function loadStocktakeChart(data, options={}) {
                 fill: '+1',
             },
             {
-                label: '{% jstrans "Maximum Cost" %}',
+                label: '{% trans "Maximum Cost" %}',
                 data: cost_max_data,
                 backgroundColor: 'rgba(220, 160, 80, 0.25)',
                 borderWidth: 2,
@@ -1047,7 +1047,7 @@ function loadPartStocktakeTable(partId, options={}) {
         showColumns: true,
         sortable: true,
         formatNoMatches: function() {
-            return '{% jstrans "No stocktake information available" %}';
+            return '{% trans "No stocktake information available" %}';
         },
         onLoadSuccess: function(response) {
             var data = response.results || response;
@@ -1057,19 +1057,19 @@ function loadPartStocktakeTable(partId, options={}) {
         columns: [
             {
                 field: 'item_count',
-                title: '{% jstrans "Stock Items" %}',
+                title: '{% trans "Stock Items" %}',
                 switchable: true,
                 sortable: true,
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Total Quantity" %}',
+                title: '{% trans "Total Quantity" %}',
                 switchable: false,
                 sortable: true,
             },
             {
                 field: 'cost',
-                title: '{% jstrans "Total Cost" %}',
+                title: '{% trans "Total Cost" %}',
                 switchable: false,
                 formatter: function(value, row) {
                     return formatPriceRange(row.cost_min, row.cost_max);
@@ -1077,12 +1077,12 @@ function loadPartStocktakeTable(partId, options={}) {
             },
             {
                 field: 'note',
-                title: '{% jstrans "Notes" %}',
+                title: '{% trans "Notes" %}',
                 switchable: true,
             },
             {
                 field: 'date',
-                title: '{% jstrans "Date" %}',
+                title: '{% trans "Date" %}',
                 switchable: false,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1105,11 +1105,11 @@ function loadPartStocktakeTable(partId, options={}) {
                     let html = '';
 
                     if (options.allow_edit) {
-                        html += makeEditButton('button-edit-stocktake', row.pk, '{% jstrans "Edit Stocktake Entry" %}');
+                        html += makeEditButton('button-edit-stocktake', row.pk, '{% trans "Edit Stocktake Entry" %}');
                     }
 
                     if (options.allow_delete) {
-                        html += makeDeleteButton('button-delete-stocktake', row.pk, '{% jstrans "Delete Stocktake Entry" %}');
+                        html += makeDeleteButton('button-delete-stocktake', row.pk, '{% trans "Delete Stocktake Entry" %}');
                     }
 
                     return wrapButtons(html);
@@ -1141,7 +1141,7 @@ function loadPartStocktakeTable(partId, options={}) {
                             icon: 'fa-sticky-note',
                         },
                     },
-                    title: '{% jstrans "Edit Stocktake Entry" %}',
+                    title: '{% trans "Edit Stocktake Entry" %}',
                     refreshTable: table,
                 });
             });
@@ -1151,7 +1151,7 @@ function loadPartStocktakeTable(partId, options={}) {
 
                 constructForm(`{% url "api-part-stocktake-list" %}${pk}/`, {
                     method: 'DELETE',
-                    title: '{% jstrans "Delete Stocktake Entry" %}',
+                    title: '{% trans "Delete Stocktake Entry" %}',
                     refreshTable: table,
                 });
             });
@@ -1183,7 +1183,7 @@ function loadPartVariantTable(table, partId, options={}) {
         },
         {
             field: 'name',
-            title: '{% jstrans "Name" %}',
+            title: '{% trans "Name" %}',
             switchable: false,
             sortable: true,
             formatter: function(value, row) {
@@ -1199,23 +1199,23 @@ function loadPartVariantTable(table, partId, options={}) {
                 html += renderLink(name, `/part/${row.pk}/`);
 
                 if (row.trackable) {
-                    html += makeIconBadge('fa-directions', '{% jstrans "Trackable part" %}');
+                    html += makeIconBadge('fa-directions', '{% trans "Trackable part" %}');
                 }
 
                 if (row.virtual) {
-                    html += makeIconBadge('fa-ghost', '{% jstrans "Virtual part" %}');
+                    html += makeIconBadge('fa-ghost', '{% trans "Virtual part" %}');
                 }
 
                 if (row.is_template) {
-                    html += makeIconBadge('fa-clone', '{% jstrans "Template part" %}');
+                    html += makeIconBadge('fa-clone', '{% trans "Template part" %}');
                 }
 
                 if (row.assembly) {
-                    html += makeIconBadge('fa-tools', '{% jstrans "Assembled part" %}');
+                    html += makeIconBadge('fa-tools', '{% trans "Assembled part" %}');
                 }
 
                 if (!row.active) {
-                    html += `<span class='badge badge-right rounded-pill bg-warning'>{% jstrans "Inactive" %}</span>`;
+                    html += `<span class='badge badge-right rounded-pill bg-warning'>{% trans "Inactive" %}</span>`;
                 }
 
                 return html;
@@ -1223,23 +1223,23 @@ function loadPartVariantTable(table, partId, options={}) {
         },
         {
             field: 'IPN',
-            title: '{% jstrans "IPN" %}',
+            title: '{% trans "IPN" %}',
             sortable: true,
         },
         {
             field: 'revision',
-            title: '{% jstrans "Revision" %}',
+            title: '{% trans "Revision" %}',
             switchable: global_settings.PART_ENABLE_REVISION,
             visible: global_settings.PART_ENABLE_REVISION,
             sortable: true,
         },
         {
             field: 'description',
-            title: '{% jstrans "Description" %}',
+            title: '{% trans "Description" %}',
         },
         {
             field: 'total_in_stock',
-            title: '{% jstrans "Stock" %}',
+            title: '{% trans "Stock" %}',
             sortable: true,
             formatter: function(value, row) {
 
@@ -1253,7 +1253,7 @@ function loadPartVariantTable(table, partId, options={}) {
 
                 if (row.variant_stock > 0) {
                     text = `<em>${text}</em>`;
-                    text += `<span title='{% jstrans "Includes variant stock" %}' class='fas fa-info-circle float-right icon-blue'></span>`;
+                    text += `<span title='{% trans "Includes variant stock" %}' class='fas fa-info-circle float-right icon-blue'></span>`;
                 }
 
                 return text;
@@ -1261,7 +1261,7 @@ function loadPartVariantTable(table, partId, options={}) {
         },
         {
             field: 'price_range',
-            title: '{% jstrans "Price Range" %}',
+            title: '{% trans "Price Range" %}',
             formatter: function(value, row) {
                 return formatPriceRange(
                     row.pricing_min,
@@ -1278,7 +1278,7 @@ function loadPartVariantTable(table, partId, options={}) {
         original: params,
         queryParams: filters,
         formatNoMatches: function() {
-            return '{% jstrans "No variants found" %}';
+            return '{% trans "No variants found" %}';
         },
         columns: cols,
         treeEnable: true,
@@ -1419,7 +1419,7 @@ function createPartParameter(part_id, options={}) {
     }
 
     options.method = 'POST';
-    options.title = '{% jstrans "Add Parameter" %}';
+    options.title = '{% trans "Add Parameter" %}';
 
     constructForm('{% url "api-part-parameter-list" %}', options);
 }
@@ -1430,7 +1430,7 @@ function createPartParameter(part_id, options={}) {
  */
 function editPartParameter(param_id, options={}) {
     options.fields = partParameterFields();
-    options.title = '{% jstrans "Edit Parameter" %}';
+    options.title = '{% trans "Edit Parameter" %}';
     options.focus = 'data';
 
     options.processBeforeUpload = function(data) {
@@ -1461,7 +1461,7 @@ function loadPartParameterTable(table, options) {
         name: 'partparameters',
         groupBy: false,
         formatNoMatches: function() {
-            return '{% jstrans "No parameters found" %}';
+            return '{% trans "No parameters found" %}';
         },
         columns: [
             {
@@ -1471,7 +1471,7 @@ function loadPartParameterTable(table, options) {
             },
             {
                 field: 'name',
-                title: '{% jstrans "Name" %}',
+                title: '{% trans "Name" %}',
                 switchable: false,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1480,7 +1480,7 @@ function loadPartParameterTable(table, options) {
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
                 switchable: true,
                 sortable: false,
                 formatter: function(value, row) {
@@ -1489,7 +1489,7 @@ function loadPartParameterTable(table, options) {
             },
             {
                 field: 'data',
-                title: '{% jstrans "Value" %}',
+                title: '{% trans "Value" %}',
                 switchable: false,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1508,7 +1508,7 @@ function loadPartParameterTable(table, options) {
             },
             {
                 field: 'units',
-                title: '{% jstrans "Units" %}',
+                title: '{% trans "Units" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1524,8 +1524,8 @@ function loadPartParameterTable(table, options) {
                     let pk = row.pk;
                     let html = '';
 
-                    html += makeEditButton('button-parameter-edit', pk, '{% jstrans "Edit parameter" %}');
-                    html += makeDeleteButton('button-parameter-delete', pk, '{% jstrans "Delete parameter" %}');
+                    html += makeEditButton('button-parameter-edit', pk, '{% trans "Edit parameter" %}');
+                    html += makeDeleteButton('button-parameter-delete', pk, '{% trans "Delete parameter" %}');
 
                     return wrapButtons(html);
                 }
@@ -1546,7 +1546,7 @@ function loadPartParameterTable(table, options) {
 
                 constructForm(`{% url "api-part-parameter-list" %}${pk}/`, {
                     method: 'DELETE',
-                    title: '{% jstrans "Delete Parameter" %}',
+                    title: '{% trans "Delete Parameter" %}',
                     refreshTable: table,
                 });
             });
@@ -1596,35 +1596,35 @@ function loadPartParameterTemplateTable(table, options={}) {
         sidePagination: 'server',
         name: 'part-parameter-templates',
         formatNoMatches: function() {
-            return '{% jstrans "No part parameter templates found" %}';
+            return '{% trans "No part parameter templates found" %}';
         },
         columns: [
             {
                 field: 'pk',
-                title: '{% jstrans "ID" %}',
+                title: '{% trans "ID" %}',
                 visible: false,
                 switchable: false,
             },
             {
                 field: 'name',
-                title: '{% jstrans "Name" %}',
+                title: '{% trans "Name" %}',
                 sortable: true,
             },
             {
                 field: 'units',
-                title: '{% jstrans "Units" %}',
+                title: '{% trans "Units" %}',
                 sortable: true,
                 switchable: true,
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
                 sortable: false,
                 switchable: true,
             },
             {
                 field: 'checkbox',
-                title: '{% jstrans "Checkbox" %}',
+                title: '{% trans "Checkbox" %}',
                 sortable: false,
                 switchable: true,
                 formatter: function(value) {
@@ -1633,7 +1633,7 @@ function loadPartParameterTemplateTable(table, options={}) {
             },
             {
                 field: 'choices',
-                title: '{% jstrans "Choices" %}',
+                title: '{% trans "Choices" %}',
                 sortable: false,
                 switchable: true,
             },
@@ -1642,8 +1642,8 @@ function loadPartParameterTemplateTable(table, options={}) {
 
                     let buttons = '';
 
-                    buttons += makeEditButton('template-edit', row.pk, '{% jstrans "Edit Template" %}');
-                    buttons += makeDeleteButton('template-delete', row.pk, '{% jstrans "Delete Template" %}');
+                    buttons += makeEditButton('template-edit', row.pk, '{% trans "Edit Template" %}');
+                    buttons += makeDeleteButton('template-delete', row.pk, '{% trans "Delete Template" %}');
 
                     return wrapButtons(buttons);
                 }
@@ -1659,7 +1659,7 @@ function loadPartParameterTemplateTable(table, options={}) {
             `/api/part/parameter/template/${pk}/`,
             {
                 fields: partParameterTemplateFields(),
-                title: '{% jstrans "Edit Part Parameter Template" %}',
+                title: '{% trans "Edit Part Parameter Template" %}',
                 refreshTable: table,
             }
         );
@@ -1671,7 +1671,7 @@ function loadPartParameterTemplateTable(table, options={}) {
 
         var html = `
         <div class='alert alert-block alert-danger'>
-            {% jstrans "Any parameters which reference this template will also be deleted" %}
+            {% trans "Any parameters which reference this template will also be deleted" %}
         </div>`;
 
         constructForm(
@@ -1679,7 +1679,7 @@ function loadPartParameterTemplateTable(table, options={}) {
             {
                 method: 'DELETE',
                 preFormContent: html,
-                title: '{% jstrans "Delete Part Parameter Template" %}',
+                title: '{% trans "Delete Part Parameter Template" %}',
                 refreshTable: table,
             }
         );
@@ -1713,7 +1713,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
         showColumns: true,
         uniqueId: 'pk',
         formatNoMatches: function() {
-            return '{% jstrans "No purchase orders found" %}';
+            return '{% trans "No purchase orders found" %}';
         },
         onPostBody: function() {
             $(table).find('.button-line-receive').click(function() {
@@ -1742,7 +1742,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
         columns: [
             {
                 field: 'order',
-                title: '{% jstrans "Purchase Order" %}',
+                title: '{% trans "Purchase Order" %}',
                 switchable: false,
                 formatter: function(value, row) {
                     var order = row.order_detail;
@@ -1765,7 +1765,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
             },
             {
                 field: 'supplier',
-                title: '{% jstrans "Supplier" %}',
+                title: '{% trans "Supplier" %}',
                 switchable: true,
                 formatter: function(value, row) {
 
@@ -1783,7 +1783,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
             },
             {
                 field: 'sku',
-                title: '{% jstrans "SKU" %}',
+                title: '{% trans "SKU" %}',
                 switchable: true,
                 formatter: function(value, row) {
                     if (row.supplier_part_detail) {
@@ -1797,7 +1797,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
             },
             {
                 field: 'mpn',
-                title: '{% jstrans "MPN" %}',
+                title: '{% trans "MPN" %}',
                 switchable: true,
                 formatter: function(value, row) {
                     if (row.supplier_part_detail && row.supplier_part_detail.manufacturer_part_detail) {
@@ -1808,7 +1808,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Quantity" %}',
+                title: '{% trans "Quantity" %}',
                 formatter: function(value, row) {
                     let data = value;
 
@@ -1818,7 +1818,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
 
                         data += makeIconBadge(
                             'fa-info-circle icon-blue',
-                            `{% jstrans "Pack Quantity" %}: ${pq} - {% jstrans "Total Quantity" %}: ${total}`
+                            `{% trans "Pack Quantity" %}: ${pq} - {% trans "Total Quantity" %}: ${total}`
                         );
                     }
 
@@ -1827,7 +1827,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
             },
             {
                 field: 'target_date',
-                title: '{% jstrans "Target Date" %}',
+                title: '{% trans "Target Date" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1857,7 +1857,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
                     if (overdue) {
                         html += makeIconBadge(
                             'fa-calendar-alt icon-red',
-                            '{% jstrans "This line item is overdue" %}',
+                            '{% trans "This line item is overdue" %}',
                         );
                     }
 
@@ -1866,7 +1866,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
             },
             {
                 field: 'received',
-                title: '{% jstrans "Received" %}',
+                title: '{% trans "Received" %}',
                 switchable: true,
                 formatter: function(value, row) {
                     var data = value;
@@ -1874,7 +1874,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
                     if (value > 0 && row.supplier_part_detail && row.supplier_part_detail.pack_quantity_native != 1.0) {
                         let pq = row.supplier_part_detail.pack_quantity_native;
                         let total = value * pq;
-                        data += `<span class='fas fa-info-circle icon-blue float-right' title='{% jstrans "Pack Quantity" %}: ${pq} - {% jstrans "Total Quantity" %}: ${total}'></span>`;
+                        data += `<span class='fas fa-info-circle icon-blue float-right' title='{% trans "Pack Quantity" %}: ${pq} - {% trans "Total Quantity" %}: ${total}'></span>`;
                     }
 
                     return data;
@@ -1882,7 +1882,7 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
             },
             {
                 field: 'purchase_price',
-                title: '{% jstrans "Price" %}',
+                title: '{% trans "Price" %}',
                 switchable: true,
                 formatter: function(value, row) {
                     return formatCurrency(row.purchase_price, {
@@ -1898,12 +1898,12 @@ function loadPartPurchaseOrderTable(table, part_id, options={}) {
 
                     if (row.received >= row.quantity) {
                         // Already received
-                        return `<span class='badge bg-success rounded-pill'>{% jstrans "Received" %}</span>`;
+                        return `<span class='badge bg-success rounded-pill'>{% trans "Received" %}</span>`;
                     } else if (row.order_detail && row.order_detail.status == {{ PurchaseOrderStatus.PLACED }}) {
                         let html = '';
                         var pk = row.pk;
 
-                        html += makeIconButton('fa-sign-in-alt', 'button-line-receive', pk, '{% jstrans "Receive line item" %}');
+                        html += makeIconButton('fa-sign-in-alt', 'button-line-receive', pk, '{% trans "Receive line item" %}');
 
                         return wrapButtons(html);
                     } else {
@@ -1940,7 +1940,7 @@ function loadRelatedPartsTable(table, part_id, options={}) {
     var columns = [
         {
             field: 'name',
-            title: '{% jstrans "Part" %}',
+            title: '{% trans "Part" %}',
             switchable: false,
             formatter: function(value, row) {
 
@@ -1955,7 +1955,7 @@ function loadRelatedPartsTable(table, part_id, options={}) {
         },
         {
             field: 'description',
-            title: '{% jstrans "Description" %}',
+            title: '{% trans "Description" %}',
             formatter: function(value, row) {
                 return getPart(row).description;
             }
@@ -1966,7 +1966,7 @@ function loadRelatedPartsTable(table, part_id, options={}) {
             switchable: false,
             formatter: function(value, row) {
                 let html = '';
-                html += makeDeleteButton('button-related-delete', row.pk, '{% jstrans "Delete part relationship" %}');
+                html += makeDeleteButton('button-related-delete', row.pk, '{% trans "Delete part relationship" %}');
 
                 return wrapButtons(html);
             }
@@ -1988,7 +1988,7 @@ function loadRelatedPartsTable(table, part_id, options={}) {
 
                 constructForm(`{% url "api-part-related-list" %}${pk}/`, {
                     method: 'DELETE',
-                    title: '{% jstrans "Delete Part Relationship" %}',
+                    title: '{% trans "Delete Part Relationship" %}',
                     refreshTable: table,
                 });
             });
@@ -2012,7 +2012,7 @@ function loadParametricPartTable(table, options={}) {
     var columns = [
         {
             field: 'name',
-            title: '{% jstrans "Part" %}',
+            title: '{% trans "Part" %}',
             switchable: false,
             sortable: true,
             formatter: function(value, row) {
@@ -2076,7 +2076,7 @@ function loadParametricPartTable(table, options={}) {
         groupBy: false,
         name: options.name || 'part-parameters',
         formatNoMatches: function() {
-            return '{% jstrans "No parts found" %}';
+            return '{% trans "No parts found" %}';
         },
         // TODO: Re-enable filter control for parameter values
         // Ref: https://github.com/inventree/InvenTree/issues/4851
@@ -2137,19 +2137,19 @@ function partGridTile(part) {
     var stock = `${part.in_stock} ${units}`;
 
     if (!part.in_stock) {
-        stock = `<span class='badge rounded-pill bg-danger'>{% jstrans "No Stock" %}</span>`;
+        stock = `<span class='badge rounded-pill bg-danger'>{% trans "No Stock" %}</span>`;
     } else if (!part.unallocated_stock) {
-        stock = `<span class='badge rounded-pill bg-warning'>{% jstrans "No Stock" %}</span>`;
+        stock = `<span class='badge rounded-pill bg-warning'>{% trans "No Stock" %}</span>`;
     }
 
-    rows += `<tr><td><b>{% jstrans "Stock" %}</b></td><td>${stock}</td></tr>`;
+    rows += `<tr><td><b>{% trans "Stock" %}</b></td><td>${stock}</td></tr>`;
 
     if (part.ordering) {
-        rows += `<tr><td><b>{% jstrans "On Order" %}</b></td><td>${part.ordering} ${units}</td></tr>`;
+        rows += `<tr><td><b>{% trans "On Order" %}</b></td><td>${part.ordering} ${units}</td></tr>`;
     }
 
     if (part.building) {
-        rows += `<tr><td><b>{% jstrans "Building" %}</b></td><td>${part.building} ${units}</td></tr>`;
+        rows += `<tr><td><b>{% trans "Building" %}</b></td><td>${part.building} ${units}</td></tr>`;
     }
 
     var html = `
@@ -2197,12 +2197,12 @@ function setPartCategory(data, options={}) {
 
     var html = `
     <div class='alert alert-block alert-info'>
-        {% jstrans "Set the part category for the selected parts" %}
+        {% trans "Set the part category for the selected parts" %}
     </div>
     `;
 
     constructForm('{% url "api-part-change-category" %}',{
-        title: '{% jstrans "Set Part Category" %}',
+        title: '{% trans "Set Part Category" %}',
         method: 'POST',
         preFormContent: html,
         fields: {
@@ -2232,7 +2232,7 @@ function makePartActions(table) {
     return [
         {
             label: 'set-category',
-            title: '{% jstrans "Set category" %}',
+            title: '{% trans "Set category" %}',
             icon: 'fa-sitemap',
             permission: 'part.change',
             callback: function(data) {
@@ -2241,7 +2241,7 @@ function makePartActions(table) {
         },
         {
             label: 'order',
-            title: '{% jstrans "Order parts" %}',
+            title: '{% trans "Order parts" %}',
             icon: 'fa-shopping-cart',
             permission: 'purchase_order.add',
             callback: function(data) {
@@ -2284,13 +2284,13 @@ function loadPartTable(table, url, options={}) {
                 url: '{% url "api-part-label-list" %}',
                 key: 'part',
             },
-            singular_name: '{% jstrans "part" %}',
-            plural_name: '{% jstrans "parts" %}',
+            singular_name: '{% trans "part" %}',
+            plural_name: '{% trans "parts" %}',
             custom_actions: [
                 {
                     label: 'parts',
                     icon: 'fa-tools',
-                    title: '{% jstrans "Part actions" %}',
+                    title: '{% trans "Part actions" %}',
                     actions: makePartActions(table),
                 }
             ]
@@ -2313,7 +2313,7 @@ function loadPartTable(table, url, options={}) {
     if (options.checkbox) {
         columns.push({
             checkbox: true,
-            title: '{% jstrans "Select" %}',
+            title: '{% trans "Select" %}',
             searchable: false,
             switchable: false,
         });
@@ -2321,7 +2321,7 @@ function loadPartTable(table, url, options={}) {
 
     columns.push({
         field: 'name',
-        title: '{% jstrans "Part" %}',
+        title: '{% trans "Part" %}',
         switchable: false,
         sortable: !options.params.ordering,
         formatter: function(value, row) {
@@ -2338,13 +2338,13 @@ function loadPartTable(table, url, options={}) {
 
     columns.push({
         field: 'IPN',
-        title: '{% jstrans "IPN" %}',
+        title: '{% trans "IPN" %}',
         sortable: !options.params.ordering
     });
 
     columns.push({
         field: 'revision',
-        title: '{% jstrans "Revision" %}',
+        title: '{% trans "Revision" %}',
         switchable: global_settings.PART_ENABLE_REVISION,
         visible: global_settings.PART_ENABLE_REVISION,
         sortable: true,
@@ -2352,7 +2352,7 @@ function loadPartTable(table, url, options={}) {
 
     columns.push({
         field: 'description',
-        title: '{% jstrans "Description" %}',
+        title: '{% trans "Description" %}',
         formatter: function(value, row) {
 
             var text = shortenString(value);
@@ -2367,21 +2367,21 @@ function loadPartTable(table, url, options={}) {
 
     columns.push({
         field: 'units',
-        title: '{% jstrans "Units" %}',
+        title: '{% trans "Units" %}',
         sortable: true,
     });
 
     columns.push({
         sortName: 'category',
         field: 'category_detail',
-        title: '{% jstrans "Category" %}',
+        title: '{% trans "Category" %}',
         sortable: true,
         formatter: function(value, row) {
             if (row.category && row.category_detail) {
                 var text = shortenString(row.category_detail.pathstring);
                 return withTitle(renderLink(text, `/part/category/${row.category}/`), row.category_detail.pathstring);
             } else {
-                return '<em>{% jstrans "No category" %}</em>';
+                return '<em>{% trans "No category" %}</em>';
             }
         }
     });
@@ -2389,7 +2389,7 @@ function loadPartTable(table, url, options={}) {
 
     columns.push({
         field: 'total_in_stock',
-        title: '{% jstrans "Stock" %}',
+        title: '{% trans "Stock" %}',
         sortable: true,
         formatter: function(value, row) {
 
@@ -2441,7 +2441,7 @@ function loadPartTable(table, url, options={}) {
     columns.push({
         field: 'pricing_min',
         sortable: false,
-        title: '{% jstrans "Price Range" %}',
+        title: '{% trans "Price Range" %}',
         formatter: function(value, row) {
             return formatPriceRange(
                 row.pricing_min,
@@ -2453,7 +2453,7 @@ function loadPartTable(table, url, options={}) {
     // External link / URL
     columns.push({
         field: 'link',
-        title: '{% jstrans "Link" %}',
+        title: '{% trans "Link" %}',
         formatter: function(value) {
             return renderLink(
                 value,
@@ -2468,7 +2468,7 @@ function loadPartTable(table, url, options={}) {
 
     columns.push({
         field: 'last_stocktake',
-        title: '{% jstrans "Last Stocktake" %}',
+        title: '{% trans "Last Stocktake" %}',
         sortable: true,
         switchable: true,
         formatter: function(value) {
@@ -2503,7 +2503,7 @@ function loadPartTable(table, url, options={}) {
         sidePagination: 'server',
         pagination: 'true',
         formatNoMatches: function() {
-            return '{% jstrans "No parts found" %}';
+            return '{% trans "No parts found" %}';
         },
         columns: columns,
         showColumns: true,
@@ -2528,7 +2528,7 @@ function loadPartTable(table, url, options={}) {
             {
                 icon: 'fas fa-bars',
                 attributes: {
-                    title: '{% jstrans "Display as list" %}',
+                    title: '{% trans "Display as list" %}',
                     id: 'view-part-list',
                 },
                 event: () => {
@@ -2544,7 +2544,7 @@ function loadPartTable(table, url, options={}) {
             {
                 icon: 'fas fa-th',
                 attributes: {
-                    title: '{% jstrans "Display as grid" %}',
+                    title: '{% trans "Display as grid" %}',
                     id: 'view-part-grid',
                 },
                 event: () => {
@@ -2642,7 +2642,7 @@ function loadPartCategoryTable(table, options) {
         parentIdField: tree_view ? 'parent' : null,
         method: 'get',
         formatNoMatches: function() {
-            return '{% jstrans "No subcategories found" %}';
+            return '{% trans "No subcategories found" %}';
         },
         url: options.url || '{% url "api-part-category-list" %}',
         queryParams: filters,
@@ -2658,7 +2658,7 @@ function loadPartCategoryTable(table, options) {
             {
                 icon: 'fas fa-bars',
                 attributes: {
-                    title: '{% jstrans "Display as list" %}',
+                    title: '{% trans "Display as list" %}',
                     id: 'view-category-list',
                 },
                 event: () => {
@@ -2678,7 +2678,7 @@ function loadPartCategoryTable(table, options) {
             {
                 icon: 'fas fa-sitemap',
                 attributes: {
-                    title: '{% jstrans "Display as tree" %}',
+                    title: '{% trans "Display as tree" %}',
                     id: 'view-category-tree',
                 },
                 event: () => {
@@ -2739,14 +2739,14 @@ function loadPartCategoryTable(table, options) {
         columns: [
             {
                 checkbox: true,
-                title: '{% jstrans "Select" %}',
+                title: '{% trans "Select" %}',
                 searchable: false,
                 switchable: false,
                 visible: false,
             },
             {
                 field: 'name',
-                title: '{% jstrans "Name" %}',
+                title: '{% trans "Name" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
@@ -2758,7 +2758,7 @@ function loadPartCategoryTable(table, options) {
                         } else {
                             html += `
                                 <a href='#' pk='${row.pk}' class='load-sub-category'>
-                                    <span class='fas fa-sync-alt' title='{% jstrans "Load Subcategories" %}'></span>
+                                    <span class='fas fa-sync-alt' title='{% trans "Load Subcategories" %}'></span>
                                 </a> `;
                         }
                     }
@@ -2774,7 +2774,7 @@ function loadPartCategoryTable(table, options) {
                     );
 
                     if (row.starred) {
-                        html += makeIconBadge('fa-bell icon-green', '{% jstrans "Subscribed category" %}');
+                        html += makeIconBadge('fa-bell icon-green', '{% trans "Subscribed category" %}');
                     }
 
                     return html;
@@ -2782,7 +2782,7 @@ function loadPartCategoryTable(table, options) {
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
                 switchable: true,
                 sortable: false,
                 formatter: function(value) {
@@ -2791,7 +2791,7 @@ function loadPartCategoryTable(table, options) {
             },
             {
                 field: 'pathstring',
-                title: '{% jstrans "Path" %}',
+                title: '{% trans "Path" %}',
                 switchable: !tree_view,
                 visible: !tree_view,
                 sortable: true,
@@ -2801,7 +2801,7 @@ function loadPartCategoryTable(table, options) {
             },
             {
                 field: 'part_count',
-                title: '{% jstrans "Parts" %}',
+                title: '{% trans "Parts" %}',
                 switchable: true,
                 sortable: true,
             }
@@ -2851,7 +2851,7 @@ function loadPartTestTemplateTable(table, options) {
     table.inventreeTable({
         method: 'get',
         formatNoMatches: function() {
-            return '{% jstrans "No test templates matching query" %}';
+            return '{% trans "No test templates matching query" %}';
         },
         url: '{% url "api-part-test-template-list" %}',
         queryParams: filters,
@@ -2865,16 +2865,16 @@ function loadPartTestTemplateTable(table, options) {
             },
             {
                 field: 'test_name',
-                title: '{% jstrans "Test Name" %}',
+                title: '{% trans "Test Name" %}',
                 sortable: true,
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
             },
             {
                 field: 'required',
-                title: '{% jstrans "Required" %}',
+                title: '{% trans "Required" %}',
                 sortable: true,
                 formatter: function(value) {
                     return yesNoLabel(value);
@@ -2882,14 +2882,14 @@ function loadPartTestTemplateTable(table, options) {
             },
             {
                 field: 'requires_value',
-                title: '{% jstrans "Requires Value" %}',
+                title: '{% trans "Requires Value" %}',
                 formatter: function(value) {
                     return yesNoLabel(value);
                 }
             },
             {
                 field: 'requires_attachment',
-                title: '{% jstrans "Requires Attachment" %}',
+                title: '{% trans "Requires Attachment" %}',
                 formatter: function(value) {
                     return yesNoLabel(value);
                 }
@@ -2902,12 +2902,12 @@ function loadPartTestTemplateTable(table, options) {
                     if (row.part == part) {
                         let html = '';
 
-                        html += makeEditButton('button-test-edit', pk, '{% jstrans "Edit test result" %}');
-                        html += makeDeleteButton('button-test-delete', pk, '{% jstrans "Delete test result" %}');
+                        html += makeEditButton('button-test-edit', pk, '{% trans "Edit test result" %}');
+                        html += makeDeleteButton('button-test-delete', pk, '{% trans "Delete test result" %}');
 
                         return wrapButtons(html);
                     } else {
-                        var text = '{% jstrans "This test is defined for a parent part" %}';
+                        var text = '{% trans "This test is defined for a parent part" %}';
 
                         return renderLink(text, `/part/${row.part}/tests/`);
                     }
@@ -2923,7 +2923,7 @@ function loadPartTestTemplateTable(table, options) {
 
                 constructForm(url, {
                     fields: partTestTemplateFields(),
-                    title: '{% jstrans "Edit Test Result Template" %}',
+                    title: '{% trans "Edit Test Result Template" %}',
                     onSuccess: function() {
                         table.bootstrapTable('refresh');
                     },
@@ -2937,7 +2937,7 @@ function loadPartTestTemplateTable(table, options) {
 
                 constructForm(url, {
                     method: 'DELETE',
-                    title: '{% jstrans "Delete Test Result Template" %}',
+                    title: '{% trans "Delete Test Result Template" %}',
                     refreshTable: table,
                 });
             });
@@ -3016,16 +3016,16 @@ function loadPartSchedulingChart(canvas_id, part_id) {
                     var date_string = entry.date;
 
                     if (date == null) {
-                        date_string = '<em>{% jstrans "No date specified" %}</em>';
-                        date_string += makeIconBadge('fa-exclamation-circle icon-red', '{% jstrans "No date specified" %}');
+                        date_string = '<em>{% trans "No date specified" %}</em>';
+                        date_string += makeIconBadge('fa-exclamation-circle icon-red', '{% trans "No date specified" %}');
                     } else if (date < today) {
-                        date_string += makeIconBadge('fa-exclamation-circle icon-yellow', '{% jstrans "Specified date is in the past" %}');
+                        date_string += makeIconBadge('fa-exclamation-circle icon-yellow', '{% trans "Specified date is in the past" %}');
                     }
 
                     var quantity_string = entry.quantity + entry.speculative_quantity;
 
                     if (entry.speculative_quantity != 0) {
-                        quantity_string += makeIconBadge('fa-question-circle icon-blue', '{% jstrans "Speculative" %}');
+                        quantity_string += makeIconBadge('fa-question-circle icon-blue', '{% trans "Speculative" %}');
                     }
 
                     // Add an entry to the scheduling table
@@ -3075,13 +3075,13 @@ function loadPartSchedulingChart(canvas_id, part_id) {
 
         var message = `
         <div class='alert alert-block alert-info'>
-            {% jstrans "No scheduling information available for this part" %}.
+            {% trans "No scheduling information available for this part" %}.
         </div>`;
 
         if (was_error) {
             message = `
                 <div class='alert alert-block alert-danger'>
-                    {% jstrans "Error fetching scheduling information for this part" %}.
+                    {% trans "Error fetching scheduling information for this part" %}.
                 </div>
             `;
         }
@@ -3177,14 +3177,14 @@ function loadPartSchedulingChart(canvas_id, part_id) {
     var data = {
         datasets: [
             {
-                label: '{% jstrans "Scheduled Stock Quantities" %}',
+                label: '{% trans "Scheduled Stock Quantities" %}',
                 data: quantity_scheduled,
                 backgroundColor: 'rgba(160, 80, 220, 0.75)',
                 borderWidth: 3,
                 borderColor: 'rgb(160, 80, 220)'
             },
             {
-                label: '{% jstrans "Minimum Quantity" %}',
+                label: '{% trans "Minimum Quantity" %}',
                 data: q_spec_min,
                 backgroundColor: 'rgba(220, 160, 80, 0.25)',
                 borderWidth: 2,
@@ -3193,7 +3193,7 @@ function loadPartSchedulingChart(canvas_id, part_id) {
                 fill: '-1',
             },
             {
-                label: '{% jstrans "Maximum Quantity" %}',
+                label: '{% trans "Maximum Quantity" %}',
                 data: q_spec_max,
                 backgroundColor: 'rgba(220, 160, 80, 0.25)',
                 borderWidth: 2,
@@ -3238,7 +3238,7 @@ function loadPartSchedulingChart(canvas_id, part_id) {
 
         data.datasets.push({
             data: minimum_stock_curve,
-            label: '{% jstrans "Minimum Stock Level" %}',
+            label: '{% trans "Minimum Stock Level" %}',
             backgroundColor: 'rgba(250, 50, 50, 0.1)',
             borderColor: 'rgba(250, 50, 50, 0.5)',
             borderDash: [5, 5],
@@ -3307,7 +3307,7 @@ function loadPartSchedulingChart(canvas_id, part_id) {
                                 delta = ` (${item.raw.delta > 0 ? '+' : ''}${item.raw.delta})`;
                             }
 
-                            return `{% jstrans "Quantity" %}: ${item.raw.y}${delta}`;
+                            return `{% trans "Quantity" %}: ${item.raw.y}${delta}`;
                         }
                     }
                 },

--- a/InvenTree/templates/js/translated/plugin.js
+++ b/InvenTree/templates/js/translated/plugin.js
@@ -43,33 +43,33 @@ function loadPluginTable(table, options={}) {
         queryParams: filters,
         sortable: true,
         formatNoMatches: function() {
-            return '{% jstrans "No plugins found" %}';
+            return '{% trans "No plugins found" %}';
         },
         columns: [
             {
                 field: 'name',
-                title: '{% jstrans "Plugin" %}',
+                title: '{% trans "Plugin" %}',
                 sortable: true,
                 switchable: false,
                 formatter: function(value, row) {
                     let html = '';
 
                     if (!row.is_installed) {
-                        html += `<span class='fa fa-question-circle' title='{% jstrans "This plugin is no longer installed" %}'></span>`;
+                        html += `<span class='fa fa-question-circle' title='{% trans "This plugin is no longer installed" %}'></span>`;
                     } else if (row.active) {
-                        html += `<span class='fa fa-check-circle icon-green' title='{% jstrans "This plugin is active" %}'></span>`;
+                        html += `<span class='fa fa-check-circle icon-green' title='{% trans "This plugin is active" %}'></span>`;
                     } else {
-                        html += `<span class='fa fa-times-circle icon-red' title ='{% jstrans "This plugin is installed but not active" %}'></span>`;
+                        html += `<span class='fa fa-times-circle icon-red' title ='{% trans "This plugin is installed but not active" %}'></span>`;
                     }
 
                     html += `&nbsp;<span>${value}</span>`;
 
                     if (row.is_builtin) {
-                        html += `<span class='badge bg-success rounded-pill badge-right'>{% jstrans "Builtin" %}</span>`;
+                        html += `<span class='badge bg-success rounded-pill badge-right'>{% trans "Builtin" %}</span>`;
                     }
 
                     if (row.is_sample) {
-                        html += `<span class='badge bg-info rounded-pill badge-right'>{% jstrans "Sample" %}</span>`;
+                        html += `<span class='badge bg-info rounded-pill badge-right'>{% trans "Sample" %}</span>`;
                     }
 
                     return html;
@@ -77,13 +77,13 @@ function loadPluginTable(table, options={}) {
             },
             {
                 field: 'meta.description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
                 sortable: false,
                 switchable: true,
             },
             {
                 field: 'meta.version',
-                title: '{% jstrans "Version" %}',
+                title: '{% trans "Version" %}',
                 formatter: function(value, row) {
                     if (value) {
                         let html = value;
@@ -100,7 +100,7 @@ function loadPluginTable(table, options={}) {
             },
             {
                 field: 'meta.author',
-                title: '{% jstrans "Author" %}',
+                title: '{% trans "Author" %}',
                 sortable: false,
             },
             {
@@ -114,9 +114,9 @@ function loadPluginTable(table, options={}) {
                     // Check if custom plugins are enabled for this instance
                     if (options.custom && !row.is_builtin && row.is_installed) {
                         if (row.active) {
-                            buttons += makeIconButton('fa-stop-circle icon-red', 'btn-plugin-disable', row.pk, '{% jstrans "Disable Plugin" %}');
+                            buttons += makeIconButton('fa-stop-circle icon-red', 'btn-plugin-disable', row.pk, '{% trans "Disable Plugin" %}');
                         } else {
-                            buttons += makeIconButton('fa-play-circle icon-green', 'btn-plugin-enable', row.pk, '{% jstrans "Enable Plugin" %}');
+                            buttons += makeIconButton('fa-play-circle icon-green', 'btn-plugin-enable', row.pk, '{% trans "Enable Plugin" %}');
                         }
                     }
 
@@ -148,14 +148,14 @@ function loadPluginTable(table, options={}) {
 function installPlugin() {
     constructForm(`/api/plugins/install/`, {
         method: 'POST',
-        title: '{% jstrans "Install Plugin" %}',
+        title: '{% trans "Install Plugin" %}',
         fields: {
             packagename: {},
             url: {},
             confirm: {},
         },
         onSuccess: function(data) {
-            let msg = '{% jstrans "The Plugin was installed" %}';
+            let msg = '{% trans "The Plugin was installed" %}';
             showMessage(msg, {style: 'success', details: data.result, timeout: 30000});
 
             // Reload the plugin table
@@ -174,19 +174,19 @@ function activatePlugin(plugin_id, active=true) {
 
     let html = active ? `
     <span class='alert alert-block alert-info'>
-    {% jstrans "Are you sure you want to enable this plugin?" %}
+    {% trans "Are you sure you want to enable this plugin?" %}
     </span>
     ` : `
     <span class='alert alert-block alert-danger'>
-    {% jstrans "Are you sure you want to disable this plugin?" %}
+    {% trans "Are you sure you want to disable this plugin?" %}
     </span>
     `;
 
     constructForm(null, {
-        title: active ? '{% jstrans "Enable Plugin" %}' : '{% jstrans "Disable Plugin" %}',
+        title: active ? '{% trans "Enable Plugin" %}' : '{% trans "Disable Plugin" %}',
         preFormContent: html,
         confirm: true,
-        submitText: active ? '{% jstrans "Enable" %}' : '{% jstrans "Disable" %}',
+        submitText: active ? '{% trans "Enable" %}' : '{% trans "Disable" %}',
         submitClass: active ? 'success' : 'danger',
         onSubmit: function(_fields, opts) {
             showModalSpinner(opts.modal);
@@ -200,7 +200,7 @@ function activatePlugin(plugin_id, active=true) {
                     method: 'PATCH',
                     success: function() {
                         $(opts.modal).modal('hide');
-                        addCachedAlert('{% jstrans "Plugin updated" %}', {style: 'success'});
+                        addCachedAlert('{% trans "Plugin updated" %}', {style: 'success'});
                         location.reload();
                     },
                     error: function(xhr) {
@@ -221,7 +221,7 @@ function reloadPlugins() {
     let url = '{% url "api-plugin-reload" %}';
 
     constructForm(url, {
-        title: '{% jstrans "Reload Plugins" %}',
+        title: '{% trans "Reload Plugins" %}',
         method: 'POST',
         confirm: true,
         fields: {

--- a/InvenTree/templates/js/translated/pricing.js
+++ b/InvenTree/templates/js/translated/pricing.js
@@ -156,7 +156,7 @@ function calculateTotalPrice(dataset, value_func, currency_func, options={}) {
 
     if (!rates) {
         console.error('Could not retrieve currency conversion information from the server');
-        return `<span class='icon-red fas fa-exclamation-circle' title='{% jstrans "Error fetching currency data" %}'></span>`;
+        return `<span class='icon-red fas fa-exclamation-circle' title='{% trans "Error fetching currency data" %}'></span>`;
     }
 
     if (!currency) {
@@ -318,7 +318,7 @@ function loadBomPricingChart(options={}) {
         search: false,
         showColumns: false,
         formatNoMatches: function() {
-            return '{% jstrans "No BOM data available" %}';
+            return '{% trans "No BOM data available" %}';
         },
         onLoadSuccess: function(data) {
             // Construct BOM pricing chart
@@ -350,12 +350,12 @@ function loadBomPricingChart(options={}) {
                 labels: graphLabels,
                 datasets: [
                     {
-                        label: '{% jstrans "Maximum Price" %}',
+                        label: '{% trans "Maximum Price" %}',
                         data: maxValues,
                         backgroundColor: colors,
                     },
                     {
-                        label: '{% jstrans "Minimum Price" %}',
+                        label: '{% trans "Minimum Price" %}',
                         data: minValues,
                         backgroundColor: colors,
                     },
@@ -366,7 +366,7 @@ function loadBomPricingChart(options={}) {
         columns: [
             {
                 field: 'sub_part',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     var url = `/part/${row.sub_part}/`;
@@ -378,17 +378,17 @@ function loadBomPricingChart(options={}) {
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Quantity" %}',
+                title: '{% trans "Quantity" %}',
                 sortable: true,
             },
             {
                 field: 'reference',
-                title: '{% jstrans "Reference" %}',
+                title: '{% trans "Reference" %}',
                 sortable: true,
             },
             {
                 field: 'pricing',
-                title: '{% jstrans "Price Range" %}',
+                title: '{% trans "Price Range" %}',
                 sortable: false,
                 formatter: function(value, row) {
                     var min_price = row.pricing_min;
@@ -460,7 +460,7 @@ function loadPartSupplierPricingTable(options={}) {
         search: false,
         showColumns: false,
         formatNoMatches: function() {
-            return '{% jstrans "No supplier pricing data available" %}';
+            return '{% trans "No supplier pricing data available" %}';
         },
         onLoadSuccess: function(data) {
             // Update supplier pricing chart
@@ -471,7 +471,7 @@ function loadPartSupplierPricingTable(options={}) {
             // Sort in increasing order of quantity
             data = data.sort((a, b) => (a.quantity - b.quantity));
 
-            var graphLabels = Array.from(data, (x) => (`${x.part_detail.SKU} - {% jstrans "Quantity" %} ${x.quantity}`));
+            var graphLabels = Array.from(data, (x) => (`${x.part_detail.SKU} - {% trans "Quantity" %} ${x.quantity}`));
             var graphValues = Array.from(data, (x) => (x.price / x.part_detail.pack_quantity_native));
 
             if (chart) {
@@ -482,7 +482,7 @@ function loadPartSupplierPricingTable(options={}) {
                 labels: graphLabels,
                 datasets: [
                     {
-                        label: '{% jstrans "Supplier Pricing" %}',
+                        label: '{% trans "Supplier Pricing" %}',
                         data: graphValues,
                         backgroundColor: 'rgba(255, 206, 86, 0.2)',
                         borderColor: 'rgb(255, 206, 86)',
@@ -495,7 +495,7 @@ function loadPartSupplierPricingTable(options={}) {
         columns: [
             {
                 field: 'supplier',
-                title: '{% jstrans "Supplier" %}',
+                title: '{% trans "Supplier" %}',
                 formatter: function(value, row) {
                     var html = '';
 
@@ -507,7 +507,7 @@ function loadPartSupplierPricingTable(options={}) {
             },
             {
                 field: 'sku',
-                title: '{% jstrans "SKU" %}',
+                title: '{% trans "SKU" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     return renderLink(
@@ -519,12 +519,12 @@ function loadPartSupplierPricingTable(options={}) {
             {
                 sortable: true,
                 field: 'quantity',
-                title: '{% jstrans "Quantity" %}',
+                title: '{% trans "Quantity" %}',
             },
             {
                 sortable: true,
                 field: 'price',
-                title: '{% jstrans "Unit Price" %}',
+                title: '{% trans "Unit Price" %}',
                 formatter: function(value, row) {
 
                     if (row.price == null) {
@@ -569,7 +569,7 @@ function loadPriceBreakTable(table, options={}) {
         pageSize: 10,
         method: 'get',
         formatNoMatches: function() {
-            return `{% jstrans "No price break data available" %}`;
+            return `{% trans "No price break data available" %}`;
         },
         queryParams: {
             part: options.part
@@ -593,7 +593,7 @@ function loadPriceBreakTable(table, options={}) {
                     labels: graphLabels,
                     datasets: [
                         {
-                            label: '{% jstrans "Unit Price" %}',
+                            label: '{% trans "Unit Price" %}',
                             data: graphData,
                             backgroundColor: 'rgba(255, 206, 86, 0.2)',
                             borderColor: 'rgb(255, 206, 86)',
@@ -613,20 +613,20 @@ function loadPriceBreakTable(table, options={}) {
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Quantity" %}',
+                title: '{% trans "Quantity" %}',
                 sortable: true,
             },
             {
                 field: 'price',
-                title: '{% jstrans "Price" %}',
+                title: '{% trans "Price" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     let html = formatCurrency(value, {currency: row.price_currency});
 
                     let buttons = '';
 
-                    buttons += makeEditButton(`button-${name}-edit`, row.pk, `{% jstrans "Edit" %} ${human_name}`);
-                    buttons += makeDeleteButton(`button-${name}-delete`, row.pk, `{% jstrans "Delete" %} ${human_name}"`);
+                    buttons += makeEditButton(`button-${name}-edit`, row.pk, `{% trans "Edit" %} ${human_name}`);
+                    buttons += makeDeleteButton(`button-${name}-delete`, row.pk, `{% trans "Delete" %} ${human_name}"`);
 
                     html += wrapButtons(buttons);
 
@@ -681,7 +681,7 @@ function initPriceBreakSet(table, options) {
                 },
             },
             method: 'POST',
-            title: '{% jstrans "Add Price Break" %}',
+            title: '{% trans "Add Price Break" %}',
             onSuccess: reloadPriceBreakTable,
         });
     });
@@ -691,7 +691,7 @@ function initPriceBreakSet(table, options) {
 
         constructForm(`${pb_url}${pk}/`, {
             method: 'DELETE',
-            title: '{% jstrans "Delete Price Break" %}',
+            title: '{% trans "Delete Price Break" %}',
             onSuccess: reloadPriceBreakTable,
         });
     });
@@ -709,7 +709,7 @@ function initPriceBreakSet(table, options) {
                     icon: 'fa-coins',
                 },
             },
-            title: '{% jstrans "Edit Price Break" %}',
+            title: '{% trans "Edit Price Break" %}',
             onSuccess: reloadPriceBreakTable,
         });
     });
@@ -752,7 +752,7 @@ function loadPurchasePriceHistoryTable(options={}) {
         search: false,
         showColumns: false,
         formatNoMatches: function() {
-            return '{% jstrans "No purchase history data available" %}';
+            return '{% trans "No purchase history data available" %}';
         },
         onLoadSuccess: function(data) {
             // Update purchase price history chart
@@ -788,7 +788,7 @@ function loadPurchasePriceHistoryTable(options={}) {
                 labels: graphLabels,
                 datasets: [
                     {
-                        label: '{% jstrans "Purchase Price History" %}',
+                        label: '{% trans "Purchase Price History" %}',
                         data: graphValues,
                         backgroundColor: 'rgba(255, 206, 86, 0.2)',
                         borderColor: 'rgb(255, 206, 86)',
@@ -801,7 +801,7 @@ function loadPurchasePriceHistoryTable(options={}) {
         columns: [
             {
                 field: 'order',
-                title: '{% jstrans "Purchase Order" %}',
+                title: '{% trans "Purchase Order" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     var order = row.order_detail;
@@ -823,7 +823,7 @@ function loadPurchasePriceHistoryTable(options={}) {
             },
             {
                 field: 'order_detail.complete_date',
-                title: '{% jstrans "Date" %}',
+                title: '{% trans "Date" %}',
                 sortable: true,
                 formatter: function(value) {
                     return renderDate(value);
@@ -831,7 +831,7 @@ function loadPurchasePriceHistoryTable(options={}) {
             },
             {
                 field: 'purchase_price',
-                title: '{% jstrans "Unit Price" %}',
+                title: '{% trans "Unit Price" %}',
                 sortable: true,
                 formatter: function(value, row) {
 
@@ -891,7 +891,7 @@ function loadSalesPriceHistoryTable(options={}) {
         search: false,
         showColumns: false,
         formatNoMatches: function() {
-            return '{% jstrans "No sales history data available" %}';
+            return '{% trans "No sales history data available" %}';
         },
         onLoadSuccess: function(data) {
             // Update sales price history chart
@@ -913,7 +913,7 @@ function loadSalesPriceHistoryTable(options={}) {
                 labels: graphLabels,
                 datasets: [
                     {
-                        label: '{% jstrans "Sale Price History" %}',
+                        label: '{% trans "Sale Price History" %}',
                         data: graphValues,
                         backgroundColor: 'rgba(255, 206, 86, 0.2)',
                         borderColor: 'rgb(255, 206, 86)',
@@ -926,7 +926,7 @@ function loadSalesPriceHistoryTable(options={}) {
         columns: [
             {
                 field: 'order',
-                title: '{% jstrans "Sales Order" %}',
+                title: '{% trans "Sales Order" %}',
                 formatter: function(value, row) {
                     var order = row.order_detail;
                     var customer = row.customer_detail;
@@ -947,14 +947,14 @@ function loadSalesPriceHistoryTable(options={}) {
             },
             {
                 field: 'shipment_date',
-                title: '{% jstrans "Date" %}',
+                title: '{% trans "Date" %}',
                 formatter: function(value, row) {
                     return renderDate(row.order_detail.shipment_date);
                 }
             },
             {
                 field: 'sale_price',
-                title: '{% jstrans "Sale Price" %}',
+                title: '{% trans "Sale Price" %}',
                 formatter: function(value, row) {
                     return formatCurrency(value, {
                         currency: row.sale_price_currency
@@ -1002,7 +1002,7 @@ function loadVariantPricingChart(options={}) {
         search: false,
         showColumns: false,
         formatNoMatches: function() {
-            return '{% jstrans "No variant data available" %}';
+            return '{% trans "No variant data available" %}';
         },
         onLoadSuccess: function(data) {
             // Construct variant pricing chart
@@ -1021,7 +1021,7 @@ function loadVariantPricingChart(options={}) {
                 labels: graphLabels,
                 datasets: [
                     {
-                        label: '{% jstrans "Minimum Price" %}',
+                        label: '{% trans "Minimum Price" %}',
                         data: minValues,
                         backgroundColor: 'rgba(200, 250, 200, 0.75)',
                         borderColor: 'rgba(200, 250, 200)',
@@ -1029,7 +1029,7 @@ function loadVariantPricingChart(options={}) {
                         fill: true,
                     },
                     {
-                        label: '{% jstrans "Maximum Price" %}',
+                        label: '{% trans "Maximum Price" %}',
                         data: maxValues,
                         backgroundColor: 'rgba(250, 220, 220, 0.75)',
                         borderColor: 'rgba(250, 220, 220)',
@@ -1042,7 +1042,7 @@ function loadVariantPricingChart(options={}) {
         columns: [
             {
                 field: 'part',
-                title: '{% jstrans "Variant Part" %}',
+                title: '{% trans "Variant Part" %}',
                 formatter: function(value, row) {
                     var name = shortenString(row.full_name);
                     var display = imageHoverIcon(row.thumbnail) + renderLink(name, `/part/${row.pk}/`);
@@ -1051,7 +1051,7 @@ function loadVariantPricingChart(options={}) {
             },
             {
                 field: 'pricing',
-                title: '{% jstrans "Price Range" %}',
+                title: '{% trans "Price Range" %}',
                 formatter: function(value, row) {
                     var min_price = row.pricing_min;
                     var max_price = row.pricing_max;

--- a/InvenTree/templates/js/translated/purchase_order.js
+++ b/InvenTree/templates/js/translated/purchase_order.js
@@ -90,7 +90,7 @@ function purchaseOrderFields(options={}) {
         supplier: {
             icon: 'fa-building',
             secondary: {
-                title: '{% jstrans "Add Supplier" %}',
+                title: '{% trans "Add Supplier" %}',
                 fields: function() {
                     var fields = companyFormFields();
 
@@ -165,24 +165,24 @@ function purchaseOrderFields(options={}) {
                 supplier_detail: true,
             },
             api_url: '{% url "api-po-list" %}',
-            label: '{% jstrans "Purchase Order" %}',
-            help_text: '{% jstrans "Select purchase order to duplicate" %}',
+            label: '{% trans "Purchase Order" %}',
+            help_text: '{% trans "Select purchase order to duplicate" %}',
         };
 
         fields.duplicate_line_items = {
             value: true,
             group: 'duplicate',
             type: 'boolean',
-            label: '{% jstrans "Duplicate Line Items" %}',
-            help_text: '{% jstrans "Duplicate all line items from the selected order" %}',
+            label: '{% trans "Duplicate Line Items" %}',
+            help_text: '{% trans "Duplicate all line items from the selected order" %}',
         };
 
         fields.duplicate_extra_lines = {
             value: true,
             group: 'duplicate',
             type: 'boolean',
-            label: '{% jstrans "Duplicate Extra Lines" %}',
-            help_text: '{% jstrans "Duplicate extra line items from the selected order" %}',
+            label: '{% trans "Duplicate Extra Lines" %}',
+            help_text: '{% trans "Duplicate extra line items from the selected order" %}',
         };
     }
 
@@ -203,7 +203,7 @@ function editPurchaseOrder(pk, options={}) {
 
     constructForm(`{% url "api-po-list" %}${pk}/`, {
         fields: fields,
-        title: '{% jstrans "Edit Purchase Order" %}',
+        title: '{% trans "Edit Purchase Order" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -220,7 +220,7 @@ function createPurchaseOrder(options={}) {
 
     if (options.duplicate_order) {
         groups.duplicate = {
-            title: '{% jstrans "Duplication Options" %}',
+            title: '{% trans "Duplication Options" %}',
             collapsible: false,
         };
     }
@@ -239,7 +239,7 @@ function createPurchaseOrder(options={}) {
                 location.href = `/order/purchase-order/${data.pk}/`;
             }
         },
-        title: options.title || '{% jstrans "Create Purchase Order" %}',
+        title: options.title || '{% trans "Create Purchase Order" %}',
     });
 }
 
@@ -311,7 +311,7 @@ function poLineItemFields(options={}) {
                 ).then(function() {
                     // Update pack size information
                     if (pack_quantity != 1) {
-                        var txt = `<span class='fas fa-info-circle icon-blue'></span> {% jstrans "Pack Quantity" %}: ${formatDecimal(pack_quantity)} ${units}`;
+                        var txt = `<span class='fas fa-info-circle icon-blue'></span> {% trans "Pack Quantity" %}: ${formatDecimal(pack_quantity)} ${units}`;
                         $(opts.modal).find('#hint_id_quantity').after(`<div class='form-info-message' id='info-pack-size'>${txt}</div>`);
                     }
                 }).then(function() {
@@ -349,7 +349,7 @@ function poLineItemFields(options={}) {
             },
             secondary: {
                 method: 'POST',
-                title: '{% jstrans "Add Supplier Part" %}',
+                title: '{% trans "Add Supplier Part" %}',
                 fields: function(data) {
                     var fields = supplierPartFields({
                         part: data.part,
@@ -430,7 +430,7 @@ function createPurchaseOrderLineItem(order, options={}) {
     constructForm('{% url "api-po-line-list" %}', {
         fields: fields,
         method: 'POST',
-        title: '{% jstrans "Add Line Item" %}',
+        title: '{% trans "Add Line Item" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -447,7 +447,7 @@ function completePurchaseOrder(order_id, options={}) {
         `/api/order/po/${order_id}/complete/`,
         {
             method: 'POST',
-            title: '{% jstrans "Complete Purchase Order" %}',
+            title: '{% trans "Complete Purchase Order" %}',
             confirm: true,
             fieldsFunction: function(opts) {
                 var fields = {
@@ -464,19 +464,19 @@ function completePurchaseOrder(order_id, options={}) {
 
                 var html = `
                 <div class='alert alert-block alert-info'>
-                    {% jstrans "Mark this order as complete?" %}
+                    {% trans "Mark this order as complete?" %}
                 </div>`;
 
                 if (opts.context.is_complete) {
                     html += `
                     <div class='alert alert-block alert-success'>
-                        {% jstrans "All line items have been received" %}
+                        {% trans "All line items have been received" %}
                     </div>`;
                 } else {
                     html += `
                     <div class='alert alert-block alert-warning'>
-                        {% jstrans 'This order has line items which have not been marked as received.' %}</br>
-                        {% jstrans 'Completing this order means that the order and line items will no longer be editable.' %}
+                        {% trans 'This order has line items which have not been marked as received.' %}</br>
+                        {% trans 'Completing this order means that the order and line items will no longer be editable.' %}
                     </div>`;
                 }
 
@@ -499,18 +499,18 @@ function cancelPurchaseOrder(order_id, options={}) {
         `/api/order/po/${order_id}/cancel/`,
         {
             method: 'POST',
-            title: '{% jstrans "Cancel Purchase Order" %}',
+            title: '{% trans "Cancel Purchase Order" %}',
             confirm: true,
             preFormContent: function(opts) {
                 var html = `
                 <div class='alert alert-info alert-block'>
-                    {% jstrans "Are you sure you wish to cancel this purchase order?" %}
+                    {% trans "Are you sure you wish to cancel this purchase order?" %}
                 </div>`;
 
                 if (!opts.context.can_cancel) {
                     html += `
                     <div class='alert alert-danger alert-block'>
-                        {% jstrans "This purchase order can not be cancelled" %}
+                        {% trans "This purchase order can not be cancelled" %}
                     </div>`;
                 }
 
@@ -531,12 +531,12 @@ function issuePurchaseOrder(order_id, options={}) {
 
     let html = `
     <div class='alert alert-block alert-warning'>
-    {% jstrans 'After placing this order, line items will no longer be editable.' %}
+    {% trans 'After placing this order, line items will no longer be editable.' %}
     </div>`;
 
     constructForm(`{% url "api-po-list" %}${order_id}/issue/`, {
         method: 'POST',
-        title: '{% jstrans "Issue Purchase Order" %}',
+        title: '{% trans "Issue Purchase Order" %}',
         confirm: true,
         preFormContent: html,
         onSuccess: function(response) {
@@ -627,8 +627,8 @@ function orderParts(parts_list, options={}) {
 
     if (parts.length == 0) {
         showAlertDialog(
-            '{% jstrans "Select Parts" %}',
-            '{% jstrans "At least one purchaseable part must be selected" %}',
+            '{% trans "Select Parts" %}',
+            '{% trans "At least one purchaseable part must be selected" %}',
         );
         return;
     }
@@ -653,7 +653,7 @@ function orderParts(parts_list, options={}) {
                 type: 'decimal',
                 min_value: 0,
                 value: quantity,
-                title: '{% jstrans "Quantity to order" %}',
+                title: '{% trans "Quantity to order" %}',
                 required: true,
             },
             {
@@ -662,7 +662,7 @@ function orderParts(parts_list, options={}) {
         );
 
         var supplier_part_prefix = `
-            <button type='button' class='input-group-text button-row-new-sp' pk='${pk}' title='{% jstrans "New supplier part" %}'>
+            <button type='button' class='input-group-text button-row-new-sp' pk='${pk}' title='{% trans "New supplier part" %}'>
                 <span class='fas fa-plus-circle icon-green'></span>
             </button>
         `;
@@ -680,7 +680,7 @@ function orderParts(parts_list, options={}) {
         );
 
         var purchase_order_prefix = `
-            <button type='button' class='input-group-text button-row-new-po' pk='${pk}' title='{% jstrans "New purchase order" %}'>
+            <button type='button' class='input-group-text button-row-new-po' pk='${pk}' title='{% trans "New purchase order" %}'>
                 <span class='fas fa-plus-circle icon-green'></span>
             </button>
         `;
@@ -703,7 +703,7 @@ function orderParts(parts_list, options={}) {
             buttons += makeRemoveButton(
                 'button-row-remove',
                 pk,
-                '{% jstrans "Remove row" %}',
+                '{% trans "Remove row" %}',
             );
         }
 
@@ -712,7 +712,7 @@ function orderParts(parts_list, options={}) {
             'fa-shopping-cart icon-blue',
             'button-row-add',
             pk,
-            '{% jstrans "Add to purchase order" %}',
+            '{% trans "Add to purchase order" %}',
         );
 
         buttons = wrapButtons(buttons);
@@ -757,10 +757,10 @@ function orderParts(parts_list, options={}) {
     <table class='table table-striped table-condensed' id='order-parts-table'>
         <thead>
             <tr>
-                <th>{% jstrans "Part" %}</th>
-                <th style='min-width: 300px;'>{% jstrans "Supplier Part" %}</th>
-                <th style='min-width: 300px;'>{% jstrans "Purchase Order" %}</th>
-                <th style='min-width: 50px;'>{% jstrans "Quantity" %}</th>
+                <th>{% trans "Part" %}</th>
+                <th style='min-width: 300px;'>{% trans "Supplier Part" %}</th>
+                <th style='min-width: 300px;'>{% trans "Purchase Order" %}</th>
+                <th style='min-width: 50px;'>{% trans "Quantity" %}</th>
                 <th><!-- Actions --></th>
             </tr>
         </thead>
@@ -800,9 +800,9 @@ function orderParts(parts_list, options={}) {
 
     constructFormBody({}, {
         preFormContent: html,
-        title: '{% jstrans "Order Parts" %}',
+        title: '{% trans "Order Parts" %}',
         hideSubmitButton: true,
-        closeText: '{% jstrans "Close" %}',
+        closeText: '{% trans "Close" %}',
         afterRender: function(fields, opts) {
             parts.forEach(function(part) {
 
@@ -842,7 +842,7 @@ function orderParts(parts_list, options={}) {
                             }
                         ).then(function() {
                             if (pack_quantity != 1) {
-                                var txt = `<span class='fas fa-info-circle icon-blue'></span> {% jstrans "Pack Quantity" %}: ${pack_quantity} ${units}`;
+                                var txt = `<span class='fas fa-info-circle icon-blue'></span> {% trans "Pack Quantity" %}: ${pack_quantity} ${units}`;
                                 $(opts.modal).find(`#id_quantity_${pk}`).after(`<div class='form-info-message' id='info-pack-size-${pk}'>${txt}</div>`);
                             }
                         });
@@ -860,7 +860,7 @@ function orderParts(parts_list, options={}) {
                     filters: supplier_part_filters,
                     onEdit: onSupplierPartChanged,
                     noResults: function(query) {
-                        return '{% jstrans "No matching supplier parts" %}';
+                        return '{% trans "No matching supplier parts" %}';
                     }
                 };
 
@@ -879,7 +879,7 @@ function orderParts(parts_list, options={}) {
                     value: options.order,
                     filters: order_filters,
                     noResults: function(query) {
-                        return '{% jstrans "No matching purchase orders" %}';
+                        return '{% trans "No matching purchase orders" %}';
                     }
                 }, null, opts);
 
@@ -1066,8 +1066,8 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
     if (line_items.length == 0) {
 
         showAlertDialog(
-            '{% jstrans "Select Line Items" %}',
-            '{% jstrans "At least one line item must be selected" %}',
+            '{% trans "Select Line Items" %}',
+            '{% trans "At least one line item must be selected" %}',
         );
         return;
     }
@@ -1096,8 +1096,8 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
         if (native_pack_quantity != 1) {
             pack_size_div = `
             <div class='alert alert-small alert-block alert-info'>
-                {% jstrans "Pack Quantity" %}: ${pack_quantity}<br>
-                {% jstrans "Received Quantity" %}: <span class='pack_received_quantity' id='items_received_quantity_${pk}'>${received}</span> ${units}
+                {% trans "Pack Quantity" %}: ${pack_quantity}<br>
+                {% trans "Received Quantity" %}: <span class='pack_received_quantity' id='items_received_quantity_${pk}'>${received}</span> ${units}
             </div>`;
         }
 
@@ -1108,7 +1108,7 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
                 type: 'decimal',
                 min_value: 0,
                 value: quantity,
-                title: '{% jstrans "Quantity to receive" %}',
+                title: '{% trans "Quantity to receive" %}',
                 required: true,
             },
             {
@@ -1122,8 +1122,8 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
             {
                 type: 'string',
                 required: false,
-                label: '{% jstrans "Batch Code" %}',
-                help_text: '{% jstrans "Enter batch code for incoming stock items" %}',
+                label: '{% trans "Batch Code" %}',
+                help_text: '{% trans "Enter batch code for incoming stock items" %}',
                 icon: 'fa-layer-group',
             },
             {
@@ -1146,8 +1146,8 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
             {
                 type: 'string',
                 required: false,
-                label: '{% jstrans "Serial Numbers" %}',
-                help_text: '{% jstrans "Enter serial numbers for incoming stock items" %}',
+                label: '{% trans "Serial Numbers" %}',
+                help_text: '{% trans "Enter serial numbers for incoming stock items" %}',
                 icon: 'fa-hashtag',
             },
             {
@@ -1171,7 +1171,7 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
             `items_location_${pk}`,
             {
                 type: 'related field',
-                label: '{% jstrans "Location" %}',
+                label: '{% trans "Location" %}',
                 required: false,
                 icon: 'fa-sitemap',
             },
@@ -1184,7 +1184,7 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
             `items_status_${pk}`,
             {
                 type: 'choice',
-                label: '{% jstrans "Stock Status" %}',
+                label: '{% trans "Stock Status" %}',
                 required: true,
                 choices: choices,
                 value: 10, // OK
@@ -1198,11 +1198,11 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
         let buttons = '';
 
         if (global_settings.BARCODE_ENABLE) {
-            buttons += makeIconButton('fa-qrcode', 'button-row-add-barcode', pk, '{% jstrans "Add barcode" %}');
-            buttons += makeIconButton('fa-unlink icon-red', 'button-row-remove-barcode', pk, '{% jstrans "Remove barcode" %}', {hidden: true});
+            buttons += makeIconButton('fa-qrcode', 'button-row-add-barcode', pk, '{% trans "Add barcode" %}');
+            buttons += makeIconButton('fa-unlink icon-red', 'button-row-remove-barcode', pk, '{% trans "Remove barcode" %}', {hidden: true});
         }
 
-        buttons += makeIconButton('fa-sitemap', 'button-row-add-location', pk, '{% jstrans "Specify location" %}', {
+        buttons += makeIconButton('fa-sitemap', 'button-row-add-location', pk, '{% trans "Specify location" %}', {
             collapseTarget: `row-destination-${pk}`
         });
 
@@ -1210,7 +1210,7 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
             'fa-layer-group',
             'button-row-add-batch',
             pk,
-            '{% jstrans "Add batch code" %}',
+            '{% trans "Add batch code" %}',
             {
                 collapseTarget: `row-batch-${pk}`
             }
@@ -1221,7 +1221,7 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
                 'fa-hashtag',
                 'button-row-add-serials',
                 pk,
-                '{% jstrans "Add serial numbers" %}',
+                '{% trans "Add serial numbers" %}',
                 {
                     collapseTarget: `row-serials-${pk}`,
                 }
@@ -1229,7 +1229,7 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
         }
 
         if (line_items.length > 1) {
-            buttons += makeRemoveButton('button-row-remove', pk, '{% jstrans "Remove row" %}');
+            buttons += makeRemoveButton('button-row-remove', pk, '{% trans "Remove row" %}');
         }
 
         buttons = wrapButtons(buttons);
@@ -1261,19 +1261,19 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
         <!-- Hidden rows for extra data entry -->
         <tr id='row-destination-${pk}' class='collapse'>
             <td colspan='2'></td>
-            <th>{% jstrans "Location" %}</th>
+            <th>{% trans "Location" %}</th>
             <td colspan='2'>${destination_input}</td>
             <td></td>
         </tr>
         <tr id='row-batch-${pk}' class='collapse'>
             <td colspan='2'></td>
-            <th>{% jstrans "Batch" %}</th>
+            <th>{% trans "Batch" %}</th>
             <td colspan='2'>${batch_input}</td>
             <td></td>
         </tr>
         <tr id='row-serials-${pk}' class='collapse'>
             <td colspan='2'></td>
-            <th>{% jstrans "Serials" %}</th>
+            <th>{% trans "Serials" %}</th>
             <td colspan=2'>${sn_input}</td>
             <td></td>
         </tr>
@@ -1297,11 +1297,11 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
     <table class='table table-condensed' id='order-receive-table'>
         <thead>
             <tr>
-                <th>{% jstrans "Part" %}</th>
-                <th>{% jstrans "Order Code" %}</th>
-                <th>{% jstrans "Received" %}</th>
-                <th style='min-width: 50px;'>{% jstrans "Quantity to Receive" %}</th>
-                <th style='min-width: 150px;'>{% jstrans "Status" %}</th>
+                <th>{% trans "Part" %}</th>
+                <th>{% trans "Order Code" %}</th>
+                <th>{% trans "Received" %}</th>
+                <th style='min-width: 50px;'>{% trans "Quantity to Receive" %}</th>
+                <th style='min-width: 150px;'>{% trans "Status" %}</th>
                 <th></th>
             </tr>
         </thead>
@@ -1326,8 +1326,8 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
         },
         preFormContent: html,
         confirm: true,
-        confirmMessage: '{% jstrans "Confirm receipt of items" %}',
-        title: '{% jstrans "Receive Purchase Order Items" %}',
+        confirmMessage: '{% trans "Confirm receipt of items" %}',
+        title: '{% trans "Receive Purchase Order Items" %}',
         afterRender: function(fields, opts) {
 
             // Run initialization routines for each line in the form
@@ -1395,11 +1395,11 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
                     let pk = btn.attr('pk');
 
                     // Scan to see if the barcode matches an existing StockItem
-                    barcodeDialog('{% jstrans "Scan Item Barcode" %}', {
-                        details: '{% jstrans "Scan barcode on incoming item (must not match any existing stock items)" %}',
+                    barcodeDialog('{% trans "Scan Item Barcode" %}', {
+                        details: '{% trans "Scan barcode on incoming item (must not match any existing stock items)" %}',
                         onScan: function(response, barcode_options) {
                             // A 'success' result means that the barcode matches something existing in the database
-                            showBarcodeMessage(barcode_options.modal, '{% jstrans "Barcode matches existing item" %}');
+                            showBarcodeMessage(barcode_options.modal, '{% trans "Barcode matches existing item" %}');
                         },
                         onError400: function(response, barcode_options) {
                             if (response.barcode_data && response.barcode_hash) {
@@ -1410,7 +1410,7 @@ function receivePurchaseOrderItems(order_id, line_items, options={}) {
                                 $(opts.modal).find(`#button-row-remove-barcode-${pk}`).show();
                                 updateFieldValue(`items_barcode_${pk}`, response.barcode_data, {}, opts);
                             } else {
-                                showBarcodeMessage(barcode_options.modal, '{% jstrans "Invalid barcode data" %}');
+                                showBarcodeMessage(barcode_options.modal, '{% trans "Invalid barcode data" %}');
                             }
                         }
                     });
@@ -1648,7 +1648,7 @@ function loadPurchaseOrderTable(table, options) {
         showCustomView: display_mode == 'calendar',
         search: display_mode != 'calendar',
         formatNoMatches: function() {
-            return '{% jstrans "No purchase orders found" %}';
+            return '{% trans "No purchase orders found" %}';
         },
         buttons: constructOrderTableButtons({
             prefix: 'purchaseorder',
@@ -1667,7 +1667,7 @@ function loadPurchaseOrderTable(table, options) {
             },
             {
                 field: 'reference',
-                title: '{% jstrans "Purchase Order" %}',
+                title: '{% trans "Purchase Order" %}',
                 sortable: true,
                 switchable: false,
                 formatter: function(value, row) {
@@ -1675,7 +1675,7 @@ function loadPurchaseOrderTable(table, options) {
                     var html = renderLink(value, `/order/purchase-order/${row.pk}/`);
 
                     if (row.overdue) {
-                        html += makeIconBadge('fa-calendar-times icon-red', '{% jstrans "Order is overdue" %}');
+                        html += makeIconBadge('fa-calendar-times icon-red', '{% trans "Order is overdue" %}');
                     }
 
                     return html;
@@ -1683,7 +1683,7 @@ function loadPurchaseOrderTable(table, options) {
             },
             {
                 field: 'supplier_detail',
-                title: '{% jstrans "Supplier" %}',
+                title: '{% trans "Supplier" %}',
                 sortable: true,
                 sortName: 'supplier__name',
                 formatter: function(value, row) {
@@ -1696,15 +1696,15 @@ function loadPurchaseOrderTable(table, options) {
             },
             {
                 field: 'supplier_reference',
-                title: '{% jstrans "Supplier Reference" %}',
+                title: '{% trans "Supplier Reference" %}',
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
             },
             {
                 field: 'project_code',
-                title: '{% jstrans "Project Code" %}',
+                title: '{% trans "Project Code" %}',
                 switchable: global_settings.PROJECT_CODES_ENABLED,
                 visible: global_settings.PROJECT_CODES_ENABLED,
                 sortable: true,
@@ -1716,7 +1716,7 @@ function loadPurchaseOrderTable(table, options) {
             },
             {
                 field: 'status',
-                title: '{% jstrans "Status" %}',
+                title: '{% trans "Status" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1725,7 +1725,7 @@ function loadPurchaseOrderTable(table, options) {
             },
             {
                 field: 'creation_date',
-                title: '{% jstrans "Date" %}',
+                title: '{% trans "Date" %}',
                 sortable: true,
                 formatter: function(value) {
                     return renderDate(value);
@@ -1733,7 +1733,7 @@ function loadPurchaseOrderTable(table, options) {
             },
             {
                 field: 'target_date',
-                title: '{% jstrans "Target Date" %}',
+                title: '{% trans "Target Date" %}',
                 sortable: true,
                 formatter: function(value) {
                     return renderDate(value);
@@ -1741,12 +1741,12 @@ function loadPurchaseOrderTable(table, options) {
             },
             {
                 field: 'line_items',
-                title: '{% jstrans "Items" %}',
+                title: '{% trans "Items" %}',
                 sortable: true,
             },
             {
                 field: 'total_price',
-                title: '{% jstrans "Total Cost" %}',
+                title: '{% trans "Total Cost" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1757,7 +1757,7 @@ function loadPurchaseOrderTable(table, options) {
             },
             {
                 field: 'responsible',
-                title: '{% jstrans "Responsible" %}',
+                title: '{% trans "Responsible" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1837,16 +1837,16 @@ function deletePurchaseOrderLineItems(items, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "All selected Line items will be deleted" %}
+    {% trans "All selected Line items will be deleted" %}
     </div>
 
     <table class='table table-striped table-condensed'>
         <tr>
-            <th>{% jstrans "Part" %}</th>
-            <th>{% jstrans "Description" %}</th>
-            <th>{% jstrans "SKU" %}</th>
-            <th>{% jstrans "MPN" %}</th>
-            <th>{% jstrans "Quantity" %}</th>
+            <th>{% trans "Part" %}</th>
+            <th>{% trans "Description" %}</th>
+            <th>{% trans "SKU" %}</th>
+            <th>{% trans "MPN" %}</th>
+            <th>{% trans "Quantity" %}</th>
         </tr>
         ${rows}
     </table>
@@ -1855,7 +1855,7 @@ function deletePurchaseOrderLineItems(items, options={}) {
     constructForm('{% url "api-po-line-list" %}', {
         method: 'DELETE',
         multi_delete: true,
-        title: '{% jstrans "Delete selected Line items?" %}',
+        title: '{% trans "Delete selected Line items?" %}',
         form_data: {
             items: ids,
         },
@@ -1910,7 +1910,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                             method: 'POST',
                             fields: fields,
                             data: data,
-                            title: '{% jstrans "Duplicate Line Item" %}',
+                            title: '{% trans "Duplicate Line Item" %}',
                             refreshTable: table,
                         });
                     }
@@ -1925,7 +1925,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
 
                 constructForm(`{% url "api-po-line-list" %}${pk}/`, {
                     fields: fields,
-                    title: '{% jstrans "Edit Line Item" %}',
+                    title: '{% trans "Edit Line Item" %}',
                     refreshTable: table,
                 });
             });
@@ -1936,7 +1936,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
 
                 constructForm(`{% url "api-po-line-list" %}${pk}/`, {
                     method: 'DELETE',
-                    title: '{% jstrans "Delete Line Item" %}',
+                    title: '{% trans "Delete Line Item" %}',
                     refreshTable: table,
                 });
             });
@@ -1984,7 +1984,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
         name: 'purchaseorderlines',
         sidePagination: 'server',
         formatNoMatches: function() {
-            return '{% jstrans "No line items found" %}';
+            return '{% trans "No line items found" %}';
         },
         queryParams: filters,
         original: options.params,
@@ -2001,7 +2001,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                 field: 'part',
                 sortable: true,
                 sortName: 'part_name',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 switchable: false,
                 formatter: function(value, row, index, field) {
                     if (row.part_detail) {
@@ -2011,18 +2011,18 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                     }
                 },
                 footerFormatter: function() {
-                    return '{% jstrans "Total" %}';
+                    return '{% trans "Total" %}';
                 }
             },
             {
                 field: 'part_detail.description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
             },
             {
                 sortable: true,
                 sortName: 'SKU',
                 field: 'supplier_part_detail.SKU',
-                title: '{% jstrans "SKU" %}',
+                title: '{% trans "SKU" %}',
                 formatter: function(value, row, index, field) {
                     if (value) {
                         return renderClipboard(renderLink(value, `/supplier-part/${row.part}/`));
@@ -2034,7 +2034,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
             {
                 sortable: false,
                 field: 'supplier_part_detail.link',
-                title: '{% jstrans "Link" %}',
+                title: '{% trans "Link" %}',
                 formatter: function(value, row, index, field) {
                     if (value) {
                         return renderLink(value, value, {external: true});
@@ -2047,7 +2047,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                 sortable: true,
                 sortName: 'MPN',
                 field: 'supplier_part_detail.manufacturer_part_detail.MPN',
-                title: '{% jstrans "MPN" %}',
+                title: '{% trans "MPN" %}',
                 formatter: function(value, row, index, field) {
                     if (row.supplier_part_detail && row.supplier_part_detail.manufacturer_part) {
                         return renderClipboard(renderLink(value, `/manufacturer-part/${row.supplier_part_detail.manufacturer_part}/`));
@@ -2059,13 +2059,13 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
             {
                 sortable: true,
                 field: 'reference',
-                title: '{% jstrans "Reference" %}',
+                title: '{% trans "Reference" %}',
             },
             {
                 sortable: true,
                 switchable: false,
                 field: 'quantity',
-                title: '{% jstrans "Quantity" %}',
+                title: '{% trans "Quantity" %}',
                 formatter: function(value, row) {
                     let units = '';
 
@@ -2078,7 +2078,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                     if (row.supplier_part_detail && row.supplier_part_detail.pack_quantity_native != 1.0) {
                         let pack_quantity = row.supplier_part_detail.pack_quantity;
                         let total = value * row.supplier_part_detail.pack_quantity_native;
-                        data += `<span class='fas fa-info-circle icon-blue float-right' title='{% jstrans "Pack Quantity" %}: ${pack_quantity} - {% jstrans "Total Quantity" %}: ${total}${units}'></span>`;
+                        data += `<span class='fas fa-info-circle icon-blue float-right' title='{% trans "Pack Quantity" %}: ${pack_quantity} - {% trans "Total Quantity" %}: ${total}${units}'></span>`;
                     }
 
                     return data;
@@ -2095,7 +2095,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                 sortable: false,
                 switchable: true,
                 field: 'supplier_part_detail.pack_quantity',
-                title: '{% jstrans "Pack Quantity" %}',
+                title: '{% trans "Pack Quantity" %}',
                 formatter: function(value, row) {
                     var units = row.part_detail.units;
 
@@ -2109,7 +2109,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
             {
                 sortable: true,
                 field: 'purchase_price',
-                title: '{% jstrans "Unit Price" %}',
+                title: '{% trans "Unit Price" %}',
                 formatter: function(value, row) {
                     return formatCurrency(row.purchase_price, {
                         currency: row.purchase_price_currency,
@@ -2119,7 +2119,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
             {
                 field: 'total_price',
                 sortable: true,
-                title: '{% jstrans "Total Price" %}',
+                title: '{% trans "Total Price" %}',
                 formatter: function(value, row) {
                     return formatCurrency(row.purchase_price * row.quantity, {
                         currency: row.purchase_price_currency
@@ -2141,13 +2141,13 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                 sortable: true,
                 field: 'target_date',
                 switchable: true,
-                title: '{% jstrans "Target Date" %}',
+                title: '{% trans "Target Date" %}',
                 formatter: function(value, row) {
                     if (row.target_date) {
                         var html = renderDate(row.target_date);
 
                         if (row.overdue) {
-                            html += makeIconBadge('fa-calendar-times icon-red', '{% jstrans "This line item is overdue" %}');
+                            html += makeIconBadge('fa-calendar-times icon-red', '{% trans "This line item is overdue" %}');
                         }
 
                         return html;
@@ -2163,7 +2163,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                 sortable: false,
                 field: 'received',
                 switchable: false,
-                title: '{% jstrans "Received" %}',
+                title: '{% trans "Received" %}',
                 formatter: function(value, row, index, field) {
                     return makeProgressBar(row.received, row.quantity, {
                         id: `order-line-progress-${row.pk}`,
@@ -2183,7 +2183,7 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
             },
             {
                 field: 'destination',
-                title: '{% jstrans "Destination" %}',
+                title: '{% trans "Destination" %}',
                 formatter: function(value, row) {
                     if (value) {
                         return renderLink(row.destination_detail.pathstring, `/stock/location/${value}/`);
@@ -2194,11 +2194,11 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
             },
             {
                 field: 'notes',
-                title: '{% jstrans "Notes" %}',
+                title: '{% trans "Notes" %}',
             },
             {
                 field: 'link',
-                title: '{% jstrans "Link" %}',
+                title: '{% trans "Link" %}',
                 formatter: function(value) {
                     if (value) {
                         return renderLink(value, value);
@@ -2214,13 +2214,13 @@ function loadPurchaseOrderLineItemTable(table, options={}) {
                     let pk = row.pk;
 
                     if (options.allow_receive && row.received < row.quantity) {
-                        buttons += makeIconButton('fa-sign-in-alt icon-green', 'button-line-receive', pk, '{% jstrans "Receive line item" %}');
+                        buttons += makeIconButton('fa-sign-in-alt icon-green', 'button-line-receive', pk, '{% trans "Receive line item" %}');
                     }
 
                     if (options.allow_edit) {
-                        buttons += makeCopyButton('button-line-duplicate', pk, '{% jstrans "Duplicate line item" %}');
-                        buttons += makeEditButton('button-line-edit', pk, '{% jstrans "Edit line item" %}');
-                        buttons += makeDeleteButton('button-line-delete', pk, '{% jstrans "Delete line item" %}');
+                        buttons += makeCopyButton('button-line-duplicate', pk, '{% trans "Duplicate line item" %}');
+                        buttons += makeEditButton('button-line-edit', pk, '{% trans "Edit line item" %}');
+                        buttons += makeDeleteButton('button-line-delete', pk, '{% trans "Delete line item" %}');
                     }
 
                     return wrapButtons(buttons);

--- a/InvenTree/templates/js/translated/report.js
+++ b/InvenTree/templates/js/translated/report.js
@@ -60,7 +60,7 @@ function selectReport(reports, items, options={}) {
 
         html += `
         <div class='alert alert-block alert-info'>
-        ${items.length} {% jstrans "items selected" %}
+        ${items.length} {% trans "items selected" %}
         </div>`;
     }
 
@@ -68,7 +68,7 @@ function selectReport(reports, items, options={}) {
     <form method='post' action='' class='js-modal-form' enctype='multipart/form-data'>
         <div class='form-group'>
             <label class='control-label requiredField' for='id_report'>
-            {% jstrans "Select Report Template" %}
+            {% trans "Select Report Template" %}
             </label>
             <div class='controls'>
                 <select id='id_report' class='select form-control name='report'>
@@ -83,7 +83,7 @@ function selectReport(reports, items, options={}) {
     });
 
     modalEnable(modal, true);
-    modalSetTitle(modal, '{% jstrans "Select Test Report Template" %}');
+    modalSetTitle(modal, '{% trans "Select Test Report Template" %}');
     modalSetContent(modal, html);
 
     attachSelect(modal);
@@ -120,8 +120,8 @@ function printReports(options) {
 
     if (!options.items || options.items.length == 0) {
         showAlertDialog(
-            '{% jstrans "Select Items" %}',
-            '{% jstrans "No items selected for printing" }',
+            '{% trans "Select Items" %}',
+            '{% trans "No items selected for printing" }',
         );
         return;
     }
@@ -137,8 +137,8 @@ function printReports(options) {
         success: function(response) {
             if (response.length == 0) {
                 showAlertDialog(
-                    '{% jstrans "No Reports Found" %}',
-                    '{% jstrans "No report templates found which match the selected items" %}',
+                    '{% trans "No Reports Found" %}',
+                    '{% trans "No report templates found which match the selected items" %}',
                 );
                 return;
             }

--- a/InvenTree/templates/js/translated/return_order.js
+++ b/InvenTree/templates/js/translated/return_order.js
@@ -57,7 +57,7 @@ function returnOrderFields(options={}) {
         customer: {
             icon: 'fa-user-tie',
             secondary: {
-                title: '{% jstrans "Add Customer" %}',
+                title: '{% trans "Add Customer" %}',
                 fields: function() {
                     var fields = companyFormFields();
                     fields.is_customer.value = true;
@@ -131,7 +131,7 @@ function createReturnOrder(options={}) {
     constructForm('{% url "api-return-order-list" %}', {
         method: 'POST',
         fields: fields,
-        title: '{% jstrans "Create Return Order" %}',
+        title: '{% trans "Create Return Order" %}',
         onSuccess: function(data) {
             location.href = `/order/return-order/${data.pk}/`;
         },
@@ -146,7 +146,7 @@ function editReturnOrder(order_id, options={}) {
 
     constructForm(`{% url "api-return-order-list" %}${order_id}/`, {
         fields: returnOrderFields(options),
-        title: '{% jstrans "Edit Return Order" %}',
+        title: '{% trans "Edit Return Order" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -161,12 +161,12 @@ function issueReturnOrder(order_id, options={}) {
 
     let html = `
     <div class='alert alert-block alert-warning'>
-    {% jstrans 'After placing this order, line items will no longer be editable.' %}
+    {% trans 'After placing this order, line items will no longer be editable.' %}
     </div>`;
 
     constructForm(`{% url "api-return-order-list" %}${order_id}/issue/`, {
         method: 'POST',
-        title: '{% jstrans "Issue Return Order" %}',
+        title: '{% trans "Issue Return Order" %}',
         confirm: true,
         preFormContent: html,
         onSuccess: function(response) {
@@ -183,14 +183,14 @@ function cancelReturnOrder(order_id, options={}) {
 
     let html = `
     <div class='alert alert-danger alert-block'>
-    {% jstrans "Are you sure you wish to cancel this Return Order?" %}
+    {% trans "Are you sure you wish to cancel this Return Order?" %}
     </div>`;
 
     constructForm(
         `{% url "api-return-order-list" %}${order_id}/cancel/`,
         {
             method: 'POST',
-            title: '{% jstrans "Cancel Return Order" %}',
+            title: '{% trans "Cancel Return Order" %}',
             confirm: true,
             preFormContent: html,
             onSuccess: function(response) {
@@ -207,7 +207,7 @@ function cancelReturnOrder(order_id, options={}) {
 function completeReturnOrder(order_id, options={}) {
     let html = `
     <div class='alert alert-block alert-warning'>
-    {% jstrans "Mark this order as complete?" %}
+    {% trans "Mark this order as complete?" %}
     </div>
     `;
 
@@ -215,7 +215,7 @@ function completeReturnOrder(order_id, options={}) {
         `{% url "api-return-order-list" %}${order_id}/complete/`,
         {
             method: 'POST',
-            title: '{% jstrans "Complete Return Order" %}',
+            title: '{% trans "Complete Return Order" %}',
             confirm: true,
             preFormContent: html,
             onSuccess: function(response) {
@@ -263,7 +263,7 @@ function loadReturnOrderTable(table, options={}) {
         showCustomView: is_calendar,
         disablePagination: is_calendar,
         formatNoMatches: function() {
-            return '{% jstrans "No return orders found" %}';
+            return '{% trans "No return orders found" %}';
         },
         onLoadSuccess: function() {
             // TODO
@@ -278,12 +278,12 @@ function loadReturnOrderTable(table, options={}) {
             {
                 sortable: true,
                 field: 'reference',
-                title: '{% jstrans "Return Order" %}',
+                title: '{% trans "Return Order" %}',
                 formatter: function(value, row) {
                     let html = renderLink(value, `/order/return-order/${row.pk}/`);
 
                     if (row.overdue) {
-                        html += makeIconBadge('fa-calendar-times icon-red', '{% jstrans "Order is overdue" %}');
+                        html += makeIconBadge('fa-calendar-times icon-red', '{% trans "Order is overdue" %}');
                     }
 
                     return html;
@@ -293,11 +293,11 @@ function loadReturnOrderTable(table, options={}) {
                 sortable: true,
                 sortName: 'customer__name',
                 field: 'customer_detail',
-                title: '{% jstrans "Customer" %}',
+                title: '{% trans "Customer" %}',
                 formatter: function(value, row) {
 
                     if (!row.customer_detail) {
-                        return '{% jstrans "Invalid Customer" %}';
+                        return '{% trans "Invalid Customer" %}';
                     }
 
                     return imageHoverIcon(row.customer_detail.image) + renderLink(row.customer_detail.name, `/company/${row.customer}/sales-orders/`);
@@ -306,16 +306,16 @@ function loadReturnOrderTable(table, options={}) {
             {
                 sortable: true,
                 field: 'customer_reference',
-                title: '{% jstrans "Customer Reference" %}',
+                title: '{% trans "Customer Reference" %}',
             },
             {
                 sortable: false,
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
             },
             {
                 field: 'project_code',
-                title: '{% jstrans "Project Code" %}',
+                title: '{% trans "Project Code" %}',
                 switchable: global_settings.PROJECT_CODES_ENABLED,
                 visible: global_settings.PROJECT_CODES_ENABLED,
                 sortable: true,
@@ -328,7 +328,7 @@ function loadReturnOrderTable(table, options={}) {
             {
                 sortable: true,
                 field: 'status',
-                title: '{% jstrans "Status" %}',
+                title: '{% trans "Status" %}',
                 formatter: function(value, row) {
                     return returnOrderStatusDisplay(row.status);
                 }
@@ -336,7 +336,7 @@ function loadReturnOrderTable(table, options={}) {
             {
                 sortable: true,
                 field: 'creation_date',
-                title: '{% jstrans "Creation Date" %}',
+                title: '{% trans "Creation Date" %}',
                 formatter: function(value) {
                     return renderDate(value);
                 }
@@ -344,19 +344,19 @@ function loadReturnOrderTable(table, options={}) {
             {
                 sortable: true,
                 field: 'target_date',
-                title: '{% jstrans "Target Date" %}',
+                title: '{% trans "Target Date" %}',
                 formatter: function(value) {
                     return renderDate(value);
                 }
             },
             {
                 field: 'line_items',
-                title: '{% jstrans "Items" %}',
+                title: '{% trans "Items" %}',
                 sortable: true,
             },
             {
                 field: 'responsible',
-                title: '{% jstrans "Responsible" %}',
+                title: '{% trans "Responsible" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
@@ -378,7 +378,7 @@ function loadReturnOrderTable(table, options={}) {
             {
                 // TODO: Add in the 'total cost' field
                 field: 'total_price',
-                title: '{% jstrans "Total Cost" %}',
+                title: '{% trans "Total Cost" %}',
                 switchable: true,
                 sortable: true,
                 visible: false,
@@ -456,7 +456,7 @@ function createReturnOrderLineItem(options={}) {
     constructForm('{% url "api-return-order-line-list" %}', {
         fields: fields,
         method: 'POST',
-        title: '{% jstrans "Add Line Item" %}',
+        title: '{% trans "Add Line Item" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -473,7 +473,7 @@ function editReturnOrderLineItem(pk, options={}) {
 
     constructForm(`{% url "api-return-order-line-list" %}${pk}/`, {
         fields: fields,
-        title: '{% jstrans "Edit Line Item" %}',
+        title: '{% trans "Edit Line Item" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -488,8 +488,8 @@ function receiveReturnOrderItems(order_id, line_items, options={}) {
 
     if (line_items.length == 0) {
         showAlertDialog(
-            '{% jstrans "Select Line Items"% }',
-            '{% jstrans "At least one line item must be selected" %}'
+            '{% trans "Select Line Items"% }',
+            '{% trans "At least one line item must be selected" %}'
         );
         return;
     }
@@ -503,7 +503,7 @@ function receiveReturnOrderItems(order_id, line_items, options={}) {
         let buttons = '';
 
         if (line_items.length > 1) {
-            buttons += makeRemoveButton('button-row-remove', pk, '{% jstrans "Remove row" %}');
+            buttons += makeRemoveButton('button-row-remove', pk, '{% trans "Remove row" %}');
         }
 
         buttons = wrapButtons(buttons);
@@ -536,8 +536,8 @@ function receiveReturnOrderItems(order_id, line_items, options={}) {
     <table class='table table-striped table-condensed' id='order-receive-table'>
         <thead>
             <tr>
-                <th>{% jstrans "Part" %}</th>
-                <th>{% jstrans "Serial Number" %}</th>
+                <th>{% trans "Part" %}</th>
+                <th>{% trans "Serial Number" %}</th>
             </tr>
         </thead>
         <tbody>${table_entries}</tbody>
@@ -558,8 +558,8 @@ function receiveReturnOrderItems(order_id, line_items, options={}) {
             }
         },
         confirm: true,
-        confirmMessage: '{% jstrans "Confirm receipt of items" %}',
-        title: '{% jstrans "Receive Return Order Items" %}',
+        confirmMessage: '{% trans "Confirm receipt of items" %}',
+        title: '{% trans "Receive Return Order Items" %}',
         afterRender: function(fields, opts) {
             // Add callback to remove rows
             $(opts.modal).find('.button-row-remove').click(function() {
@@ -666,7 +666,7 @@ function loadReturnOrderLineItemTable(options={}) {
 
                 constructForm(`{% url "api-return-order-line-list" %}${pk}/`, {
                     fields: returnOrderLineItemFields(),
-                    title: '{% jstrans "Edit Line Item" %}',
+                    title: '{% trans "Edit Line Item" %}',
                     refreshTable: table,
                 });
             });
@@ -679,7 +679,7 @@ function loadReturnOrderLineItemTable(options={}) {
 
                 constructForm(`{% url "api-return-order-line-list" %}${pk}/`, {
                     method: 'DELETE',
-                    title: '{% jstrans "Delete Line Item" %}',
+                    title: '{% trans "Delete Line Item" %}',
                     refreshTable: table,
                 });
             });
@@ -690,7 +690,7 @@ function loadReturnOrderLineItemTable(options={}) {
         url: '{% url "api-return-order-line-list" %}',
         name: 'returnorderlineitems',
         formatNoMatches: function() {
-            return '{% jstrans "No matching line items" %}';
+            return '{% trans "No matching line items" %}';
         },
         onPostBody: setupCallbacks,
         queryParams: filters,
@@ -707,7 +707,7 @@ function loadReturnOrderLineItemTable(options={}) {
                 field: 'part',
                 sortable: true,
                 switchable: false,
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 formatter: function(value, row) {
                     let part = row.part_detail;
                     let html = thumbnailImage(part.thumbnail) + ' ';
@@ -719,18 +719,18 @@ function loadReturnOrderLineItemTable(options={}) {
                 field: 'item',
                 sortable: true,
                 switchable: false,
-                title: '{% jstrans "Item" %}',
+                title: '{% trans "Item" %}',
                 formatter: function(value, row) {
-                    return renderLink(`{% jstrans "Serial Number" %}: ${row.item_detail.serial}`, `/stock/item/${row.item}/`);
+                    return renderLink(`{% trans "Serial Number" %}: ${row.item_detail.serial}`, `/stock/item/${row.item}/`);
                 }
             },
             {
                 field: 'reference',
-                title: '{% jstrans "Reference" %}',
+                title: '{% trans "Reference" %}',
             },
             {
                 field: 'outcome',
-                title: '{% jstrans "Outcome" %}',
+                title: '{% trans "Outcome" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     return returnOrderLineItemStatusDisplay(value);
@@ -738,7 +738,7 @@ function loadReturnOrderLineItemTable(options={}) {
             },
             {
                 field: 'price',
-                title: '{% jstrans "Price" %}',
+                title: '{% trans "Price" %}',
                 formatter: function(value, row) {
                     return formatCurrency(row.price, {
                         currency: row.price_currency,
@@ -748,12 +748,12 @@ function loadReturnOrderLineItemTable(options={}) {
             {
                 sortable: true,
                 field: 'target_date',
-                title: '{% jstrans "Target Date" %}',
+                title: '{% trans "Target Date" %}',
                 formatter: function(value, row) {
                     let html = renderDate(value);
 
                     if (row.overdue) {
-                        html += makeIconBadge('fa-calendar-times icon-red', '{% jstrans "This line item is overdue" %}');
+                        html += makeIconBadge('fa-calendar-times icon-red', '{% trans "This line item is overdue" %}');
                     }
 
                     return html;
@@ -761,7 +761,7 @@ function loadReturnOrderLineItemTable(options={}) {
             },
             {
                 field: 'received_date',
-                title: '{% jstrans "Received" %}',
+                title: '{% trans "Received" %}',
                 sortable: true,
                 formatter: function(value) {
                     if (!value) {
@@ -773,11 +773,11 @@ function loadReturnOrderLineItemTable(options={}) {
             },
             {
                 field: 'notes',
-                title: '{% jstrans "Notes" %}',
+                title: '{% trans "Notes" %}',
             },
             {
                 field: 'link',
-                title: '{% jstrans "Link" %}',
+                title: '{% trans "Link" %}',
                 formatter: function(value, row) {
                     if (value) {
                         return renderLink(value, value);
@@ -795,14 +795,14 @@ function loadReturnOrderLineItemTable(options={}) {
                     if (options.allow_edit) {
 
                         if (options.allow_receive && !row.received_date) {
-                            buttons += makeIconButton('fa-sign-in-alt icon-green', 'button-line-receive', pk, '{% jstrans "Mark item as received" %}');
+                            buttons += makeIconButton('fa-sign-in-alt icon-green', 'button-line-receive', pk, '{% trans "Mark item as received" %}');
                         }
 
-                        buttons += makeEditButton('button-line-edit', pk, '{% jstrans "Edit line item" %}');
+                        buttons += makeEditButton('button-line-edit', pk, '{% trans "Edit line item" %}');
                     }
 
                     if (options.allow_delete) {
-                        buttons += makeDeleteButton('button-line-delete', pk, '{% jstrans "Delete line item" %}');
+                        buttons += makeDeleteButton('button-line-delete', pk, '{% trans "Delete line item" %}');
                     }
 
                     return wrapButtons(buttons);

--- a/InvenTree/templates/js/translated/sales_order.js
+++ b/InvenTree/templates/js/translated/sales_order.js
@@ -83,7 +83,7 @@ function salesOrderFields(options={}) {
         customer: {
             icon: 'fa-user-tie',
             secondary: {
-                title: '{% jstrans "Add Customer" %}',
+                title: '{% trans "Add Customer" %}',
                 fields: function() {
                     var fields = companyFormFields();
                     fields.is_customer.value = true;
@@ -158,7 +158,7 @@ function createSalesOrder(options={}) {
     constructForm('{% url "api-so-list" %}', {
         method: 'POST',
         fields: fields,
-        title: '{% jstrans "Create Sales Order" %}',
+        title: '{% trans "Create Sales Order" %}',
         onSuccess: function(data) {
             location.href = `/order/sales-order/${data.pk}/`;
         },
@@ -173,7 +173,7 @@ function editSalesOrder(order_id, options={}) {
 
     constructForm(`{% url "api-so-list" %}${order_id}/`, {
         fields: salesOrderFields(options),
-        title: '{% jstrans "Edit Sales Order" %}',
+        title: '{% trans "Edit Sales Order" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         }
@@ -234,7 +234,7 @@ function createSalesOrderLineItem(options={}) {
     constructForm('{% url "api-so-line-list" %}', {
         fields: fields,
         method: 'POST',
-        title: '{% jstrans "Add Line Item" %}',
+        title: '{% trans "Add Line Item" %}',
         onSuccess: function(response) {
             handleFormSuccess(response, options);
         },
@@ -288,17 +288,17 @@ function completeSalesOrderShipment(shipment_id, options={}) {
             if (!allocations || allocations.length == 0) {
                 html = `
                 <div class='alert alert-block alert-danger'>
-                {% jstrans "No stock items have been allocated to this shipment" %}
+                {% trans "No stock items have been allocated to this shipment" %}
                 </div>
                 `;
             } else {
                 html = `
-                {% jstrans "The following stock items will be shipped" %}
+                {% trans "The following stock items will be shipped" %}
                 <table class='table table-striped table-condensed'>
                     <thead>
                         <tr>
-                            <th>{% jstrans "Part" %}</th>
-                            <th>{% jstrans "Stock Item" %}</th>
+                            <th>{% trans "Part" %}</th>
+                            <th>{% trans "Stock Item" %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -312,9 +312,9 @@ function completeSalesOrderShipment(shipment_id, options={}) {
                     var stock = '';
 
                     if (allocation.serial) {
-                        stock = `{% jstrans "Serial Number" %}: ${allocation.serial}`;
+                        stock = `{% trans "Serial Number" %}: ${allocation.serial}`;
                     } else {
-                        stock = `{% jstrans "Quantity" %}: ${allocation.quantity}`;
+                        stock = `{% trans "Quantity" %}: ${allocation.quantity}`;
                     }
 
                     html += `
@@ -333,7 +333,7 @@ function completeSalesOrderShipment(shipment_id, options={}) {
 
             constructForm(`{% url "api-so-shipment-list" %}${shipment_id}/ship/`, {
                 method: 'POST',
-                title: `{% jstrans "Complete Shipment" %} ${shipment.reference}`,
+                title: `{% trans "Complete Shipment" %} ${shipment.reference}`,
                 fields: {
                     shipment_date: {
                         value: moment().format('YYYY-MM-DD'),
@@ -357,7 +357,7 @@ function completeSalesOrderShipment(shipment_id, options={}) {
                 },
                 preFormContent: html,
                 confirm: true,
-                confirmMessage: '{% jstrans "Confirm Shipment" %}',
+                confirmMessage: '{% trans "Confirm Shipment" %}',
                 buttons: options.buttons,
                 onSuccess: function(data) {
                     // Reload tables
@@ -413,11 +413,11 @@ function completePendingShipments(order_id, options={}) {
 
         if (!pending_shipments.length) {
             html += `
-            {% jstrans "No pending shipments found" %}
+            {% trans "No pending shipments found" %}
             `;
         } else {
             html += `
-            {% jstrans "No stock items have been allocated to pending shipments" %}
+            {% trans "No stock items have been allocated to pending shipments" %}
             `;
         }
 
@@ -427,7 +427,7 @@ function completePendingShipments(order_id, options={}) {
 
         constructForm(`{% url "api-so-shipment-list" %}0/ship/`, {
             method: 'POST',
-            title: '{% jstrans "Complete Shipments" %}',
+            title: '{% trans "Complete Shipments" %}',
             preFormContent: html,
             onSubmit: function(fields, options) {
                 handleFormSuccess(fields, options);
@@ -449,7 +449,7 @@ function completePendingShipmentsHelper(shipments, shipment_idx, options={}) {
                 buttons: [
                     {
                         name: 'skip',
-                        title: `{% jstrans "Skip" %}`,
+                        title: `{% trans "Skip" %}`,
                         onClick: function(form_options) {
                             if (form_options.modal) {
                                 $(form_options.modal).modal('hide');
@@ -481,7 +481,7 @@ function completeSalesOrder(order_id, options={}) {
         `/api/order/so/${order_id}/complete/`,
         {
             method: 'POST',
-            title: '{% jstrans "Complete Sales Order" %}',
+            title: '{% trans "Complete Sales Order" %}',
             confirm: true,
             fieldsFunction: function(opts) {
                 var fields = {
@@ -497,21 +497,21 @@ function completeSalesOrder(order_id, options={}) {
             preFormContent: function(opts) {
                 var html = `
                 <div class='alert alert-block alert-info'>
-                    {% jstrans "Mark this order as complete?" %}
+                    {% trans "Mark this order as complete?" %}
                 </div>`;
 
                 if (opts.context.pending_shipments) {
                     html += `
                     <div class='alert alert-block alert-danger'>
-                    {% jstrans "Order cannot be completed as there are incomplete shipments" %}<br>
+                    {% trans "Order cannot be completed as there are incomplete shipments" %}<br>
                     </div>`;
                 }
 
                 if (!opts.context.is_complete) {
                     html += `
                     <div class='alert alert-block alert-warning'>
-                    {% jstrans "This order has line items which have not been completed." %}<br>
-                    {% jstrans "Completing this order means that the order and line items will no longer be editable." %}
+                    {% trans "This order has line items which have not been completed." %}<br>
+                    {% trans "Completing this order means that the order and line items will no longer be editable." %}
                     </div>`;
                 }
 
@@ -532,12 +532,12 @@ function issueSalesOrder(order_id, options={}) {
 
     let html = `
     <div class='alert alert-block alert-info'>
-    {% jstrans "Issue this Sales Order?" %}
+    {% trans "Issue this Sales Order?" %}
     </div>`;
 
     constructForm(`{% url "api-so-list" %}${order_id}/issue/`, {
         method: 'POST',
-        title: '{% jstrans "Issue Sales Order" %}',
+        title: '{% trans "Issue Sales Order" %}',
         confirm: true,
         preFormContent: html,
         onSuccess: function(response) {
@@ -556,12 +556,12 @@ function cancelSalesOrder(order_id, options={}) {
         `/api/order/so/${order_id}/cancel/`,
         {
             method: 'POST',
-            title: '{% jstrans "Cancel Sales Order" %}',
+            title: '{% trans "Cancel Sales Order" %}',
             confirm: true,
             preFormContent: function(opts) {
                 var html = `
                 <div class='alert alert-block alert-warning'>
-                {% jstrans "Cancelling this order means that the order will no longer be editable." %}
+                {% trans "Cancelling this order means that the order will no longer be editable." %}
                 </div>`;
 
                 return html;
@@ -615,7 +615,7 @@ function createSalesOrderShipment(options={}) {
                 constructForm('{% url "api-so-shipment-list" %}', {
                     method: 'POST',
                     fields: fields,
-                    title: '{% jstrans "Create New Shipment" %}',
+                    title: '{% trans "Create New Shipment" %}',
                     onSuccess: function(data) {
                         if (options.onSuccess) {
                             options.onSuccess(data);
@@ -725,7 +725,7 @@ function loadSalesOrderTable(table, options) {
         showCustomView: display_mode == 'calendar',
         disablePagination: display_mode == 'calendar',
         formatNoMatches: function() {
-            return '{% jstrans "No sales orders found" %}';
+            return '{% trans "No sales orders found" %}';
         },
         buttons: constructOrderTableButtons({
             prefix: 'salesorder',
@@ -766,12 +766,12 @@ function loadSalesOrderTable(table, options) {
             {
                 sortable: true,
                 field: 'reference',
-                title: '{% jstrans "Sales Order" %}',
+                title: '{% trans "Sales Order" %}',
                 formatter: function(value, row) {
                     var html = renderLink(value, `/order/sales-order/${row.pk}/`);
 
                     if (row.overdue) {
-                        html += makeIconBadge('fa-calendar-times icon-red', '{% jstrans "Order is overdue" %}');
+                        html += makeIconBadge('fa-calendar-times icon-red', '{% trans "Order is overdue" %}');
                     }
 
                     return html;
@@ -781,11 +781,11 @@ function loadSalesOrderTable(table, options) {
                 sortable: true,
                 sortName: 'customer__name',
                 field: 'customer_detail',
-                title: '{% jstrans "Customer" %}',
+                title: '{% trans "Customer" %}',
                 formatter: function(value, row) {
 
                     if (!row.customer_detail) {
-                        return '{% jstrans "Invalid Customer" %}';
+                        return '{% trans "Invalid Customer" %}';
                     }
 
                     return imageHoverIcon(row.customer_detail.image) + renderLink(row.customer_detail.name, `/company/${row.customer}/sales-orders/`);
@@ -794,16 +794,16 @@ function loadSalesOrderTable(table, options) {
             {
                 sortable: true,
                 field: 'customer_reference',
-                title: '{% jstrans "Customer Reference" %}',
+                title: '{% trans "Customer Reference" %}',
             },
             {
                 sortable: false,
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
             },
             {
                 field: 'project_code',
-                title: '{% jstrans "Project Code" %}',
+                title: '{% trans "Project Code" %}',
                 switchable: global_settings.PROJECT_CODES_ENABLED,
                 visible: global_settings.PROJECT_CODES_ENABLED,
                 sortable: true,
@@ -816,7 +816,7 @@ function loadSalesOrderTable(table, options) {
             {
                 sortable: true,
                 field: 'status',
-                title: '{% jstrans "Status" %}',
+                title: '{% trans "Status" %}',
                 formatter: function(value, row) {
                     return salesOrderStatusDisplay(row.status);
                 }
@@ -824,7 +824,7 @@ function loadSalesOrderTable(table, options) {
             {
                 sortable: true,
                 field: 'creation_date',
-                title: '{% jstrans "Creation Date" %}',
+                title: '{% trans "Creation Date" %}',
                 formatter: function(value) {
                     return renderDate(value);
                 }
@@ -832,7 +832,7 @@ function loadSalesOrderTable(table, options) {
             {
                 sortable: true,
                 field: 'target_date',
-                title: '{% jstrans "Target Date" %}',
+                title: '{% trans "Target Date" %}',
                 formatter: function(value) {
                     return renderDate(value);
                 }
@@ -840,7 +840,7 @@ function loadSalesOrderTable(table, options) {
             {
                 sortable: true,
                 field: 'shipment_date',
-                title: '{% jstrans "Shipment Date" %}',
+                title: '{% trans "Shipment Date" %}',
                 formatter: function(value) {
                     return renderDate(value);
                 }
@@ -848,11 +848,11 @@ function loadSalesOrderTable(table, options) {
             {
                 sortable: true,
                 field: 'line_items',
-                title: '{% jstrans "Items" %}'
+                title: '{% trans "Items" %}'
             },
             {
                 field: 'total_price',
-                title: '{% jstrans "Total Cost" %}',
+                title: '{% trans "Total Cost" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
@@ -905,15 +905,15 @@ function loadSalesOrderShipmentTable(table, options={}) {
 
         let html = '';
 
-        html += makeEditButton('button-shipment-edit', pk, '{% jstrans "Edit shipment" %}');
+        html += makeEditButton('button-shipment-edit', pk, '{% trans "Edit shipment" %}');
 
         if (!options.shipped) {
-            html += makeIconButton('fa-truck icon-green', 'button-shipment-ship', pk, '{% jstrans "Complete shipment" %}');
+            html += makeIconButton('fa-truck icon-green', 'button-shipment-ship', pk, '{% trans "Complete shipment" %}');
         }
 
         var enable_delete = row.allocations && row.allocations.length == 0;
 
-        html += makeDeleteButton('button-shipment-delete', pk, '{% jstrans "Delete shipment" %}', {disabled: !enable_delete});
+        html += makeDeleteButton('button-shipment-delete', pk, '{% trans "Delete shipment" %}', {disabled: !enable_delete});
 
         return wrapButtons(html);
     }
@@ -930,7 +930,7 @@ function loadSalesOrderShipmentTable(table, options={}) {
 
             constructForm(`{% url "api-so-shipment-list" %}${pk}/`, {
                 fields: fields,
-                title: '{% jstrans "Edit Shipment" %}',
+                title: '{% trans "Edit Shipment" %}',
                 refreshTable: table,
             });
         });
@@ -945,7 +945,7 @@ function loadSalesOrderShipmentTable(table, options={}) {
             var pk = $(this).attr('pk');
 
             constructForm(`{% url "api-so-shipment-list" %}${pk}/`, {
-                title: '{% jstrans "Delete Shipment" %}',
+                title: '{% trans "Delete Shipment" %}',
                 method: 'DELETE',
                 refreshTable: table,
             });
@@ -978,7 +978,7 @@ function loadSalesOrderShipmentTable(table, options={}) {
             }
         },
         formatNoMatches: function() {
-            return '{% jstrans "No matching shipments found" %}';
+            return '{% trans "No matching shipments found" %}';
         },
         columns: [
             {
@@ -989,13 +989,13 @@ function loadSalesOrderShipmentTable(table, options={}) {
             {
                 visible: show_so_reference,
                 field: 'order_detail',
-                title: '{% jstrans "Sales Order" %}',
+                title: '{% trans "Sales Order" %}',
                 switchable: false,
                 formatter: function(value, row) {
                     var html = renderLink(row.order_detail.reference, `/order/sales-order/${row.order}/`);
 
                     if (row.overdue) {
-                        html += makeIconBadge('fa-calendar-times icon-red', '{% jstrans "Order is overdue" %}');
+                        html += makeIconBadge('fa-calendar-times icon-red', '{% trans "Order is overdue" %}');
                     }
 
                     return html;
@@ -1003,12 +1003,12 @@ function loadSalesOrderShipmentTable(table, options={}) {
             },
             {
                 field: 'reference',
-                title: '{% jstrans "Shipment Reference" %}',
+                title: '{% trans "Shipment Reference" %}',
                 switchable: false,
             },
             {
                 field: 'allocations',
-                title: '{% jstrans "Items" %}',
+                title: '{% trans "Items" %}',
                 switchable: false,
                 sortable: true,
                 formatter: function(value, row) {
@@ -1021,39 +1021,39 @@ function loadSalesOrderShipmentTable(table, options={}) {
             },
             {
                 field: 'shipment_date',
-                title: '{% jstrans "Shipment Date" %}',
+                title: '{% trans "Shipment Date" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     if (value) {
                         return renderDate(value);
                     } else {
-                        return '<em>{% jstrans "Not shipped" %}</em>';
+                        return '<em>{% trans "Not shipped" %}</em>';
                     }
                 }
             },
             {
                 field: 'delivery_date',
-                title: '{% jstrans "Delivery Date" %}',
+                title: '{% trans "Delivery Date" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     if (value) {
                         return renderDate(value);
                     } else {
-                        return '<em>{% jstrans "Unknown" %}</em>';
+                        return '<em>{% trans "Unknown" %}</em>';
                     }
                 }
             },
             {
                 field: 'tracking_number',
-                title: '{% jstrans "Tracking" %}',
+                title: '{% trans "Tracking" %}',
             },
             {
                 field: 'invoice_number',
-                title: '{% jstrans "Invoice" %}',
+                title: '{% trans "Invoice" %}',
             },
             {
                 field: 'link',
-                title: '{% jstrans "Link" %}',
+                title: '{% trans "Link" %}',
                 formatter: function(value) {
                     if (value) {
                         return renderLink(value, value);
@@ -1064,7 +1064,7 @@ function loadSalesOrderShipmentTable(table, options={}) {
             },
             {
                 field: 'notes',
-                title: '{% jstrans "Notes" %}',
+                title: '{% trans "Notes" %}',
                 visible: false,
                 switchable: false,
                 // TODO: Implement 'notes' field
@@ -1106,7 +1106,7 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
             makeRemoveButton(
                 'button-row-remove',
                 pk,
-                '{% jstrans "Remove row" %}',
+                '{% trans "Remove row" %}',
             )
         );
 
@@ -1118,7 +1118,7 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
                 type: 'decimal',
                 min_value: 0,
                 value: quantity || 0,
-                title: '{% jstrans "Specify stock allocation quantity" %}',
+                title: '{% trans "Specify stock allocation quantity" %}',
                 required: true,
             },
             {
@@ -1168,8 +1168,8 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
 
     if (table_entries.length == 0) {
         showAlertDialog(
-            '{% jstrans "Select Parts" %}',
-            '{% jstrans "You must select at least one part to allocate" %}',
+            '{% trans "Select Parts" %}',
+            '{% trans "You must select at least one part to allocate" %}',
         );
 
         return;
@@ -1182,8 +1182,8 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
         'take_from',
         {
             type: 'related field',
-            label: '{% jstrans "Source Location" %}',
-            help_text: '{% jstrans "Select source location (leave blank to take from all locations)" %}',
+            label: '{% trans "Source Location" %}',
+            help_text: '{% trans "Select source location (leave blank to take from all locations)" %}',
             required: false,
         },
         {},
@@ -1194,9 +1194,9 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
     <table class='table table-striped table-condensed' id='stock-allocation-table'>
         <thead>
             <tr>
-                <th>{% jstrans "Part" %}</th>
-                <th style='min-width: 250px;'>{% jstrans "Stock Item" %}</th>
-                <th>{% jstrans "Quantity" %}</th>
+                <th>{% trans "Part" %}</th>
+                <th style='min-width: 250px;'>{% trans "Stock Item" %}</th>
+                <th>{% trans "Quantity" %}</th>
                 <th></th>
         </thead>
         <tbody>
@@ -1216,7 +1216,7 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
                 auto_fill: true,
                 secondary: {
                     method: 'POST',
-                    title: '{% jstrans "Add Shipment" %}',
+                    title: '{% trans "Add Shipment" %}',
                     fields: function() {
                         var ref = null;
 
@@ -1267,8 +1267,8 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
         },
         preFormContent: html,
         confirm: true,
-        confirmMessage: '{% jstrans "Confirm stock allocation" %}',
-        title: '{% jstrans "Allocate Stock Items to Sales Order" %}',
+        confirmMessage: '{% trans "Confirm stock allocation" %}',
+        title: '{% trans "Allocate Stock Items to Sales Order" %}',
         afterRender: function(fields, opts) {
 
             // Initialize source location field
@@ -1280,7 +1280,7 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
                 type: 'related field',
                 value: options.source_location || null,
                 noResults: function(query) {
-                    return '{% jstrans "No matching stock locations" %}';
+                    return '{% trans "No matching stock locations" %}';
                 },
             };
 
@@ -1359,7 +1359,7 @@ function allocateStockToSalesOrder(order_id, line_items, options={}) {
                             return filters;
                         },
                         noResults: function(query) {
-                            return '{% jstrans "No matching stock items" %}';
+                            return '{% trans "No matching stock items" %}';
                         }
                     },
                     null,
@@ -1474,7 +1474,7 @@ function loadSalesOrderAllocationTable(table, options={}) {
         paginationVAlign: 'bottom',
         original: options.params,
         formatNoMatches: function() {
-            return '{% jstrans "No sales order allocations found" %}';
+            return '{% trans "No sales order allocations found" %}';
         },
         columns: [
             {
@@ -1485,7 +1485,7 @@ function loadSalesOrderAllocationTable(table, options={}) {
             {
                 field: 'order',
                 switchable: false,
-                title: '{% jstrans "Order" %}',
+                title: '{% trans "Order" %}',
                 formatter: function(value, row) {
 
                     var ref = `${row.order_detail.reference}`;
@@ -1496,37 +1496,37 @@ function loadSalesOrderAllocationTable(table, options={}) {
             {
                 field: 'item',
                 switchable: false,
-                title: '{% jstrans "Stock Item" %}',
+                title: '{% trans "Stock Item" %}',
                 formatter: function(value, row) {
                     // Render a link to the particular stock item
 
                     var link = `/stock/item/${row.item}/`;
-                    var text = `{% jstrans "Stock Item" %} ${row.item}`;
+                    var text = `{% trans "Stock Item" %} ${row.item}`;
 
                     return renderLink(text, link);
                 }
             },
             {
                 field: 'location',
-                title: '{% jstrans "Location" %}',
+                title: '{% trans "Location" %}',
                 formatter: function(value, row) {
                     return locationDetail(row.item_detail, true);
                 }
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Quantity" %}',
+                title: '{% trans "Quantity" %}',
                 sortable: true,
             },
             {
                 field: 'shipment_date',
-                title: '{% jstrans "Shipped" %}',
+                title: '{% trans "Shipped" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     if (value) {
                         return renderDate(value);
                     } else {
-                        return `<em>{% jstrans "Not shipped" %}</em>`;
+                        return `<em>{% trans "Not shipped" %}</em>`;
                     }
                 }
             }
@@ -1566,7 +1566,7 @@ function showAllocationSubTable(index, row, element, options) {
                     fields: {
                         quantity: {},
                     },
-                    title: '{% jstrans "Edit Stock Allocation" %}',
+                    title: '{% trans "Edit Stock Allocation" %}',
                     refreshTable: options.table,
                 },
             );
@@ -1580,8 +1580,8 @@ function showAllocationSubTable(index, row, element, options) {
                 `/api/order/so-allocation/${pk}/`,
                 {
                     method: 'DELETE',
-                    confirmMessage: '{% jstrans "Confirm Delete Operation" %}',
-                    title: '{% jstrans "Delete Stock Allocation" %}',
+                    confirmMessage: '{% trans "Confirm Delete Operation" %}',
+                    title: '{% trans "Delete Stock Allocation" %}',
                     refreshTable: options.table,
                 }
             );
@@ -1595,20 +1595,20 @@ function showAllocationSubTable(index, row, element, options) {
         columns: [
             {
                 field: 'part_detail',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 formatter: function(part, row) {
                     return imageHoverIcon(part.thumbnail) + renderLink(part.full_name, `/part/${part.pk}/`);
                 }
             },
             {
                 field: 'allocated',
-                title: '{% jstrans "Stock Item" %}',
+                title: '{% trans "Stock Item" %}',
                 formatter: function(value, row, index, field) {
                     let item = row.item_detail;
-                    let text = `{% jstrans "Quantity" %}: ${row.quantity}`;
+                    let text = `{% trans "Quantity" %}: ${row.quantity}`;
 
                     if (item && item.serial != null && row.quantity == 1) {
-                        text = `{% jstrans "Serial Number" %}: ${item.serial}`;
+                        text = `{% trans "Serial Number" %}: ${item.serial}`;
                     }
 
                     return renderLink(text, `/stock/item/${row.item}/`);
@@ -1616,19 +1616,19 @@ function showAllocationSubTable(index, row, element, options) {
             },
             {
                 field: 'location',
-                title: '{% jstrans "Location" %}',
+                title: '{% trans "Location" %}',
                 formatter: function(value, row, index, field) {
 
                     if (row.shipment_date) {
-                        return `<em>{% jstrans "Shipped to customer" %} - ${row.shipment_date}</em>`;
+                        return `<em>{% trans "Shipped to customer" %} - ${row.shipment_date}</em>`;
                     } else if (row.location) {
                         // Location specified
                         return renderLink(
-                            row.location_detail.pathstring || '{% jstrans "Location" %}',
+                            row.location_detail.pathstring || '{% trans "Location" %}',
                             `/stock/location/${row.location}/`
                         );
                     } else {
-                        return `<em>{% jstrans "Stock location not specified" %}</em>`;
+                        return `<em>{% trans "Stock location not specified" %}</em>`;
                     }
                 },
             },
@@ -1641,10 +1641,10 @@ function showAllocationSubTable(index, row, element, options) {
                     let pk = row.pk;
 
                     if (row.shipment_date) {
-                        html += `<span class='badge bg-success badge-right'>{% jstrans "Shipped" %}</span>`;
+                        html += `<span class='badge bg-success badge-right'>{% trans "Shipped" %}</span>`;
                     } else {
-                        html += makeEditButton('button-allocation-edit', pk, '{% jstrans "Edit stock allocation" %}');
-                        html += makeDeleteButton('button-allocation-delete', pk, '{% jstrans "Delete stock allocation" %}');
+                        html += makeEditButton('button-allocation-edit', pk, '{% trans "Edit stock allocation" %}');
+                        html += makeDeleteButton('button-allocation-delete', pk, '{% trans "Delete stock allocation" %}');
                     }
 
                     return wrapButtons(html);
@@ -1689,13 +1689,13 @@ function showFulfilledSubTable(index, row, element, options) {
             },
             {
                 field: 'stock',
-                title: '{% jstrans "Stock Item" %}',
+                title: '{% trans "Stock Item" %}',
                 formatter: function(value, row) {
                     var text = '';
                     if (row.serial && row.quantity == 1) {
-                        text = `{% jstrans "Serial Number" %}: ${row.serial}`;
+                        text = `{% trans "Serial Number" %}: ${row.serial}`;
                     } else {
-                        text = `{% jstrans "Quantity" %}: ${row.quantity}`;
+                        text = `{% trans "Quantity" %}: ${row.quantity}`;
                     }
 
                     return renderLink(text, `/stock/item/${row.pk}/`);
@@ -1703,11 +1703,11 @@ function showFulfilledSubTable(index, row, element, options) {
             },
             {
                 field: 'location',
-                title: '{% jstrans "Location" %}',
+                title: '{% trans "Location" %}',
                 formatter: function(value, row) {
                     if (row.customer) {
                         return renderLink(
-                            '{% jstrans "Shipped to customer" %}',
+                            '{% trans "Shipped to customer" %}',
                             `/company/${row.customer}/`
                         );
                     } else if (row.location && row.location_detail) {
@@ -1716,7 +1716,7 @@ function showFulfilledSubTable(index, row, element, options) {
                             `/stock/location/${row.location}`,
                         );
                     } else {
-                        return `<em>{% jstrans "Stock location not specified" %}</em>`;
+                        return `<em>{% trans "Stock location not specified" %}</em>`;
                     }
                 }
             }
@@ -1793,7 +1793,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
             sortable: true,
             sortName: 'part_detail.name',
             field: 'part',
-            title: '{% jstrans "Part" %}',
+            title: '{% trans "Part" %}',
             switchable: false,
             formatter: function(value, row, index, field) {
                 if (row.part_detail) {
@@ -1803,25 +1803,25 @@ function loadSalesOrderLineItemTable(table, options={}) {
                 }
             },
             footerFormatter: function() {
-                return '{% jstrans "Total" %}';
+                return '{% trans "Total" %}';
             },
         },
         {
             sortable: false,
             field: 'part_detail.description',
-            title: '{% jstrans "Description" %}',
+            title: '{% trans "Description" %}',
             switchable: true,
         },
         {
             sortable: true,
             field: 'reference',
-            title: '{% jstrans "Reference" %}',
+            title: '{% trans "Reference" %}',
             switchable: true,
         },
         {
             sortable: true,
             field: 'quantity',
-            title: '{% jstrans "Quantity" %}',
+            title: '{% trans "Quantity" %}',
             footerFormatter: function(data) {
                 return data.map(function(row) {
                     return +row['quantity'];
@@ -1834,7 +1834,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
         {
             sortable: true,
             field: 'sale_price',
-            title: '{% jstrans "Unit Price" %}',
+            title: '{% trans "Unit Price" %}',
             formatter: function(value, row) {
                 return formatCurrency(row.sale_price, {
                     currency: row.sale_price_currency
@@ -1844,7 +1844,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
         {
             field: 'total_price',
             sortable: true,
-            title: '{% jstrans "Total Price" %}',
+            title: '{% trans "Total Price" %}',
             formatter: function(value, row) {
                 return formatCurrency(row.sale_price * row.quantity, {
                     currency: row.sale_price_currency,
@@ -1864,7 +1864,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
         },
         {
             field: 'target_date',
-            title: '{% jstrans "Target Date" %}',
+            title: '{% trans "Target Date" %}',
             sortable: true,
             switchable: true,
             formatter: function(value, row) {
@@ -1872,7 +1872,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                     var html = renderDate(row.target_date);
 
                     if (row.overdue) {
-                        html += makeIconBadge('fa-calendar-times', '{% jstrans "This line item is overdue" %}');
+                        html += makeIconBadge('fa-calendar-times', '{% trans "This line item is overdue" %}');
                     }
 
                     return html;
@@ -1890,7 +1890,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
         columns.push(
             {
                 field: 'stock',
-                title: '{% jstrans "Available Stock" %}',
+                title: '{% trans "Available Stock" %}',
                 formatter: function(value, row) {
 
                     let available = row.available_stock + row.available_variant_stock;
@@ -1904,17 +1904,17 @@ function loadSalesOrderLineItemTable(table, options={}) {
                         html = renderLink(available, url);
 
                         if (row.available_variant_stock && row.available_variant_stock > 0) {
-                            html += makeIconBadge('fa-info-circle icon-blue', '{% jstrans "Includes variant stock" %}');
+                            html += makeIconBadge('fa-info-circle icon-blue', '{% trans "Includes variant stock" %}');
                         }
                     } else {
-                        html += `<span class='badge rounded-pill bg-danger'>{% jstrans "No Stock Available" %}</span>`;
+                        html += `<span class='badge rounded-pill bg-danger'>{% trans "No Stock Available" %}</span>`;
                     }
 
                     if (required > 0) {
                         if (available >= required) {
-                            html += makeIconBadge('fa-check-circle icon-green', '{% jstrans "Sufficient stock available" %}');
+                            html += makeIconBadge('fa-check-circle icon-green', '{% trans "Sufficient stock available" %}');
                         } else {
-                            html += makeIconBadge('fa-times-circle icon-red', '{% jstrans "Insufficient stock available" %}');
+                            html += makeIconBadge('fa-times-circle icon-red', '{% trans "Insufficient stock available" %}');
                         }
                     }
 
@@ -1926,7 +1926,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
         columns.push(
             {
                 field: 'allocated',
-                title: '{% jstrans "Allocated" %}',
+                title: '{% trans "Allocated" %}',
                 switchable: false,
                 sortable: true,
                 formatter: function(value, row, index, field) {
@@ -1954,7 +1954,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
     columns.push({
         field: 'shipped',
-        title: '{% jstrans "Shipped" %}',
+        title: '{% trans "Shipped" %}',
         switchable: false,
         sortable: true,
         formatter: function(value, row) {
@@ -1979,12 +1979,12 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
     columns.push({
         field: 'notes',
-        title: '{% jstrans "Notes" %}',
+        title: '{% trans "Notes" %}',
     });
 
     columns.push({
         field: 'link',
-        title: '{% jstrans "Link" %}',
+        title: '{% trans "Link" %}',
         formatter: function(value) {
             if (value) {
                 return renderLink(value, value);
@@ -2005,37 +2005,37 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
                 if (options.allow_edit && (row.shipped < row.quantity)) {
                     if (part.trackable) {
-                        buttons += makeIconButton('fa-hashtag icon-green', 'button-add-by-sn', pk, '{% jstrans "Allocate serial numbers" %}');
+                        buttons += makeIconButton('fa-hashtag icon-green', 'button-add-by-sn', pk, '{% trans "Allocate serial numbers" %}');
                     }
-                    buttons += makeIconButton('fa-sign-in-alt icon-green', 'button-add', pk, '{% jstrans "Allocate stock" %}');
+                    buttons += makeIconButton('fa-sign-in-alt icon-green', 'button-add', pk, '{% trans "Allocate stock" %}');
                     if (part.purchaseable) {
-                        buttons += makeIconButton('fa-shopping-cart', 'button-buy', row.part, '{% jstrans "Purchase stock" %}');
+                        buttons += makeIconButton('fa-shopping-cart', 'button-buy', row.part, '{% trans "Purchase stock" %}');
                     }
 
                     if (part.assembly) {
-                        buttons += makeIconButton('fa-tools', 'button-build', row.part, '{% jstrans "Build stock" %}');
+                        buttons += makeIconButton('fa-tools', 'button-build', row.part, '{% trans "Build stock" %}');
                     }
                 }
             }
 
-            buttons += makeIconButton('fa-dollar-sign icon-green', 'button-price', pk, '{% jstrans "Calculate price" %}');
+            buttons += makeIconButton('fa-dollar-sign icon-green', 'button-price', pk, '{% trans "Calculate price" %}');
 
             if (options.allow_edit) {
-                buttons += makeCopyButton('button-duplicate', pk, '{% jstrans "Duplicate line item" %}');
-                buttons += makeEditButton('button-edit', pk, '{% jstrans "Edit line item" %}');
+                buttons += makeCopyButton('button-duplicate', pk, '{% trans "Duplicate line item" %}');
+                buttons += makeEditButton('button-edit', pk, '{% trans "Edit line item" %}');
             }
 
             if (options.allow_delete) {
                 var delete_disabled = false;
 
-                var title = '{% jstrans "Delete line item" %}';
+                var title = '{% trans "Delete line item" %}';
 
                 if (row.shipped) {
                     delete_disabled = true;
-                    title = '{% jstrans "Cannot be deleted as items have been shipped" %}';
+                    title = '{% trans "Cannot be deleted as items have been shipped" %}';
                 } else if (row.allocated) {
                     delete_disabled = true;
-                    title = '{% jstrans "Cannot be deleted as items have been allocated" %}';
+                    title = '{% trans "Cannot be deleted as items have been allocated" %}';
                 }
 
                 // Prevent deletion of the line item if items have been allocated or shipped!
@@ -2067,7 +2067,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                         method: 'POST',
                         fields: fields,
                         data: data,
-                        title: '{% jstrans "Duplicate Line Item" %}',
+                        title: '{% trans "Duplicate Line Item" %}',
                         refreshTable: table,
                     });
                 }
@@ -2080,7 +2080,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
             constructForm(`{% url "api-so-line-list" %}${pk}/`, {
                 fields: soLineItemFields(),
-                title: '{% jstrans "Edit Line Item" %}',
+                title: '{% trans "Edit Line Item" %}',
                 onSuccess: reloadTable,
             });
         });
@@ -2091,7 +2091,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
             constructForm(`{% url "api-so-line-list" %}${pk}/`, {
                 method: 'DELETE',
-                title: '{% jstrans "Delete Line Item" %}',
+                title: '{% trans "Delete Line Item" %}',
                 onSuccess: reloadTable,
             });
         });
@@ -2106,7 +2106,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
                         constructForm(`{% url "api-so-list" %}${options.order}/allocate-serials/`, {
                             method: 'POST',
-                            title: '{% jstrans "Allocate Serial Numbers" %}',
+                            title: '{% trans "Allocate Serial Numbers" %}',
                             fields: {
                                 line_item: {
                                     value: pk,
@@ -2205,7 +2205,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
             launchModalForm(
                 '{% url "line-pricing" %}',
                 {
-                    submit_text: '{% jstrans "Calculate price" %}',
+                    submit_text: '{% trans "Calculate price" %}',
                     data: {
                         line_item: pk,
                         quantity: row.quantity,
@@ -2213,7 +2213,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
                     buttons: [
                         {
                             name: 'update_price',
-                            title: '{% jstrans "Update Unit Price" %}'
+                            title: '{% trans "Update Unit Price" %}'
                         },
                     ],
                     success: reloadTable,
@@ -2227,7 +2227,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
         name: 'salesorderlineitems',
         sidePagination: 'client',
         formatNoMatches: function() {
-            return '{% jstrans "No matching line items" %}';
+            return '{% trans "No matching line items" %}';
         },
         queryParams: filters,
         original: options.params,

--- a/InvenTree/templates/js/translated/search.js
+++ b/InvenTree/templates/js/translated/search.js
@@ -127,7 +127,7 @@ function updateSearch() {
             filters.active = true;
         }
 
-        addSearchQuery('part', '{% jstrans "Parts" %}', filters);
+        addSearchQuery('part', '{% trans "Parts" %}', filters);
     }
 
     if (checkPermission('part') && checkPermission('purchase_order')) {
@@ -144,18 +144,18 @@ function updateSearch() {
         }
 
         if (user_settings.SEARCH_PREVIEW_SHOW_SUPPLIER_PARTS) {
-            addSearchQuery('supplierpart', '{% jstrans "Supplier Parts" %}', filters);
+            addSearchQuery('supplierpart', '{% trans "Supplier Parts" %}', filters);
         }
 
         if (user_settings.SEARCH_PREVIEW_SHOW_MANUFACTURER_PARTS) {
-            addSearchQuery('manufacturerpart', '{% jstrans "Manufacturer Parts" %}', filters);
+            addSearchQuery('manufacturerpart', '{% trans "Manufacturer Parts" %}', filters);
         }
     }
 
     if (checkPermission('part_category') && user_settings.SEARCH_PREVIEW_SHOW_CATEGORIES) {
         let filters = {};
 
-        addSearchQuery('partcategory', '{% jstrans "Part Categories" %}', filters);
+        addSearchQuery('partcategory', '{% trans "Part Categories" %}', filters);
     }
 
     if (checkPermission('stock') && user_settings.SEARCH_PREVIEW_SHOW_STOCK) {
@@ -169,13 +169,13 @@ function updateSearch() {
             filters.in_stock = true;
         }
 
-        addSearchQuery('stockitem', '{% jstrans "Stock Items" %}', filters);
+        addSearchQuery('stockitem', '{% trans "Stock Items" %}', filters);
     }
 
     if (checkPermission('stock_location') && user_settings.SEARCH_PREVIEW_SHOW_LOCATIONS) {
         let filters = {};
 
-        addSearchQuery('stocklocation', '{% jstrans "Stock Locations" %}', filters);
+        addSearchQuery('stocklocation', '{% trans "Stock Locations" %}', filters);
     }
 
     if (checkPermission('build') && user_settings.SEARCH_PREVIEW_SHOW_BUILD_ORDERS) {
@@ -183,13 +183,13 @@ function updateSearch() {
             part_detail: true
         };
 
-        addSearchQuery('build', '{% jstrans "Build Orders" %}', filters);
+        addSearchQuery('build', '{% trans "Build Orders" %}', filters);
     }
 
     if ((checkPermission('sales_order') || checkPermission('purchase_order')) && user_settings.SEARCH_PREVIEW_SHOW_COMPANIES) {
         let filters = {};
 
-        addSearchQuery('company', '{% jstrans "Companies" %}', filters);
+        addSearchQuery('company', '{% trans "Companies" %}', filters);
     }
 
     if (checkPermission('purchase_order') && user_settings.SEARCH_PREVIEW_SHOW_PURCHASE_ORDERS) {
@@ -202,7 +202,7 @@ function updateSearch() {
             filters.outstanding = true;
         }
 
-        addSearchQuery('purchaseorder', '{% jstrans "Purchase Orders" %}', filters);
+        addSearchQuery('purchaseorder', '{% trans "Purchase Orders" %}', filters);
     }
 
     if (checkPermission('sales_order') && user_settings.SEARCH_PREVIEW_SHOW_SALES_ORDERS) {
@@ -216,7 +216,7 @@ function updateSearch() {
             filters.outstanding = true;
         }
 
-        addSearchQuery('salesorder', '{% jstrans "Sales Orders" %}', filters);
+        addSearchQuery('salesorder', '{% trans "Sales Orders" %}', filters);
     }
 
     if (checkPermission('return_order') && user_settings.SEARCH_PREVIEW_SHOW_RETURN_ORDERS) {
@@ -229,14 +229,14 @@ function updateSearch() {
             filters.outstanding = true;
         }
 
-        addSearchQuery('returnorder', '{% jstrans "Return Orders" %}', filters);
+        addSearchQuery('returnorder', '{% trans "Return Orders" %}', filters);
     }
 
     let ctx = $('#offcanvas-search').find('#search-context');
 
     ctx.html(`
     <div class='alert alert-block alert-secondary'>
-        <span class='fas fa-spinner fa-spin'></span> <em>{% jstrans "Searching" %}</em>
+        <span class='fas fa-spinner fa-spin'></span> <em>{% trans "Searching" %}</em>
     </div>
     `);
 
@@ -267,7 +267,7 @@ function updateSearch() {
                 } else {
                     ctx.html(`
                     <div class='alert alert-block alert-warning'>
-                        <span class='fas fa-exclamation-circle'></span> <em>{% jstrans "No results" %}</em>
+                        <span class='fas fa-exclamation-circle'></span> <em>{% trans "No results" %}</em>
                     </div>
                     `);
                 }
@@ -289,7 +289,7 @@ function clearSearchResults() {
 
     panel.find('#search-context').html(`
     <div class='alert alert-block alert-info'>
-        <span class='fas fa-search'></span> <em>{% jstrans "Enter search query" %}</em>
+        <span class='fas fa-search'></span> <em>{% trans "Enter search query" %}</em>
     </div>
     `);
 
@@ -339,7 +339,7 @@ function addSearchResults(results, resultType, resultCount) {
     let renderer = resultType.renderer;
     let renderParams = resultType.renderParams;
 
-    let resultText = resultCount == 1 ? '{% jstrans "result" %}' : '{% jstrans "results" %}';
+    let resultText = resultCount == 1 ? '{% trans "result" %}' : '{% trans "results" %}';
 
     // Add the result group to the panel
     panel.find('#search-results').append(`
@@ -349,10 +349,10 @@ function addSearchResults(results, resultType, resultCount) {
                 <h5>${title}</h5><span class='float-right'><em><small>&nbsp;-&nbsp;${resultCount} ${resultText}</small></em></span>
                 <span class='flex' style='flex-grow: 1;'></span>
                 <div class='search-result-group-buttons btn-group float-right' role='group'>
-                    <button class='btn btn-outline-secondary' id='hide-results-${key}' title='{% jstrans "Minimize results" %}'>
+                    <button class='btn btn-outline-secondary' id='hide-results-${key}' title='{% trans "Minimize results" %}'>
                         <span class='fas fa-chevron-up'></span>
                     </button>
-                    <button class='btn btn-outline-secondary' id='remove-results-${key}' title='{% jstrans "Remove results" %}'>
+                    <button class='btn btn-outline-secondary' id='remove-results-${key}' title='{% trans "Remove results" %}'>
                         <span class='fas fa-times icon-red'></span>
                     </button>
                 </div>

--- a/InvenTree/templates/js/translated/stock.js
+++ b/InvenTree/templates/js/translated/stock.js
@@ -95,7 +95,7 @@ function serializeStockItem(pk, options={}) {
     var url = `/api/stock/${pk}/serialize/`;
 
     options.method = 'POST';
-    options.title = '{% jstrans "Serialize Stock Item" %}';
+    options.title = '{% trans "Serialize Stock Item" %}';
 
     options.fields = {
         quantity: {},
@@ -116,9 +116,9 @@ function serializeStockItem(pk, options={}) {
         inventreeGet(`{% url "api-part-list" %}${options.part}/serial-numbers/`, {}, {
             success: function(data) {
                 if (data.next) {
-                    options.fields.serial_numbers.placeholder = `{% jstrans "Next available serial number" %}: ${data.next}`;
+                    options.fields.serial_numbers.placeholder = `{% trans "Next available serial number" %}: ${data.next}`;
                 } else if (data.latest) {
-                    options.fields.serial_numbers.placeholder = `{% jstrans "Latest serial number" %}: ${data.latest}`;
+                    options.fields.serial_numbers.placeholder = `{% trans "Latest serial number" %}: ${data.latest}`;
                 }
             },
             async: false,
@@ -126,7 +126,7 @@ function serializeStockItem(pk, options={}) {
     }
 
     options.confirm = true;
-    options.confirmMessage = '{% jstrans "Confirm Stock Serialization" %}';
+    options.confirmMessage = '{% trans "Confirm Stock Serialization" %}';
 
     constructForm(url, options);
 }
@@ -136,7 +136,7 @@ function stockLocationTypeFields() {
         name: {},
         description: {},
         icon: {
-            help_text: `{% jstrans "Default icon for all locations that have no icon set (optional) - Explore all available icons on" %} <a href="https://fontawesome.com/v5/search?s=solid" target="_blank" rel="noopener noreferrer">Font Awesome</a>.`,
+            help_text: `{% trans "Default icon for all locations that have no icon set (optional) - Explore all available icons on" %} <a href="https://fontawesome.com/v5/search?s=solid" target="_blank" rel="noopener noreferrer">Font Awesome</a>.`,
             placeholder: 'fas fa-box',
             icon: "fa-icons",
         },
@@ -149,7 +149,7 @@ function stockLocationTypeFields() {
 function stockLocationFields(options={}) {
     var fields = {
         parent: {
-            help_text: '{% jstrans "Parent stock location" %}',
+            help_text: '{% trans "Parent stock location" %}',
             required: false,
             tree_picker: {
                 url: '{% url "api-location-tree" %}',
@@ -163,7 +163,7 @@ function stockLocationFields(options={}) {
         external: {},
         location_type: {
             secondary: {
-                title: '{% jstrans "Add Location type" %}',
+                title: '{% trans "Add Location type" %}',
                 fields: function() {
                     const fields = stockLocationTypeFields();
 
@@ -172,7 +172,7 @@ function stockLocationFields(options={}) {
             },
         },
         custom_icon: {
-            help_text: `{% jstrans "Icon (optional) - Explore all available icons on" %} <a href="https://fontawesome.com/v5/search?s=solid" target="_blank" rel="noopener noreferrer">Font Awesome</a>.`,
+            help_text: `{% trans "Icon (optional) - Explore all available icons on" %} <a href="https://fontawesome.com/v5/search?s=solid" target="_blank" rel="noopener noreferrer">Font Awesome</a>.`,
             placeholder: 'fas fa-box',
             icon: "fa-icons",
         },
@@ -199,7 +199,7 @@ function editStockLocation(pk, options={}) {
 
     options.fields = stockLocationFields(options);
 
-    options.title = '{% jstrans "Edit Stock Location" %}';
+    options.title = '{% trans "Edit Stock Location" %}';
 
     constructForm(url, options);
 }
@@ -214,10 +214,10 @@ function createStockLocation(options={}) {
 
     options.method = 'POST';
     options.fields = stockLocationFields(options);
-    options.title = '{% jstrans "New Stock Location" %}';
+    options.title = '{% trans "New Stock Location" %}';
     options.persist = true;
-    options.persistMessage = '{% jstrans "Create another location after this one" %}';
-    options.successMessage = '{% jstrans "Stock location created" %}';
+    options.persistMessage = '{% trans "Create another location after this one" %}';
+    options.successMessage = '{% trans "Stock location created" %}';
 
     constructForm(url, options);
 }
@@ -231,32 +231,32 @@ function deleteStockLocation(pk, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "Are you sure you want to delete this stock location?" %}
+    {% trans "Are you sure you want to delete this stock location?" %}
     </div>
     `;
 
     var subChoices = [
         {
             value: 0,
-            display_name: '{% jstrans "Move to parent stock location" %}',
+            display_name: '{% trans "Move to parent stock location" %}',
         },
         {
             value: 1,
-            display_name: '{% jstrans "Delete" %}',
+            display_name: '{% trans "Delete" %}',
         }
     ];
 
     constructForm(url, {
-        title: '{% jstrans "Delete Stock Location" %}',
+        title: '{% trans "Delete Stock Location" %}',
         method: 'DELETE',
         fields: {
             'delete_stock_items': {
-                label: '{% jstrans "Action for stock items in this stock location" %}',
+                label: '{% trans "Action for stock items in this stock location" %}',
                 choices: subChoices,
                 type: 'choice'
             },
             'delete_sub_locations': {
-                label: '{% jstrans "Action for sub-locations" %}',
+                label: '{% trans "Action for sub-locations" %}',
                 choices: subChoices,
                 type: 'choice'
             },
@@ -291,9 +291,9 @@ function stockItemFields(options={}) {
                             success: function(data) {
                                 var placeholder = '';
                                 if (data.next) {
-                                    placeholder = `{% jstrans "Next available serial number" %}: ${data.next}`;
+                                    placeholder = `{% trans "Next available serial number" %}: ${data.next}`;
                                 } else if (data.latest) {
-                                    placeholder = `{% jstrans "Latest serial number" %}: ${data.latest}`;
+                                    placeholder = `{% trans "Latest serial number" %}: ${data.latest}`;
                                 }
 
                                 setFormInputPlaceholder('serial_numbers', placeholder, opts);
@@ -310,7 +310,7 @@ function stockItemFields(options={}) {
                         clearFormInput('serial_numbers', opts);
                         disableFormInput('serial_numbers', opts);
 
-                        setFormInputPlaceholder('serial_numbers', '{% jstrans "This part cannot be serialized" %}', opts);
+                        setFormInputPlaceholder('serial_numbers', '{% trans "This part cannot be serialized" %}', opts);
                     }
 
                     // Enable / disable fields based on purchaseable status
@@ -346,7 +346,7 @@ function stockItemFields(options={}) {
             }
         },
         use_pack_size: {
-            help_text: '{% jstrans "Add given quantity as packs instead of individual items" %}',
+            help_text: '{% trans "Add given quantity as packs instead of individual items" %}',
         },
         location: {
             icon: 'fa-sitemap',
@@ -359,13 +359,13 @@ function stockItemFields(options={}) {
             },
         },
         quantity: {
-            help_text: '{% jstrans "Enter initial quantity for this stock item" %}',
+            help_text: '{% trans "Enter initial quantity for this stock item" %}',
         },
         serial_numbers: {
             icon: 'fa-hashtag',
             type: 'string',
-            label: '{% jstrans "Serial Numbers" %}',
-            help_text: '{% jstrans "Enter serial numbers for new stock (or leave blank)" %}',
+            label: '{% trans "Serial Numbers" %}',
+            help_text: '{% trans "Enter serial numbers for new stock (or leave blank)" %}',
             required: false,
         },
         serial: {
@@ -436,7 +436,7 @@ function duplicateStockItem(pk, options) {
     if (!options.onSuccess) {
         options.onSuccess = function(response) {
 
-            showAlertOrCache('{% jstrans "Stock item duplicated" %}', true, {style: 'success'});
+            showAlertOrCache('{% trans "Stock item duplicated" %}', true, {style: 'success'});
 
             window.location.href = `/stock/item/${response.pk}/`;
         };
@@ -456,7 +456,7 @@ function duplicateStockItem(pk, options) {
             options.groups = stockItemGroups(options);
 
             options.method = 'POST';
-            options.title = '{% jstrans "Duplicate Stock Item" %}';
+            options.title = '{% trans "Duplicate Stock Item" %}';
 
             constructForm('{% url "api-stock-list" %}', options);
         }
@@ -472,12 +472,12 @@ function deleteStockItem(pk, options={}) {
 
     var html = `
     <div class='alert alert-block alert-danger'>
-    {% jstrans "Are you sure you want to delete this stock item?" %}
+    {% trans "Are you sure you want to delete this stock item?" %}
     </div>`;
 
     constructForm(url, {
         method: 'DELETE',
-        title: '{% jstrans "Delete Stock Item" %}',
+        title: '{% trans "Delete Stock Item" %}',
         preFormContent: html,
         onSuccess: function(response) {
             handleFormSuccess(response, options);
@@ -498,7 +498,7 @@ function editStockItem(pk, options={}) {
     options.fields = stockItemFields(options);
     options.groups = stockItemGroups(options);
 
-    options.title = '{% jstrans "Edit Stock Item" %}';
+    options.title = '{% trans "Edit Stock Item" %}';
 
     // Query parameters for retrieving stock item data
     options.params = {
@@ -534,14 +534,14 @@ function createNewStockItem(options={}) {
 
     var url = '{% url "api-stock-list" %}';
 
-    options.title = '{% jstrans "New Stock Item" %}';
+    options.title = '{% trans "New Stock Item" %}';
     options.method = 'POST';
 
     options.create = true;
 
     options.persist = true;
-    options.persistMessage = '{% jstrans "Create another item after this one" %}';
-    options.successMessage = '{% jstrans "Stock item created" %}';
+    options.persistMessage = '{% trans "Create another item after this one" %}';
+    options.successMessage = '{% trans "Stock item created" %}';
 
     options.fields = stockItemFields(options);
     options.groups = stockItemGroups(options);
@@ -552,7 +552,7 @@ function createNewStockItem(options={}) {
             if (response.pk) {
                 var url = `/stock/item/${response.pk}/`;
 
-                addCachedAlert('{% jstrans "Created new stock item" %}', {
+                addCachedAlert('{% trans "Created new stock item" %}', {
                     icon: 'fas fa-boxes',
                 });
 
@@ -561,11 +561,11 @@ function createNewStockItem(options={}) {
 
                 // Multiple stock items have been created (i.e. serialized stock)
                 var details = `
-                <br>{% jstrans "Quantity" %}: ${response.quantity}
-                <br>{% jstrans "Serial Numbers" %}: ${response.serial_numbers}
+                <br>{% trans "Quantity" %}: ${response.quantity}
+                <br>{% trans "Serial Numbers" %}: ${response.serial_numbers}
                 `;
 
-                showMessage('{% jstrans "Created multiple stock items" %}', {
+                showMessage('{% trans "Created multiple stock items" %}', {
                     icon: 'fas fa-boxes',
                     details: details,
                 });
@@ -590,12 +590,12 @@ function createNewStockItem(options={}) {
 function findStockItemBySerialNumber(part_id) {
 
     constructFormBody({}, {
-        title: '{% jstrans "Find Serial Number" %}',
+        title: '{% trans "Find Serial Number" %}',
         fields: {
             serial: {
-                label: '{% jstrans "Serial Number" %}',
-                help_text: '{% jstrans "Enter serial number" %}',
-                placeholder: '{% jstrans "Enter serial number" %}',
+                label: '{% trans "Serial Number" %}',
+                help_text: '{% trans "Enter serial number" %}',
+                placeholder: '{% trans "Enter serial number" %}',
                 required: true,
                 type: 'string',
                 value: '',
@@ -611,7 +611,7 @@ function findStockItemBySerialNumber(part_id) {
                 handleFormErrors(
                     {
                         'serial': [
-                            '{% jstrans "Enter a serial number" %}',
+                            '{% trans "Enter a serial number" %}',
                         ]
                     }, fields, opts
                 );
@@ -631,7 +631,7 @@ function findStockItemBySerialNumber(part_id) {
                             handleFormErrors(
                                 {
                                     'serial': [
-                                        '{% jstrans "No matching serial number" %}',
+                                        '{% trans "No matching serial number" %}',
                                     ]
                                 }, fields, opts
                             );
@@ -640,7 +640,7 @@ function findStockItemBySerialNumber(part_id) {
                             handleFormErrors(
                                 {
                                     'serial': [
-                                        '{% jstrans "More than one matching result found" %}',
+                                        '{% trans "More than one matching result found" %}',
                                     ]
                                 }, fields, opts
                             );
@@ -673,9 +673,9 @@ function assignStockToCustomer(items, options={}) {
     <table class='table table-striped table-condensed' id='stock-assign-table'>
     <thead>
         <tr>
-            <th>{% jstrans "Part" %}</th>
-            <th>{% jstrans "Stock Item" %}</th>
-            <th>{% jstrans "Location" %}</th>
+            <th>{% trans "Part" %}</th>
+            <th>{% trans "Stock Item" %}</th>
+            <th>{% trans "Location" %}</th>
             <th></th>
         </tr>
     </thead>
@@ -697,9 +697,9 @@ function assignStockToCustomer(items, options={}) {
         var quantity = '';
 
         if (item.serial && item.quantity == 1) {
-            quantity = `{% jstrans "Serial" %}: ${item.serial}`;
+            quantity = `{% trans "Serial" %}: ${item.serial}`;
         } else {
-            quantity = `{% jstrans "Quantity" %}: ${item.quantity}`;
+            quantity = `{% trans "Quantity" %}: ${item.quantity}`;
         }
 
         quantity += status;
@@ -711,7 +711,7 @@ function assignStockToCustomer(items, options={}) {
         buttons += makeRemoveButton(
             'button-stock-item-remove',
             pk,
-            '{% jstrans "Remove row" %}',
+            '{% trans "Remove row" %}',
         );
 
         buttons += '</div>';
@@ -748,8 +748,8 @@ function assignStockToCustomer(items, options={}) {
             },
         },
         confirm: true,
-        confirmMessage: '{% jstrans "Confirm stock assignment" %}',
-        title: '{% jstrans "Assign Stock to Customer" %}',
+        confirmMessage: '{% trans "Confirm stock assignment" %}',
+        title: '{% trans "Assign Stock to Customer" %}',
         afterRender: function(fields, opts) {
             // Add button callbacks to remove rows
             $(opts.modal).find('.button-stock-item-remove').click(function() {
@@ -826,11 +826,11 @@ function mergeStockItems(items, options={}) {
     // Generate HTML content for the form
     var html = `
     <div class='alert alert-block alert-danger'>
-    <h5>{% jstrans "Warning: Merge operation cannot be reversed" %}</h5>
-    <strong>{% jstrans "Some information will be lost when merging stock items" %}:</strong>
+    <h5>{% trans "Warning: Merge operation cannot be reversed" %}</h5>
+    <strong>{% trans "Some information will be lost when merging stock items" %}:</strong>
     <ul>
-        <li>{% jstrans "Stock transaction history will be deleted for merged items" %}</li>
-        <li>{% jstrans "Supplier part information will be deleted for merged items" %}</li>
+        <li>{% trans "Stock transaction history will be deleted for merged items" %}</li>
+        <li>{% trans "Supplier part information will be deleted for merged items" %}</li>
     </ul>
     </div>
     `;
@@ -839,9 +839,9 @@ function mergeStockItems(items, options={}) {
     <table class='table table-striped table-condensed' id='stock-merge-table'>
     <thead>
         <tr>
-            <th>{% jstrans "Part" %}</th>
-            <th>{% jstrans "Stock Item" %}</th>
-            <th>{% jstrans "Location" %}</th>
+            <th>{% trans "Part" %}</th>
+            <th>{% trans "Stock Item" %}</th>
+            <th>{% trans "Location" %}</th>
             <th></th>
         </tr>
     </thead>
@@ -868,9 +868,9 @@ function mergeStockItems(items, options={}) {
         var quantity = '';
 
         if (item.serial && item.quantity == 1) {
-            quantity = `{% jstrans "Serial" %}: ${item.serial}`;
+            quantity = `{% trans "Serial" %}: ${item.serial}`;
         } else {
-            quantity = `{% jstrans "Quantity" %}: ${item.quantity}`;
+            quantity = `{% trans "Quantity" %}: ${item.quantity}`;
         }
 
         quantity += stockStatusDisplay(item.status, {classes: 'float-right'});
@@ -880,7 +880,7 @@ function mergeStockItems(items, options={}) {
                 'fa-times icon-red',
                 'button-stock-item-remove',
                 pk,
-                '{% jstrans "Remove row" %}',
+                '{% trans "Remove row" %}',
             )
         );
 
@@ -925,8 +925,8 @@ function mergeStockItems(items, options={}) {
             allow_mismatched_status: {},
         },
         confirm: true,
-        confirmMessage: '{% jstrans "Confirm stock item merge" %}',
-        title: '{% jstrans "Merge Stock Items" %}',
+        confirmMessage: '{% trans "Confirm stock item merge" %}',
+        title: '{% trans "Merge Stock Items" %}',
         afterRender: function(fields, opts) {
             // Add button callbacks to remove rows
             $(opts.modal).find('.button-stock-item-remove').click(function() {
@@ -1021,29 +1021,29 @@ function adjustStock(action, items, options={}) {
 
     switch (action) {
     case 'move':
-        formTitle = '{% jstrans "Transfer Stock" %}';
-        actionTitle = '{% jstrans "Move" %}';
+        formTitle = '{% trans "Transfer Stock" %}';
+        actionTitle = '{% trans "Move" %}';
         specifyLocation = true;
         allowSerializedStock = true;
         url = '{% url "api-stock-transfer" %}';
         break;
     case 'count':
-        formTitle = '{% jstrans "Count Stock" %}';
-        actionTitle = '{% jstrans "Count" %}';
+        formTitle = '{% trans "Count Stock" %}';
+        actionTitle = '{% trans "Count" %}';
         url = '{% url "api-stock-count" %}';
         break;
     case 'take':
-        formTitle = '{% jstrans "Remove Stock" %}';
-        actionTitle = '{% jstrans "Take" %}';
+        formTitle = '{% trans "Remove Stock" %}';
+        actionTitle = '{% trans "Take" %}';
         url = '{% url "api-stock-remove" %}';
         break;
     case 'add':
-        formTitle = '{% jstrans "Add Stock" %}';
-        actionTitle = '{% jstrans "Add" %}';
+        formTitle = '{% trans "Add Stock" %}';
+        actionTitle = '{% trans "Add" %}';
         url = '{% url "api-stock-add" %}';
         break;
     case 'delete':
-        formTitle = '{% jstrans "Delete Stock" %}';
+        formTitle = '{% trans "Delete Stock" %}';
         allowSerializedStock = true;
         break;
     default:
@@ -1055,9 +1055,9 @@ function adjustStock(action, items, options={}) {
     <table class='table table-striped table-condensed' id='stock-adjust-table'>
     <thead>
     <tr>
-        <th>{% jstrans "Part" %}</th>
-        <th>{% jstrans "Stock" %}</th>
-        <th>{% jstrans "Location" %}</th>
+        <th>{% trans "Part" %}</th>
+        <th>{% trans "Stock" %}</th>
+        <th>{% trans "Location" %}</th>
         <th>${actionTitle || ''}</th>
         <th></th>
     </tr>
@@ -1127,7 +1127,7 @@ function adjustStock(action, items, options={}) {
         }
 
         if (item.batch) {
-            quantity += ` - <small>{% jstrans "Batch" %}: ${item.batch}</small>`;
+            quantity += ` - <small>{% trans "Batch" %}: ${item.batch}</small>`;
         }
 
         var actionInput = '';
@@ -1140,7 +1140,7 @@ function adjustStock(action, items, options={}) {
                     min_value: minValue,
                     max_value: maxValue,
                     value: value,
-                    title: readonly ? '{% jstrans "Quantity cannot be adjusted for serialized stock" %}' : '{% jstrans "Specify stock quantity" %}',
+                    title: readonly ? '{% trans "Quantity cannot be adjusted for serialized stock" %}' : '{% trans "Specify stock quantity" %}',
                     required: true,
                 },
                 {
@@ -1152,7 +1152,7 @@ function adjustStock(action, items, options={}) {
         let buttons = wrapButtons(makeRemoveButton(
             'button-stock-item-remove',
             pk,
-            '{% jstrans "Remove stock item" %}',
+            '{% trans "Remove stock item" %}',
         ));
 
         html += `
@@ -1174,8 +1174,8 @@ function adjustStock(action, items, options={}) {
 
     if (itemCount == 0) {
         showAlertDialog(
-            '{% jstrans "Select Stock Items" %}',
-            '{% jstrans "Select at least one available stock item" %}',
+            '{% trans "Select Stock Items" %}',
+            '{% trans "Select at least one available stock item" %}',
         );
 
         return;
@@ -1221,7 +1221,7 @@ function adjustStock(action, items, options={}) {
         fields: extraFields,
         preFormContent: html,
         confirm: true,
-        confirmMessage: '{% jstrans "Confirm stock adjustment" %}',
+        confirmMessage: '{% trans "Confirm stock adjustment" %}',
         title: formTitle,
         afterRender: function(fields, opts) {
             // Add button callbacks to remove rows
@@ -1357,14 +1357,14 @@ function removeStockRow(e) {
 function passFailBadge(result) {
 
     if (result) {
-        return `<span class='badge badge-right rounded-pill bg-success'>{% jstrans "PASS" %}</span>`;
+        return `<span class='badge badge-right rounded-pill bg-success'>{% trans "PASS" %}</span>`;
     } else {
-        return `<span class='badge badge-right rounded-pill bg-danger'>{% jstrans "FAIL" %}</span>`;
+        return `<span class='badge badge-right rounded-pill bg-danger'>{% trans "FAIL" %}</span>`;
     }
 }
 
 function noResultBadge() {
-    return `<span class='badge badge-right rounded-pill bg-info'>{% jstrans "NO RESULT" %}</span>`;
+    return `<span class='badge badge-right rounded-pill bg-info'>{% trans "NO RESULT" %}</span>`;
 }
 
 function formatDate(row) {
@@ -1426,15 +1426,15 @@ function loadStockTestResultsTable(table, options) {
 
         if (row.requires_attachment == false && row.requires_value == false && !row.result) {
             // Enable a "quick tick" option for this test result
-            html += makeIconButton('fa-check-circle icon-green', 'button-test-tick', row.test_name, '{% jstrans "Pass test" %}');
+            html += makeIconButton('fa-check-circle icon-green', 'button-test-tick', row.test_name, '{% trans "Pass test" %}');
         }
 
-        html += makeIconButton('fa-plus icon-green', 'button-test-add', row.test_name, '{% jstrans "Add test result" %}');
+        html += makeIconButton('fa-plus icon-green', 'button-test-add', row.test_name, '{% trans "Add test result" %}');
 
         if (!grouped && row.result != null) {
             var pk = row.pk;
-            html += makeEditButton('button-test-edit', pk, '{% jstrans "Edit test result" %}');
-            html += makeDeleteButton('button-test-delete', pk, '{% jstrans "Delete test result" %}');
+            html += makeEditButton('button-test-edit', pk, '{% trans "Edit test result" %}');
+            html += makeDeleteButton('button-test-delete', pk, '{% trans "Delete test result" %}');
         }
 
         return wrapButtons(html);
@@ -1453,7 +1453,7 @@ function loadStockTestResultsTable(table, options) {
         uniqueId: 'pk',
         treeShowField: 'test_name',
         formatNoMatches: function() {
-            return '{% jstrans "No test results found" %}';
+            return '{% trans "No test results found" %}';
         },
         queryParams: filters,
         original: params,
@@ -1472,7 +1472,7 @@ function loadStockTestResultsTable(table, options) {
             },
             {
                 field: 'test_name',
-                title: '{% jstrans "Test" %}',
+                title: '{% trans "Test" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     var html = value;
@@ -1492,14 +1492,14 @@ function loadStockTestResultsTable(table, options) {
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
                 formatter: function(value, row) {
                     return row.description || row.test_description;
                 }
             },
             {
                 field: 'value',
-                title: '{% jstrans "Value" %}',
+                title: '{% trans "Value" %}',
                 formatter: function(value, row) {
                     var html = value;
 
@@ -1513,11 +1513,11 @@ function loadStockTestResultsTable(table, options) {
             },
             {
                 field: 'notes',
-                title: '{% jstrans "Notes" %}',
+                title: '{% trans "Notes" %}',
             },
             {
                 field: 'date',
-                title: '{% jstrans "Test Date" %}',
+                title: '{% trans "Test Date" %}',
                 sortable: true,
                 formatter: function(value, row) {
                     return formatDate(row);
@@ -1664,7 +1664,7 @@ function loadStockTestResultsTable(table, options) {
                     hidden: true,
                 }
             },
-            title: '{% jstrans "Add Test Result" %}',
+            title: '{% trans "Add Test Result" %}',
             onSuccess: reloadTestTable,
         });
     });
@@ -1679,7 +1679,7 @@ function loadStockTestResultsTable(table, options) {
 
         constructForm(url, {
             fields: stockItemTestResultFields(),
-            title: '{% jstrans "Edit Test Result" %}',
+            title: '{% trans "Edit Test Result" %}',
             onSuccess: reloadTestTable,
         });
     });
@@ -1696,12 +1696,12 @@ function loadStockTestResultsTable(table, options) {
 
         var html = `
         <div class='alert alert-block alert-danger'>
-        <strong>{% jstrans "Delete test result" %}:</strong> ${row.test_name || row.test || row.key}
+        <strong>{% trans "Delete test result" %}:</strong> ${row.test_name || row.test || row.key}
         </div>`;
 
         constructForm(url, {
             method: 'DELETE',
-            title: '{% jstrans "Delete Test Result" %}',
+            title: '{% trans "Delete Test Result" %}',
             onSuccess: reloadTestTable,
             preFormContent: html,
         });
@@ -1729,29 +1729,29 @@ function locationDetail(row, showLink=true) {
     let url = '';
 
     if (row.consumed_by) {
-        text = '{% jstrans "Consumed by build order" %}';
+        text = '{% trans "Consumed by build order" %}';
         url = `/build/${row.consumed_by}/`;
     } else if (row.is_building && row.build) {
         // StockItem is currently being built!
-        text = '{% jstrans "In production" %}';
+        text = '{% trans "In production" %}';
         url = `/build/${row.build}/`;
     } else if (row.belongs_to) {
         // StockItem is installed inside a different StockItem
-        text = `{% jstrans "Installed in Stock Item" %} ${row.belongs_to}`;
+        text = `{% trans "Installed in Stock Item" %} ${row.belongs_to}`;
         url = `/stock/item/${row.belongs_to}/?display=installed-items`;
     } else if (row.customer) {
         // StockItem has been assigned to a customer
-        text = '{% jstrans "Shipped to customer" %}';
+        text = '{% trans "Shipped to customer" %}';
         url = `/company/${row.customer}/?display=assigned-stock`;
     } else if (row.sales_order) {
         // StockItem has been assigned to a sales order
-        text = '{% jstrans "Assigned to Sales Order" %}';
+        text = '{% trans "Assigned to Sales Order" %}';
         url = `/order/sales-order/${row.sales_order}/`;
     } else if (row.location && row.location_detail) {
         text = shortenString(row.location_detail.pathstring);
         url = `/stock/location/${row.location}/`;
     } else {
-        text = '<i>{% jstrans "No stock location set" %}</i>';
+        text = '<i>{% trans "No stock location set" %}</i>';
         url = '';
     }
 
@@ -1771,7 +1771,7 @@ function makeStockActions(table) {
         {
             label: 'add',
             icon: 'fa-plus-circle icon-green',
-            title: '{% jstrans "Add stock" %}',
+            title: '{% trans "Add stock" %}',
             permission: 'stock.change',
             callback: function(data) {
                 stockAdjustment('add', data, table);
@@ -1780,7 +1780,7 @@ function makeStockActions(table) {
         {
             label: 'remove',
             icon: 'fa-minus-circle icon-red',
-            title: '{% jstrans "Remove stock" %}',
+            title: '{% trans "Remove stock" %}',
             permission: 'stock.change',
             callback: function(data) {
                 stockAdjustment('take', data, table);
@@ -1789,7 +1789,7 @@ function makeStockActions(table) {
         {
             label: 'stocktake',
             icon: 'fa-check-circle icon-blue',
-            title: '{% jstrans "Count stock" %}',
+            title: '{% trans "Count stock" %}',
             permission: 'stock.change',
             callback: function(data) {
                 stockAdjustment('count', data, table);
@@ -1798,7 +1798,7 @@ function makeStockActions(table) {
         {
             label: 'move',
             icon: 'fa-exchange-alt icon-blue',
-            title: '{% jstrans "Transfer stock" %}',
+            title: '{% trans "Transfer stock" %}',
             permission: 'stock.change',
             callback: function(data) {
                 stockAdjustment('move', data, table);
@@ -1807,7 +1807,7 @@ function makeStockActions(table) {
         {
             label: 'status',
             icon: 'fa-info-circle icon-blue',
-            title: '{% jstrans "Change stock status" %}',
+            title: '{% trans "Change stock status" %}',
             permission: 'stock.change',
             callback: function(data) {
                 setStockStatus(data, {table: table});
@@ -1816,14 +1816,14 @@ function makeStockActions(table) {
         {
             label: 'merge',
             icon: 'fa-object-group',
-            title: '{% jstrans "Merge stock" %}',
+            title: '{% trans "Merge stock" %}',
             permission: 'stock.change',
             callback: function(data) {
                 mergeStockItems(data, {
                     success: function(response) {
                         $(table).bootstrapTable('refresh');
 
-                        showMessage('{% jstrans "Merged stock items" %}', {
+                        showMessage('{% trans "Merged stock items" %}', {
                             style: 'success',
                         });
                     }
@@ -1833,7 +1833,7 @@ function makeStockActions(table) {
         {
             label: 'order',
             icon: 'fa-shopping-cart',
-            title: '{% jstrans "Order stock" %}',
+            title: '{% trans "Order stock" %}',
             permission: 'stock.change',
             callback: function(data) {
                 let parts = [];
@@ -1852,7 +1852,7 @@ function makeStockActions(table) {
         {
             label: 'assign',
             icon: 'fa-user-tie',
-            title: '{% jstrans "Assign to customer" %}',
+            title: '{% trans "Assign to customer" %}',
             permission: 'stock.change',
             callback: function(data) {
                 assignStockToCustomer(data, {
@@ -1865,7 +1865,7 @@ function makeStockActions(table) {
         {
             label: 'delete',
             icon: 'fa-trash-alt icon-red',
-            title: '{% jstrans "Delete stock" %}',
+            title: '{% trans "Delete stock" %}',
             permission: 'stock.delete',
             callback: function(data) {
                 stockAdjustment('delete', data, table);
@@ -1919,13 +1919,13 @@ function loadStockTable(table, options) {
                 url: '{% url "api-stockitem-label-list" %}',
                 key: 'item',
             },
-            singular_name: '{% jstrans "stock item" %}',
-            plural_name: '{% jstrans "stock items" %}',
+            singular_name: '{% trans "stock item" %}',
+            plural_name: '{% trans "stock items" %}',
             barcode_actions: [
                 {
                     icon: 'fa-sitemap',
                     label: 'scantolocation',
-                    title: '{% jstrans "Scan to location" %}',
+                    title: '{% trans "Scan to location" %}',
                     permission: 'stock.change',
                     callback: function(items) {
                         scanItemsIntoLocation(items);
@@ -1936,7 +1936,7 @@ function loadStockTable(table, options) {
                 {
                     actions: makeStockActions(table),
                     icon: 'fa-boxes',
-                    title: '{% jstrans "Stock Actions" %}',
+                    title: '{% trans "Stock Actions" %}',
                     label: 'stock',
                 }
             ]
@@ -1950,7 +1950,7 @@ function loadStockTable(table, options) {
     var columns = [
         {
             checkbox: true,
-            title: '{% jstrans "Select" %}',
+            title: '{% trans "Select" %}',
             searchable: false,
             switchable: false,
         },
@@ -1964,7 +1964,7 @@ function loadStockTable(table, options) {
 
     col = {
         field: 'part',
-        title: '{% jstrans "Part" %}',
+        title: '{% trans "Part" %}',
         sortName: 'part__name',
         visible: options.params['part_detail'],
         switchable: options.params['part_detail'],
@@ -1980,7 +1980,7 @@ function loadStockTable(table, options) {
                 } else {
                     html += `
                     <a href='#' pk='${row.pk}' class='load-sub-items' id='load-sub-items-${row.pk}'>
-                        <span class='fas fa-sync-alt' title='{% jstrans "Load installed items" %}'></span>
+                        <span class='fas fa-sync-alt' title='{% trans "Load installed items" %}'></span>
                     </a>`;
                 }
             }
@@ -2003,7 +2003,7 @@ function loadStockTable(table, options) {
 
     col = {
         field: 'IPN',
-        title: '{% jstrans "IPN" %}',
+        title: '{% trans "IPN" %}',
         sortName: 'part__IPN',
         visible: options.params['part_detail'],
         switchable: options.params['part_detail'],
@@ -2025,7 +2025,7 @@ function loadStockTable(table, options) {
 
     columns.push({
         field: 'part_detail.description',
-        title: '{% jstrans "Description" %}',
+        title: '{% trans "Description" %}',
         visible: options.params['part_detail'],
         switchable: options.params['part_detail'],
         formatter: function(value, row) {
@@ -2037,7 +2037,7 @@ function loadStockTable(table, options) {
     col = {
         field: 'quantity',
         sortName: 'stock',
-        title: '{% jstrans "Stock" %}',
+        title: '{% trans "Stock" %}',
         sortable: true,
         formatter: function(value, row) {
 
@@ -2058,46 +2058,46 @@ function loadStockTable(table, options) {
             var html = renderLink(val, `/stock/item/${row.pk}/`);
 
             if (row.is_building) {
-                html += makeIconBadge('fa-tools', '{% jstrans "Stock item is in production" %}');
+                html += makeIconBadge('fa-tools', '{% trans "Stock item is in production" %}');
             }
 
             if (row.sales_order) {
                 // Stock item has been assigned to a sales order
-                html += makeIconBadge('fa-truck', '{% jstrans "Stock item assigned to sales order" %}');
+                html += makeIconBadge('fa-truck', '{% trans "Stock item assigned to sales order" %}');
             } else if (row.customer) {
                 // StockItem has been assigned to a customer
-                html += makeIconBadge('fa-user', '{% jstrans "Stock item assigned to customer" %}');
+                html += makeIconBadge('fa-user', '{% trans "Stock item assigned to customer" %}');
             } else if (row.allocated) {
                 if (row.serial != null && row.quantity == 1) {
-                    html += makeIconBadge('fa-bookmark icon-yellow', '{% jstrans "Serialized stock item has been allocated" %}');
+                    html += makeIconBadge('fa-bookmark icon-yellow', '{% trans "Serialized stock item has been allocated" %}');
                 } else if (row.allocated >= row.quantity) {
-                    html += makeIconBadge('fa-bookmark icon-yellow', '{% jstrans "Stock item has been fully allocated" %}');
+                    html += makeIconBadge('fa-bookmark icon-yellow', '{% trans "Stock item has been fully allocated" %}');
                 } else {
-                    html += makeIconBadge('fa-bookmark', '{% jstrans "Stock item has been partially allocated" %}');
+                    html += makeIconBadge('fa-bookmark', '{% trans "Stock item has been partially allocated" %}');
                 }
             } else if (row.belongs_to) {
-                html += makeIconBadge('fa-box', '{% jstrans "Stock item has been installed in another item" %}');
+                html += makeIconBadge('fa-box', '{% trans "Stock item has been installed in another item" %}');
             } else if (row.consumed_by) {
-                html += makeIconBadge('fa-tools', '{% jstrans "Stock item has been consumed by a build order" %}');
+                html += makeIconBadge('fa-tools', '{% trans "Stock item has been consumed by a build order" %}');
             }
 
             if (row.expired) {
-                html += makeIconBadge('fa-calendar-times icon-red', '{% jstrans "Stock item has expired" %}');
+                html += makeIconBadge('fa-calendar-times icon-red', '{% trans "Stock item has expired" %}');
             } else if (row.stale) {
-                html += makeIconBadge('fa-stopwatch', '{% jstrans "Stock item will expire soon" %}');
+                html += makeIconBadge('fa-stopwatch', '{% trans "Stock item will expire soon" %}');
             }
 
             // Special stock status codes
             if (row.status == stockCodes.REJECTED.key) {
-                html += makeIconBadge('fa-times-circle icon-red', '{% jstrans "Stock item has been rejected" %}');
+                html += makeIconBadge('fa-times-circle icon-red', '{% trans "Stock item has been rejected" %}');
             } else if (row.status == stockCodes.LOST.key) {
-                html += makeIconBadge('fa-question-circle', '{% jstrans "Stock item is lost" %}');
+                html += makeIconBadge('fa-question-circle', '{% trans "Stock item is lost" %}');
             } else if (row.status == stockCodes.DESTROYED.key) {
-                html += makeIconBadge('fa-skull-crossbones', '{% jstrans "Stock item is destroyed" %}');
+                html += makeIconBadge('fa-skull-crossbones', '{% trans "Stock item is destroyed" %}');
             }
 
             if (row.quantity <= 0) {
-                html += `<span class='badge badge-right rounded-pill bg-danger'>{% jstrans "Depleted" %}</span>`;
+                html += `<span class='badge badge-right rounded-pill bg-danger'>{% trans "Depleted" %}</span>`;
             }
 
             return html;
@@ -2143,7 +2143,7 @@ function loadStockTable(table, options) {
 
     col = {
         field: 'status',
-        title: '{% jstrans "Status" %}',
+        title: '{% trans "Status" %}',
         formatter: function(value) {
             return stockStatusDisplay(value);
         },
@@ -2157,7 +2157,7 @@ function loadStockTable(table, options) {
 
     col = {
         field: 'batch',
-        title: '{% jstrans "Batch" %}',
+        title: '{% trans "Batch" %}',
     };
 
     if (!options.params.ordering) {
@@ -2168,7 +2168,7 @@ function loadStockTable(table, options) {
 
     col = {
         field: 'location_detail.pathstring',
-        title: '{% jstrans "Location" %}',
+        title: '{% trans "Location" %}',
         sortName: 'location',
         formatter: function(value, row) {
             return locationDetail(row);
@@ -2183,7 +2183,7 @@ function loadStockTable(table, options) {
 
     col = {
         field: 'stocktake_date',
-        title: '{% jstrans "Stocktake" %}',
+        title: '{% trans "Stocktake" %}',
         formatter: function(value) {
             return renderDate(value);
         }
@@ -2197,7 +2197,7 @@ function loadStockTable(table, options) {
 
     col = {
         field: 'expiry_date',
-        title: '{% jstrans "Expiry Date" %}',
+        title: '{% trans "Expiry Date" %}',
         visible: global_settings.STOCK_ENABLE_EXPIRY,
         switchable: global_settings.STOCK_ENABLE_EXPIRY,
         formatter: function(value) {
@@ -2213,7 +2213,7 @@ function loadStockTable(table, options) {
 
     col = {
         field: 'updated',
-        title: '{% jstrans "Last Updated" %}',
+        title: '{% trans "Last Updated" %}',
         formatter: function(value) {
             return renderDate(value);
         }
@@ -2227,7 +2227,7 @@ function loadStockTable(table, options) {
 
     columns.push({
         field: 'purchase_order',
-        title: '{% jstrans "Purchase Order" %}',
+        title: '{% trans "Purchase Order" %}',
         formatter: function(value, row) {
             if (!value) {
                 return '-';
@@ -2247,7 +2247,7 @@ function loadStockTable(table, options) {
     col = {
 
         field: 'supplier_part',
-        title: '{% jstrans "Supplier Part" %}',
+        title: '{% trans "Supplier Part" %}',
         visible: options.params['supplier_part_detail'] || false,
         switchable: options.params['supplier_part_detail'] || false,
         formatter: function(value, row) {
@@ -2262,7 +2262,7 @@ function loadStockTable(table, options) {
             if (row.supplier_part_detail) {
                 text = `${row.supplier_part_detail.SKU}`;
             } else {
-                text = `<i>{% jstrans "Supplier part not specified" %}</i>`;
+                text = `<i>{% trans "Supplier part not specified" %}</i>`;
             }
 
             return renderClipboard(renderLink(text, link));
@@ -2278,7 +2278,7 @@ function loadStockTable(table, options) {
 
     columns.push({
         field: 'purchase_price',
-        title: '{% jstrans "Purchase Price" %}',
+        title: '{% trans "Purchase Price" %}',
         sortable: false,
         formatter: function(value, row) {
             let html = formatCurrency(value, {
@@ -2309,7 +2309,7 @@ function loadStockTable(table, options) {
     // This is not sortable, and may default to the 'price range' for the parent part
     columns.push({
         field: 'stock_value',
-        title: '{% jstrans "Stock Value" %}',
+        title: '{% trans "Stock Value" %}',
         sortable: false,
         switchable: true,
         formatter: function(value, row) {
@@ -2391,11 +2391,11 @@ function loadStockTable(table, options) {
 
     columns.push({
         field: 'packaging',
-        title: '{% jstrans "Packaging" %}',
+        title: '{% trans "Packaging" %}',
     },
     {
         field: 'notes',
-        title: '{% jstrans "Notes" %}',
+        title: '{% trans "Notes" %}',
     });
 
     // Function to request subset of items which are installed *within* a particular item
@@ -2437,7 +2437,7 @@ function loadStockTable(table, options) {
     table.inventreeTable({
         method: 'get',
         formatNoMatches: function() {
-            return '{% jstrans "No stock items matching query" %}';
+            return '{% trans "No stock items matching query" %}';
         },
         url: options.url || '{% url "api-stock-list" %}',
         queryParams: filters,
@@ -2540,8 +2540,8 @@ function loadStockLocationTable(table, options) {
             url: '{% url "api-stocklocation-label-list" %}',
             key: 'location'
         },
-        singular_name: '{% jstrans "stock location" %}',
-        plural_name: '{% jstrans "stock locations" %}',
+        singular_name: '{% trans "stock location" %}',
+        plural_name: '{% trans "stock locations" %}',
     });
 
     filters = Object.assign(filters, params);
@@ -2637,7 +2637,7 @@ function loadStockLocationTable(table, options) {
             {
                 icon: 'fas fa-bars',
                 attributes: {
-                    title: '{% jstrans "Display as list" %}',
+                    title: '{% trans "Display as list" %}',
                     id: 'view-location-list',
                 },
                 event: () => {
@@ -2657,7 +2657,7 @@ function loadStockLocationTable(table, options) {
             {
                 icon: 'fas fa-sitemap',
                 attributes: {
-                    title: '{% jstrans "Display as tree" %}',
+                    title: '{% trans "Display as tree" %}',
                     id: 'view-location-tree',
                 },
                 event: () => {
@@ -2678,13 +2678,13 @@ function loadStockLocationTable(table, options) {
         columns: [
             {
                 checkbox: true,
-                title: '{% jstrans "Select" %}',
+                title: '{% trans "Select" %}',
                 searchable: false,
                 switchable: false,
             },
             {
                 field: 'name',
-                title: '{% jstrans "Name" %}',
+                title: '{% trans "Name" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value, row) {
@@ -2696,7 +2696,7 @@ function loadStockLocationTable(table, options) {
                         } else {
                             html += `
                                 <a href='#' pk='${row.pk}' class='load-sub-location'>
-                                    <span class='fas fa-sync-alt' title='{% jstrans "Load Sublocations" %}'></span>
+                                    <span class='fas fa-sync-alt' title='{% trans "Load Sublocations" %}'></span>
                                 </a> `;
                         }
                     }
@@ -2716,7 +2716,7 @@ function loadStockLocationTable(table, options) {
             },
             {
                 field: 'description',
-                title: '{% jstrans "Description" %}',
+                title: '{% trans "Description" %}',
                 switchable: true,
                 sortable: false,
                 formatter: function(value) {
@@ -2725,7 +2725,7 @@ function loadStockLocationTable(table, options) {
             },
             {
                 field: 'pathstring',
-                title: '{% jstrans "Path" %}',
+                title: '{% trans "Path" %}',
                 switchable: true,
                 sortable: true,
                 formatter: function(value) {
@@ -2734,13 +2734,13 @@ function loadStockLocationTable(table, options) {
             },
             {
                 field: 'items',
-                title: '{% jstrans "Stock Items" %}',
+                title: '{% trans "Stock Items" %}',
                 switchable: true,
                 sortable: true,
             },
             {
                 field: 'structural',
-                title: '{% jstrans "Structural" %}',
+                title: '{% trans "Structural" %}',
                 switchable: true,
                 sortable: false,
                 formatter: function(value) {
@@ -2749,7 +2749,7 @@ function loadStockLocationTable(table, options) {
             },
             {
                 field: 'external',
-                title: '{% jstrans "External" %}',
+                title: '{% trans "External" %}',
                 switchable: true,
                 sortable: false,
                 formatter: function(value) {
@@ -2758,7 +2758,7 @@ function loadStockLocationTable(table, options) {
             },
             {
                 field: 'location_type',
-                title: '{% jstrans "Location type" %}',
+                title: '{% trans "Location type" %}',
                 switchable: true,
                 sortable: false,
                 formatter: function(value, row) {
@@ -2789,7 +2789,7 @@ function loadStockTrackingTable(table, options) {
     // Date
     cols.push({
         field: 'date',
-        title: '{% jstrans "Date" %}',
+        title: '{% trans "Date" %}',
         sortable: true,
         formatter: function(value) {
             return renderDate(value, {showTime: true});
@@ -2799,7 +2799,7 @@ function loadStockTrackingTable(table, options) {
     // Stock transaction description
     cols.push({
         field: 'label',
-        title: '{% jstrans "Description" %}',
+        title: '{% trans "Description" %}',
         formatter: function(value, row) {
             var html = '<b>' + value + '</b>';
 
@@ -2814,23 +2814,23 @@ function loadStockTrackingTable(table, options) {
     // Stock transaction details
     cols.push({
         field: 'deltas',
-        title: '{% jstrans "Details" %}',
+        title: '{% trans "Details" %}',
         formatter: function(details, row) {
 
             if (!details || !Object.keys(details).length) {
-                return `<small><em>{% jstrans "No changes" %}</em></small>`;
+                return `<small><em>{% trans "No changes" %}</em></small>`;
             }
 
             let html = `<table class='table table-condensed' id='tracking-table-${row.pk}'>`;
 
             // Part information
             if (details.part) {
-                html += `<tr><th>{% jstrans "Part" %}</th><td>`;
+                html += `<tr><th>{% trans "Part" %}</th><td>`;
 
                 if (details.part_detail) {
                     html += renderLink(details.part_detail.full_name, `/part/${details.part}/`);
                 } else {
-                    html += `{% jstrans "Part information unavailable" %}`;
+                    html += `{% trans "Part information unavailable" %}`;
                 }
 
                 html += `</td></tr>`;
@@ -2839,7 +2839,7 @@ function loadStockTrackingTable(table, options) {
             // Location information
             if (details.location) {
 
-                html += `<tr><th>{% jstrans "Location" %}</th>`;
+                html += `<tr><th>{% trans "Location" %}</th>`;
 
                 html += '<td>';
 
@@ -2852,7 +2852,7 @@ function loadStockTrackingTable(table, options) {
                     );
                 } else {
                     // An invalid location (may have been deleted?)
-                    html += `<i>{% jstrans "Location no longer exists" %}</i>`;
+                    html += `<i>{% trans "Location no longer exists" %}</i>`;
                 }
 
                 html += '</td></tr>';
@@ -2860,7 +2860,7 @@ function loadStockTrackingTable(table, options) {
 
             // BuildOrder Information
             if (details.buildorder) {
-                html += `<tr><th>{% jstrans "Build Order" %}</th>`;
+                html += `<tr><th>{% trans "Build Order" %}</th>`;
                 html += `<td>`;
 
                 if (details.buildorder_detail) {
@@ -2869,13 +2869,13 @@ function loadStockTrackingTable(table, options) {
                         `/build/${details.buildorder}/`
                     );
                 } else {
-                    html += `<i>{% jstrans "Build order no longer exists" %}</i>`;
+                    html += `<i>{% trans "Build order no longer exists" %}</i>`;
                 }
             }
 
             // PurchaseOrder Information
             if (details.purchaseorder) {
-                html += `<tr><th>{% jstrans "Purchase Order" %}</th>`;
+                html += `<tr><th>{% trans "Purchase Order" %}</th>`;
                 html += '<td>';
 
                 if (details.purchaseorder_detail) {
@@ -2884,7 +2884,7 @@ function loadStockTrackingTable(table, options) {
                         `/order/purchase-order/${details.purchaseorder}/`
                     );
                 } else {
-                    html += `<i>{% jstrans "Purchase order no longer exists" %}</i>`;
+                    html += `<i>{% trans "Purchase order no longer exists" %}</i>`;
                 }
 
                 html += '</td></tr>';
@@ -2892,7 +2892,7 @@ function loadStockTrackingTable(table, options) {
 
             // SalesOrder information
             if (details.salesorder) {
-                html += `<tr><th>{% jstrans "Sales Order" %}</th>`;
+                html += `<tr><th>{% trans "Sales Order" %}</th>`;
                 html += '<td>';
 
                 if (details.salesorder_detail) {
@@ -2901,7 +2901,7 @@ function loadStockTrackingTable(table, options) {
                         `/order/sales-order/${details.salesorder}/`
                     );
                 } else {
-                    html += `<em>{% jstrans "Sales Order no longer exists" %}</em>`;
+                    html += `<em>{% trans "Sales Order no longer exists" %}</em>`;
                 }
 
                 html += `</td></tr>`;
@@ -2909,7 +2909,7 @@ function loadStockTrackingTable(table, options) {
 
             // ReturnOrder information
             if (details.returnorder) {
-                html += `<tr><th>{% jstrans "Return Order" %}</th>`;
+                html += `<tr><th>{% trans "Return Order" %}</th>`;
                 html += '<td>';
 
                 if (details.returnorder_detail) {
@@ -2918,7 +2918,7 @@ function loadStockTrackingTable(table, options) {
                         `/order/return-order/${details.returnorder}/`
                     );
                 } else {
-                    html += `<em>{% jstrans "Return Order no longer exists" %}</em>`;
+                    html += `<em>{% trans "Return Order no longer exists" %}</em>`;
                 }
 
                 html += `</td></tr>`;
@@ -2927,7 +2927,7 @@ function loadStockTrackingTable(table, options) {
             // Customer information
             if (details.customer) {
 
-                html += `<tr><th>{% jstrans "Customer" %}</td>`;
+                html += `<tr><th>{% trans "Customer" %}</td>`;
 
                 html += '<td>';
 
@@ -2937,7 +2937,7 @@ function loadStockTrackingTable(table, options) {
                         details.customer_detail.url
                     );
                 } else {
-                    html += `<i>{% jstrans "Customer no longer exists" %}</i>`;
+                    html += `<i>{% trans "Customer no longer exists" %}</i>`;
                 }
 
                 html += '</td></tr>';
@@ -2945,7 +2945,7 @@ function loadStockTrackingTable(table, options) {
 
             // Stockitem information
             if (details.stockitem) {
-                html += '<tr><th>{% jstrans "Stock Item" %}</td>';
+                html += '<tr><th>{% trans "Stock Item" %}</td>';
 
                 html += '<td>';
 
@@ -2955,7 +2955,7 @@ function loadStockTrackingTable(table, options) {
                         `/stock/item/${details.stockitem}/`
                     );
                 } else {
-                    html += `<i>{% jstrans "Stock item no longer exists" %}</i>`;
+                    html += `<i>{% trans "Stock item no longer exists" %}</i>`;
                 }
 
                 html += '</td></tr>';
@@ -2963,7 +2963,7 @@ function loadStockTrackingTable(table, options) {
 
             // Status information
             if (details.status) {
-                html += `<tr><th>{% jstrans "Status" %}</td>`;
+                html += `<tr><th>{% trans "Status" %}</td>`;
 
                 html += '<td>';
                 html += stockStatusDisplay(details.status);
@@ -2973,7 +2973,7 @@ function loadStockTrackingTable(table, options) {
 
             // Quantity information
             if (details.added) {
-                html += '<tr><th>{% jstrans "Added" %}</th>';
+                html += '<tr><th>{% trans "Added" %}</th>';
 
                 html += `<td>${details.added}</td>`;
 
@@ -2981,7 +2981,7 @@ function loadStockTrackingTable(table, options) {
             }
 
             if (details.removed) {
-                html += '<tr><th>{% jstrans "Removed" %}</th>';
+                html += '<tr><th>{% trans "Removed" %}</th>';
 
                 html += `<td>${details.removed}</td>`;
 
@@ -2989,7 +2989,7 @@ function loadStockTrackingTable(table, options) {
             }
 
             if (details.quantity) {
-                html += '<tr><th>{% jstrans "Quantity" %}</th>';
+                html += '<tr><th>{% trans "Quantity" %}</th>';
 
                 html += `<td>${details.quantity}</td>`;
 
@@ -3004,13 +3004,13 @@ function loadStockTrackingTable(table, options) {
 
     cols.push({
         field: 'user',
-        title: '{% jstrans "User" %}',
+        title: '{% trans "User" %}',
         formatter: function(value, row) {
             if (value) {
                 // TODO - Format the user's first and last names
                 return row.user_detail.username;
             } else {
-                return `<i>{% jstrans "No user information" %}</i>`;
+                return `<i>{% trans "No user information" %}</i>`;
             }
         }
     });
@@ -3053,12 +3053,12 @@ function loadInstalledInTable(table, options) {
             part_detail: true,
         },
         formatNoMatches: function() {
-            return '{% jstrans "No installed items" %}';
+            return '{% trans "No installed items" %}';
         },
         columns: [
             {
                 field: 'part',
-                title: '{% jstrans "Part" %}',
+                title: '{% trans "Part" %}',
                 formatter: function(value, row) {
                     var html = '';
 
@@ -3072,13 +3072,13 @@ function loadInstalledInTable(table, options) {
             },
             {
                 field: 'quantity',
-                title: '{% jstrans "Quantity" %}',
+                title: '{% trans "Quantity" %}',
                 formatter: function(value, row) {
 
                     var html = '';
 
                     if (row.serial && row.quantity == 1) {
-                        html += `{% jstrans "Serial" %}: ${row.serial}`;
+                        html += `{% trans "Serial" %}: ${row.serial}`;
                     } else {
                         html += `${row.quantity}`;
                     }
@@ -3088,14 +3088,14 @@ function loadInstalledInTable(table, options) {
             },
             {
                 field: 'status',
-                title: '{% jstrans "Status" %}',
+                title: '{% trans "Status" %}',
                 formatter: function(value) {
                     return stockStatusDisplay(value);
                 }
             },
             {
                 field: 'batch',
-                title: '{% jstrans "Batch" %}',
+                title: '{% trans "Batch" %}',
             },
             {
                 field: 'buttons',
@@ -3105,7 +3105,7 @@ function loadInstalledInTable(table, options) {
                     let pk = row.pk;
                     let html = '';
 
-                    html += makeIconButton('fa-unlink', 'button-uninstall', pk, '{% jstrans "Uninstall Stock Item" %}');
+                    html += makeIconButton('fa-unlink', 'button-uninstall', pk, '{% trans "Uninstall Stock Item" %}');
 
                     return wrapButtons(html);
                 }
@@ -3140,7 +3140,7 @@ function uninstallStockItem(installed_item_id, options={}) {
         {
             confirm: true,
             method: 'POST',
-            title: '{% jstrans "Uninstall Stock Item" %}',
+            title: '{% trans "Uninstall Stock Item" %}',
             fields: {
                 location: {
                     icon: 'fa-sitemap',
@@ -3162,7 +3162,7 @@ function uninstallStockItem(installed_item_id, options={}) {
                 if (installed_item_id == null) {
                     html += `
                     <div class='alert alert-block alert-info'>
-                    {% jstrans "Select stock item to uninstall" %}
+                    {% trans "Select stock item to uninstall" %}
                     </div>`;
                 }
 
@@ -3183,13 +3183,13 @@ function installStockItem(stock_item_id, part_id, options={}) {
 
     var html = `
     <div class='alert alert-block alert-info'>
-        <strong>{% jstrans "Install another stock item into this item" %}</strong><br>
-        {% jstrans "Stock items can only be installed if they meet the following criteria" %}:<br>
+        <strong>{% trans "Install another stock item into this item" %}</strong><br>
+        {% trans "Stock items can only be installed if they meet the following criteria" %}:<br>
         <ul>
-            <li>{% jstrans "The Stock Item links to a Part which is the BOM for this Stock Item" %}</li>
-            <li>{% jstrans "The Stock Item is currently available in stock" %}</li>
-            <li>{% jstrans "The Stock Item is not already installed in another item" %}</li>
-            <li>{% jstrans "The Stock Item is tracked by either a batch code or serial number" %}</li>
+            <li>{% trans "The Stock Item links to a Part which is the BOM for this Stock Item" %}</li>
+            <li>{% trans "The Stock Item is currently available in stock" %}</li>
+            <li>{% trans "The Stock Item is not already installed in another item" %}</li>
+            <li>{% trans "The Stock Item is tracked by either a batch code or serial number" %}</li>
         </ul>
     </div>`;
 
@@ -3201,8 +3201,8 @@ function installStockItem(stock_item_id, part_id, options={}) {
                 part: {
                     type: 'related field',
                     required: 'true',
-                    label: '{% jstrans "Part" %}',
-                    help_text: '{% jstrans "Select part to install" %}',
+                    label: '{% trans "Part" %}',
+                    help_text: '{% trans "Select part to install" %}',
                     model: 'part',
                     api_url: '{% url "api-part-list" %}',
                     auto_fill: true,
@@ -3236,7 +3236,7 @@ function installStockItem(stock_item_id, part_id, options={}) {
                 quantity: {},
             },
             confirm: true,
-            title: '{% jstrans "Install Stock Item" %}',
+            title: '{% trans "Install Stock Item" %}',
             preFormContent: html,
             onSuccess: function(response) {
                 if (options.onSuccess) {
@@ -3264,8 +3264,8 @@ function setStockStatus(items, options={}) {
 
     if (items.length == 0) {
         showAlertDialog(
-            '{% jstrans "Select Stock Items" %}',
-            '{% jstrans "Select one or more stock items" %}'
+            '{% trans "Select Stock Items" %}',
+            '{% trans "Select one or more stock items" %}'
         );
         return;
     }
@@ -3278,11 +3278,11 @@ function setStockStatus(items, options={}) {
 
     let html = `
     <div class='alert alert-info alert-block>
-    {% jstrans "Selected stock items" %}: ${items.length}
+    {% trans "Selected stock items" %}: ${items.length}
     </div>`;
 
     constructForm('{% url "api-stock-change-status" %}', {
-        title: '{% jstrans "Change Stock Status" %}',
+        title: '{% trans "Change Stock Status" %}',
         method: 'POST',
         preFormContent: html,
         fields: {

--- a/InvenTree/templates/js/translated/table_filters.js
+++ b/InvenTree/templates/js/translated/table_filters.js
@@ -21,7 +21,7 @@
 // Construct a dynamic API filter for the "issued by" field
 function constructIssuedByFilter() {
     return {
-        title: '{% jstrans "Issued By" %}',
+        title: '{% trans "Issued By" %}',
         options: function() {
             let users = {};
 
@@ -45,7 +45,7 @@ function constructIssuedByFilter() {
 // Construct a dynamic API filter for the "project" field
 function constructProjectCodeFilter() {
     return {
-        title: '{% jstrans "Project Code" %}',
+        title: '{% trans "Project Code" %}',
         options: function() {
             let project_codes = {};
 
@@ -71,7 +71,7 @@ function constructProjectCodeFilter() {
 function constructHasProjectCodeFilter() {
     return {
         type: 'bool',
-        title: '{% jstrans "Has project code" %}',
+        title: '{% trans "Has project code" %}',
     };
 }
 
@@ -86,20 +86,20 @@ function getAttachmentFilters() {
 function getReturnOrderFilters() {
     var filters = {
         status: {
-            title: '{% jstrans "Order status" %}',
+            title: '{% trans "Order status" %}',
             options: returnOrderCodes
         },
         outstanding: {
             type: 'bool',
-            title: '{% jstrans "Outstanding" %}',
+            title: '{% trans "Outstanding" %}',
         },
         overdue: {
             type: 'bool',
-            title: '{% jstrans "Overdue" %}',
+            title: '{% trans "Overdue" %}',
         },
         assigned_to_me: {
             type: 'bool',
-            title: '{% jstrans "Assigned to me" %}',
+            title: '{% trans "Assigned to me" %}',
         },
     };
 
@@ -117,10 +117,10 @@ function getReturnOrderLineItemFilters() {
     return {
         received: {
             type: 'bool',
-            title: '{% jstrans "Received" %}',
+            title: '{% trans "Received" %}',
         },
         outcome: {
-            title: '{% jstrans "Outcome" %}',
+            title: '{% trans "Outcome" %}',
             options: returnOrderLineItemCodes,
         }
     };
@@ -132,19 +132,19 @@ function getVariantsTableFilters() {
     return {
         active: {
             type: 'bool',
-            title: '{% jstrans "Active" %}',
+            title: '{% trans "Active" %}',
         },
         template: {
             type: 'bool',
-            title: '{% jstrans "Template" %}',
+            title: '{% trans "Template" %}',
         },
         virtual: {
             type: 'bool',
-            title: '{% jstrans "Virtual" %}',
+            title: '{% trans "Virtual" %}',
         },
         trackable: {
             type: 'bool',
-            title: '{% jstrans "Trackable" %}',
+            title: '{% trans "Trackable" %}',
         },
     };
 }
@@ -155,43 +155,43 @@ function getBOMTableFilters() {
     return {
         sub_part_trackable: {
             type: 'bool',
-            title: '{% jstrans "Trackable Part" %}',
+            title: '{% trans "Trackable Part" %}',
         },
         sub_part_assembly: {
             type: 'bool',
-            title: '{% jstrans "Assembled Part" %}',
+            title: '{% trans "Assembled Part" %}',
         },
         available_stock: {
             type: 'bool',
-            title: '{% jstrans "Has Available Stock" %}',
+            title: '{% trans "Has Available Stock" %}',
         },
         on_order: {
             type: 'bool',
-            title: '{% jstrans "On Order" %}',
+            title: '{% trans "On Order" %}',
         },
         validated: {
             type: 'bool',
-            title: '{% jstrans "Validated" %}',
+            title: '{% trans "Validated" %}',
         },
         inherited: {
             type: 'bool',
-            title: '{% jstrans "Gets inherited" %}',
+            title: '{% trans "Gets inherited" %}',
         },
         allow_variants: {
             type: 'bool',
-            title: '{% jstrans "Allow Variant Stock" %}',
+            title: '{% trans "Allow Variant Stock" %}',
         },
         optional: {
             type: 'bool',
-            title: '{% jstrans "Optional" %}',
+            title: '{% trans "Optional" %}',
         },
         consumable: {
             type: 'bool',
-            title: '{% jstrans "Consumable" %}',
+            title: '{% trans "Consumable" %}',
         },
         has_pricing: {
             type: 'bool',
-            title: '{% jstrans "Has Pricing" %}',
+            title: '{% trans "Has Pricing" %}',
         },
     };
 }
@@ -208,19 +208,19 @@ function getUsedInTableFilters() {
     return {
         'inherited': {
             type: 'bool',
-            title: '{% jstrans "Gets inherited" %}',
+            title: '{% trans "Gets inherited" %}',
         },
         'optional': {
             type: 'bool',
-            title: '{% jstrans "Optional" %}',
+            title: '{% trans "Optional" %}',
         },
         'part_active': {
             type: 'bool',
-            title: '{% jstrans "Active" %}',
+            title: '{% trans "Active" %}',
         },
         'part_trackable': {
             type: 'bool',
-            title: '{% jstrans "Trackable" %}',
+            title: '{% trans "Trackable" %}',
         },
     };
 }
@@ -231,19 +231,19 @@ function getStockLocationFilters() {
     return {
         cascade: {
             type: 'bool',
-            title: '{% jstrans "Include sublocations" %}',
-            description: '{% jstrans "Include locations" %}',
+            title: '{% trans "Include sublocations" %}',
+            description: '{% trans "Include locations" %}',
         },
         structural: {
             type: 'bool',
-            title: '{% jstrans "Structural" %}',
+            title: '{% trans "Structural" %}',
         },
         external: {
             type: 'bool',
-            title: '{% jstrans "External" %}',
+            title: '{% trans "External" %}',
         },
         location_type: {
-            title: '{% jstrans "Location type" %}',
+            title: '{% trans "Location type" %}',
             options: function() {
                 const locationTypes = {};
 
@@ -264,7 +264,7 @@ function getStockLocationFilters() {
         },
         has_location_type: {
             type: 'bool',
-            title: '{% jstrans "Has location type" %}'
+            title: '{% trans "Has location type" %}'
         },
     };
 }
@@ -275,16 +275,16 @@ function getPartCategoryFilters() {
     return {
         cascade: {
             type: 'bool',
-            title: '{% jstrans "Include subcategories" %}',
-            description: '{% jstrans "Include subcategories" %}',
+            title: '{% trans "Include subcategories" %}',
+            description: '{% trans "Include subcategories" %}',
         },
         structural: {
             type: 'bool',
-            title: '{% jstrans "Structural" %}',
+            title: '{% trans "Structural" %}',
         },
         starred: {
             type: 'bool',
-            title: '{% jstrans "Subscribed" %}',
+            title: '{% trans "Subscribed" %}',
         },
     };
 }
@@ -295,23 +295,23 @@ function getCustomerStockFilters() {
     return {
         serialized: {
             type: 'bool',
-            title: '{% jstrans "Is Serialized" %}',
+            title: '{% trans "Is Serialized" %}',
         },
         serial_gte: {
-            title: '{% jstrans "Serial number GTE" %}',
-            description: '{% jstrans "Serial number greater than or equal to" %}',
+            title: '{% trans "Serial number GTE" %}',
+            description: '{% trans "Serial number greater than or equal to" %}',
         },
         serial_lte: {
-            title: '{% jstrans "Serial number LTE" %}',
-            description: '{% jstrans "Serial number less than or equal to" %}',
+            title: '{% trans "Serial number LTE" %}',
+            description: '{% trans "Serial number less than or equal to" %}',
         },
         serial: {
-            title: '{% jstrans "Serial number" %}',
-            description: '{% jstrans "Serial number" %}',
+            title: '{% trans "Serial number" %}',
+            description: '{% trans "Serial number" %}',
         },
         batch: {
-            title: '{% jstrans "Batch" %}',
-            description: '{% jstrans "Batch code" %}',
+            title: '{% trans "Batch" %}',
+            description: '{% trans "Batch code" %}',
         },
     };
 }
@@ -322,109 +322,109 @@ function getStockTableFilters() {
     var filters = {
         active: {
             type: 'bool',
-            title: '{% jstrans "Active parts" %}',
-            description: '{% jstrans "Show stock for active parts" %}',
+            title: '{% trans "Active parts" %}',
+            description: '{% trans "Show stock for active parts" %}',
         },
         assembly: {
             type: 'bool',
-            title: '{% jstrans "Assembly" %}',
-            description: '{% jstrans "Part is an assembly" %}',
+            title: '{% trans "Assembly" %}',
+            description: '{% trans "Part is an assembly" %}',
         },
         allocated: {
             type: 'bool',
-            title: '{% jstrans "Is allocated" %}',
-            description: '{% jstrans "Item has been allocated" %}',
+            title: '{% trans "Is allocated" %}',
+            description: '{% trans "Item has been allocated" %}',
         },
         available: {
             type: 'bool',
-            title: '{% jstrans "Available" %}',
-            description: '{% jstrans "Stock is available for use" %}',
+            title: '{% trans "Available" %}',
+            description: '{% trans "Stock is available for use" %}',
         },
         cascade: {
             type: 'bool',
-            title: '{% jstrans "Include sublocations" %}',
-            description: '{% jstrans "Include stock in sublocations" %}',
+            title: '{% trans "Include sublocations" %}',
+            description: '{% trans "Include stock in sublocations" %}',
         },
         depleted: {
             type: 'bool',
-            title: '{% jstrans "Depleted" %}',
-            description: '{% jstrans "Show stock items which are depleted" %}',
+            title: '{% trans "Depleted" %}',
+            description: '{% trans "Show stock items which are depleted" %}',
         },
         in_stock: {
             type: 'bool',
-            title: '{% jstrans "In Stock" %}',
-            description: '{% jstrans "Show items which are in stock" %}',
+            title: '{% trans "In Stock" %}',
+            description: '{% trans "Show items which are in stock" %}',
         },
         is_building: {
             type: 'bool',
-            title: '{% jstrans "In Production" %}',
-            description: '{% jstrans "Show items which are in production" %}',
+            title: '{% trans "In Production" %}',
+            description: '{% trans "Show items which are in production" %}',
         },
         include_variants: {
             type: 'bool',
-            title: '{% jstrans "Include Variants" %}',
-            description: '{% jstrans "Include stock items for variant parts" %}',
+            title: '{% trans "Include Variants" %}',
+            description: '{% trans "Include stock items for variant parts" %}',
         },
         installed: {
             type: 'bool',
-            title: '{% jstrans "Installed" %}',
-            description: '{% jstrans "Show stock items which are installed in another item" %}',
+            title: '{% trans "Installed" %}',
+            description: '{% trans "Show stock items which are installed in another item" %}',
         },
         sent_to_customer: {
             type: 'bool',
-            title: '{% jstrans "Sent to customer" %}',
-            description: '{% jstrans "Show items which have been assigned to a customer" %}',
+            title: '{% trans "Sent to customer" %}',
+            description: '{% trans "Show items which have been assigned to a customer" %}',
         },
         serialized: {
             type: 'bool',
-            title: '{% jstrans "Is Serialized" %}',
+            title: '{% trans "Is Serialized" %}',
         },
         serial: {
-            title: '{% jstrans "Serial number" %}',
-            description: '{% jstrans "Serial number" %}',
+            title: '{% trans "Serial number" %}',
+            description: '{% trans "Serial number" %}',
         },
         serial_gte: {
-            title: '{% jstrans "Serial number GTE" %}',
-            description: '{% jstrans "Serial number greater than or equal to" %}',
+            title: '{% trans "Serial number GTE" %}',
+            description: '{% trans "Serial number greater than or equal to" %}',
         },
         serial_lte: {
-            title: '{% jstrans "Serial number LTE" %}',
-            description: '{% jstrans "Serial number less than or equal to" %}',
+            title: '{% trans "Serial number LTE" %}',
+            description: '{% trans "Serial number less than or equal to" %}',
         },
         status: {
             options: stockCodes,
-            title: '{% jstrans "Stock status" %}',
-            description: '{% jstrans "Stock status" %}',
+            title: '{% trans "Stock status" %}',
+            description: '{% trans "Stock status" %}',
         },
         has_batch: {
-            title: '{% jstrans "Has batch code" %}',
+            title: '{% trans "Has batch code" %}',
             type: 'bool',
         },
         batch: {
-            title: '{% jstrans "Batch" %}',
-            description: '{% jstrans "Batch code" %}',
+            title: '{% trans "Batch" %}',
+            description: '{% trans "Batch code" %}',
         },
         tracked: {
-            title: '{% jstrans "Tracked" %}',
-            description: '{% jstrans "Stock item is tracked by either batch code or serial number" %}',
+            title: '{% trans "Tracked" %}',
+            description: '{% trans "Stock item is tracked by either batch code or serial number" %}',
             type: 'bool',
         },
         has_purchase_price: {
             type: 'bool',
-            title: '{% jstrans "Has purchase price" %}',
-            description: '{% jstrans "Show stock items which have a purchase price set" %}',
+            title: '{% trans "Has purchase price" %}',
+            description: '{% trans "Show stock items which have a purchase price set" %}',
         },
         expiry_date_lte: {
             type: 'date',
-            title: '{% jstrans "Expiry Date before" %}',
+            title: '{% trans "Expiry Date before" %}',
         },
         expiry_date_gte: {
             type: 'date',
-            title: '{% jstrans "Expiry Date after" %}',
+            title: '{% trans "Expiry Date after" %}',
         },
         external: {
             type: 'bool',
-            title: '{% jstrans "External Location" %}',
+            title: '{% trans "External Location" %}',
         }
     };
 
@@ -432,14 +432,14 @@ function getStockTableFilters() {
     if (global_settings.STOCK_ENABLE_EXPIRY) {
         filters.expired = {
             type: 'bool',
-            title: '{% jstrans "Expired" %}',
-            description: '{% jstrans "Show stock items which have expired" %}',
+            title: '{% trans "Expired" %}',
+            description: '{% trans "Show stock items which have expired" %}',
         };
 
         filters.stale = {
             type: 'bool',
-            title: '{% jstrans "Stale" %}',
-            description: '{% jstrans "Show stock which is close to expiring" %}',
+            title: '{% trans "Stale" %}',
+            description: '{% trans "Show stock which is close to expiring" %}',
         };
     }
 
@@ -453,11 +453,11 @@ function getStockTestTableFilters() {
     return {
         result: {
             type: 'bool',
-            title: '{% jstrans "Test Passed" %}',
+            title: '{% trans "Test Passed" %}',
         },
         include_installed: {
             type: 'bool',
-            title: '{% jstrans "Include Installed Items" %}',
+            title: '{% trans "Include Installed Items" %}',
         }
     };
 }
@@ -474,7 +474,7 @@ function getPartTestTemplateFilters() {
     return {
         required: {
             type: 'bool',
-            title: '{% jstrans "Required" %}',
+            title: '{% trans "Required" %}',
         },
     };
 }
@@ -485,19 +485,19 @@ function getPluginTableFilters() {
     return {
         active: {
             type: 'bool',
-            title: '{% jstrans "Active" %}',
+            title: '{% trans "Active" %}',
         },
         builtin: {
             type: 'bool',
-            title: '{% jstrans "Builtin" %}',
+            title: '{% trans "Builtin" %}',
         },
         sample: {
             type: 'bool',
-            title: '{% jstrans "Sample" %}',
+            title: '{% trans "Sample" %}',
         },
         installed: {
             type: 'bool',
-            title: '{% jstrans "Installed" %}'
+            title: '{% trans "Installed" %}'
         },
     };
 }
@@ -508,23 +508,23 @@ function getBuildTableFilters() {
 
     let filters = {
         status: {
-            title: '{% jstrans "Build status" %}',
+            title: '{% trans "Build status" %}',
             options: buildCodes,
         },
         active: {
             type: 'bool',
-            title: '{% jstrans "Active" %}',
+            title: '{% trans "Active" %}',
         },
         overdue: {
             type: 'bool',
-            title: '{% jstrans "Overdue" %}',
+            title: '{% trans "Overdue" %}',
         },
         assigned_to_me: {
             type: 'bool',
-            title: '{% jstrans "Assigned to me" %}',
+            title: '{% trans "Assigned to me" %}',
         },
         assigned_to: {
-            title: '{% jstrans "Responsible" %}',
+            title: '{% trans "Responsible" %}',
             options: function() {
                 var ownersList = {};
                 inventreeGet('{% url "api-owner-list" %}', {}, {
@@ -564,23 +564,23 @@ function getBuildLineTableFilters() {
     return {
         allocated: {
             type: 'bool',
-            title: '{% jstrans "Allocated" %}',
+            title: '{% trans "Allocated" %}',
         },
         available: {
             type: 'bool',
-            title: '{% jstrans "Available" %}',
+            title: '{% trans "Available" %}',
         },
         tracked: {
             type: 'bool',
-            title: '{% jstrans "Tracked" %}',
+            title: '{% trans "Tracked" %}',
         },
         consumable: {
             type: 'bool',
-            title: '{% jstrans "Consumable" %}',
+            title: '{% trans "Consumable" %}',
         },
         optional: {
             type: 'bool',
-            title: '{% jstrans "Optional" %}',
+            title: '{% trans "Optional" %}',
         },
     };
 }
@@ -591,14 +591,14 @@ function getPurchaseOrderLineItemFilters() {
     return {
         pending: {
             type: 'bool',
-            title: '{% jstrans "Pending" %}',
+            title: '{% trans "Pending" %}',
         },
         received: {
             type: 'bool',
-            title: '{% jstrans "Received" %}',
+            title: '{% trans "Received" %}',
         },
         order_status: {
-            title: '{% jstrans "Order status" %}',
+            title: '{% trans "Order status" %}',
             options: purchaseOrderCodes,
         },
     };
@@ -610,20 +610,20 @@ function getPurchaseOrderFilters() {
 
     var filters = {
         status: {
-            title: '{% jstrans "Order status" %}',
+            title: '{% trans "Order status" %}',
             options: purchaseOrderCodes,
         },
         outstanding: {
             type: 'bool',
-            title: '{% jstrans "Outstanding" %}',
+            title: '{% trans "Outstanding" %}',
         },
         overdue: {
             type: 'bool',
-            title: '{% jstrans "Overdue" %}',
+            title: '{% trans "Overdue" %}',
         },
         assigned_to_me: {
             type: 'bool',
-            title: '{% jstrans "Assigned to me" %}',
+            title: '{% trans "Assigned to me" %}',
         },
     };
 
@@ -641,7 +641,7 @@ function getSalesOrderAllocationFilters() {
     return {
         outstanding: {
             type: 'bool',
-            title: '{% jstrans "Outstanding" %}',
+            title: '{% trans "Outstanding" %}',
         }
     };
 }
@@ -651,20 +651,20 @@ function getSalesOrderAllocationFilters() {
 function getSalesOrderFilters() {
     var filters = {
         status: {
-            title: '{% jstrans "Order status" %}',
+            title: '{% trans "Order status" %}',
             options: salesOrderCodes,
         },
         outstanding: {
             type: 'bool',
-            title: '{% jstrans "Outstanding" %}',
+            title: '{% trans "Outstanding" %}',
         },
         overdue: {
             type: 'bool',
-            title: '{% jstrans "Overdue" %}',
+            title: '{% trans "Overdue" %}',
         },
         assigned_to_me: {
             type: 'bool',
-            title: '{% jstrans "Assigned to me" %}',
+            title: '{% trans "Assigned to me" %}',
         },
     };
 
@@ -682,7 +682,7 @@ function getSalesOrderLineItemFilters() {
     return {
         completed: {
             type: 'bool',
-            title: '{% jstrans "Completed" %}',
+            title: '{% trans "Completed" %}',
         },
     };
 }
@@ -693,7 +693,7 @@ function getSupplierPartFilters() {
     return {
         active: {
             type: 'bool',
-            title: '{% jstrans "Active parts" %}',
+            title: '{% trans "Active parts" %}',
         },
     };
 }
@@ -704,75 +704,75 @@ function getPartTableFilters() {
     return {
         cascade: {
             type: 'bool',
-            title: '{% jstrans "Include subcategories" %}',
-            description: '{% jstrans "Include parts in subcategories" %}',
+            title: '{% trans "Include subcategories" %}',
+            description: '{% trans "Include parts in subcategories" %}',
         },
         active: {
             type: 'bool',
-            title: '{% jstrans "Active" %}',
-            description: '{% jstrans "Show active parts" %}',
+            title: '{% trans "Active" %}',
+            description: '{% trans "Show active parts" %}',
         },
         assembly: {
             type: 'bool',
-            title: '{% jstrans "Assembly" %}',
+            title: '{% trans "Assembly" %}',
         },
         unallocated_stock: {
             type: 'bool',
-            title: '{% jstrans "Available stock" %}',
+            title: '{% trans "Available stock" %}',
         },
         component: {
             type: 'bool',
-            title: '{% jstrans "Component" %}',
+            title: '{% trans "Component" %}',
         },
         has_units: {
             type: 'bool',
-            title: '{% jstrans "Has Units" %}',
-            description: '{% jstrans "Part has defined units" %}',
+            title: '{% trans "Has Units" %}',
+            description: '{% trans "Part has defined units" %}',
         },
         has_ipn: {
             type: 'bool',
-            title: '{% jstrans "Has IPN" %}',
-            description: '{% jstrans "Part has internal part number" %}',
+            title: '{% trans "Has IPN" %}',
+            description: '{% trans "Part has internal part number" %}',
         },
         has_stock: {
             type: 'bool',
-            title: '{% jstrans "In stock" %}',
+            title: '{% trans "In stock" %}',
         },
         low_stock: {
             type: 'bool',
-            title: '{% jstrans "Low stock" %}',
+            title: '{% trans "Low stock" %}',
         },
         purchaseable: {
             type: 'bool',
-            title: '{% jstrans "Purchasable" %}',
+            title: '{% trans "Purchasable" %}',
         },
         salable: {
             type: 'bool',
-            title: '{% jstrans "Salable" %}',
+            title: '{% trans "Salable" %}',
         },
         starred: {
             type: 'bool',
-            title: '{% jstrans "Subscribed" %}',
+            title: '{% trans "Subscribed" %}',
         },
         stocktake: {
             type: 'bool',
-            title: '{% jstrans "Has stocktake entries" %}',
+            title: '{% trans "Has stocktake entries" %}',
         },
         is_template: {
             type: 'bool',
-            title: '{% jstrans "Template" %}',
+            title: '{% trans "Template" %}',
         },
         trackable: {
             type: 'bool',
-            title: '{% jstrans "Trackable" %}',
+            title: '{% trans "Trackable" %}',
         },
         virtual: {
             type: 'bool',
-            title: '{% jstrans "Virtual" %}',
+            title: '{% trans "Virtual" %}',
         },
         has_pricing: {
             type: 'bool',
-            title: '{% jstrans "Has Pricing" %}',
+            title: '{% trans "Has Pricing" %}',
         },
     };
 }
@@ -789,15 +789,15 @@ function getCompanyFilters() {
     return {
         is_manufacturer: {
             type: 'bool',
-            title: '{% jstrans "Manufacturer" %}',
+            title: '{% trans "Manufacturer" %}',
         },
         is_supplier: {
             type: 'bool',
-            title: '{% jstrans "Supplier" %}',
+            title: '{% trans "Supplier" %}',
         },
         is_customer: {
             type: 'bool',
-            title: '{% jstrans "Customer" %}',
+            title: '{% trans "Customer" %}',
         },
     };
 }
@@ -814,15 +814,15 @@ function getPartParameterTemplateFilters() {
     return {
         checkbox: {
             type: 'bool',
-            title: '{% jstrans "Checkbox" %}',
+            title: '{% trans "Checkbox" %}',
         },
         has_choices: {
             type: 'bool',
-            title: '{% jstrans "Has Choices" %}',
+            title: '{% trans "Has Choices" %}',
         },
         has_units: {
             type: 'bool',
-            title: '{% jstrans "Has Units" %}',
+            title: '{% trans "Has Units" %}',
         }
     };
 }

--- a/InvenTree/templates/js/translated/tables.js
+++ b/InvenTree/templates/js/translated/tables.js
@@ -89,7 +89,7 @@ function constructOrderTableButtons(options={}) {
     // Calendar view button
     if (!options.disableCalendarView) {
         buttons.push({
-            html: `<button type='button' name='${idx++}' class='btn ${class_calendar}' title='{% jstrans "Display calendar view" %}'><span class='fas fa-calendar-alt'></span></button>`,
+            html: `<button type='button' name='${idx++}' class='btn ${class_calendar}' title='{% trans "Display calendar view" %}'><span class='fas fa-calendar-alt'></span></button>`,
             event: function() {
                 buttonCallback('calendar');
             }
@@ -99,7 +99,7 @@ function constructOrderTableButtons(options={}) {
     // List view button
     if (!options.disableListView) {
         buttons.push({
-            html: `<button type='button' name='${idx++}' class='btn ${class_list}' title='{% jstrans "Display list view" %}'><span class='fas fa-th-list'></span></button>`,
+            html: `<button type='button' name='${idx++}' class='btn ${class_list}' title='{% trans "Display list view" %}'><span class='fas fa-th-list'></span></button>`,
             event: function() {
                 buttonCallback('list');
             }
@@ -109,7 +109,7 @@ function constructOrderTableButtons(options={}) {
     // Tree view button
     if (!options.disableTreeView) {
         buttons.push({
-            html: `<button type='button' name='${idx++}' class='btn ${class_tree}' title='{% jstrans "Display tree view" %}'><span class='fas fa-sitemap'></span></button>`,
+            html: `<button type='button' name='${idx++}' class='btn ${class_tree}' title='{% trans "Display tree view" %}'><span class='fas fa-sitemap'></span></button>`,
             event: function() {
                 buttonCallback('tree');
             }
@@ -127,13 +127,13 @@ function constructExpandCollapseButtons(table, idx=0) {
 
     return [
         {
-            html: `<button type='button' name='${idx++}' class='btn btn-outline-secondary' title='{% jstrans "Expand all rows" %}'><span class='fas fa-expand'></span></button>`,
+            html: `<button type='button' name='${idx++}' class='btn btn-outline-secondary' title='{% trans "Expand all rows" %}'><span class='fas fa-expand'></span></button>`,
             event: function() {
                 $(table).bootstrapTable('expandAllRows');
             }
         },
         {
-            html: `<button type='button' name='${idx++}' class='btn btn-outline-secondary' title='{% jstrans "Collapse all rows" %}'><span class='fas fa-compress'></span></button>`,
+            html: `<button type='button' name='${idx++}' class='btn btn-outline-secondary' title='{% trans "Collapse all rows" %}'><span class='fas fa-compress'></span></button>`,
             event: function() {
                 $(table).bootstrapTable('collapseAllRows');
             }
@@ -183,11 +183,11 @@ function downloadTableData(table, opts={}) {
     url += '?';
 
     constructFormBody({}, {
-        title: opts.title || '{% jstrans "Export Table Data" %}',
+        title: opts.title || '{% trans "Export Table Data" %}',
         fields: {
             format: {
-                label: '{% jstrans "Format" %}',
-                help_text: '{% jstrans "Select File Format" %}',
+                label: '{% trans "Format" %}',
+                help_text: '{% trans "Select File Format" %}',
                 required: true,
                 type: 'choice',
                 value: 'csv',
@@ -526,39 +526,39 @@ function customGroupSorter(sortName, sortOrder, sortData) {
 
     $.fn.bootstrapTable.locales['en-US-custom'] = {
         formatLoadingMessage: function() {
-            return '{% jstrans "Loading data" %}';
+            return '{% trans "Loading data" %}';
         },
         formatRecordsPerPage: function(pageNumber) {
-            return `${pageNumber} {% jstrans "rows per page" %}`;
+            return `${pageNumber} {% trans "rows per page" %}`;
         },
         formatShowingRows: function(pageFrom, pageTo, totalRows) {
 
             if (totalRows === undefined || isNaN(totalRows)) {
-                return '{% jstrans "Showing all rows" %}';
+                return '{% trans "Showing all rows" %}';
             } else {
-                return `{% jstrans "Showing" %} ${pageFrom} {% jstrans "to" %} ${pageTo} {% jstrans "of" %} ${totalRows} {% jstrans "rows" %}`;
+                return `{% trans "Showing" %} ${pageFrom} {% trans "to" %} ${pageTo} {% trans "of" %} ${totalRows} {% trans "rows" %}`;
             }
         },
         formatSearch: function() {
-            return '{% jstrans "Search" %}';
+            return '{% trans "Search" %}';
         },
         formatNoMatches: function() {
-            return '{% jstrans "No matching results" %}';
+            return '{% trans "No matching results" %}';
         },
         formatPaginationSwitch: function() {
-            return '{% jstrans "Hide/Show pagination" %}';
+            return '{% trans "Hide/Show pagination" %}';
         },
         formatRefresh: function() {
-            return '{% jstrans "Refresh" %}';
+            return '{% trans "Refresh" %}';
         },
         formatToggle: function() {
-            return '{% jstrans "Toggle" %}';
+            return '{% trans "Toggle" %}';
         },
         formatColumns: function() {
-            return '{% jstrans "Columns" %}';
+            return '{% trans "Columns" %}';
         },
         formatAllRows: function() {
-            return '{% jstrans "All" %}';
+            return '{% trans "All" %}';
         },
     };
 

--- a/ci/check_js_templates.py
+++ b/ci/check_js_templates.py
@@ -50,7 +50,6 @@ def check_prohibited_tags(data):
         'for',
         'endfor',
         'trans',
-        'jstrans',
         'load',
         'include',
         'url',
@@ -85,7 +84,7 @@ for filename in pathlib.Path(js_dynamic_dir).rglob('*.js'):
     with open(filename, 'r') as js_file:
         data = js_file.readlines()
 
-    invalid_tags = ['trans', 'jstrans']
+    invalid_tags = ['blocktrans', 'blocktranslate', 'trans', 'translate']
 
     err_count = 0
 


### PR DESCRIPTION
PR https://github.com/inventree/InvenTree/pull/6288 added a custom `{% jstrans %}` template tag, used to enforce string escaping for templated javascript content.

*However* this has broken our translation context information, as can be seen in [this PR](https://github.com/inventree/InvenTree/pull/6279/files) where ~120K lines of context data have been removed.

This is because when Django compiles the translations, it looks for `{% trans "string" %}` in each line when defining
the context of the translation (and not `{% jstrans %}`)

To remedy this, this PR *removes* the `{% jstrans %}` tag, and replaces all calls to this tag with a normal `{% trans %}` tag (but with an extra `escape=True` argument).