### PR TITLE
[PUI] Logout Fixes

### DIFF
--- a/InvenTree/InvenTree/exceptions.py
+++ b/InvenTree/InvenTree/exceptions.py
@@ -53,7 +53,10 @@ def log_error(path, error_name=None, error_info=None, error_data=None):
     if error_data:
         data = error_data
     else:
-        data = '\n'.join(traceback.format_exception(kind, info, data))
+        try:
+            data = '\n'.join(traceback.format_exception(kind, info, data))
+        except AttributeError:
+            data = 'No traceback information available'
 
     # Log error to stderr
     logger.error(info)

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -26,7 +26,6 @@ from dotenv import load_dotenv
 
 from InvenTree.config import get_boolean_setting, get_custom_file, get_setting
 from InvenTree.sentry import default_sentry_dsn, init_sentry
-from InvenTree.tracing import setup_instruments, setup_tracing
 from InvenTree.version import checkMinPythonVersion, inventreeApiVersion
 
 from . import config, locales
@@ -740,7 +739,10 @@ if SENTRY_ENABLED and SENTRY_DSN:  # pragma: no cover
 TRACING_ENABLED = get_boolean_setting(
     'INVENTREE_TRACING_ENABLED', 'tracing.enabled', False
 )
+
 if TRACING_ENABLED:  # pragma: no cover
+    from InvenTree.tracing import setup_instruments, setup_tracing
+
     _t_endpoint = get_setting('INVENTREE_TRACING_ENDPOINT', 'tracing.endpoint', None)
     _t_headers = get_setting('INVENTREE_TRACING_HEADERS', 'tracing.headers', None, dict)
 

--- a/InvenTree/InvenTree/urls.py
+++ b/InvenTree/InvenTree/urls.py
@@ -148,6 +148,7 @@ apipatterns = [
                 SocialAccountDisconnectView.as_view(),
                 name='social_account_disconnect',
             ),
+            path('logout/', users.api.Logout.as_view(), name='api-logout'),
             path('', include('dj_rest_auth.urls')),
         ]),
     ),

--- a/InvenTree/common/api.py
+++ b/InvenTree/common/api.py
@@ -668,6 +668,13 @@ common_api_urls = [
             path('', BackgroundTaskOverview.as_view(), name='api-task-overview'),
         ]),
     ),
+    path(
+        'error-report/',
+        include([
+            path('<int:pk>/', ErrorMessageDetail.as_view(), name='api-error-detail'),
+            path('', ErrorMessageList.as_view(), name='api-error-list'),
+        ]),
+    ),
     # Project codes
     path(
         'project-code/',

--- a/InvenTree/common/tests.py
+++ b/InvenTree/common/tests.py
@@ -658,6 +658,30 @@ class PluginSettingsApiTest(PluginMixin, InvenTreeAPITestCase):
         ...
 
 
+class ErrorReportTest(InvenTreeAPITestCase):
+    """Unit tests for the error report API."""
+
+    def test_error_list(self):
+        """Test error list."""
+        from InvenTree.exceptions import log_error
+
+        url = reverse('api-error-list')
+        response = self.get(url, expected_code=200)
+        self.assertEqual(len(response.data), 0)
+
+        # Throw an error!
+        log_error(
+            'test error', error_name='My custom error', error_info={'test': 'data'}
+        )
+
+        response = self.get(url, expected_code=200)
+        self.assertEqual(len(response.data), 1)
+
+        err = response.data[0]
+        for k in ['when', 'info', 'data', 'path']:
+            self.assertIn(k, err)
+
+
 class TaskListApiTests(InvenTreeAPITestCase):
     """Unit tests for the background task API endpoints."""
 

--- a/InvenTree/users/api.py
+++ b/InvenTree/users/api.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user, login
 from django.contrib.auth.models import Group, User
 from django.urls import include, path, re_path
 
+from dj_rest_auth.views import LogoutView
 from rest_framework import exceptions, permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -198,6 +199,29 @@ class GroupList(ListCreateAPI):
     search_fields = ['name']
 
     ordering_fields = ['name']
+
+
+class Logout(LogoutView):
+    """API view for logging out via API."""
+
+    def logout(self, request):
+        """Logout the current user.
+
+        Deletes user token associated with request.
+        """
+        from InvenTree.middleware import get_token_from_request
+
+        if request.user:
+            token_key = get_token_from_request(request)
+
+            if token_key:
+                try:
+                    token = ApiToken.objects.get(key=token_key, user=request.user)
+                    token.delete()
+                except ApiToken.DoesNotExist:
+                    pass
+
+        return super().logout(request)
 
 
 class GetAuthToken(APIView):

--- a/src/frontend/src/functions/auth.tsx
+++ b/src/frontend/src/functions/auth.tsx
@@ -48,16 +48,17 @@ export const doClassicLogin = async (username: string, password: string) => {
  * Logout the user (invalidate auth token)
  */
 export const doClassicLogout = async () => {
+  // Set token in context
+  const { setToken } = useSessionState.getState();
+
+  setToken(undefined);
+
   // Logout from the server session
   await api.post(apiUrl(ApiPaths.user_logout));
 
-  // Set token in context
-  const { setToken } = useSessionState.getState();
-  setToken(undefined);
-
   notifications.show({
     title: t`Logout successful`,
-    message: t`See you soon.`,
+    message: t`You have been logged out`,
     color: 'green',
     icon: <IconCheck size="1rem" />
   });


### PR DESCRIPTION
This PR addresses some issues with PUI logout, due to our custom API token implementation.

The default `LogoutView` class implemented in `dj-rest-auth` does not account for our extended token framework, so this PR adds a custom logout view which handles this correctly.