### PR TITLE
Specify empty OIDC prefix

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -1000,6 +1000,10 @@ SOCIALACCOUNT_PROVIDERS = get_setting(
 
 SOCIALACCOUNT_STORE_TOKENS = True
 
+# Explicitly set empty URL prefix for OIDC
+# Ref: https://docs.allauth.org/en/latest/release-notes/recent.html#backwards-incompatible-changes
+SOCIALACCOUNT_OPENID_CONNECT_URL_PREFIX = ''
+
 # settings for allauth
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = get_setting(
     'INVENTREE_LOGIN_CONFIRM_DAYS', 'login_confirm_days', 3, typecast=int

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -1001,6 +1001,7 @@ SOCIALACCOUNT_PROVIDERS = get_setting(
 SOCIALACCOUNT_STORE_TOKENS = True
 
 # Explicitly set empty URL prefix for OIDC
+# The SOCIALACCOUNT_OPENID_CONNECT_URL_PREFIX setting was introduced in v0.60.0
 # Ref: https://docs.allauth.org/en/latest/release-notes/recent.html#backwards-incompatible-changes
 SOCIALACCOUNT_OPENID_CONNECT_URL_PREFIX = ''
 

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -1002,7 +1002,7 @@ SOCIALACCOUNT_STORE_TOKENS = True
 
 # Explicitly set empty URL prefix for OIDC
 # The SOCIALACCOUNT_OPENID_CONNECT_URL_PREFIX setting was introduced in v0.60.0
-# Ref: https://docs.allauth.org/en/latest/release-notes/recent.html#backwards-incompatible-changes
+# Ref: https://github.com/pennersr/django-allauth/blob/0.60.0/ChangeLog.rst#backwards-incompatible-changes
 SOCIALACCOUNT_OPENID_CONNECT_URL_PREFIX = ''
 
 # settings for allauth


### PR DESCRIPTION
- Ref: https://github.com/inventree/InvenTree/discussions/6273

Specifies explicitly empty prefix for OIDC providers to maintain backwards compatibility