### PR TITLE
Fix urls loading for plugin testing

### DIFF
--- a/InvenTree/plugin/urls.py
+++ b/InvenTree/plugin/urls.py
@@ -1,5 +1,6 @@
 """URL lookup for plugin app."""
 
+from django.conf import settings
 from django.urls import include, re_path
 
 PLUGIN_BASE = 'plugin'  # Constant for links
@@ -15,7 +16,7 @@ def get_plugin_urls():
     # Only allow custom routing if the setting is enabled
     if InvenTreeSetting.get_setting(
         'ENABLE_PLUGINS_URL', False, create=False, cache=False
-    ):
+    ) or settings.PLUGIN_TESTING:
         for plugin in registry.plugins.values():
             if plugin.mixin_enabled('urls'):
                 urls.append(plugin.urlpatterns)

--- a/InvenTree/plugin/urls.py
+++ b/InvenTree/plugin/urls.py
@@ -14,9 +14,12 @@ def get_plugin_urls():
     urls = []
 
     # Only allow custom routing if the setting is enabled
-    if InvenTreeSetting.get_setting(
-        'ENABLE_PLUGINS_URL', False, create=False, cache=False
-    ) or settings.PLUGIN_TESTING:
+    if (
+        InvenTreeSetting.get_setting(
+            'ENABLE_PLUGINS_URL', False, create=False, cache=False
+        )
+        or settings.PLUGIN_TESTING
+    ):
         for plugin in registry.plugins.values():
             if plugin.mixin_enabled('urls'):
                 urls.append(plugin.urlpatterns)

--- a/InvenTree/plugin/urls.py
+++ b/InvenTree/plugin/urls.py
@@ -18,7 +18,7 @@ def get_plugin_urls():
         InvenTreeSetting.get_setting(
             'ENABLE_PLUGINS_URL', False, create=False, cache=False
         )
-        or settings.PLUGIN_TESTING
+        or settings.PLUGIN_TESTING_SETUP
     ):
         for plugin in registry.plugins.values():
             if plugin.mixin_enabled('urls'):


### PR DESCRIPTION
#5648 has broken my plugin testing CI setup. 

https://github.com/inventree/InvenTree/pull/5648/files#diff-5b51ddf4fb2cbf458278a6627285ebdd20c82e3e4276be8cd74fb63bc6d25abfL14-R19

Basically, I set `INVENTREE_PLUGIN_TESTING: True` and `INVENTREE_PLUGIN_TESTING_SETUP: True` . This already sets up and loads my plugin that was installed via `pip install -e /path/to/plugin` before and the tests run fine. However now the urls are not activated which results in failing tests. This PR proposes a fix for this problem.