### PR TITLE
BuildOrder: UI bug fix

### DIFF
--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -1094,7 +1094,7 @@ function loadBuildOutputTable(build_info, options={}) {
     var params = options.params || {};
 
     // test templates for the part being assembled
-    let test_templates = null;
+    let test_templates = [];
 
     // tracked line items for this build
     let has_tracked_lines = false;
@@ -1138,6 +1138,9 @@ function loadBuildOutputTable(build_info, options={}) {
                         test_templates.push(item);
                     }
                 });
+            },
+            error: function() {
+                test_templates = [];
             }
         }
     );


### PR DESCRIPTION
Fix bug where test templates are requested for a non-trackable output