### PR TITLE
Use registry.get_plugin()

### DIFF
--- a/InvenTree/common/notifications.py
+++ b/InvenTree/common/notifications.py
@@ -142,7 +142,7 @@ class NotificationMethod:
             return False
 
         # Check if method globally enabled
-        plg_instance = registry.plugins.get(plg_cls.NAME.lower())
+        plg_instance = registry.get_plugin(plg_cls.NAME.lower())
         if plg_instance and not plg_instance.get_setting(self.GLOBAL_SETTING):
             return True
 

--- a/InvenTree/plugin/base/event/events.py
+++ b/InvenTree/plugin/base/event/events.py
@@ -89,7 +89,7 @@ def process_event(plugin_slug, event, *args, **kwargs):
     This function is run by the background worker process.
     This function may queue multiple functions to be handled by the background worker.
     """
-    plugin = registry.plugins.get(plugin_slug, None)
+    plugin = registry.get_plugin(plugin_slug)
 
     if plugin is None:  # pragma: no cover
         logger.error("Could not find matching plugin for '%s'", plugin_slug)

--- a/InvenTree/plugin/base/event/mixins.py
+++ b/InvenTree/plugin/base/event/mixins.py
@@ -9,7 +9,7 @@ class EventMixin:
     Implementing classes must provide a "process_event" function:
     """
 
-    def wants_process_event(self, event):
+    def wants_process_event(self, event: str) -> bool:
         """Function to subscribe to events.
 
         Return true if you're interested in the given event, false if not.
@@ -17,7 +17,7 @@ class EventMixin:
         # Default implementation always returns true (backwards compatibility)
         return True
 
-    def process_event(self, event, *args, **kwargs):
+    def process_event(self, event: str, *args, **kwargs) -> None:
         """Function to handle events.
 
         Must be overridden by plugin

--- a/InvenTree/plugin/builtin/integration/core_notifications.py
+++ b/InvenTree/plugin/builtin/integration/core_notifications.py
@@ -133,7 +133,7 @@ class InvenTreeCoreNotificationsPlugin(
 
         def send_bulk(self):
             """Send the notifications out via slack."""
-            instance = registry.plugins.get(self.get_plugin().NAME.lower())
+            instance = registry.get_plugin(self.get_plugin().NAME.lower())
             url = instance.get_setting('NOTIFICATION_SLACK_URL')
 
             if not url:

--- a/InvenTree/plugin/builtin/integration/test_core_notifications.py
+++ b/InvenTree/plugin/builtin/integration/test_core_notifications.py
@@ -19,7 +19,7 @@ class CoreNotificationTestTests(BaseNotificationIntegrationTest):
         self.assertEqual(len(mail.outbox), 0)
 
         # enable plugin and set mail setting to true
-        plugin = registry.plugins.get('inventreecorenotificationsplugin')
+        plugin = registry.get_plugin('inventreecorenotificationsplugin')
         plugin.set_setting('ENABLE_NOTIFICATION_EMAILS', True)
         NotificationUserSetting.set_setting(
             key='NOTIFICATION_METHOD_MAIL',


### PR DESCRIPTION
- Instead of registry.plugins.get()
- get_plugin checks registry hash
- performs registry reload if necessary