### PR TITLE
Maintenance Mode Fix

### DIFF
--- a/InvenTree/InvenTree/backends.py
+++ b/InvenTree/InvenTree/backends.py
@@ -34,13 +34,13 @@ class InvenTreeMaintenanceModeBackend(AbstractStateBackend):
             )
         )
 
-        logger.debug('Maintenance mode state: {state}'.format(state=value))
+        logger.debug('Maintenance mode state: %s', value)
 
         return value
 
     def set_value(self, value: bool, retries: int = 5):
         """Set the state of the maintenance mode."""
-        logger.debug('Setting maintenance mode state: {state}'.format(state=value))
+        logger.debug('Setting maintenance mode state: %s', value)
 
         while retries > 0:
             try:

--- a/InvenTree/InvenTree/backends.py
+++ b/InvenTree/InvenTree/backends.py
@@ -1,0 +1,47 @@
+"""Custom backend implementations."""
+
+import logging
+
+from django.db.utils import IntegrityError, OperationalError, ProgrammingError
+
+from maintenance_mode.backends import AbstractStateBackend
+
+import common.models
+import InvenTree.helpers
+
+logger = logging.getLogger('inventree')
+
+
+class InvenTreeMaintenanceModeBackend(AbstractStateBackend):
+    """Custom backend for managing state of maintenance mode.
+
+    Stores the current state of the maintenance mode in the database,
+    using an InvenTreeSetting object.
+    """
+
+    SETTING_KEY = '_MAINTENANCE_MODE'
+
+    def get_value(self) -> bool:
+        """Get the current state of the maintenance mode.
+
+        Returns:
+            bool: True if maintenance mode is active, False otherwise.
+        """
+        value = InvenTree.helpers.str2bool(
+            common.models.InvenTreeSetting.get_setting(
+                self.SETTING_KEY, False, create=False, cache=False
+            )
+        )
+
+        logger.debug('Maintenance mode state: {state}'.format(state=value))
+
+        return value
+
+    def set_value(self, value: bool):
+        """Set the state of the maintenance mode."""
+        logger.debug('Setting maintenance mode state: {state}'.format(state=value))
+
+        try:
+            common.models.InvenTreeSetting.set_setting(self.SETTING_KEY, value)
+        except (IntegrityError, OperationalError, ProgrammingError):
+            logger.warning('Failed to set maintenance mode state in database')

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -1080,8 +1080,8 @@ MARKDOWNIFY = {
 IGNORED_ERRORS = [Http404, django.core.exceptions.PermissionDenied]
 
 # Maintenance mode
-MAINTENANCE_MODE_RETRY_AFTER = 60
-MAINTENANCE_MODE_STATE_BACKEND = 'maintenance_mode.backends.StaticStorageBackend'
+MAINTENANCE_MODE_RETRY_AFTER = 10
+MAINTENANCE_MODE_STATE_BACKEND = 'InvenTree.backends.InvenTreeMaintenanceModeBackend'
 
 # Are plugins enabled?
 PLUGINS_ENABLED = get_boolean_setting(


### PR DESCRIPTION
There are ongoing issues with using the StaticFiles backend for `django-maintentance-mode`.

This PR provides a custom backend which utilizes the `InvenTreeSetting` DB storage class. Hopefully should provide more reliability.

- Fixes https://github.com/inventree/InvenTree/issues/6352
- Fixes https://github.com/inventree/InvenTree/issues/6156