### PR TITLE
Update docker package requirements

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -7,9 +7,8 @@ setuptools>=69.0.0
 wheel>=0.41.0
 
 # Database links
-psycopg2>=2.9.9
+psycopg[binary]>=3.1.18
 mysqlclient>=2.2.0
-pgcli>=3.1.0
 mariadb>=1.1.8
 
 # gunicorn web server


### PR DESCRIPTION
- Replace psycopg2 with psycopg[binary]
- Ref: https://learndjango.com/tutorials/psycopg3-binary-and-django-42-installation-quick-t

---------------------------

Recent update to django 4.2 has broken postgresql integration (in docker) - mostly because the docker image still uses `psycopg2` instead of `psycopg3`