### PR TITLE
Fix display of allocated stock items in build table

### DIFF
--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -1023,7 +1023,7 @@ class BuildItemSerializer(InvenTreeModelSerializer):
         """Determine which extra details fields should be included"""
         part_detail = kwargs.pop('part_detail', True)
         location_detail = kwargs.pop('location_detail', True)
-        stock_detail = kwargs.pop('stock_detail', False)
+        stock_detail = kwargs.pop('stock_detail', True)
         build_detail = kwargs.pop('build_detail', False)
 
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
- Include stock_detail in BuildLine serializer by default