### PR TITLE
Mention the API version bump in CONTRIBUTION.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ The HEAD of the "stable" branch represents the latest stable release code.
 
 ## API versioning
 
-The [API version](https://github.com/inventree/InvenTree/blob/master/InvenTree/InvenTree/api_version.py) needs to be bumped every time when the API changed.
+The [API version](https://github.com/inventree/InvenTree/blob/master/InvenTree/InvenTree/api_version.py) needs to be bumped every time when the API is changed.
 
 ## Environment
 ### Target version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,10 @@ The HEAD of the "stable" branch represents the latest stable release code.
 - When approved, the branch is merged back *into* stable, with an incremented PATCH number (e.g. 0.4.1 -> 0.4.2)
 - The bugfix *must* also be cherry picked into the *master* branch.
 
+## API versioning
+
+The [API version](https://github.com/inventree/InvenTree/blob/master/InvenTree/InvenTree/api_version.py) needs to be bumped every time when the API changed.
+
 ## Environment
 ### Target version
 We are currently targeting:


### PR DESCRIPTION
I had to lookup this again recently, so I think it has it's own place in the CONTRIBUTING.md

If necessary we can add more wording on what do we mean under API change?