### PR TITLE
Update Proxy support for django 4.2

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -120,8 +120,6 @@ STATIC_ROOT = config.get_static_dir()
 # The filesystem location for uploaded meadia files
 MEDIA_ROOT = config.get_media_dir()
 
-''
-
 # List of allowed hosts (default = allow all)
 # Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = get_setting(

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -120,7 +120,10 @@ STATIC_ROOT = config.get_static_dir()
 # The filesystem location for uploaded meadia files
 MEDIA_ROOT = config.get_media_dir()
 
+''
+
 # List of allowed hosts (default = allow all)
+# Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = get_setting(
     'INVENTREE_ALLOWED_HOSTS',
     config_key='allowed_hosts',
@@ -128,7 +131,30 @@ ALLOWED_HOSTS = get_setting(
     typecast=list,
 )
 
+# List of trusted origins for unsafe requests
+# Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins
+CSRF_TRUSTED_ORIGINS = get_setting(
+    'INVENTREE_TRUSTED_ORIGINS',
+    config_key='trusted_origins',
+    default_value=[],
+    typecast=list,
+)
+
+USE_X_FORWARDED_HOST = get_boolean_setting(
+    'INVENTREE_USE_X_FORWARDED_HOST',
+    config_key='use_x_forwarded_host',
+    default_value=False,
+)
+
+USE_X_FORWARDED_PORT = get_boolean_setting(
+    'INVENTREE_USE_X_FORWARDED_PORT',
+    config_key='use_x_forwarded_port',
+    default_value=False,
+)
+
 # Cross Origin Resource Sharing (CORS) options
+# Refer to the django-cors-headers documentation for more information
+# Ref: https://github.com/adamchainz/django-cors-headers
 
 # Extract CORS options from configuration file
 CORS_ALLOW_ALL_ORIGINS = get_boolean_setting(

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -161,7 +161,11 @@ CORS_ALLOW_ALL_ORIGINS = get_boolean_setting(
     'INVENTREE_CORS_ORIGIN_ALLOW_ALL', config_key='cors.allow_all', default_value=DEBUG
 )
 
-CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_CREDENTIALS = get_boolean_setting(
+    'INVENTREE_CORS_ALLOW_CREDENTIALS',
+    config_key='cors.allow_credentials',
+    default_value=True,
+)
 
 # Only allow CORS access to API and media endpoints
 CORS_URLS_REGEX = r'^/(api|media|static)/.*$'

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -188,10 +188,9 @@ use_x_forwarded_port: false
 
 # Cross Origin Resource Sharing (CORS) settings (see https://github.com/adamchainz/django-cors-headers)
 cors:
-  # CORS_ALLOW_ALL_ORIGINS - If True, the whitelist will not be used and all origins will be accepted.
   allow_all: True
+  allow_credentials: True,
 
-  # CORS_ALLOWED_ORIGINS - A list of origins that are authorized to make cross-site HTTP requests. Defaults to []
   # whitelist:
   # - https://example.com
   # - https://sub.example.com

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -171,13 +171,27 @@ auto_update: False
 allowed_hosts:
   - '*'
 
-# Cross Origin Resource Sharing (CORS) settings (see https://github.com/ottoyiu/django-cors-headers)
-# Following parameters are
+# Trusted origins (see CSRF_TRUSTED_ORIGINS in Django settings documentation)
+# If you are running behind a proxy, you may need to add the proxy address here
+trusted_origins:
+  - 'http://localhost:8000'
+
+
+# Proxy forwarding settings
+# If InvenTree is running behind a proxy, you may need to configure these settings
+
+# Override with the environment variable INVENTREE_USE_X_FORWARDED_HOST
+use_x_forwarded_host: false
+
+# Override with the environment variable INVENTREE_USE_X_FORWARDED_PORT
+use_x_forwarded_port: false
+
+# Cross Origin Resource Sharing (CORS) settings (see https://github.com/adamchainz/django-cors-headers)
 cors:
-  # CORS_ORIGIN_ALLOW_ALL - If True, the whitelist will not be used and all origins will be accepted.
+  # CORS_ALLOW_ALL_ORIGINS - If True, the whitelist will not be used and all origins will be accepted.
   allow_all: True
 
-  # CORS_ORIGIN_WHITELIST - A list of origins that are authorized to make cross-site HTTP requests. Defaults to []
+  # CORS_ALLOWED_ORIGINS - A list of origins that are authorized to make cross-site HTTP requests. Defaults to []
   # whitelist:
   # - https://example.com
   # - https://sub.example.com

--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -196,18 +196,28 @@ A list of currency codes (e.g. *AUD*, *CAD*, *JPY*, *USD*) can be specified usin
 !!! tip "More Info"
     Read the [currencies documentation](../settings/currency.md) for more information on currency support in InvenTree
 
-## Allowed Hosts / CORS
+## Server Access
 
-By default, all hosts are allowed, and CORS requests are enabled from any origin.
+Depending on how your InvenTree installation is configured, you will need to pay careful attention to the following settings. If you are running your server behind a proxy, or want to adjust support for CORS requests, one or more of the following settings may need to be adjusted.
+
+!!! warning "Advanced Users"
+    The following settings require a certain assumed level of knowledge. You should also refer to the [django documentation](https://docs.djangoproject.com/en/4.2/ref/settings/) for more information.
 
 !!! danger "Not Secure"
     Allowing access from any host is not secure, and should be adjusted for your installation.
 
+!!! info "Environment Variables"
+    Note that a provided environment variable will override the value provided in the configuration file.
+
 | Environment Variable | Configuration File | Description | Default |
 | --- | --- | --- | --- |
 | INVENTREE_ALLOWED_HOSTS | allowed_hosts | List of allowed hosts | `*` |
+| INVENTREE_TRUSTED_ORIGINS | trusted_origins | List of trusted origins | *Empty list* |
+| INVENTREE_USE_X_FORWARDED_HOST | use_x_forwarded_host | Use forwarded host header | False |
+| INVENTREE_USE_X_FORWARDED_PORT | use_x_forwarded_port | Use forwarded port header | False |
 | INVENTREE_CORS_ORIGIN_ALLOW_ALL | cors.allow_all | Allow all remote URLS for CORS checks | False |
 | INVENTREE_CORS_ORIGIN_WHITELIST | cors.whitelist | List of whitelisted CORS URLs | *Empty list* |
+| INVENTREE_CORS_ALLOW_CREDENTIALS | cors.allow_credentials | Allow cookies in cross-site requests | True |
 
 !!! info "Configuration File"
     Allowed hosts and CORS options must be changed in the configuration file, and cannot be set via environment variables


### PR DESCRIPTION
Improve support for django configuration, in particular around host / proxy settings.

Updating to django 4.2 has changed the way that some core settings are specified, and these now need to be explicitly configured for InvenTree to run properly behind a proxy.

Ref : https://github.com/inventree/InvenTree/pull/6452 (turns out the issue is proxy, not db)