### PR TITLE
Maintenance Mode Update

### DIFF
--- a/InvenTree/InvenTree/backends.py
+++ b/InvenTree/InvenTree/backends.py
@@ -17,8 +17,7 @@ logger = logging.getLogger('inventree')
 class InvenTreeMaintenanceModeBackend(AbstractStateBackend):
     """Custom backend for managing state of maintenance mode.
 
-    Stores the current state of the maintenance mode in the database,
-    using an InvenTreeSetting object.
+    Stores a timestamp in the database to determine when maintenance mode will elapse.
     """
 
     SETTING_KEY = '_MAINTENANCE_MODE'

--- a/InvenTree/InvenTree/backends.py
+++ b/InvenTree/InvenTree/backends.py
@@ -9,7 +9,6 @@ from django.db.utils import IntegrityError, OperationalError, ProgrammingError
 from maintenance_mode.backends import AbstractStateBackend
 
 import common.models
-import InvenTree.ready
 
 logger = logging.getLogger('inventree')
 
@@ -50,7 +49,7 @@ class InvenTreeMaintenanceModeBackend(AbstractStateBackend):
 
     def set_value(self, value: bool, retries: int = 5, minutes: int = 5):
         """Set the state of the maintenance mode.
-        
+
         Instead of simply writing "true" or "false" to the setting,
         we write a timestamp to the setting, which is used to determine
         when maintenance mode will elapse.

--- a/InvenTree/InvenTree/backends.py
+++ b/InvenTree/InvenTree/backends.py
@@ -1,5 +1,6 @@
 """Custom backend implementations."""
 
+import datetime
 import logging
 import time
 
@@ -30,26 +31,45 @@ class InvenTreeMaintenanceModeBackend(AbstractStateBackend):
         """
         try:
             setting = common.models.InvenTreeSetting.objects.get(key=self.SETTING_KEY)
-            value = InvenTree.helpers.str2bool(setting.value)
+            value = str(setting.value).strip()
         except common.models.InvenTreeSetting.DoesNotExist:
             # Database is accessible, but setting is not available - assume False
-            value = False
+            return False
         except (IntegrityError, OperationalError, ProgrammingError):
             # Database is inaccessible - assume we are not in maintenance mode
-            logger.warning('Failed to read maintenance mode state - assuming True')
-            value = True
+            logger.debug('Failed to read maintenance mode state - assuming True')
+            return True
 
-        logger.debug('Maintenance mode state: %s', value)
+        # Extract timestamp from string
+        try:
+            # If the timestamp is in the past, we are now *out* of maintenance mode
+            timestamp = datetime.datetime.fromisoformat(value)
+            return timestamp > datetime.datetime.now()
+        except ValueError:
+            # If the value is not a valid timestamp, assume maintenance mode is not active
+            return False
 
-        return value
-
-    def set_value(self, value: bool, retries: int = 5):
-        """Set the state of the maintenance mode."""
+    def set_value(self, value: bool, retries: int = 5, minutes: int = 5):
+        """Set the state of the maintenance mode.
+        
+        Instead of simply writing "true" or "false" to the setting,
+        we write a timestamp to the setting, which is used to determine
+        when maintenance mode will elapse.
+        This ensures that we will always *exit* maintenance mode after a certain time period.
+        """
         logger.debug('Setting maintenance mode state: %s', value)
+
+        if value:
+            # Save as isoformat
+            timestamp = datetime.datetime.now() + datetime.timedelta(minutes=minutes)
+            timestamp = timestamp.isoformat()
+        else:
+            # Blank timestamp means maintenance mode is not active
+            timestamp = ''
 
         while retries > 0:
             try:
-                common.models.InvenTreeSetting.set_setting(self.SETTING_KEY, value)
+                common.models.InvenTreeSetting.set_setting(self.SETTING_KEY, timestamp)
 
                 # Read the value back to confirm
                 if self.get_value() == value:


### PR DESCRIPTION
A small tweak for maintenance mode implementation.

Real world testing has revealed that there is still a possible for the system to be left in "maintenance mode" - either due to a race condition or an exception being thrown in between mode being set "true" and "false". The source of this has not yet been uncovered.

However the effect of this is that the system is left permanently in maintenance mode, and thus inaccessible. It requires administrator intervention at this point.

This PR implements a tweak to the maintenance mode implementation. Instead of saving a simple binary "True" / "False" value to the database, we save a timestamp (in the future). It is assumed that by that time, we are out of maintenance mode. When we exit maintenance mode we invalidate that timestamp by writing a blank value.

When we check the current state of maintenance mode, we check if the timestamp value is in the future.

At the very least if we are erroneously left in maintenance mode, that state will only persist for a few minutes.