### PR TITLE
Fix APICallMixin url_args handling

### DIFF
--- a/InvenTree/plugin/base/integration/APICallMixin.py
+++ b/InvenTree/plugin/base/integration/APICallMixin.py
@@ -2,6 +2,7 @@
 
 import json as json_pkg
 import logging
+from collections.abc import Iterable
 
 import requests
 
@@ -107,7 +108,9 @@ class APICallMixin:
         """Returns an encoded path for the provided dict."""
         groups = []
         for key, val in arguments.items():
-            groups.append(f'{key}={",".join([str(a) for a in val])}')
+            if isinstance(val, Iterable) and not isinstance(val, str):
+                val = ','.join([str(a) for a in val])
+            groups.append(f'{key}={val}')
         return f'?{"&".join(groups)}'
 
     def api_call(

--- a/InvenTree/plugin/base/integration/test_mixins.py
+++ b/InvenTree/plugin/base/integration/test_mixins.py
@@ -263,14 +263,17 @@ class APICallMixinTest(BaseMixinDefinition, TestCase):
         """Test that building up args work."""
         # api_build_url_args
         # 1 arg
-        result = self.mixin.api_build_url_args({'a': 'b'})
-        self.assertEqual(result, '?a=b')
+        result = self.mixin.api_build_url_args({'a': 'abc123'})
+        self.assertEqual(result, '?a=abc123')
+        # non string arg
+        result = self.mixin.api_build_url_args({'a': 1})
+        self.assertEqual(result, '?a=1')
         # more args
-        result = self.mixin.api_build_url_args({'a': 'b', 'c': 'd'})
-        self.assertEqual(result, '?a=b&c=d')
+        result = self.mixin.api_build_url_args({'a': 'b', 'c': 42})
+        self.assertEqual(result, '?a=b&c=42')
         # list args
-        result = self.mixin.api_build_url_args({'a': 'b', 'c': ['d', 'e', 'f']})
-        self.assertEqual(result, '?a=b&c=d,e,f')
+        result = self.mixin.api_build_url_args({'a': 'b', 'c': ['d', 'efgh', 1337]})
+        self.assertEqual(result, '?a=b&c=d,efgh,1337')
 
     def test_api_call(self):
         """Test that api calls work."""


### PR DESCRIPTION
The current implementation of `APICallMixin.api_call` handles `url_args` very weirdly. This improves the behavior, so that non single character string args will be handled correctly.

Before:
```py
>>> api_build_url_args({'a': 'abc123'})
'?a=a,b,c,1,2,3'
```

After:
```py
>>> api_build_url_args({'a': 'abc123'})
'?a=abc123'
```