### PR TITLE
Added pdf2image kwargs

### DIFF
--- a/InvenTree/machine/machine_types/label_printer.py
+++ b/InvenTree/machine/machine_types/label_printer.py
@@ -183,7 +183,7 @@ class LabelPrinterBaseDriver(BaseDriver):
             use_cairo (bool): Whether to use the pdftocairo backend for rendering which provides better results in tests,
                 see [#6488](https://github.com/inventree/InvenTree/pull/6488) for details. If False, pdftoppm is used (default: True)
             pdf2image_kwargs (dict): Additional keyword arguments to pass to the
-                [`pdf2image.convert_from_bytes`](https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes) method
+                [`pdf2image.convert_from_bytes`](https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes) method (optional)
         """
         label.object_to_print = item
         png = self.machine_plugin.render_to_png(label, request, **kwargs)

--- a/InvenTree/machine/machine_types/label_printer.py
+++ b/InvenTree/machine/machine_types/label_printer.py
@@ -180,7 +180,10 @@ class LabelPrinterBaseDriver(BaseDriver):
         Keyword Arguments:
             pdf_data (bytes): The pdf document as bytes (optional)
             dpi (int): The dpi used to render the image (optional)
-            pdf2image_kwargs (dict): Additional keyword arguments to pass to the pdf2image.convert_from_bytes method (optional)
+            use_cairo(bool): Whether to use the pdftocairo backend for rendering which provides better results
+                see https://github.com/inventree/InvenTree/pull/6488 for details. If False, pdftoppm is used (default: True)
+            pdf2image_kwargs(dict): Additional keyword arguments to pass to the pdf2image.convert_from_bytes method
+                see https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes
         """
         label.object_to_print = item
         png = self.machine_plugin.render_to_png(label, request, **kwargs)

--- a/InvenTree/machine/machine_types/label_printer.py
+++ b/InvenTree/machine/machine_types/label_printer.py
@@ -180,10 +180,10 @@ class LabelPrinterBaseDriver(BaseDriver):
         Keyword Arguments:
             pdf_data (bytes): The pdf document as bytes (optional)
             dpi (int): The dpi used to render the image (optional)
-            use_cairo (bool): Whether to use the pdftocairo backend for rendering which provides better results
+            use_cairo (bool): Whether to use the pdftocairo backend for rendering which provides better results in tests,
                 see [#6488](https://github.com/inventree/InvenTree/pull/6488) for details. If False, pdftoppm is used (default: True)
-            pdf2image_kwargs (dict): Additional keyword arguments to pass to the pdf2image.convert_from_bytes method
-                see [`pdf2image.convert_from_bytes`](https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes)
+            pdf2image_kwargs (dict): Additional keyword arguments to pass to the
+                [`pdf2image.convert_from_bytes`](https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes) method
         """
         label.object_to_print = item
         png = self.machine_plugin.render_to_png(label, request, **kwargs)

--- a/InvenTree/machine/machine_types/label_printer.py
+++ b/InvenTree/machine/machine_types/label_printer.py
@@ -181,9 +181,9 @@ class LabelPrinterBaseDriver(BaseDriver):
             pdf_data (bytes): The pdf document as bytes (optional)
             dpi (int): The dpi used to render the image (optional)
             use_cairo (bool): Whether to use the pdftocairo backend for rendering which provides better results
-                see https://github.com/inventree/InvenTree/pull/6488 for details. If False, pdftoppm is used (default: True)
+                see [#6488](https://github.com/inventree/InvenTree/pull/6488) for details. If False, pdftoppm is used (default: True)
             pdf2image_kwargs (dict): Additional keyword arguments to pass to the pdf2image.convert_from_bytes method
-                see https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes
+                see [`pdf2image.convert_from_bytes`](https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes)
         """
         label.object_to_print = item
         png = self.machine_plugin.render_to_png(label, request, **kwargs)

--- a/InvenTree/machine/machine_types/label_printer.py
+++ b/InvenTree/machine/machine_types/label_printer.py
@@ -180,6 +180,7 @@ class LabelPrinterBaseDriver(BaseDriver):
         Keyword Arguments:
             pdf_data (bytes): The pdf document as bytes (optional)
             dpi (int): The dpi used to render the image (optional)
+            pdf2image_kwargs (dict): Additional keyword arguments to pass to the pdf2image.convert_from_bytes method (optional)
         """
         label.object_to_print = item
         png = self.machine_plugin.render_to_png(label, request, **kwargs)

--- a/InvenTree/machine/machine_types/label_printer.py
+++ b/InvenTree/machine/machine_types/label_printer.py
@@ -180,9 +180,9 @@ class LabelPrinterBaseDriver(BaseDriver):
         Keyword Arguments:
             pdf_data (bytes): The pdf document as bytes (optional)
             dpi (int): The dpi used to render the image (optional)
-            use_cairo(bool): Whether to use the pdftocairo backend for rendering which provides better results
+            use_cairo (bool): Whether to use the pdftocairo backend for rendering which provides better results
                 see https://github.com/inventree/InvenTree/pull/6488 for details. If False, pdftoppm is used (default: True)
-            pdf2image_kwargs(dict): Additional keyword arguments to pass to the pdf2image.convert_from_bytes method
+            pdf2image_kwargs (dict): Additional keyword arguments to pass to the pdf2image.convert_from_bytes method
                 see https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes
         """
         label.object_to_print = item

--- a/InvenTree/plugin/base/label/mixins.py
+++ b/InvenTree/plugin/base/label/mixins.py
@@ -76,7 +76,16 @@ class LabelPrintingMixin:
             raise ValidationError(_('Error rendering label to HTML'))
 
     def render_to_png(self, label: LabelTemplate, request=None, **kwargs):
-        """Render this label to PNG format."""
+        """Render this label to PNG format.
+
+        Arguments:
+            label: The LabelTemplate object to render
+            request: The HTTP request object which triggered this print job
+        Keyword Arguments:
+            pdf_data: The raw PDF data of the rendered label (if already rendered)
+            dpi: The DPI to use for the PNG rendering
+            pdf2image_kwargs: Additional keyword arguments to pass to the pdf2image.convert_from_bytes method
+        """
         # Check if pdf data is provided
         pdf_data = kwargs.get('pdf_data', None)
 
@@ -86,10 +95,13 @@ class LabelPrintingMixin:
             )
 
         dpi = kwargs.get('dpi', InvenTreeSetting.get_setting('LABEL_DPI', 300))
+        pdf2image_kwargs = kwargs.get('pdf2image_kwargs', {})
 
         # Convert to png data
         try:
-            return pdf2image.convert_from_bytes(pdf_data, dpi=dpi)[0]
+            return pdf2image.convert_from_bytes(pdf_data, dpi=dpi, **pdf2image_kwargs)[
+                0
+            ]
         except Exception as e:
             log_error('label.render_to_png')
             raise ValidationError(_('Error rendering label to PNG'))

--- a/InvenTree/plugin/base/label/mixins.py
+++ b/InvenTree/plugin/base/label/mixins.py
@@ -84,7 +84,10 @@ class LabelPrintingMixin:
         Keyword Arguments:
             pdf_data: The raw PDF data of the rendered label (if already rendered)
             dpi: The DPI to use for the PNG rendering
+            use_cairo: Whether to use the pdftocairo backend for rendering which provides better results
+                see #6488. If False, pdftoppm is used (default: True)
             pdf2image_kwargs: Additional keyword arguments to pass to the pdf2image.convert_from_bytes method
+                see https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes
         """
         # Check if pdf data is provided
         pdf_data = kwargs.get('pdf_data', None)
@@ -94,14 +97,15 @@ class LabelPrintingMixin:
                 self.render_to_pdf(label, request, **kwargs).get_document().write_pdf()
             )
 
-        dpi = kwargs.get('dpi', InvenTreeSetting.get_setting('LABEL_DPI', 300))
-        pdf2image_kwargs = kwargs.get('pdf2image_kwargs', {})
+        pdf2image_kwargs = {
+            'dpi': kwargs.get('dpi', InvenTreeSetting.get_setting('LABEL_DPI', 300)),
+            'use_pdftocairo': kwargs.get('use_cairo', True),
+            **kwargs.get('pdf2image_kwargs', {}),
+        }
 
         # Convert to png data
         try:
-            return pdf2image.convert_from_bytes(pdf_data, dpi=dpi, **pdf2image_kwargs)[
-                0
-            ]
+            return pdf2image.convert_from_bytes(pdf_data, **pdf2image_kwargs)[0]
         except Exception as e:
             log_error('label.render_to_png')
             raise ValidationError(_('Error rendering label to PNG'))

--- a/InvenTree/plugin/base/label/mixins.py
+++ b/InvenTree/plugin/base/label/mixins.py
@@ -84,10 +84,10 @@ class LabelPrintingMixin:
         Keyword Arguments:
             pdf_data: The raw PDF data of the rendered label (if already rendered)
             dpi: The DPI to use for the PNG rendering
-            use_cairo: Whether to use the pdftocairo backend for rendering which provides better results
-                see #6488. If False, pdftoppm is used (default: True)
-            pdf2image_kwargs: Additional keyword arguments to pass to the pdf2image.convert_from_bytes method
-                see https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes
+            use_cairo (bool): Whether to use the pdftocairo backend for rendering which provides better results in tests,
+                see [#6488](https://github.com/inventree/InvenTree/pull/6488) for details. If False, pdftoppm is used (default: True)
+            pdf2image_kwargs (dict): Additional keyword arguments to pass to the
+                [`pdf2image.convert_from_bytes`](https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes) method
         """
         # Check if pdf data is provided
         pdf_data = kwargs.get('pdf_data', None)

--- a/InvenTree/plugin/base/label/mixins.py
+++ b/InvenTree/plugin/base/label/mixins.py
@@ -87,7 +87,7 @@ class LabelPrintingMixin:
             use_cairo (bool): Whether to use the pdftocairo backend for rendering which provides better results in tests,
                 see [#6488](https://github.com/inventree/InvenTree/pull/6488) for details. If False, pdftoppm is used (default: True)
             pdf2image_kwargs (dict): Additional keyword arguments to pass to the
-                [`pdf2image.convert_from_bytes`](https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes) method
+                [`pdf2image.convert_from_bytes`](https://pdf2image.readthedocs.io/en/latest/reference.html#pdf2image.pdf2image.convert_from_bytes) method (optional)
         """
         # Check if pdf data is provided
         pdf_data = kwargs.get('pdf_data', None)


### PR DESCRIPTION
While investigating some print quality issues, I noticed that there are some issues with the rendered png. So I first looked into to intermediately generated pdf, but everything looks fine there. So I suspect this has something todo with the png rendering. After a lot of playing with different options I found out that the pdf2image library has an optional setting (`use_pdftocairo=True`) to use `pdftocairo` instead of `pdftoppm` which is used by default. 

| pdftoppm (current) | pdftocairo |
|--------|--------|
| ![image](https://github.com/inventree/InvenTree/assets/76838159/aafa9c9f-a236-4dff-80ea-f68082fcc5c7) | ![image](https://github.com/inventree/InvenTree/assets/76838159/54ad1cbb-41b0-440a-b9c6-4d2dabe4577e) | 
| No sharp edges are rendered, which results in not always quadratical QR code pixels | |

So this PR adds an option to let the developer specify some custom options to pass over to `pdf2image.convert_from_bytes(...)`. Not sure if we should use Cairo by default, as this may can break some printing plugins?