### PR TITLE
Plugin context fix

### DIFF
--- a/InvenTree/plugin/views.py
+++ b/InvenTree/plugin/views.py
@@ -39,6 +39,6 @@ class InvenTreePluginViewMixin:
         ctx = super().get_context_data(**kwargs)
 
         if settings.PLUGINS_ENABLED:
-            ctx['plugin_panels'] = self.get_plugin_panels(ctx)
+            ctx['plugin_panels'] = self.get_plugin_panels(ctx.copy())
 
         return ctx


### PR DESCRIPTION
- Provide a *copy* of the page context to pass to plugin
- Prevents plugins from overriding page context when rendering

----------------

This fixes a very subtle (and hard to track down) bug where a broken plugin was corrupting the page rendering context data.