### PR TITLE
Fix broken URL

### DIFF
--- a/InvenTree/templates/js/translated/company.js
+++ b/InvenTree/templates/js/translated/company.js
@@ -226,7 +226,7 @@ function createSupplierPart(options={}) {
     var header = '';
     if (options.part) {
         var part_model = {};
-        inventreeGet(`{% url "api-part-list" %}${options.part}/.*`, {}, {
+        inventreeGet(`{% url "api-part-list" %}${options.part}/`, {}, {
             async: false,
             success: function(response) {
                 part_model = response;


### PR DESCRIPTION
Small fix for a URL in the API forms which was broken by the recent pathing cleanup.