### PR TITLE
Default site

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -120,61 +120,6 @@ STATIC_ROOT = config.get_static_dir()
 # The filesystem location for uploaded meadia files
 MEDIA_ROOT = config.get_media_dir()
 
-# List of allowed hosts (default = allow all)
-# Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = get_setting(
-    'INVENTREE_ALLOWED_HOSTS',
-    config_key='allowed_hosts',
-    default_value=['*'],
-    typecast=list,
-)
-
-# List of trusted origins for unsafe requests
-# Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins
-CSRF_TRUSTED_ORIGINS = get_setting(
-    'INVENTREE_TRUSTED_ORIGINS',
-    config_key='trusted_origins',
-    default_value=[],
-    typecast=list,
-)
-
-USE_X_FORWARDED_HOST = get_boolean_setting(
-    'INVENTREE_USE_X_FORWARDED_HOST',
-    config_key='use_x_forwarded_host',
-    default_value=False,
-)
-
-USE_X_FORWARDED_PORT = get_boolean_setting(
-    'INVENTREE_USE_X_FORWARDED_PORT',
-    config_key='use_x_forwarded_port',
-    default_value=False,
-)
-
-# Cross Origin Resource Sharing (CORS) options
-# Refer to the django-cors-headers documentation for more information
-# Ref: https://github.com/adamchainz/django-cors-headers
-
-# Extract CORS options from configuration file
-CORS_ALLOW_ALL_ORIGINS = get_boolean_setting(
-    'INVENTREE_CORS_ORIGIN_ALLOW_ALL', config_key='cors.allow_all', default_value=DEBUG
-)
-
-CORS_ALLOW_CREDENTIALS = get_boolean_setting(
-    'INVENTREE_CORS_ALLOW_CREDENTIALS',
-    config_key='cors.allow_credentials',
-    default_value=True,
-)
-
-# Only allow CORS access to API and media endpoints
-CORS_URLS_REGEX = r'^/(api|media|static)/.*$'
-
-CORS_ALLOWED_ORIGINS = get_setting(
-    'INVENTREE_CORS_ORIGIN_WHITELIST',
-    config_key='cors.whitelist',
-    default_value=[],
-    typecast=list,
-)
-
 # Needed for the parts importer, directly impacts the maximum parts that can be uploaded
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 
@@ -1023,6 +968,69 @@ SOCIAL_BACKENDS = get_setting(
 
 if not SITE_MULTI:
     INSTALLED_APPS.remove('django.contrib.sites')
+
+# List of allowed hosts (default = allow all)
+# Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = get_setting(
+    'INVENTREE_ALLOWED_HOSTS',
+    config_key='allowed_hosts',
+    default_value=['*'],
+    typecast=list,
+)
+
+# List of trusted origins for unsafe requests
+# Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins
+CSRF_TRUSTED_ORIGINS = get_setting(
+    'INVENTREE_TRUSTED_ORIGINS',
+    config_key='trusted_origins',
+    default_value=[],
+    typecast=list,
+)
+
+# If a list of trusted is not specified, but a site URL has been specified, use that
+if SITE_URL and len(CSRF_TRUSTED_ORIGINS) == 0:
+    CSRF_TRUSTED_ORIGINS.append(SITE_URL)
+
+USE_X_FORWARDED_HOST = get_boolean_setting(
+    'INVENTREE_USE_X_FORWARDED_HOST',
+    config_key='use_x_forwarded_host',
+    default_value=False,
+)
+
+USE_X_FORWARDED_PORT = get_boolean_setting(
+    'INVENTREE_USE_X_FORWARDED_PORT',
+    config_key='use_x_forwarded_port',
+    default_value=False,
+)
+
+# Cross Origin Resource Sharing (CORS) options
+# Refer to the django-cors-headers documentation for more information
+# Ref: https://github.com/adamchainz/django-cors-headers
+
+# Extract CORS options from configuration file
+CORS_ALLOW_ALL_ORIGINS = get_boolean_setting(
+    'INVENTREE_CORS_ORIGIN_ALLOW_ALL', config_key='cors.allow_all', default_value=DEBUG
+)
+
+CORS_ALLOW_CREDENTIALS = get_boolean_setting(
+    'INVENTREE_CORS_ALLOW_CREDENTIALS',
+    config_key='cors.allow_credentials',
+    default_value=True,
+)
+
+# Only allow CORS access to API and media endpoints
+CORS_URLS_REGEX = r'^/(api|media|static)/.*$'
+
+CORS_ALLOWED_ORIGINS = get_setting(
+    'INVENTREE_CORS_ORIGIN_WHITELIST',
+    config_key='cors.whitelist',
+    default_value=[],
+    typecast=list,
+)
+
+# If no CORS origins are specified, but a site URL has been specified, use that
+if SITE_URL and len(CORS_ALLOWED_ORIGINS) == 0:
+    CORS_ALLOWED_ORIGINS.append(SITE_URL)
 
 for app in SOCIAL_BACKENDS:
     # Ensure that the app starts with 'allauth.socialaccount.providers'

--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -222,14 +222,6 @@ Depending on how your InvenTree installation is configured, you will need to pay
 | INVENTREE_USE_X_FORWARDED_PORT | use_x_forwarded_port | Use forwarded port header | False |
 | INVENTREE_CORS_ALLOW_CREDENTIALS | cors.allow_credentials | Allow cookies in cross-site requests | True |
 
-!!! info "Configuration File"
-    Allowed hosts and CORS options must be changed in the configuration file, and cannot be set via environment variables
-
-For further information, refer to the following documentation:
-
-* [Django ALLOWED_HOSTS](https://docs.djangoproject.com/en/2.2/ref/settings/#allowed-hosts)
-* [Django CORS headers](https://github.com/OttoYiu/django-cors-headers)
-
 ## File Storage Locations
 
 InvenTree requires some external directories for storing files:

--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -209,14 +209,17 @@ Depending on how your InvenTree installation is configured, you will need to pay
 !!! info "Environment Variables"
     Note that a provided environment variable will override the value provided in the configuration file.
 
+!!! success "INVENTREE_SITE_URL"
+    If you have specified the `INVENTREE_SITE_URL`, this will automatically be used as a trusted CSRF and CORS host (see below).
+
 | Environment Variable | Configuration File | Description | Default |
 | --- | --- | --- | --- |
 | INVENTREE_ALLOWED_HOSTS | allowed_hosts | List of allowed hosts | `*` |
-| INVENTREE_TRUSTED_ORIGINS | trusted_origins | List of trusted origins | *Empty list* |
+| INVENTREE_TRUSTED_ORIGINS | trusted_origins | List of trusted origins. Refer to the [django documentation](https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins) | Uses the *INVENTREE_SITE_URL* parameter, if set. Otherwise, an empty list. |
+| INVENTREE_CORS_ORIGIN_ALLOW_ALL | cors.allow_all | Allow all remote URLS for CORS checks | False |
+| INVENTREE_CORS_ORIGIN_WHITELIST | cors.whitelist | List of whitelisted CORS URLs. Refer to the [django-cors-headers documentation](https://github.com/adamchainz/django-cors-headers#cors_allowed_origins-sequencestr) | Uses the *INVENTREE_SITE_URL* parameter, if set. Otherwise, an empty list. |
 | INVENTREE_USE_X_FORWARDED_HOST | use_x_forwarded_host | Use forwarded host header | False |
 | INVENTREE_USE_X_FORWARDED_PORT | use_x_forwarded_port | Use forwarded port header | False |
-| INVENTREE_CORS_ORIGIN_ALLOW_ALL | cors.allow_all | Allow all remote URLS for CORS checks | False |
-| INVENTREE_CORS_ORIGIN_WHITELIST | cors.whitelist | List of whitelisted CORS URLs | *Empty list* |
 | INVENTREE_CORS_ALLOW_CREDENTIALS | cors.allow_credentials | Allow cookies in cross-site requests | True |
 
 !!! info "Configuration File"


### PR DESCRIPTION
Simplifies server configuration, specifically around setting `CSRF_TRUSTED_ORIGINS` and `CORS_ALLOWED_ORIGINS` values.

- If an `INVENTREE_SITE_URL` parameter is provided, this will automatically be set for these values
- User can still override this by specifying values for `CSRF` and `CORS` hosts