### PR TITLE
Fix schema test on a pass

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -161,7 +161,7 @@ jobs:
         if: needs.paths-filter.outputs.api == 'false'
         run: |
           diff --color -u InvenTree/schema.yml api.yaml
-          diff -u InvenTree/schema.yml api.yaml && echo "no difference in API schema " || echo "differences in API schema" && exit 2
+          diff -u InvenTree/schema.yml api.yaml && echo "no difference in API schema " || exit 2
       - name: Check schema - including warnings
         run: invoke schema
         continue-on-error: true


### PR DESCRIPTION
Due to a malformed bash command valid schemas (no diff) did not pass. This fixes that problem