### PR TITLE
[Feature] Engineering Units

### DIFF
--- a/InvenTree/InvenTree/conversion.py
+++ b/InvenTree/InvenTree/conversion.py
@@ -152,20 +152,18 @@ def convert_physical_value(value: str, unit: str = None, strip_units=True):
     if not value:
         raise ValidationError(_('No value provided'))
 
-    # Construct a set of values to "attempt" to convert
-    attempts = set()
-
-    # Original value, unmodified
-    attempts.add(value)
+    # Construct a list of values to "attempt" to convert
+    attempts = [value]
 
     # Attempt to convert from engineering notation
     eng = from_engineering_notation(value)
-    attempts.add(eng)
+    attempts.append(eng)
 
     # Append the unit, if provided
+    # These are the "final" attempts to convert the value, and *must* appear after previous attempts
     if unit:
-        attempts.add(f'{value}{unit}')
-        attempts.add(f'{eng}{unit}')
+        attempts.append(f'{value}{unit}')
+        attempts.append(f'{eng}{unit}')
 
     value = None
 

--- a/InvenTree/InvenTree/tests.py
+++ b/InvenTree/InvenTree/tests.py
@@ -82,6 +82,19 @@ class ConversionTest(TestCase):
             )
             self.assertAlmostEqual(output, expected, 12)
 
+    def test_scientific_notation(self):
+        """Test that scientific notation is handled correctly."""
+        tests = [
+            ('3E2', 300),
+            ('-12.3E-3', -0.0123),
+            ('1.23E-3', 0.00123),
+            ('99E9', 99000000000),
+        ]
+
+        for val, expected in tests:
+            output = InvenTree.conversion.convert_physical_value(val, strip_units=True)
+            self.assertAlmostEqual(output, expected, 6)
+
     def test_base_units(self):
         """Test conversion to specified base units."""
         tests = {

--- a/InvenTree/InvenTree/tests.py
+++ b/InvenTree/InvenTree/tests.py
@@ -58,6 +58,30 @@ class ConversionTest(TestCase):
             q = InvenTree.conversion.convert_physical_value(val, 'm')
             self.assertAlmostEqual(q, expected, 3)
 
+    def test_engineering_units(self):
+        """Test that conversion works with engineering notation."""
+        # Run some basic checks over the helper function
+        tests = [
+            ('3', '3'),
+            ('3k3', '3.3k'),
+            ('123R45', '123.45R'),
+            ('10n5F', '10.5nF'),
+        ]
+
+        for val, expected in tests:
+            self.assertEqual(
+                InvenTree.conversion.from_engineering_notation(val), expected
+            )
+
+        # Now test the conversion function
+        tests = [('33k3ohm', 33300), ('123kohm45', 123450), ('10n005', 0.000000010005)]
+
+        for val, expected in tests:
+            output = InvenTree.conversion.convert_physical_value(
+                val, 'ohm', strip_units=True
+            )
+            self.assertAlmostEqual(output, expected, 12)
+
     def test_base_units(self):
         """Test conversion to specified base units."""
         tests = {

--- a/docs/docs/concepts/units.md
+++ b/docs/docs/concepts/units.md
@@ -11,6 +11,33 @@ Support for real-world "physical" units of measure is implemented using the [pin
 - Enforce use of compatible units when creating part parameters
 - Enable custom units as required
 
+### Unit Conversion
+
+InvenTree uses the pint library to convert between compatible units of measure. For example, it is possible to convert between units of mass (e.g. grams, kilograms, pounds, etc) or units of length (e.g. millimeters, inches, etc). This is a powerful feature that ensures that units are used consistently throughout the application.
+
+### Engineering Notation
+
+We support the use of engineering notation for units, which allows for easy conversion between units of different orders of magnitude. For example, the following values would all be considered *valid*:
+
+- `10k3` : `10,300`
+- `10M3` : `10,000,000`
+- `3n02` : `0.00000000302`
+
+### Scientific Notation
+
+Scientific notation is also supported, and can be used to represent very large or very small numbers. For example, the following values would all be considered *valid*:
+
+- `1E-3` : `0.001`
+- `1E3` : `1000`
+- `-123.45E-3` : `-0.12345`
+
+!!! tip "Case Sensitive"
+    Support for scientific notation is case sensitive. For example, `1E3` is a valid value, but `1e3` is not.
+
+### Case Sensitivity
+
+The pint library is case sensitive, and units must be specified in the correct case. For example, `kg` is a valid unit, but `KG` is not. In particular, you need to pay close attention when using SI prefixes (e.g. `k` for kilo, `M` for mega, `n` for nano, etc).
+
 ## Unit Support
 
 Physical units are supported by the following InvenTree subsystems:


### PR DESCRIPTION
Adds support for "engineering notation" for parameters which have units.

e.g. `10k3` = `10.3k`

Also improves unit testing and documentation for conversion in general.