### PR TITLE
Dependabot/pip/cryptography 42.0.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,7 +33,7 @@ coverage[toml]==5.5
     #   coveralls
 coveralls==2.1.2
     # via -r requirements-dev.in
-cryptography==42.0.2
+cryptography==42.0.4
     # via
     #   -c requirements.txt
     #   pdfminer-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,7 @@ backoff==2.2.1
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 bleach[css]==6.1.0
-    # via
-    #   bleach
-    #   django-markdownify
+    # via django-markdownify
 brotli==1.1.0
     # via fonttools
 certifi==2024.2.2
@@ -175,9 +173,7 @@ et-xmlfile==1.1.0
 feedparser==6.0.11
     # via -r requirements.in
 fonttools[woff]==4.47.2
-    # via
-    #   fonttools
-    #   weasyprint
+    # via weasyprint
 googleapis-common-protos==1.62.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -304,7 +300,6 @@ pyjwt[crypto]==2.8.0
     # via
     #   django-allauth
     #   djangorestframework-simplejwt
-    #   pyjwt
 pyphen==0.14.0
     # via weasyprint
 pypng==0.20220715.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,9 @@ backoff==2.2.1
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 bleach[css]==6.1.0
-    # via django-markdownify
+    # via
+    #   bleach
+    #   django-markdownify
 brotli==1.1.0
     # via fonttools
 certifi==2024.2.2
@@ -39,7 +41,7 @@ coreapi==2.3.3
     # via -r requirements.in
 coreschema==0.0.4
     # via coreapi
-cryptography==42.0.2
+cryptography==42.0.4
     # via
     #   -r requirements.in
     #   djangorestframework-simplejwt
@@ -173,7 +175,9 @@ et-xmlfile==1.1.0
 feedparser==6.0.11
     # via -r requirements.in
 fonttools[woff]==4.47.2
-    # via weasyprint
+    # via
+    #   fonttools
+    #   weasyprint
 googleapis-common-protos==1.62.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -300,6 +304,7 @@ pyjwt[crypto]==2.8.0
     # via
     #   django-allauth
     #   djangorestframework-simplejwt
+    #   pyjwt
 pyphen==0.14.0
     # via weasyprint
 pypng==0.20220715.0


### PR DESCRIPTION
Replaces https://github.com/inventree/InvenTree/pull/6544 - contains merge fix
Closes #6544