### PR TITLE
Dependabot/pip/cryptography 42.0.4 (#6545)

### DIFF
--- a/InvenTree/build/test_api.py
+++ b/InvenTree/build/test_api.py
@@ -837,7 +837,7 @@ class BuildAllocationTest(BuildAPITest):
         si.quantity = 100
         si.save()
 
-        response = self.post(
+        self.post(
             self.url,
             {
                 "items": [
@@ -860,7 +860,7 @@ class BuildAllocationTest(BuildAPITest):
             lft=0, rght=0
         )
 
-        response = self.post(
+        self.post(
             self.url,
             {
                 "items": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,7 +33,7 @@ coverage==5.5
     #   coveralls
 coveralls==2.1.2
     # via -r requirements-dev.in
-cryptography==41.0.6
+cryptography==42.0.4
     # via
     #   -c requirements.txt
     #   pdfminer-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ coreapi==2.3.3
     # via -r requirements.in
 coreschema==0.0.4
     # via coreapi
-cryptography==41.0.6
+cryptography==42.0.4
     # via
     #   -r requirements.in
     #   djangorestframework-simplejwt


### PR DESCRIPTION
* Bump cryptography from 42.0.2 to 42.0.4

Bumps [cryptography](https://github.com/pyca/cryptography) from 42.0.2 to 42.0.4.
- [Changelog](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pyca/cryptography/compare/42.0.2...42.0.4)

---
updated-dependencies:
- dependency-name: cryptography dependency-type: direct:production ...



* fix merge

---------