### PR TITLE
Move get_scheduled_tasks call into register_tasks function

### DIFF
--- a/InvenTree/plugin/base/integration/ScheduleMixin.py
+++ b/InvenTree/plugin/base/integration/ScheduleMixin.py
@@ -50,8 +50,6 @@ class ScheduleMixin:
     def __init__(self):
         """Register mixin."""
         super().__init__()
-        self.scheduled_tasks = self.get_scheduled_tasks()
-        self.validate_scheduled_tasks()
 
         self.add_mixin('schedule', 'has_scheduled_tasks', __class__)
 
@@ -156,6 +154,9 @@ class ScheduleMixin:
 
     def register_tasks(self):
         """Register the tasks with the database."""
+        self.scheduled_tasks = self.get_scheduled_tasks()
+        self.validate_scheduled_tasks()
+
         try:
             from django_q.models import Schedule
 

--- a/InvenTree/plugin/base/integration/ScheduleMixin.py
+++ b/InvenTree/plugin/base/integration/ScheduleMixin.py
@@ -51,6 +51,8 @@ class ScheduleMixin:
         """Register mixin."""
         super().__init__()
 
+        self.scheduled_tasks = []
+
         self.add_mixin('schedule', 'has_scheduled_tasks', __class__)
 
     @classmethod

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -88,7 +88,7 @@ class ScheduledTaskPluginTests(TestCase):
             pass
 
         with self.assertRaises(MixinImplementationError):
-            NoSchedules()
+            NoSchedules().register_tasks()
 
         class WrongFuncSchedules(Base):
             """Plugin with broken functions.
@@ -102,7 +102,7 @@ class ScheduledTaskPluginTests(TestCase):
                 pass  # pragma: no cover
 
         with self.assertRaises(MixinImplementationError):
-            WrongFuncSchedules()
+            WrongFuncSchedules().register_tasks()
 
         class WrongFuncSchedules1(WrongFuncSchedules):
             """Plugin with broken functions.
@@ -113,7 +113,7 @@ class ScheduledTaskPluginTests(TestCase):
             SCHEDULED_TASKS = {'test': {'func': 'test', 'minutes': 30}}
 
         with self.assertRaises(MixinImplementationError):
-            WrongFuncSchedules1()
+            WrongFuncSchedules1().register_tasks()
 
         class WrongFuncSchedules2(WrongFuncSchedules):
             """Plugin with broken functions.
@@ -124,7 +124,7 @@ class ScheduledTaskPluginTests(TestCase):
             SCHEDULED_TASKS = {'test': {'func': 'test', 'minutes': 30}}
 
         with self.assertRaises(MixinImplementationError):
-            WrongFuncSchedules2()
+            WrongFuncSchedules2().register_tasks()
 
         class WrongFuncSchedules3(WrongFuncSchedules):
             """Plugin with broken functions.
@@ -137,7 +137,7 @@ class ScheduledTaskPluginTests(TestCase):
             }
 
         with self.assertRaises(MixinImplementationError):
-            WrongFuncSchedules3()
+            WrongFuncSchedules3().register_tasks()
 
         class WrongFuncSchedules4(WrongFuncSchedules):
             """Plugin with broken functions.
@@ -148,4 +148,4 @@ class ScheduledTaskPluginTests(TestCase):
             SCHEDULED_TASKS = {'test': {'func': 'test', 'schedule': 'I'}}
 
         with self.assertRaises(MixinImplementationError):
-            WrongFuncSchedules4()
+            WrongFuncSchedules4().register_tasks()

--- a/InvenTree/plugin/samples/integration/test_scheduled_task.py
+++ b/InvenTree/plugin/samples/integration/test_scheduled_task.py
@@ -21,6 +21,11 @@ class ExampleScheduledTaskPluginTests(TestCase):
         # check that the built-in function is running
         self.assertEqual(plg.member_func(), False)
 
+        # register
+        plg.register_tasks()
+        # check that schedule was registers
+        from django_q.models import Schedule
+
         # check that the tasks are defined
         self.assertEqual(
             plg.get_task_names(),
@@ -30,11 +35,6 @@ class ExampleScheduledTaskPluginTests(TestCase):
                 'plugin.schedule.world',
             ],
         )
-
-        # register
-        plg.register_tasks()
-        # check that schedule was registers
-        from django_q.models import Schedule
 
         scheduled_plugin_tasks = Schedule.objects.filter(name__istartswith='plugin.')
         self.assertEqual(len(scheduled_plugin_tasks), 3)


### PR DESCRIPTION
The documentation of the `get_scheduled_tasks`:
https://github.com/inventree/InvenTree/blob/5dbd3030d1e983a63812dfe32f6951d977496fbc/InvenTree/plugin/base/integration/ScheduleMixin.py#L105-L109 function in the `ScheduleMixin` states that you can override it, if you want the scheduled tasks to be "dynamic" i.e. influenced by plugin settings.

Doing this breaks settings initialization pretty badly though, because the `get_scheduled_tasks` function gets called in `__init__.py`. That means any `get_setting` calls in it, will be resolved **before** any Mixins (most importantly the `SettingsMixin`) are actually loaded. The setting will still be created, but it won't be initialized correctly, thus it's `default` value won't be set which can then result in errors in the `ScheduleMixin` code which essentially completely lock up the server.

Moving the relevant code to the `register_tasks` function resolves this.