### PR TITLE
Fix tranlation pipeline

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -56,7 +56,7 @@ runs:
       - name: Install Specific Python Dependencies
         if: ${{ inputs.pip-dependency }}
         shell: bash
-        run: pip3 install ${{ inputs.pip-dependency }}
+        run: uv pip install ${{ inputs.pip-dependency }}
 
       # NPM installs
       - name: Install node.js ${{ env.node_version }}
@@ -82,7 +82,7 @@ runs:
       - name: Install dev requirements
         if: ${{ inputs.dev-install == 'true' ||inputs.install == 'true' }}
         shell: bash
-        run: pip install -r requirements-dev.txt
+        run: uv pip install -r requirements-dev.txt
       - name: Run invoke install
         if: ${{ inputs.install == 'true' }}
         shell: bash

--- a/.github/workflows/check_translations.yaml
+++ b/.github/workflows/check_translations.yaml
@@ -9,7 +9,6 @@ on:
       - l10
 
 jobs:
-
   check:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check_translations.yaml
+++ b/.github/workflows/check_translations.yaml
@@ -9,6 +9,7 @@ on:
       - l10
 
 jobs:
+
   check:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check_translations.yaml
+++ b/.github/workflows/check_translations.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - l10
 
+env:
+  python_version: 3.9
+
 jobs:
 
   check:
@@ -21,7 +24,6 @@ jobs:
       INVENTREE_MEDIA_ROOT: ./media
       INVENTREE_STATIC_ROOT: ./static
       INVENTREE_BACKUP_DIR: ./backup
-      python_version: 3.9
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/check_translations.yaml
+++ b/.github/workflows/check_translations.yaml
@@ -26,17 +26,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
-      - name: Set Up Python ${{ env.python_version }}
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # pin@v4.7.1
+      - name: Environment Setup
+        uses: ./.github/actions/setup
         with:
-          python-version: ${{ env.python_version }}
-          cache: 'pip'
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install gettext
-          pip3 install invoke
-          invoke install
+          install: true
+          apt-dependency: gettext
       - name: Test Translations
         run: invoke translate
       - name: Check Migration Files

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+env:
+  python_version: 3.9
+  node_version: 16
+
 jobs:
   build:
 

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -22,20 +22,12 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
-      - name: Set up Python 3.9
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # pin@v4.7.1
+      - name: Environment Setup
+        uses: ./.github/actions/setup
         with:
-          python-version: 3.9
-      - name: Set up Node 16
-        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7  # pin to v3.8.2
-        with:
-          node-version: 16
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gettext
-          pip3 install invoke
-          invoke install
+          install: true
+          npm: true
+          apt-dependency: gettext
       - name: Make Translations
         run: invoke translate
       - name: Commit files


### PR DESCRIPTION
#6499 failed once it was on master due to not using the central environment setup step in that workflow.
This PR:
- switches the `check_translations` and `translations` workflows to use the central environment step and define dependency versions globally
- makes a bit more use of uv in workflows (more for consistency than performance)