### PR TITLE
Fix postgresql isolation level

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -571,6 +571,11 @@ db_options = db_config.get('OPTIONS', db_config.get('options', {}))
 
 # Specific options for postgres backend
 if 'postgres' in db_engine:  # pragma: no cover
+    from psycopg2.extensions import (
+        ISOLATION_LEVEL_READ_COMMITTED,
+        ISOLATION_LEVEL_SERIALIZABLE,
+    )
+
     # Connection timeout
     if 'connect_timeout' not in db_options:
         # The DB server is in the same data center, it should not take very
@@ -634,7 +639,11 @@ if 'postgres' in db_engine:  # pragma: no cover
         serializable = get_boolean_setting(
             'INVENTREE_DB_ISOLATION_SERIALIZABLE', 'database.serializable', False
         )
-        db_options['isolation_level'] = 4 if serializable else 2
+        db_options['isolation_level'] = (
+            ISOLATION_LEVEL_SERIALIZABLE
+            if serializable
+            else ISOLATION_LEVEL_READ_COMMITTED
+        )
 
 # Specific options for MySql / MariaDB backend
 elif 'mysql' in db_engine:  # pragma: no cover


### PR DESCRIPTION
So after fixing my deployment again, I was getting a whole bunch of `django.db.utils.OperationalError: could not serialize access due to concurrent update` errors which also made the interface feel noticeably sluggish (things would straight up not load ~50% of the time).

Looking at the existing issues regarding that error, this seems to be caused by the postgresql isolation level setting being set to `ISOLATION_LEVEL_SERIALIZABLE`, which seems to have been messed up during the switch to Django 4 in #6173.

I tested this patch on my production server and by clicking through random pages furiously for 2 minutes and didn't get any further errors (before there were sometimes multiple when visiting a single page).