### PR TITLE
BOM / Build Updates

### DIFF
--- a/InvenTree/InvenTree/api_version.py
+++ b/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,16 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 177
+INVENTREE_API_VERSION = 178
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v178 - 2024-02-29 : https://github.com/inventree/InvenTree/pull/6604
+    - Adds "external_stock" field to the Part API endpoint
+    - Adds "external_stock" field to the BomItem API endpoint
+    - Adds "external_stock" field to the BuildLine API endpoint
+    - Stock quantites represented in the BuildLine API endpoint are now filtered by Build.source_location
 
 v177 - 2024-02-27 : https://github.com/inventree/InvenTree/pull/6581
     - Adds "subcategoies" count to PartCategoryTree serializer

--- a/InvenTree/build/serializers.py
+++ b/InvenTree/build/serializers.py
@@ -1083,6 +1083,7 @@ class BuildLineSerializer(InvenTreeModelSerializer):
             'available_substitute_stock',
             'available_variant_stock',
             'total_available_stock',
+            'external_stock',
         ]
 
         read_only_fields = [
@@ -1124,6 +1125,7 @@ class BuildLineSerializer(InvenTreeModelSerializer):
     available_substitute_stock = serializers.FloatField(read_only=True)
     available_variant_stock = serializers.FloatField(read_only=True)
     total_available_stock = serializers.FloatField(read_only=True)
+    external_stock = serializers.FloatField(read_only=True)
 
     @staticmethod
     def annotate_queryset(queryset):
@@ -1195,6 +1197,11 @@ class BuildLineSerializer(InvenTreeModelSerializer):
                 F('total_stock') - F('allocated_to_sales_orders') - F('allocated_to_build_orders'),
                 output_field=models.DecimalField(),
             )
+        )
+
+        # Add 'external stock' annotations
+        queryset = queryset.annotate(
+            external_stock=part.filters.annotate_total_stock(reference=ref, filter=Q(location__external=True))
         )
 
         ref = 'bom_item__substitutes__part__'

--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -200,6 +200,11 @@
         <div id='build-lines-toolbar'>
             {% include "filter_list.html" with id='buildlines' %}
         </div>
+        {% if build.take_from %}
+        <div class='alert alert-block alert-info'>
+            {% trans "Available stock has been filtered based on specified source location for this build order" %}
+        </div>
+        {% endif %}
         <table class='table table-striped table-condensed' id='build-lines-table' data-toolbar='#build-lines-toolbar'></table>
     </div>
 </div>

--- a/InvenTree/build/templates/build/detail.html
+++ b/InvenTree/build/templates/build/detail.html
@@ -374,6 +374,9 @@ onPanelLoad('allocate', function() {
         "#build-lines-table",
         {{ build.pk }},
         {
+            {% if build.take_from %}
+            location: {{ build.take_from.pk }},
+            {% endif %}
             {% if build.project_code %}
             project_code: {{ build.project_code.pk }},
             {% endif %}

--- a/InvenTree/part/filters.py
+++ b/InvenTree/part/filters.py
@@ -119,28 +119,16 @@ def annotate_total_stock(reference: str = '', filter: Q = None):
         stock_filter: Q object which defines how to filter the stock items
     """
     # Stock filter only returns 'in stock' items
-    if filter is None:
-        filter = stock.models.StockItem.IN_STOCK_FILTER
+    stock_filter = stock.models.StockItem.IN_STOCK_FILTER
+
+    if filter is not None:
+        stock_filter &= filter
 
     return Coalesce(
-        SubquerySum(f'{reference}stock_items__quantity', filter=filter),
+        SubquerySum(f'{reference}stock_items__quantity', filter=stock_filter),
         Decimal(0),
         output_field=models.DecimalField(),
     )
-
-
-def annotate_internal_stock(reference: str = ''):
-    """Annotate "internal" stock quantity."""
-    filter = stock.models.StockItem.IN_STOCK_FILTER & Q(location__external=False)
-
-    return annotate_total_stock(reference, filter)
-
-
-def annotate_external_stock(reference: str = ''):
-    """Annotate "external" stock quantity."""
-    filter = stock.models.StockItem.IN_STOCK_FILTER & Q(location__external=True)
-
-    return annotate_total_stock(reference, filter)
 
 
 def annotate_build_order_requirements(reference: str = ''):

--- a/InvenTree/part/filters.py
+++ b/InvenTree/part/filters.py
@@ -219,9 +219,7 @@ def annotate_sales_order_allocations(reference: str = ''):
     )
 
 
-def variant_stock_query(
-    reference: str = '', filter: Q = stock.models.StockItem.IN_STOCK_FILTER
-):
+def variant_stock_query(reference: str = '', filter: Q = None):
     """Create a queryset to retrieve all stock items for variant parts under the specified part.
 
     - Useful for annotating a queryset with aggregated information about variant parts
@@ -230,11 +228,16 @@ def variant_stock_query(
         reference: The relationship reference of the part from the current model
         filter: Q object which defines how to filter the returned StockItem instances
     """
+    stock_filter = stock.models.StockItem.IN_STOCK_FILTER
+
+    if filter:
+        stock_filter &= filter
+
     return stock.models.StockItem.objects.filter(
         part__tree_id=OuterRef(f'{reference}tree_id'),
         part__lft__gt=OuterRef(f'{reference}lft'),
         part__rght__lt=OuterRef(f'{reference}rght'),
-    ).filter(filter)
+    ).filter(stock_filter)
 
 
 def annotate_variant_quantity(subquery: Q, reference: str = 'quantity'):

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -610,6 +610,7 @@ class PartSerializer(
             'stock_item_count',
             'suppliers',
             'total_in_stock',
+            'external_stock',
             'unallocated_stock',
             'variant_stock',
             # Fields only used for Part creation
@@ -734,6 +735,12 @@ class PartSerializer(
             )
         )
 
+        queryset = queryset.annotate(
+            external_stock=part.filters.annotate_total_stock(
+                filter=Q(location__external=True)
+            )
+        )
+
         # Annotate with the total 'available stock' quantity
         # This is the current stock, minus any allocations
         queryset = queryset.annotate(
@@ -780,14 +787,17 @@ class PartSerializer(
     allocated_to_sales_orders = serializers.FloatField(read_only=True)
     building = serializers.FloatField(read_only=True)
     in_stock = serializers.FloatField(read_only=True)
-    ordering = serializers.FloatField(read_only=True)
+    ordering = serializers.FloatField(read_only=True, label=_('On Order'))
     required_for_build_orders = serializers.IntegerField(read_only=True)
     required_for_sales_orders = serializers.IntegerField(read_only=True)
-    stock_item_count = serializers.IntegerField(read_only=True)
-    suppliers = serializers.IntegerField(read_only=True)
-    total_in_stock = serializers.FloatField(read_only=True)
-    unallocated_stock = serializers.FloatField(read_only=True)
-    variant_stock = serializers.FloatField(read_only=True)
+    stock_item_count = serializers.IntegerField(read_only=True, label=_('Stock Items'))
+    suppliers = serializers.IntegerField(read_only=True, label=_('Suppliers'))
+    total_in_stock = serializers.FloatField(read_only=True, label=_('Total Stock'))
+    external_stock = serializers.FloatField(read_only=True, label=_('External Stock'))
+    unallocated_stock = serializers.FloatField(
+        read_only=True, label=_('Unallocated Stock')
+    )
+    variant_stock = serializers.FloatField(read_only=True, label=_('Variant Stock'))
 
     minimum_stock = serializers.FloatField()
 

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -1539,7 +1539,9 @@ class BomItemSerializer(InvenTree.serializers.InvenTreeModelSerializer):
 
         # Calculate 'external_stock'
         queryset = queryset.annotate(
-            external_stock=part.filters.annotate_external_stock(reference=ref)
+            external_stock=part.filters.annotate_total_stock(
+                reference=ref, filter=Q(location__external=True)
+            )
         )
 
         ref = 'substitutes__part__'

--- a/InvenTree/part/serializers.py
+++ b/InvenTree/part/serializers.py
@@ -1387,6 +1387,7 @@ class BomItemSerializer(InvenTree.serializers.InvenTreeModelSerializer):
             'available_stock',
             'available_substitute_stock',
             'available_variant_stock',
+            'external_stock',
             # Annotated field describing quantity on order
             'on_order',
             # Annotated field describing quantity being built
@@ -1455,6 +1456,8 @@ class BomItemSerializer(InvenTree.serializers.InvenTreeModelSerializer):
 
     available_substitute_stock = serializers.FloatField(read_only=True)
     available_variant_stock = serializers.FloatField(read_only=True)
+
+    external_stock = serializers.FloatField(read_only=True)
 
     @staticmethod
     def setup_eager_loading(queryset):
@@ -1532,6 +1535,11 @@ class BomItemSerializer(InvenTree.serializers.InvenTreeModelSerializer):
                 - F('allocated_to_build_orders'),
                 output_field=models.DecimalField(),
             )
+        )
+
+        # Calculate 'external_stock'
+        queryset = queryset.annotate(
+            external_stock=part.filters.annotate_external_stock(reference=ref)
         )
 
         ref = 'substitutes__part__'

--- a/InvenTree/templates/js/translated/bom.js
+++ b/InvenTree/templates/js/translated/bom.js
@@ -1172,10 +1172,16 @@ function loadBomTable(table, options={}) {
 
             var available_stock = availableQuantity(row);
 
+            var external_stock = row.external_stock ?? 0;
+
             var text = renderLink(`${available_stock}`, url);
 
             if (row.sub_part_detail && row.sub_part_detail.units) {
                 text += ` <small>${row.sub_part_detail.units}</small>`;
+            }
+
+            if (external_stock > 0) {
+                text += makeIconBadge('fa-sitemap', `{% trans "External stock" %}: ${external_stock}`);
             }
 
             if (available_stock <= 0) {

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -2618,6 +2618,10 @@ function loadBuildLineTable(table, build_id, options={}) {
                         icons += makeIconBadge('fa-tools icon-blue', `{% trans "In Production" %}: ${formatDecimal(row.in_production)}`);
                     }
 
+                    if (row.external_stock > 0) {
+                        icons += makeIconBadge('fa-sitemap', `{% trans "External stock" %}: ${row.external_stock}`);
+                    }
+
                     return renderLink(text, url) + icons;
                 }
             },

--- a/InvenTree/templates/js/translated/build.js
+++ b/InvenTree/templates/js/translated/build.js
@@ -2730,6 +2730,7 @@ function loadBuildLineTable(table, build_id, options={}) {
 
         allocateStockToBuild(build_id, [row], {
             output: options.output,
+            source_location: options.location,
             success: function() {
                 $(table).bootstrapTable('refresh');
             }

--- a/InvenTree/templates/js/translated/part.js
+++ b/InvenTree/templates/js/translated/part.js
@@ -2804,6 +2804,15 @@ function loadPartCategoryTable(table, options) {
                 title: '{% trans "Parts" %}',
                 switchable: true,
                 sortable: true,
+            },
+            {
+                field: 'structural',
+                title: '{% trans "Structural" %}',
+                switchable: true,
+                sortable: true,
+                formatter: function(value) {
+                    return yesNoLabel(value);
+                }
             }
         ]
     });

--- a/src/frontend/src/tables/bom/BomTable.tsx
+++ b/src/frontend/src/tables/bom/BomTable.tsx
@@ -142,7 +142,7 @@ export function BomTable({
       },
       {
         accessor: 'available_stock',
-
+        sortable: true,
         render: (record) => {
           let extra: ReactNode[] = [];
 
@@ -156,6 +156,14 @@ export function BomTable({
             ) : (
               available_stock
             );
+
+          if (record.external_stock > 0) {
+            extra.push(
+              <Text key="external">
+                {t`External stock`}: {record.external_stock}
+              </Text>
+            );
+          }
 
           if (record.available_substitute_stock > 0) {
             extra.push(

--- a/src/frontend/src/tables/build/BuildLineTable.tsx
+++ b/src/frontend/src/tables/build/BuildLineTable.tsx
@@ -94,6 +94,15 @@ export default function BuildLineTable({ params = {} }: { params?: any }) {
       );
     }
 
+    // Account for "external" stock
+    if (record.external_stock > 0) {
+      extra.push(
+        <Text key="external" size="sm">
+          {t`External stock`}: {record.external_stock}
+        </Text>
+      );
+    }
+
     return (
       <TableHoverCard
         value={

--- a/src/frontend/src/tables/part/PartTable.tsx
+++ b/src/frontend/src/tables/part/PartTable.tsx
@@ -113,7 +113,17 @@ function partTableColumns(): TableColumn[] {
 
         if (available != stock) {
           extra.push(
-            <Text key="available">{t`Available` + `: ${available}`}</Text>
+            <Text key="available">
+              {t`Available`}: {available}
+            </Text>
+          );
+        }
+
+        if (record.external_stock > 0) {
+          extra.push(
+            <Text key="external">
+              {t`External stock`}: {record.external_stock}
+            </Text>
           );
         }
 


### PR DESCRIPTION
This PR adds some more information to the stock / BOM / Build API endpoints, for improved clarity on available stock.

### External Stock

- Adds an "external_stock" field, which indicates how much stock is "external"
- Adds this field to the "part" serializer
- Adds this field to the "bom_item" serializer
- Adds this field to the "build_item" serializer
- Add indicator for this value to various tables

### Build Stock

The "build line" table now filters stock availability based on the specified "source location" for the build order.

If the build order specifies a "source location" then only stock within that location will be accounted for in the "available" column