### PR TITLE
[Docker] Fix broken image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -137,17 +137,10 @@ jobs:
             inventree/inventree
             ghcr.io/inventree/inventree
 
-      - name: Build Dockerfile
-        id: build-docker
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # pin@v5.0.0
-        with:
-          context: .
-          load: true
-          tags: inventree-test
-
       - name: Test Docker Image
         id: test-docker
         run: |
+          docker build . --target production --tag inventree-test
           docker run --rm inventree-test invoke --version
           docker run --rm inventree-test invoke --list
           docker run --rm inventree-test gunicorn --version

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -74,6 +74,14 @@ jobs:
           python3 ci/version_check.py
           echo "git_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "git_commit_date=$(git show -s --format=%ci)" >> $GITHUB_ENV
+      - name: Test Docker Image
+        id: test-docker
+        run: |
+          docker build . --target production --tag inventree-test
+          docker run --rm inventree-test invoke --version
+          docker run --rm inventree-test invoke --list
+          docker run --rm inventree-test gunicorn --version
+          docker run --rm inventree-test pg_dump --version
       - name: Build Docker Image
         # Build the development docker image (using docker-compose.yml)
         run: docker-compose build --no-cache
@@ -136,15 +144,6 @@ jobs:
           images: |
             inventree/inventree
             ghcr.io/inventree/inventree
-
-      - name: Test Docker Image
-        id: test-docker
-        run: |
-          docker build . --target production --tag inventree-test
-          docker run --rm inventree-test invoke --version
-          docker run --rm inventree-test invoke --list
-          docker run --rm inventree-test gunicorn --version
-          docker run --rm inventree-test pg_dump --version
 
       - name: Push Docker Images
         id: push-docker

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -143,12 +143,15 @@ jobs:
         with:
           context: .
           load: true
-          tags: inventree/inventree:test
+          tags: inventree-test
 
       - name: Test Docker Image
         id: test-docker
         run: |
-          docker run --rm inventree/inventree:test invoke --list
+          docker run --rm inventree-test invoke --version
+          docker run --rm inventree-test invoke --list
+          docker run --rm inventree-test gunicorn --version
+          docker run --rm inventree-test pg_dump --version
 
       - name: Push Docker Images
         id: push-docker

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -137,8 +137,21 @@ jobs:
             inventree/inventree
             ghcr.io/inventree/inventree
 
-      - name: Build and Push
-        id: build-and-push
+      - name: Build Dockerfile
+        id: build-docker
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # pin@v5.0.0
+        with:
+          context: .
+          load: true
+          tags: inventree/inventree:test
+
+      - name: Test Docker Image
+        id: test-docker
+        run: |
+          docker run --rm inventree/inventree:test invoke --list
+
+      - name: Push Docker Images
+        id: push-docker
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # pin@v5.0.0
         with:
@@ -152,9 +165,3 @@ jobs:
           build-args: |
             commit_hash=${{ env.git_commit_hash }}
             commit_date=${{ env.git_commit_date }}
-
-      - name: Sign the published image
-        if: ${{ false }} # github.event_name != 'pull_request'
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ ENV INVENTREE_BACKGROUND_WORKERS="4"
 ENV INVENTREE_WEB_ADDR=0.0.0.0
 ENV INVENTREE_WEB_PORT=8000
 
+ENV VIRTUAL_ENV=/usr/local
+
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.build-date=${DATE} \
       org.label-schema.vendor="inventree" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,6 @@ ENV INVENTREE_BACKGROUND_WORKERS="4"
 ENV INVENTREE_WEB_ADDR=0.0.0.0
 ENV INVENTREE_WEB_PORT=8000
 
-ENV VIRTUAL_ENV=/usr/local
-
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.build-date=${DATE} \
       org.label-schema.vendor="inventree" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,6 @@ ENV INVENTREE_BACKGROUND_WORKERS="4"
 ENV INVENTREE_WEB_ADDR=0.0.0.0
 ENV INVENTREE_WEB_PORT=8000
 
-ENV VIRTUAL_ENV=/usr/local
-
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.build-date=${DATE} \
       org.label-schema.vendor="inventree" \
@@ -99,7 +97,7 @@ FROM inventree_base as prebuild
 
 ENV PATH=/root/.local/bin:$PATH
 RUN ./install_build_packages.sh --no-cache --virtual .build-deps && \
-    pip install --user -r base_requirements.txt -r requirements.txt --no-cache && \
+    pip install -r base_requirements.txt -r requirements.txt --no-cache && \
     apk --purge del .build-deps
 
 # Frontend builder image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ FROM inventree_base as prebuild
 
 ENV PATH=/root/.local/bin:$PATH
 RUN ./install_build_packages.sh --no-cache --virtual .build-deps && \
-    pip install -r base_requirements.txt -r requirements.txt --no-cache && \
+    pip install --user -r base_requirements.txt -r requirements.txt --no-cache && \
     apk --purge del .build-deps
 
 # Frontend builder image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,11 @@ RUN apk add --no-cache \
     libjpeg libwebp zlib \
     # Weasyprint requirements : https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#alpine-3-12
     py3-pip py3-pillow py3-cffi py3-brotli pango poppler-utils openldap \
-    # Core database packages
-    postgresql13-client && \
+    # Postgres client
+    postgresql13-client \
+    # MySQL / MariaDB client
+    mariadb-client mariadb-connector-c \
+    && \
     # fonts
     apk --update --upgrade --no-cache add fontconfig ttf-freefont font-noto terminus-font && fc-cache -f
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ FROM inventree_base as prebuild
 
 ENV PATH=/root/.local/bin:$PATH
 RUN ./install_build_packages.sh --no-cache --virtual .build-deps && \
-    pip install --user uv --no-cache-dir && pip install -r base_requirements.txt -r requirements.txt --no-cache && \
+    pip install --user -r base_requirements.txt -r requirements.txt --no-cache && \
     apk --purge del .build-deps
 
 # Frontend builder image:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,10 +71,7 @@ services:
     # Uses gunicorn as the web server
     inventree-server:
         # If you wish to specify a particular InvenTree version, do so here
-        # image: inventree/inventree:${INVENTREE_TAG:-stable}
-        build:
-            context: ..
-            target: production
+        image: inventree/inventree:${INVENTREE_TAG:-stable}
         container_name: inventree-server
         # Only change this port if you understand the stack.
         expose:
@@ -89,19 +86,19 @@ services:
         restart: unless-stopped
 
     # Background worker process handles long-running or periodic tasks
-    # inventree-worker:
-    #     # If you wish to specify a particular InvenTree version, do so here
-    #     image: inventree/inventree:${INVENTREE_TAG:-stable}
-    #     container_name: inventree-worker
-    #     command: invoke worker
-    #     depends_on:
-    #         - inventree-server
-    #     env_file:
-    #         - .env
-    #     volumes:
-    #         # Data volume must map to /home/inventree/data
-    #         - ${INVENTREE_EXT_VOLUME}:/home/inventree/data:z
-    #     restart: unless-stopped
+    inventree-worker:
+        # If you wish to specify a particular InvenTree version, do so here
+        image: inventree/inventree:${INVENTREE_TAG:-stable}
+        container_name: inventree-worker
+        command: invoke worker
+        depends_on:
+            - inventree-server
+        env_file:
+            - .env
+        volumes:
+            # Data volume must map to /home/inventree/data
+            - ${INVENTREE_EXT_VOLUME}:/home/inventree/data:z
+        restart: unless-stopped
 
     # caddy acts as reverse proxy and static file server
     # https://hub.docker.com/_/caddy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,7 +71,10 @@ services:
     # Uses gunicorn as the web server
     inventree-server:
         # If you wish to specify a particular InvenTree version, do so here
-        image: inventree/inventree:${INVENTREE_TAG:-stable}
+        # image: inventree/inventree:${INVENTREE_TAG:-stable}
+        build:
+            context: ..
+            target: production
         container_name: inventree-server
         # Only change this port if you understand the stack.
         expose:
@@ -86,19 +89,19 @@ services:
         restart: unless-stopped
 
     # Background worker process handles long-running or periodic tasks
-    inventree-worker:
-        # If you wish to specify a particular InvenTree version, do so here
-        image: inventree/inventree:${INVENTREE_TAG:-stable}
-        container_name: inventree-worker
-        command: invoke worker
-        depends_on:
-            - inventree-server
-        env_file:
-            - .env
-        volumes:
-            # Data volume must map to /home/inventree/data
-            - ${INVENTREE_EXT_VOLUME}:/home/inventree/data:z
-        restart: unless-stopped
+    # inventree-worker:
+    #     # If you wish to specify a particular InvenTree version, do so here
+    #     image: inventree/inventree:${INVENTREE_TAG:-stable}
+    #     container_name: inventree-worker
+    #     command: invoke worker
+    #     depends_on:
+    #         - inventree-server
+    #     env_file:
+    #         - .env
+    #     volumes:
+    #         # Data volume must map to /home/inventree/data
+    #         - ${INVENTREE_EXT_VOLUME}:/home/inventree/data:z
+    #     restart: unless-stopped
 
     # caddy acts as reverse proxy and static file server
     # https://hub.docker.com/_/caddy

--- a/docker/install_build_packages.sh
+++ b/docker/install_build_packages.sh
@@ -4,6 +4,7 @@
 # Note that for postgreslql, we use the 13 version, which matches the version used in the InvenTree docker image
 
 apk add gcc g++ musl-dev openssl-dev libffi-dev cargo python3-dev openldap-dev \
+    libstdc++ build-base linux-headers py3-grpcio \
     jpeg-dev openjpeg-dev libwebp-dev zlib-dev \
     sqlite sqlite-dev \
     mariadb-connector-c-dev mariadb-client mariadb-dev \

--- a/requirements.in
+++ b/requirements.in
@@ -45,7 +45,7 @@ python-barcode[images]                  # Barcode generator
 python-dotenv                           # Environment variable management
 pyyaml>=6.0.1                           # YAML parsing
 qrcode[pil]                             # QR code generator
-rapidfuzz                        # Fuzzy string matching
+rapidfuzz                               # Fuzzy string matching
 regex                                   # Advanced regular expressions
 sentry-sdk                              # Error reporting (optional)
 setuptools                              # Standard dependency
@@ -53,6 +53,7 @@ tablib[xls,xlsx,yaml]                   # Support for XLS and XLSX formats
 weasyprint                              # PDF generation
 
 # OpenTelemetry dependencies
+grpcio==1.54.2                          # Pinned to ensure docker image builds correctly
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -137,7 +137,7 @@ googleapis-common-protos==1.62.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.60.1
+grpcio==1.54.2
     # via opentelemetry-exporter-otlp-proto-grpc
 gunicorn==21.2.0
 html5lib==1.1


### PR DESCRIPTION
More work on improving docker image and CI

- Closes https://github.com/inventree/InvenTree/issues/6628
- Closes https://github.com/inventree/InvenTree/issues/6625
- Closes https://github.com/inventree/InvenTree/issues/6632
- Closes https://github.com/inventree/InvenTree/issues/6627
- Closes https://github.com/inventree/InvenTree/issues/6623


Additionally, recent docker images `0.14.0` / `stable` / `latest` *do not work* - a bunch of libraries are not installed correctly after https://github.com/inventree/InvenTree/pull/6562

So, this PR also runs some checks on the `production` docker image *before* pushing to docker hub.

Ref: https://docs.docker.com/build/ci/github-actions/test-before-push/