### PR TITLE
Fix function signatures in migration tasks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -397,11 +397,11 @@ def migrate(c):
 )
 def update(
     c,
-    skip_backup: bool = False,
-    frontend: bool = False,
-    no_frontend: bool = False,
-    skip_static: bool = False,
-    uv: bool = False,
+    skip_backup = False,
+    frontend = False,
+    no_frontend = False,
+    skip_static = False,
+    uv = False,
 ):
     """Update InvenTree installation.
 
@@ -552,7 +552,7 @@ def export_records(
     post=[rebuild_models, rebuild_thumbnails],
 )
 def import_records(
-    c, filename='data.json', clear: bool = False, retain_temp: bool = False
+    c, filename='data.json', clear = False, retain_temp = False
 ):
     """Import database records from a file."""
     # Get an absolute path to the supplied filename


### PR DESCRIPTION
Small PR to fix function signatures in python 3.10 (only one tested), as they clash with argument type definitions needed by `importlib`, as discussed in https://github.com/inventree/InvenTree/discussions/6641

```
Traceback (most recent call last):
  File "/usr/local/bin/inv", line 8, in <module>
    sys.exit(program.run())
  File "/usr/lib/python3/dist-packages/invoke/program.py", line 373, in run
    self.parse_collection()
  File "/usr/lib/python3/dist-packages/invoke/program.py", line 465, in parse_collection
    self.load_collection()
  File "/usr/lib/python3/dist-packages/invoke/program.py", line 696, in load_collection
    module, parent = loader.load(coll_name)
  File "/usr/lib/python3/dist-packages/invoke/loader.py", line 76, in load
    module = imp.load_module(name, fd, path, desc)
  File "/usr/lib/python3.10/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.10/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 719, in _load
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/InvenTree/tasks.py", line 398, in <module>
    def update(
  File "/usr/lib/python3/dist-packages/invoke/tasks.py", line 338, in inner
    obj = klass(
  File "/usr/lib/python3/dist-packages/invoke/tasks.py", line 76, in __init__
    self.positional = self.fill_implicit_positionals(positional)
  File "/usr/lib/python3/dist-packages/invoke/tasks.py", line 167, in fill_implicit_positionals
    args, spec_dict = self.argspec(self.body)
  File "/usr/lib/python3/dist-packages/invoke/tasks.py", line 153, in argspec
    spec = inspect.getargspec(func)
  File "/usr/lib/python3.10/inspect.py", line 1237, in getargspec
    raise ValueError("Function has keyword-only parameters or annotations"
ValueError: Function has keyword-only parameters or annotations, use inspect.signature() API which can support them
```