### PR TITLE
Use whitenoise for static file handling

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -20,7 +20,6 @@ env:
   INVENTREE_MEDIA_ROOT: ../test_inventree_media
   INVENTREE_STATIC_ROOT: ../test_inventree_static
   INVENTREE_BACKUP_DIR: ../test_inventree_backup
-  INVENTREE_SITE_URL: http://localhost:8000
 
 jobs:
   paths-filter:

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -20,6 +20,7 @@ env:
   INVENTREE_MEDIA_ROOT: ../test_inventree_media
   INVENTREE_STATIC_ROOT: ../test_inventree_static
   INVENTREE_BACKUP_DIR: ../test_inventree_backup
+  INVENTREE_SITE_URL: http://localhost:8000
 
 jobs:
   paths-filter:

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -1062,6 +1062,15 @@ CORS_ALLOWED_ORIGIN_REGEXES = get_setting(
 if DEBUG:
     CORS_ALLOWED_ORIGIN_REGEXES.append(r'^http://localhost:\d+$')
 
+if CORS_ALLOW_ALL_ORIGINS:
+    logger.info('CORS: All origins allowed')
+else:
+    if CORS_ALLOWED_ORIGINS:
+        logger.info('CORS: Whitelisted origins: %s', CORS_ALLOWED_ORIGINS)
+
+    if CORS_ALLOWED_ORIGIN_REGEXES:
+        logger.info('CORS: Whitelisted origin regexes: %s', CORS_ALLOWED_ORIGIN_REGEXES)
+
 for app in SOCIAL_BACKENDS:
     # Ensure that the app starts with 'allauth.socialaccount.providers'
     social_prefix = 'allauth.socialaccount.providers.'

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -980,6 +980,9 @@ ALLOWED_HOSTS = get_setting(
 )
 
 if DEBUG and not ALLOWED_HOSTS:
+    logger.warning(
+        'No ALLOWED_HOSTS specified. Defaulting to ["*"] for debug mode. This is not recommended for production use'
+    )
     ALLOWED_HOSTS = ['*']
 
 if SITE_URL and SITE_URL not in ALLOWED_HOSTS:
@@ -987,9 +990,7 @@ if SITE_URL and SITE_URL not in ALLOWED_HOSTS:
 
 if not ALLOWED_HOSTS:
     logger.error(
-        'No allowed hosts specified.\n\
-        Please specify a list of allowed hosts in the configuration file,\n\
-        or specify INVENTREE_SITE_URL'
+        'No ALLOWED_HOSTS specified. Please provide a list of allowed hosts, or specify INVENTREE_SITE_URL'
     )
     sys.exit(1)
 

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -975,12 +975,23 @@ if not SITE_MULTI:
 ALLOWED_HOSTS = get_setting(
     'INVENTREE_ALLOWED_HOSTS',
     config_key='allowed_hosts',
-    default_value=['*'],
+    default_value=[],
     typecast=list,
 )
 
+if DEBUG and not ALLOWED_HOSTS:
+    ALLOWED_HOSTS = ['*']
+
 if SITE_URL and SITE_URL not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append(SITE_URL)
+
+if not ALLOWED_HOSTS:
+    logger.error(
+        'No allowed hosts specified.\n\
+        Please specify a list of allowed hosts in the configuration file,\n\
+        or specify INVENTREE_SITE_URL'
+    )
+    sys.exit(1)
 
 # List of trusted origins for unsafe requests
 # Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -994,7 +994,6 @@ if not ALLOWED_HOSTS:
     logger.error(
         'No ALLOWED_HOSTS specified. Please provide a list of allowed hosts, or specify INVENTREE_SITE_URL'
     )
-    sys.exit(1)
 
 # List of trusted origins for unsafe requests
 # Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins

--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -205,6 +205,7 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'user_sessions',  # db user sessions
+    'whitenoise.runserver_nostatic',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
@@ -249,6 +250,7 @@ MIDDLEWARE = CONFIG.get(
         'django.middleware.locale.LocaleMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'corsheaders.middleware.CorsMiddleware',
+        'whitenoise.middleware.WhiteNoiseMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'InvenTree.middleware.InvenTreeRemoteUserMiddleware',  # Remote / proxy auth

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -163,14 +163,14 @@ auto_update: False
 # Allowed hosts (see ALLOWED_HOSTS in Django settings documentation)
 # A list of strings representing the host/domain names that this Django site can serve.
 # Default behaviour is to allow all hosts (THIS IS NOT SECURE!)
-allowed_hosts:
-  - '*'
+# allowed_hosts:
+# - '*'
 
 # Trusted origins (see CSRF_TRUSTED_ORIGINS in Django settings documentation)
 # If you are running behind a proxy, you may need to add the proxy address here
-trusted_origins:
-  - 'http://localhost:8000'
-
+# trusted_origins:
+#   - 'http://localhost'
+#   - 'http://*.localhost'
 
 # Proxy forwarding settings
 # If InvenTree is running behind a proxy, you may need to configure these settings
@@ -183,12 +183,14 @@ use_x_forwarded_port: false
 
 # Cross Origin Resource Sharing (CORS) settings (see https://github.com/adamchainz/django-cors-headers)
 cors:
-  allow_all: True
-  allow_credentials: True,
+  allow_all: false
+  allow_credentials: true
 
   # whitelist:
   # - https://example.com
   # - https://sub.example.com
+
+  # regex:
 
 # MEDIA_ROOT is the local filesystem location for storing uploaded files
 #media_root: '/home/inventree/data/media'

--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -183,8 +183,9 @@ use_x_forwarded_port: false
 
 # Cross Origin Resource Sharing (CORS) settings (see https://github.com/adamchainz/django-cors-headers)
 cors:
-  allow_all: false
   allow_credentials: true
+
+  # allow_all: false
 
   # whitelist:
   # - https://example.com

--- a/requirements.in
+++ b/requirements.in
@@ -51,6 +51,7 @@ sentry-sdk                              # Error reporting (optional)
 setuptools                              # Standard dependency
 tablib[xls,xlsx,yaml]                   # Support for XLS and XLSX formats
 weasyprint                              # PDF generation
+whitenoise                              # Enhanced static file serving
 
 # OpenTelemetry dependencies
 grpcio

--- a/requirements.txt
+++ b/requirements.txt
@@ -342,6 +342,7 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
+whitenoise==6.6.0
 wrapt==1.16.0
     # via
     #   deprecated


### PR DESCRIPTION
- Fixes https://github.com/inventree/InvenTree/issues/5948
- Uses [whitenoise](https://whitenoise.readthedocs.io/en/latest/django.html) as a replacement for django's built-in static file server
- Still really only useful for "development" - as whitenoise is not a recommended solution for serving media files

### Example

- Running local dev server at `http://localhost:8000`
- vite server running at `http://localhost:5173`
- allows CORS requests for static files

![image](https://github.com/inventree/InvenTree/assets/10080325/c1d8c6f1-fa63-476b-8eef-de6f3f114622)
