### PR TITLE
Cache exception handling

### DIFF
--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -291,7 +291,6 @@ class BaseInvenTreeSetting(models.Model):
         try:
             cache.set(ckey, self, timeout=3600)
         except Exception:
-            # Some characters cause issues with caching; ignore and move on
             pass
 
     @classmethod

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -554,16 +554,18 @@ class BaseInvenTreeSetting(models.Model):
         # Unless otherwise specified, attempt to create the setting
         create = kwargs.pop('create', True)
 
+        # Perform cache lookup by default
+        do_cache = kwargs.pop('cache', True)
+
         # Prevent saving to the database during data import
         if InvenTree.ready.isImportingData():
             create = False
+            do_cache = False
 
         # Prevent saving to the database during migrations
         if InvenTree.ready.isRunningMigrations():
             create = False
-
-        # Perform cache lookup by default
-        do_cache = kwargs.pop('cache', True)
+            do_cache = False
 
         ckey = cls.create_cache_key(key, **kwargs)
 
@@ -575,7 +577,7 @@ class BaseInvenTreeSetting(models.Model):
                 if cached_setting is not None:
                     return cached_setting
 
-            except AppRegistryNotReady:
+            except Exception:
                 # Cache is not ready yet
                 do_cache = False
 

--- a/InvenTree/common/models.py
+++ b/InvenTree/common/models.py
@@ -290,7 +290,7 @@ class BaseInvenTreeSetting(models.Model):
 
         try:
             cache.set(ckey, self, timeout=3600)
-        except TypeError:
+        except Exception:
             # Some characters cause issues with caching; ignore and move on
             pass
 

--- a/InvenTree/common/settings.py
+++ b/InvenTree/common/settings.py
@@ -14,7 +14,10 @@ def currency_code_default():
     """Returns the default currency code (or USD if not specified)."""
     from common.models import InvenTreeSetting
 
-    cached_value = cache.get('currency_code_default', '')
+    try:
+        cached_value = cache.get('currency_code_default', '')
+    except Exception:
+        cached_value = None
 
     if cached_value:
         return cached_value

--- a/InvenTree/users/models.py
+++ b/InvenTree/users/models.py
@@ -717,7 +717,10 @@ def check_user_role(user, role, permission):
     # First, check the cache
     key = f'role_{user}_{role}_{permission}'
 
-    result = cache.get(key)
+    try:
+        result = cache.get(key)
+    except Exception:
+        result = None
 
     if result is not None:
         return result


### PR DESCRIPTION
If a caching exception occurs (e.g. redis cache is not yet available) then an exception can kill the server. 
This PR makes the cache calls more resilient to such potential failures.