### PR TITLE
settings.py  - fix default value

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -734,7 +734,7 @@ if TRACING_ENABLED:  # pragma: no cover
         _t_resources = get_setting(
             'INVENTREE_TRACING_RESOURCES',
             'tracing.resources',
-            default_value={},
+            default_value=None,
             typecast=dict,
         )
         cstm_tags = {'inventree.env.' + k: v for k, v in inventree_tags.items()}


### PR DESCRIPTION

- Use None instead of empty dict
- Ref: https://github.com/inventree/InvenTree/pull/6676