### PR TITLE
Test key fix

### DIFF
--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -91,7 +91,7 @@ def generateTestKey(test_name: str) -> str:
     key = re.sub(r'[^a-zA-Z0-9_]', '', key)
 
     # If the key starts with a digit, prefix with an underscore
-    if key[0].isdigit():
+    if len(key) > 0 and key[0].isdigit():
         key = '_' + key
 
     return key

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -87,11 +87,24 @@ def generateTestKey(test_name: str) -> str:
     key = test_name.strip().lower()
     key = key.replace(' ', '')
 
-    # Remove any characters that cannot be used to represent a variable
-    key = ''.join([c for c in key if c.isidentifier() and c.isprintable()])
+    def valid_char(char: str):
+        """Determine if a particular character is valid for use in a test key."""
+        if not char.isprintable():
+            return False
 
-    # If the key starts with a digit, prefix with an underscore
-    if len(key) > 0 and key[0].isdigit():
+        if char.isidentifier():
+            return True
+
+        if char.isalnum():
+            return True
+
+        return False
+
+    # Remove any characters that cannot be used to represent a variable
+    key = ''.join([c for c in key if valid_char(c)])
+
+    # If the key starts with a non-identifier character, prefix with an underscore
+    if len(key) > 0 and not key[0].isidentifier():
         key = '_' + key
 
     return key

--- a/InvenTree/InvenTree/helpers.py
+++ b/InvenTree/InvenTree/helpers.py
@@ -88,7 +88,7 @@ def generateTestKey(test_name: str) -> str:
     key = key.replace(' ', '')
 
     # Remove any characters that cannot be used to represent a variable
-    key = re.sub(r'[^a-zA-Z0-9_]', '', key)
+    key = ''.join([c for c in key if c.isidentifier() and c.isprintable()])
 
     # If the key starts with a digit, prefix with an underscore
     if len(key) > 0 and key[0].isdigit():

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -3428,6 +3428,13 @@ class PartTestTemplate(InvenTree.models.InvenTreeMetadataModel):
 
         self.key = helpers.generateTestKey(self.test_name)
 
+        if len(self.key) == 0:
+            raise ValidationError({
+                'test_name': _(
+                    'Invalid template name - must include at least one alphanumeric character'
+                )
+            })
+
         self.validate_unique()
         super().clean()
 

--- a/InvenTree/part/models.py
+++ b/InvenTree/part/models.py
@@ -3452,7 +3452,9 @@ class PartTestTemplate(InvenTree.models.InvenTreeMetadataModel):
 
         if tests.exists():
             raise ValidationError({
-                'test_name': _('Test with this name already exists for this part')
+                'test_name': _(
+                    'Test template with the same key already exists for part'
+                )
             })
 
         super().validate_unique(exclude)

--- a/InvenTree/part/test_part.py
+++ b/InvenTree/part/test_part.py
@@ -442,6 +442,18 @@ class TestTemplateTest(TestCase):
             with self.assertRaises(ValidationError):
                 template.clean()
 
+        valid_names = [
+            'Собранный щит',
+            '!! 123 Собранный щит <><><> $$$$$ !!!',
+            '----hello world----',
+            'Olá Mundo',
+            '我不懂中文',
+        ]
+
+        for name in valid_names:
+            template = PartTestTemplate(part=variant, test_name=name)
+            template.clean()
+
 
 class PartSettingsTest(InvenTreeTestCase):
     """Tests to ensure that the user-configurable default values work as expected.

--- a/InvenTree/part/test_part.py
+++ b/InvenTree/part/test_part.py
@@ -431,6 +431,17 @@ class TestTemplateTest(TestCase):
 
         self.assertEqual(variant.getTestTemplates().count(), n + 1)
 
+    def test_key_generation(self):
+        """Test the key generation method."""
+        variant = Part.objects.get(pk=10004)
+
+        invalid_names = ['', '+', '+++++++', '   ', '<>$&&&']
+
+        for name in invalid_names:
+            template = PartTestTemplate(part=variant, test_name=name)
+            with self.assertRaises(ValidationError):
+                template.clean()
+
 
 class PartSettingsTest(InvenTreeTestCase):
     """Tests to ensure that the user-configurable default values work as expected.


### PR DESCRIPTION
Ref: https://github.com/inventree/InvenTree/issues/6684

- Handles case where zero-length test key would be generated
- Improves validation of `PartTestTemplate`
- Adds unit tests