### PR TITLE
Caddy fix

### DIFF
--- a/InvenTree/config_template.yaml
+++ b/InvenTree/config_template.yaml
@@ -163,8 +163,8 @@ auto_update: False
 # Allowed hosts (see ALLOWED_HOSTS in Django settings documentation)
 # A list of strings representing the host/domain names that this Django site can serve.
 # Default behaviour is to allow all hosts (THIS IS NOT SECURE!)
-# allowed_hosts:
-# - '*'
+allowed_hosts:
+  - '*'
 
 # Trusted origins (see CSRF_TRUSTED_ORIGINS in Django settings documentation)
 # If you are running behind a proxy, you may need to add the proxy address here
@@ -183,9 +183,8 @@ use_x_forwarded_port: false
 
 # Cross Origin Resource Sharing (CORS) settings (see https://github.com/adamchainz/django-cors-headers)
 cors:
+  allow_all: true
   allow_credentials: true
-
-  # allow_all: false
 
   # whitelist:
   # - https://example.com
@@ -199,11 +198,8 @@ cors:
 # STATIC_ROOT is the local filesystem location for storing static files
 #static_root: '/home/inventree/data/static'
 
-### Backup configuration options ###
 # INVENTREE_BACKUP_DIR is the local filesystem location for storing backups
-backup_storage: django.core.files.storage.FileSystemStorage
 #backup_dir: '/home/inventree/data/backup'
-#backup_options:
 
 # Background worker options
 background:

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -4,33 +4,50 @@
 # - INVENTREE_SERVER: The internal URL of the Inventree container (default: http://inventree-server:8000)
 
 (log_common) {
-    log {
-        output file /var/log/caddy/{args.0}.access.log
-    }
+	log {
+		output file /var/log/caddy/{args[0]}.access.log
+	}
+}
+
+(cors-headers) {
+	header Access-Control-Allow-Origin *
+	header Access-Control-Allow-Methods GET,HEAD,OPTIONS
+	header Access-Control-Allow-Headers User-Agent,Content-Type
+
+	@cors_preflight{args[0]} method OPTIONS
+
+	handle @cors_preflight{args[0]} {
+		respond "" 204
+	}
 }
 
 # Change the host to your domain (this will serve at inventree.localhost)
 {$INVENTREE_SITE_URL:inventree.localhost} {
-    import log_common inventree
+	import log_common inventree
 
-    encode gzip
+	encode gzip
 
-    request_body {
-        max_size 100MB
-    }
+	request_body {
+		max_size 100MB
+	}
 
-    handle_path /static/* {
-        root * /var/www/static
-        file_server
-    }
+	handle_path /static/* {
+		import cors-headers static
 
-    handle_path /media/* {
-        forward_auth {$INVENTREE_SERVER:"http://inventree-server:8000"} {
-            uri /auth/
-        }
-        root * /var/www/media
-        file_server
-    }
+		root * /var/www/static
+		file_server
+	}
 
-    reverse_proxy {$INVENTREE_SERVER:"http://inventree-server:8000"}
+	handle_path /media/* {
+		import cors-headers media
+
+		root * /var/www/media
+		file_server
+
+		forward_auth {$INVENTREE_SERVER:"http://inventree-server:8000"} {
+			uri /auth/
+		}
+	}
+
+	reverse_proxy {$INVENTREE_SERVER:"http://inventree-server:8000"}
 }


### PR DESCRIPTION
- Closes https://github.com/inventree/InvenTree/issues/6663
- Supply CORS headers upstream for /static/ and /media/ paths