### PR TITLE
Fix undefined tabValue (#6470)

### DIFF
--- a/src/frontend/src/components/nav/Header.tsx
+++ b/src/frontend/src/components/nav/Header.tsx
@@ -3,7 +3,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { IconBell, IconSearch } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useMatch, useNavigate, useParams } from 'react-router-dom';
 
 import { api } from '../../App';
 import { navTabs as mainNavTabs } from '../../defaults/links';
@@ -100,8 +100,9 @@ export function Header() {
 
 function NavTabs() {
   const { classes } = InvenTreeStyle();
-  const { tabValue } = useParams();
   const navigate = useNavigate();
+  const match = useMatch(':tabName/*');
+  const tabValue = match?.params.tabName;
 
   return (
     <Tabs


### PR DESCRIPTION
#6470 Points out that the new UI nav bar does not correctly set the `;tabValue` on initial page load.

This is because `useParams` will return the params from the route as defined in the router. Our router does not define `:tabValue/*` for all routes so the object returned from `useParams` does not have a `tabValue` property and is therefore undefined on initial page load.

This PR uses `useMatch` to create a new URL match for `:tabName/*` and sets the `tabValue` variable correctly.

The result, is a navbar that always has the correct tab shown as active.