### PR TITLE
handle report previewing errors

### DIFF
--- a/src/frontend/src/components/editors/TemplateEditor/PdfPreview/PdfPreview.tsx
+++ b/src/frontend/src/components/editors/TemplateEditor/PdfPreview/PdfPreview.tsx
@@ -1,4 +1,4 @@
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import { forwardRef, useImperativeHandle, useState } from 'react';
 
 import { api } from '../../../../App';
@@ -36,7 +36,16 @@ export const PdfPreviewComponent: PreviewAreaComponent = forwardRef(
         );
 
         if (preview.status !== 200) {
-          if (preview.data?.non_field_errors) {
+          if (templateType === 'report') {
+            let data;
+            try {
+              data = JSON.parse(await preview.data.text());
+            } catch (err) {
+              throw new Error(t`Failed to parse error response from server.`);
+            }
+
+            throw new Error(data.detail?.join(', '));
+          } else if (preview.data?.non_field_errors) {
             throw new Error(preview.data?.non_field_errors.join(', '));
           }
 


### PR DESCRIPTION
When requesting the preview of a label template, the response type always is json (either with an error or with the path to a rendered pdf), but when requesting the preview of a report the axios response type is set to `blob`, because the PDF normally is directly returned as a blob. However if there are some errors, the server returns json format, but axios still parses this as a blob. This PR ensures that the error blob is first parsed as JSON and then the correct error is thrown to be handled by the TemplateEditor. Of course, this mess has to be changed along with some other things if we refactor the label/report API.

fixes #6705 