### PR TITLE
Add ability to test event triggers

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -1202,6 +1202,9 @@ PLUGIN_RETRY = get_setting(
 )  # How often should plugin loading be tried?
 PLUGIN_FILE_CHECKED = False  # Was the plugin file checked?
 
+# Flag to allow table events during testing
+TESTING_TABLE_EVENTS = False
+
 # User interface customization values
 CUSTOM_LOGO = get_custom_file(
     'INVENTREE_CUSTOM_LOGO', 'customize.logo', 'custom logo', lookup_media=True

--- a/InvenTree/plugin/base/event/events.py
+++ b/InvenTree/plugin/base/event/events.py
@@ -117,7 +117,7 @@ def allow_table_event(table_name):
         return False  # pragma: no cover
 
     # Prevent table events when in testing mode (saves a lot of time)
-    if settings.TESTING:
+    if settings.TESTING and not settings.TESTING_TABLE_EVENTS:
         return False
 
     table_name = table_name.lower().strip()


### PR DESCRIPTION
Adds django setting to alllow for testing table event propagation in CI tests.

Closes #6734 