### PR TITLE
Fix PUI build workflow

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -507,7 +507,7 @@ jobs:
       - name: Install dependencies
         run: cd src/frontend && yarn install
       - name: Build frontend
-        run: cd src/frontend && npm run build
+        run: cd src/frontend && npm run compile && npm run build
       - name: Zip frontend
         run: |
           cd InvenTree/web/static

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: cd src/frontend && yarn install
       - name: Build frontend
-        run: cd src/frontend && npm run build
+        run: cd src/frontend && npm run compile && npm run build
       - name: Zip frontend
         run: |
           cd InvenTree/web/static/web


### PR DESCRIPTION
As per #6727 it seems like we missed to include the compiled translations the whole time in the artifact builds. This PR adds the lingui compile step to the artifact and release build.

I suggest we could also back port this change to 0.14.x

---
**EDIT:** Tested the build produced by [this run](https://github.com/inventree/InvenTree/actions/runs/8341836937/job/22828730734?pr=6754), works now.