### PR TITLE
[CI] Bump upload to v4 to ensure schema-push still works

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -149,7 +149,7 @@ jobs:
       - name: Export API Documentation
         run: invoke schema --ignore-warnings --filename InvenTree/schema.yml
       - name: Upload schema
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3.1.3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4.3.1
         with:
           name: schema.yml
           path: InvenTree/schema.yml


### PR DESCRIPTION
See https://github.com/inventree/InvenTree/pull/6836#issuecomment-2016977467 for details. Upload and download action need to be in the same major version.