### PR TITLE
Remove port from ALLOWED_HOST entries

### DIFF
--- a/InvenTree/InvenTree/settings.py
+++ b/InvenTree/InvenTree/settings.py
@@ -1017,7 +1017,10 @@ if not ALLOWED_HOSTS:
 # Ensure that the ALLOWED_HOSTS do not contain any scheme info
 for i, host in enumerate(ALLOWED_HOSTS):
     if '://' in host:
-        ALLOWED_HOSTS[i] = host.split('://')[1]
+        ALLOWED_HOSTS[i] = host = host.split('://')[1]
+
+    if ':' in host:
+        ALLOWED_HOSTS[i] = host = host.split(':')[0]
 
 # List of trusted origins for unsafe requests
 # Ref: https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins


### PR DESCRIPTION
- Fixes https://github.com/inventree/InvenTree/issues/6870
- Strip trailling port information from `ALLOWED_HOSTS`