### PR TITLE
Add test start, end date and test station to the next gen UI

### DIFF
--- a/src/frontend/src/components/forms/fields/ApiFormField.tsx
+++ b/src/frontend/src/components/forms/fields/ApiFormField.tsx
@@ -216,7 +216,6 @@ export function ApiFormField({
           />
         );
       case 'date':
-        return <DateField controller={controller} definition={definition} />;
       case 'datetime':
         return <DateField controller={controller} definition={definition} />;
       case 'integer':

--- a/src/frontend/src/components/forms/fields/ApiFormField.tsx
+++ b/src/frontend/src/components/forms/fields/ApiFormField.tsx
@@ -64,6 +64,7 @@ export type ApiFormFieldType = {
     | 'string'
     | 'boolean'
     | 'date'
+    | 'datetime'
     | 'integer'
     | 'decimal'
     | 'float'
@@ -215,6 +216,8 @@ export function ApiFormField({
           />
         );
       case 'date':
+        return <DateField controller={controller} definition={definition} />;
+      case 'datetime':
         return <DateField controller={controller} definition={definition} />;
       case 'integer':
       case 'decimal':

--- a/src/frontend/src/components/forms/fields/DateField.tsx
+++ b/src/frontend/src/components/forms/fields/DateField.tsx
@@ -1,4 +1,6 @@
 import { DateInput } from '@mantine/dates';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { useCallback, useId, useMemo } from 'react';
 import { FieldValues, UseControllerReturn } from 'react-hook-form';
 
@@ -11,6 +13,8 @@ export default function DateField({
   controller: UseControllerReturn<FieldValues, any>;
   definition: ApiFormFieldType;
 }) {
+  dayjs.extend(customParseFormat);
+
   const fieldId = useId();
 
   const {
@@ -18,13 +22,16 @@ export default function DateField({
     fieldState: { error }
   } = controller;
 
+  const valueFormat =
+    definition.field_type == 'date' ? 'YYYY-MM-DD' : 'YYYY-MM-DD HH:mm:ss';
+
   const onChange = useCallback(
     (value: any) => {
       // Convert the returned date object to a string
       if (value) {
         value = value.toString();
         let date = new Date(value);
-        value = date.toISOString().split('T')[0];
+        value = dayjs(value).format(valueFormat);
       }
 
       field.onChange(value);
@@ -50,7 +57,7 @@ export default function DateField({
       value={dateValue}
       clearable={!definition.required}
       onChange={onChange}
-      valueFormat="YYYY-MM-DD"
+      valueFormat={valueFormat}
       label={definition.label}
       description={definition.description}
       placeholder={definition.placeholder}

--- a/src/frontend/src/components/forms/fields/DateField.tsx
+++ b/src/frontend/src/components/forms/fields/DateField.tsx
@@ -6,6 +6,8 @@ import { FieldValues, UseControllerReturn } from 'react-hook-form';
 
 import { ApiFormFieldType } from './ApiFormField';
 
+dayjs.extend(customParseFormat);
+
 export default function DateField({
   controller,
   definition
@@ -13,8 +15,6 @@ export default function DateField({
   controller: UseControllerReturn<FieldValues, any>;
   definition: ApiFormFieldType;
 }) {
-  dayjs.extend(customParseFormat);
-
   const fieldId = useId();
 
   const {

--- a/src/frontend/src/defaults/formatters.tsx
+++ b/src/frontend/src/defaults/formatters.tsx
@@ -88,6 +88,7 @@ export function formatPriceRange(
 
 interface renderDateOptionsType {
   showTime?: boolean;
+  showSeconds?: boolean;
 }
 
 /*
@@ -106,6 +107,9 @@ export function renderDate(date: string, options: renderDateOptionsType = {}) {
 
   if (options.showTime) {
     fmt += ' HH:mm';
+    if (options.showSeconds) {
+      fmt += ':ss';
+    }
   }
 
   const m = dayjs(date);

--- a/src/frontend/src/tables/stock/StockItemTestResultTable.tsx
+++ b/src/frontend/src/tables/stock/StockItemTestResultTable.tsx
@@ -202,6 +202,41 @@ export default function StockItemTestResultTable({
             </Group>
           );
         }
+      },
+      {
+        accessor: 'test_station',
+        sortable: true,
+        title: t`Test station`
+      },
+      {
+        accessor: 'started_datetime',
+        sortable: true,
+        title: t`Started`,
+        render: (record: any) => {
+          return (
+            <Group position="apart">
+              {renderDate(record.started_datetime, {
+                showTime: true,
+                showSeconds: true
+              })}
+            </Group>
+          );
+        }
+      },
+      {
+        accessor: 'finished_datetime',
+        sortable: true,
+        title: t`Finished`,
+        render: (record: any) => {
+          return (
+            <Group position="apart">
+              {renderDate(record.finished_datetime, {
+                showTime: true,
+                showSeconds: true
+              })}
+            </Group>
+          );
+        }
       }
     ];
   }, [itemId]);
@@ -218,6 +253,9 @@ export default function StockItemTestResultTable({
       value: {},
       attachment: {},
       notes: {},
+      test_station: {},
+      started_datetime: {},
+      finished_datetime: {},
       stock_item: {
         value: itemId,
         hidden: true


### PR DESCRIPTION
Following upon this:
https://github.com/inventree/InvenTree/pull/6149#issuecomment-2002637842

Here is a PR which adds the new test fields to the React UI.