### PR TITLE
Allow for non-square logos in Navbar

### DIFF
--- a/InvenTree/templates/navbar.html
+++ b/InvenTree/templates/navbar.html
@@ -14,7 +14,7 @@
 <nav class="navbar {% if sticky %}fixed-top{% endif %} navbar-expand-lg navbar-light">
   <div class="container-fluid">
     <div class="navbar-header clearfix content-heading">
-      <a class="navbar-brand" id='logo' href="{% url 'index' %}" style="padding-top: 7px; padding-bottom: 5px;"><img src="{% inventree_logo %}" alt="{% trans 'InvenTree logo' %}" width="32" height="32" style="display:block; margin: auto;"/></a>
+      <a class="navbar-brand" id='logo' href="{% url 'index' %}" style="padding-top: 7px; padding-bottom: 5px;"><img src="{% inventree_logo %}" alt="{% trans 'InvenTree logo' %}" max-width="64" height="32" style="display:block; margin: auto;"/></a>
     </div>
     <div class="navbar-collapse collapse" id="navbar-objects">
       <ul class="navbar-nav">


### PR DESCRIPTION
Some Logos are not "squareable", so they currently look either distorted (without user intervention) or way too small (by manually squaring it)

By loosening the width restriction, most logos, square or rectangular (max ratio 2:1), will not be distorted and scaled automatically.