### PR TITLE
Set write permission on specific job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,6 +16,8 @@ jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: |
       github.event.pull_request.merged == true
       && contains(github.event.pull_request.labels.*.name, 'backport')

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ on:
     types: [ "labeled", "closed" ]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   backport:


### PR DESCRIPTION
This reduces the likelihood of implicit write permissions for jobs where it is not intended