### PR TITLE
Add support for django-query-count

### DIFF
--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -282,7 +282,7 @@ QUERYCOUNT = {
     },
     'IGNORE_REQUEST_PATTERNS': ['^(?!\/(api)?(plugin)?\/).*'],
     'IGNORE_SQL_PATTERNS': [],
-    'DISPLAY_DUPLICATES': None,
+    'DISPLAY_DUPLICATES': 3,
     'RESPONSE_HEADER': 'X-Django-Query-Count',
 }
 

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -268,6 +268,8 @@ MIDDLEWARE = CONFIG.get(
     ],
 )
 
+# In DEBUG mode, add support for django-querycount
+# Ref: https://github.com/bradmontgomery/django-querycount
 if DEBUG and get_boolean_setting(
     'INVENTREE_DEBUG_QUERYCOUNT', 'debug_querycount', False
 ):

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -268,6 +268,24 @@ MIDDLEWARE = CONFIG.get(
     ],
 )
 
+if DEBUG and get_boolean_setting(
+    'INVENTREE_DEBUG_QUERYCOUNT', 'debug_querycount', False
+):
+    MIDDLEWARE.append('querycount.middleware.QueryCountMiddleware')
+
+QUERYCOUNT = {
+    'THRESHOLDS': {
+        'MEDIUM': 50,
+        'HIGH': 200,
+        'MIN_TIME_TO_LOG': 0,
+        'MIN_QUERY_COUNT_TO_LOG': 0,
+    },
+    'IGNORE_REQUEST_PATTERNS': ['^(?!\/(api)?(plugin)?\/).*'],
+    'IGNORE_SQL_PATTERNS': [],
+    'DISPLAY_DUPLICATES': None,
+    'RESPONSE_HEADER': 'X-Django-Query-Count',
+}
+
 AUTHENTICATION_BACKENDS = CONFIG.get(
     'authentication_backends',
     [

--- a/src/backend/requirements-dev.in
+++ b/src/backend/requirements-dev.in
@@ -2,6 +2,7 @@
 -c requirements.txt
 coverage[toml]                          # Unit test coverage
 coveralls==2.1.2                        # Coveralls linking (for tracking coverage)  # PINNED 2022-06-28 - Old version needed for correct upload
+django-querycount                       # Display number of URL queries for requests
 django-slowtests                        # Show which unit tests are running slowly
 django-test-migrations                  # Unit testing for database migrations
 isort                                   # python import sorting

--- a/src/backend/requirements-dev.txt
+++ b/src/backend/requirements-dev.txt
@@ -25,6 +25,7 @@ distlib==0.3.8
     # via virtualenv
 django==4.2.11
     # via django-slowtests
+django-querycount==0.8.3
 django-slowtests==1.1.1
 django-test-migrations==1.3.0
 docopt==0.6.2


### PR DESCRIPTION
In `DEBUG` mode (and with a particular env var set) this PR enables support for query-count reporting on the `/api/` and `/plugin/` endpoints.

This is a setup I use a lot for debugging inefficient database queries, and it is very useful!

Ref: https://github.com/bradmontgomery/django-querycount