### PR TITLE
[BUG] Include .vite subdir in PUI releases

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -534,8 +534,8 @@ jobs:
         run: cd src/frontend && yarn run compile && yarn run build
       - name: Zip frontend
         run: |
-          cd src/backend/InvenTree/web/static/web
-          zip -r frontend-build.zip ./
+          cd src/backend/InvenTree/web/static
+          zip -r frontend-build.zip web/ web/.vite
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4.3.1
         with:
           name: frontend-build

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -534,8 +534,8 @@ jobs:
         run: cd src/frontend && yarn run compile && yarn run build
       - name: Zip frontend
         run: |
-          cd src/backend/InvenTree/web/static
-          zip -r frontend-build.zip web/
+          cd src/backend/InvenTree/web/static/web
+          zip -r frontend-build.zip ./
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4.3.1
         with:
           name: frontend-build

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -531,7 +531,7 @@ jobs:
       - name: Install dependencies
         run: cd src/frontend && yarn install
       - name: Build frontend
-        run: cd src/frontend && npm run compile && npm run build
+        run: cd src/frontend && yarn run compile && yarn run build
       - name: Zip frontend
         run: |
           cd src/backend/InvenTree/web/static

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
         includePrivate: true,
         multipleVersions: true,
         output: {
-          file: '../../InvenTree/web/static/web/.vite/dependencies.json',
+          file: '../backend/InvenTree/web/static/web/.vite/dependencies.json',
           template(dependencies) {
             return JSON.stringify(dependencies);
           }


### PR DESCRIPTION
This PR:
- fixes a wrong path in the license export
- includes the .vite directory in the ziped releases
- uses yarn as a runner instead of npm for consistency