### PR TITLE
Revert "Bump sqren/backport-github-action from 8.9.3 to 9.3.1"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,7 +27,7 @@ jobs:
       )
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@f7073a2287aefc1fa12685eb25a712ab5620445c # pin@v9.2.2
+        uses: sqren/backport-github-action@f54e19901f2a57f8b82360f2490d47ee82ec82c6 # pin@v9.2.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: backport-to-


### PR DESCRIPTION
- Reverts inventree/InvenTree#6802
- Closes https://github.com/inventree/InvenTree/issues/6963

Update to backport action workflow file has broken the process.

- [Last good run](https://github.com/inventree/InvenTree/actions/runs/8388984729/job/22974250981) 
- [Example broken run](https://github.com/inventree/InvenTree/actions/runs/8502604152/job/23287000070)
