### PR TITLE
[CI] Optimize runs

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -220,7 +220,8 @@ jobs:
     name: Tests - inventree-python
     runs-on: ubuntu-20.04
 
-    needs: pre-commit
+    needs: [ 'pre-commit', 'paths-filter' ]
+    if: needs.paths-filter.outputs.server == 'true' || needs.paths-filter.outputs.force == 'true'
 
     env:
       wrapper_name: inventree-python
@@ -261,7 +262,8 @@ jobs:
     name: Tests - DB [SQLite] + Coverage
     runs-on: ubuntu-20.04
 
-    needs: [ 'pre-commit' ]
+    needs: [ 'pre-commit', 'paths-filter' ]
+    if: needs.paths-filter.outputs.server == 'true' || needs.paths-filter.outputs.force == 'true'
     continue-on-error: true # continue if a step fails so that coverage gets pushed
 
     env:
@@ -306,7 +308,8 @@ jobs:
   postgres:
     name: Tests - DB [PostgreSQL]
     runs-on: ubuntu-20.04
-    needs: [ 'pre-commit' ]
+    needs: [ 'pre-commit', 'paths-filter' ]
+    if: needs.paths-filter.outputs.server == 'true' || needs.paths-filter.outputs.force == 'true'
 
     env:
       INVENTREE_DB_ENGINE: django.db.backends.postgresql
@@ -350,7 +353,8 @@ jobs:
     name: Tests - DB [MySQL]
     runs-on: ubuntu-20.04
 
-    needs: [ 'pre-commit' ]
+    needs: [ 'pre-commit', 'paths-filter' ]
+    if: needs.paths-filter.outputs.server == 'true' || needs.paths-filter.outputs.force == 'true'
 
     env:
       # Database backend configuration

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -300,6 +300,7 @@ jobs:
           parallel: true
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
+        if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: inventree/InvenTree
@@ -439,6 +440,7 @@ jobs:
           git-branch: ${{ github.ref }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
+        if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: inventree/InvenTree
@@ -543,6 +545,7 @@ jobs:
           parallel: true
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
+        if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: inventree/InvenTree


### PR DESCRIPTION
Small CI adjustment discovered during #6987:
- Only run backend tests if required
- Always upload coverage to Coveralls (cuts down on iterative debug times and is very compute - cheap)