### PR TITLE
[CI] Re-add playwright reporting

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -524,9 +524,10 @@ jobs:
       - name: Install Playwright Browsers
         run: cd src/frontend && npx playwright install --with-deps
       - name: Run Playwright tests
+        id: tests
         run: cd src/frontend && npx nyc playwright test
       - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.tests.outcome == 'failure' }}
         with:
           name: playwright-report
           path: src/frontend/playwright-report/

--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -525,6 +525,12 @@ jobs:
         run: cd src/frontend && npx playwright install --with-deps
       - name: Run Playwright tests
         run: cd src/frontend && npx nyc playwright test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: src/frontend/playwright-report/
+          retention-days: 14
       - name: Report coverage
         if: always()
         run: cd src/frontend && npx nyc report --report-dir ./coverage --temp-dir .nyc_output --reporter=lcov --exclude-after-remap false

--- a/src/frontend/playwright.config.ts
+++ b/src/frontend/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 2 : undefined,
-  reporter: process.env.CI ? 'github' : 'list',
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['github']] : 'list',
 
   /* Configure projects for major browsers */
   projects: [


### PR DESCRIPTION
This re-adds the playwright reporting now that I have figured out why it was flaks (report config section missing).

Discoverd during #6987