### PR TITLE
[PUI] Fix licensing dialog

### DIFF
--- a/src/frontend/src/components/modals/LicenseModal.tsx
+++ b/src/frontend/src/components/modals/LicenseModal.tsx
@@ -40,7 +40,7 @@ export function LicenceView(entries: Readonly<any[]>) {
         </Accordion>
       ) : (
         <Text>
-          <Trans>No Information provided - this likely a server issue</Trans>
+          <Trans>No Information provided - this is likely a server issue</Trans>
         </Text>
       )}
     </Stack>

--- a/src/frontend/src/components/modals/LicenseModal.tsx
+++ b/src/frontend/src/components/modals/LicenseModal.tsx
@@ -53,6 +53,8 @@ export function LicenseModal() {
         .catch(() => {})
   });
 
+  const rspdata = !data ? [] : Object.keys(data ?? {});
+
   return (
     <Stack spacing="xs">
       <Divider />
@@ -69,16 +71,16 @@ export function LicenseModal() {
           </Text>
         </Alert>
       ) : (
-        <Tabs defaultValue={Object.keys(data)[0] ?? ''}>
+        <Tabs defaultValue={rspdata[0] ?? ''}>
           <Tabs.List>
-            {Object.keys(data ?? {}).map((key) => (
+            {rspdata.map((key) => (
               <Tabs.Tab key={key} value={key}>
                 <Trans>{key} Packages</Trans>
               </Tabs.Tab>
             ))}
           </Tabs.List>
 
-          {Object.keys(data ?? {}).map((key) => (
+          {rspdata.map((key) => (
             <Tabs.Panel key={key} value={key}>
               {LicenceView(data[key] ?? [])}
             </Tabs.Panel>

--- a/src/frontend/src/components/modals/LicenseModal.tsx
+++ b/src/frontend/src/components/modals/LicenseModal.tsx
@@ -20,7 +20,7 @@ export function LicenceView(entries: Readonly<any[]>) {
   return (
     <Stack spacing="xs">
       <Divider />
-      {entries?.length > 0 && (
+      {entries?.length > 0 ? (
         <Accordion variant="contained" defaultValue="-">
           {entries?.map((entry: any, index: number) => (
             <Accordion.Item key={entry.name} value={`entry-${index}`}>
@@ -38,6 +38,10 @@ export function LicenceView(entries: Readonly<any[]>) {
             </Accordion.Item>
           ))}
         </Accordion>
+      ) : (
+        <Text>
+          <Trans>No Information provided - this likely a server issue</Trans>
+        </Text>
       )}
     </Stack>
   );


### PR DESCRIPTION
This helps if the licensing for either platform is not available or empty; currently, the modal just crashes.

Discovered during #6987