### PR TITLE
Admin shell

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Dummy requirements file to trigger the package pipeline
-# The new requirements file is located in src/backend/requirements.txt
+# The backend requirements file is located in src/backend/requirements.txt
 #

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -288,6 +288,22 @@ QUERYCOUNT = {
     'RESPONSE_HEADER': 'X-Django-Query-Count',
 }
 
+ADMIN_SHELL_ENABLE = False
+ADMIN_SHELL_IMPORT_DJANGO = False
+ADMIN_SHELL_IMPORT_MODELS = False
+
+# In DEBUG mode, add support for django-admin-shell
+# Ref: https://github.com/djk2/django-admin-shell
+if (
+    DEBUG
+    and INVENTREE_ADMIN_ENABLED
+    and get_boolean_setting('INVENTREE_DEBUG_SHELL', 'debug_shell', False)
+):
+    INSTALLED_APPS.append('django_admin_shell')
+    ADMIN_SHELL_ENABLE = True
+
+    logger.warning('Admin shell is enabled')
+
 AUTHENTICATION_BACKENDS = CONFIG.get(
     'authentication_backends',
     [

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -299,10 +299,17 @@ if (
     and INVENTREE_ADMIN_ENABLED
     and get_boolean_setting('INVENTREE_DEBUG_SHELL', 'debug_shell', False)
 ):
-    INSTALLED_APPS.append('django_admin_shell')
-    ADMIN_SHELL_ENABLE = True
+    try:
+        import django_admin_shell
 
-    logger.warning('Admin shell is enabled')
+        INSTALLED_APPS.append('django_admin_shell')
+        ADMIN_SHELL_ENABLE = True
+
+        logger.warning('Admin shell is enabled')
+    except ModuleNotFoundError:
+        logger.warning(
+            'django-admin-shell is not installed - Admin shell is not enabled'
+        )
 
 AUTHENTICATION_BACKENDS = CONFIG.get(
     'authentication_backends',

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -298,7 +298,7 @@ if (
     DEBUG
     and INVENTREE_ADMIN_ENABLED
     and get_boolean_setting('INVENTREE_DEBUG_SHELL', 'debug_shell', False)
-):
+):  # noqa
     try:
         import django_admin_shell
 

--- a/src/backend/InvenTree/InvenTree/urls.py
+++ b/src/backend/InvenTree/InvenTree/urls.py
@@ -435,7 +435,11 @@ classic_frontendpatterns = [
 urlpatterns = []
 
 if settings.INVENTREE_ADMIN_ENABLED:
-    admin_url = (settings.INVENTREE_ADMIN_URL,)
+    admin_url = settings.INVENTREE_ADMIN_URL
+
+    if settings.ADMIN_SHELL_ENABLE:
+        urlpatterns += [path(f'{admin_url}/shell/', include('django_admin_shell.urls'))]
+
     urlpatterns += [
         path(f'{admin_url}/error_log/', include('error_report.urls')),
         path(f'{admin_url}/', admin.site.urls, name='inventree-admin'),

--- a/src/backend/InvenTree/InvenTree/urls.py
+++ b/src/backend/InvenTree/InvenTree/urls.py
@@ -437,7 +437,7 @@ urlpatterns = []
 if settings.INVENTREE_ADMIN_ENABLED:
     admin_url = settings.INVENTREE_ADMIN_URL
 
-    if settings.ADMIN_SHELL_ENABLE:
+    if settings.ADMIN_SHELL_ENABLE:  # noqa
         urlpatterns += [path(f'{admin_url}/shell/', include('django_admin_shell.urls'))]
 
     urlpatterns += [

--- a/src/backend/requirements-dev.in
+++ b/src/backend/requirements-dev.in
@@ -2,6 +2,7 @@
 -c requirements.txt
 coverage[toml]                          # Unit test coverage
 coveralls==2.1.2                        # Coveralls linking (for tracking coverage)  # PINNED 2022-06-28 - Old version needed for correct upload
+django-admin-shell                      # Remote shell access
 django-querycount                       # Display number of URL queries for requests
 django-slowtests                        # Show which unit tests are running slowly
 django-test-migrations                  # Unit testing for database migrations

--- a/src/backend/requirements-dev.txt
+++ b/src/backend/requirements-dev.txt
@@ -24,7 +24,10 @@ cryptography==42.0.5
 distlib==0.3.8
     # via virtualenv
 django==4.2.11
-    # via django-slowtests
+    # via
+    #   django-admin-shell
+    #   django-slowtests
+django-admin-shell==2.0.1
 django-querycount==0.8.3
 django-slowtests==1.1.1
 django-test-migrations==1.3.0


### PR DESCRIPTION
Adds optional integration with [django-debug-shell](https://github.com/djk2/django-admin-shell)

- Allows optional shell access in development mode, for users with superuser access
- Requires `DEBUG` mode to be enabled (disabled for production)
- Requires environment var / configuration parameter to be set
- Package is *not* installed as part of default requirements (but is as part of dev-requirements)
