### PR TITLE
Allow write permission for backport.yml

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ on:
     types: [ "labeled", "closed" ]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   backport:


### PR DESCRIPTION
Try adding write permission to the entire file to fix ongoing issues with backport workflow

Ref: https://github.com/inventree/InvenTree/actions/runs/8668164506/job/23772666652