### PR TITLE
[PUI] Add quick login via url

### DIFF
--- a/src/frontend/src/pages/Auth/Login.tsx
+++ b/src/frontend/src/pages/Auth/Login.tsx
@@ -52,7 +52,6 @@ export default function Login() {
 
     // check if we got login params (login and password)
     if (searchParams.has('login') && searchParams.has('password')) {
-      console.log('got login params');
       doBasicLogin(
         searchParams.get('login') ?? '',
         searchParams.get('password') ?? ''

--- a/src/frontend/src/pages/Auth/Login.tsx
+++ b/src/frontend/src/pages/Auth/Login.tsx
@@ -2,7 +2,7 @@ import { Trans, t } from '@lingui/macro';
 import { Center, Container, Paper, Text } from '@mantine/core';
 import { useDisclosure, useToggle } from '@mantine/hooks';
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { setApiDefaults } from '../../App';
 import { AuthFormOptions } from '../../components/forms/AuthFormOptions';
@@ -13,7 +13,7 @@ import {
 } from '../../components/forms/AuthenticationForm';
 import { InstanceOptions } from '../../components/forms/InstanceOptions';
 import { defaultHostKey } from '../../defaults/defaultHostList';
-import { checkLoginState } from '../../functions/auth';
+import { checkLoginState, doBasicLogin } from '../../functions/auth';
 import { useServerApiState } from '../../states/ApiState';
 import { useLocalState } from '../../states/LocalState';
 
@@ -33,6 +33,7 @@ export default function Login() {
   const [loginMode, setMode] = useDisclosure(true);
   const navigate = useNavigate();
   const location = useLocation();
+  const [searchParams] = useSearchParams();
 
   // Data manipulation functions
   function ChangeHost(newHost: string): void {
@@ -48,6 +49,17 @@ export default function Login() {
     }
 
     checkLoginState(navigate, location?.state?.redirectFrom, true);
+
+    // check if we got login params (login and password)
+    if (searchParams.has('login') && searchParams.has('password')) {
+      console.log('got login params');
+      doBasicLogin(
+        searchParams.get('login') ?? '',
+        searchParams.get('password') ?? ''
+      ).then(() => {
+        navigate(location?.state?.redirectFrom ?? '/home');
+      });
+    }
   }, []);
 
   // Fetch server data on mount if no server data is present

--- a/src/frontend/tests/defaults.ts
+++ b/src/frontend/tests/defaults.ts
@@ -4,3 +4,8 @@ export const user = {
   username: 'allaccess',
   password: 'nolimits'
 };
+
+export const adminuser = {
+  username: 'admin',
+  password: 'inventree'
+};

--- a/src/frontend/tests/pui_command.spec.ts
+++ b/src/frontend/tests/pui_command.spec.ts
@@ -2,13 +2,10 @@ import { expect, systemKey, test } from './baseFixtures.js';
 import { user } from './defaults.js';
 
 test('PUI - Quick Command', async ({ page }) => {
-  await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
   await page.goto('./platform/');
 
   await expect(page).toHaveTitle('InvenTree');
@@ -48,13 +45,11 @@ test('PUI - Quick Command', async ({ page }) => {
 });
 
 test('PUI - Quick Command - no keys', async ({ page }) => {
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
   await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
 
   await expect(page).toHaveTitle('InvenTree');
   await page.waitForURL('**/platform');

--- a/src/frontend/tests/pui_command.spec.ts
+++ b/src/frontend/tests/pui_command.spec.ts
@@ -51,10 +51,8 @@ test('PUI - Quick Command - no keys', async ({ page }) => {
   await page.waitForURL('**/platform/*');
   await page.goto('./platform/');
 
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform');
-  // wait for the page to load - 0.5s
-  await page.waitForTimeout(500);
+  // wait for the page to load
+  await page.waitForTimeout(200);
 
   // Open Spotlight with Button
   await page.getByRole('button', { name: 'Open spotlight' }).click();

--- a/src/frontend/tests/pui_general.spec.ts
+++ b/src/frontend/tests/pui_general.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './baseFixtures.js';
+import { test } from './baseFixtures.js';
 import { adminuser, user } from './defaults.js';
 
 test('PUI - Parts', async ({ page }) => {

--- a/src/frontend/tests/pui_general.spec.ts
+++ b/src/frontend/tests/pui_general.spec.ts
@@ -1,14 +1,11 @@
 import { expect, test } from './baseFixtures.js';
-import { user } from './defaults.js';
+import { adminuser, user } from './defaults.js';
 
 test('PUI - Parts', async ({ page }) => {
-  await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
   await page.goto('./platform/home');
 
   await page.getByRole('tab', { name: 'Parts' }).click();
@@ -39,13 +36,10 @@ test('PUI - Parts', async ({ page }) => {
 });
 
 test('PUI - Parts - Manufacturer Parts', async ({ page }) => {
-  await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
 
   await page.goto('./platform/part/84/manufacturers');
   await page.getByRole('tab', { name: 'Manufacturers' }).click();
@@ -57,13 +51,10 @@ test('PUI - Parts - Manufacturer Parts', async ({ page }) => {
 });
 
 test('PUI - Parts - Supplier Parts', async ({ page }) => {
-  await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
 
   await page.goto('./platform/part/15/suppliers');
   await page.getByRole('tab', { name: 'Suppliers' }).click();
@@ -75,13 +66,10 @@ test('PUI - Parts - Supplier Parts', async ({ page }) => {
 });
 
 test('PUI - Sales', async ({ page }) => {
-  await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
 
   await page.goto('./platform/sales/');
   await page.waitForURL('**/platform/sales/**');
@@ -131,13 +119,11 @@ test('PUI - Sales', async ({ page }) => {
 });
 
 test('PUI - Scanning', async ({ page }) => {
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
   await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
 
   await page.getByLabel('Homenav').click();
   await page.getByRole('button', { name: 'System Information' }).click();
@@ -158,13 +144,11 @@ test('PUI - Scanning', async ({ page }) => {
 });
 
 test('PUI - Admin', async ({ page }) => {
-  await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
+  await page.goto(
+    `./platform/login/?login=${adminuser.username}&password=${adminuser.password}`
+  );
   await page.waitForURL('**/platform/*');
-  await page.getByLabel('username').fill('admin');
-  await page.getByLabel('password').fill('inventree');
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
+  await page.goto('./platform/');
 
   // User settings
   await page.getByRole('button', { name: 'admin' }).click();
@@ -213,13 +197,11 @@ test('PUI - Admin', async ({ page }) => {
 });
 
 test('PUI - Language / Color', async ({ page }) => {
-  await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
   await page.waitForURL('**/platform/*');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
+  await page.goto('./platform/');
 
   await page.getByRole('button', { name: 'Ally Access' }).click();
   await page.getByRole('menuitem', { name: 'Logout' }).click();
@@ -253,13 +235,10 @@ test('PUI - Language / Color', async ({ page }) => {
 });
 
 test('PUI - Company', async ({ page }) => {
-  await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
 
   await page.goto('./platform/company/1/details');
   await page

--- a/src/frontend/tests/pui_stock.spec.ts
+++ b/src/frontend/tests/pui_stock.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './baseFixtures.js';
+import { test } from './baseFixtures.js';
 import { user } from './defaults.js';
 
 test('PUI - Stock', async ({ page }) => {

--- a/src/frontend/tests/pui_stock.spec.ts
+++ b/src/frontend/tests/pui_stock.spec.ts
@@ -2,13 +2,10 @@ import { expect, test } from './baseFixtures.js';
 import { user } from './defaults.js';
 
 test('PUI - Stock', async ({ page }) => {
-  await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
 
   await page.goto('./platform/stock');
   await page.waitForURL('**/platform/stock/location/index/details');
@@ -24,13 +21,11 @@ test('PUI - Stock', async ({ page }) => {
 });
 
 test('PUI - Build', async ({ page }) => {
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
   await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
 
   await page.getByRole('tab', { name: 'Build' }).click();
   await page.getByText('Widget Assembly Variant').click();
@@ -44,13 +39,11 @@ test('PUI - Build', async ({ page }) => {
 });
 
 test('PUI - Purchasing', async ({ page }) => {
+  await page.goto(
+    `./platform/login/?login=${user.username}&password=${user.password}`
+  );
+  await page.waitForURL('**/platform/*');
   await page.goto('./platform/');
-  await expect(page).toHaveTitle('InvenTree');
-  await page.waitForURL('**/platform/');
-  await page.getByLabel('username').fill(user.username);
-  await page.getByLabel('password').fill(user.password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await page.waitForURL('**/platform');
 
   await page.getByRole('tab', { name: 'Purchasing' }).click();
   await page.getByRole('cell', { name: 'PO0012' }).click();


### PR DESCRIPTION
This PR:
- Adds the url based login method (user + pwd) that we use for the demo to PUI
- Switches most tests (all that do not explicitly test user login UI) to use this method as it is easier to compute