### PR TITLE
Catch potential missing element

### DIFF
--- a/src/backend/InvenTree/common/views.py
+++ b/src/backend/InvenTree/common/views.py
@@ -269,7 +269,7 @@ class FileManagementFormView(MultiStepFormView):
                 for idx, item in row_data.items():
                     column_data = {
                         'name': self.column_names[idx],
-                        'guess': self.column_selections[idx],
+                        'guess': self.column_selections.get(idx, ''),
                     }
 
                     cell_data = {'cell': item, 'idx': idx, 'column': column_data}


### PR DESCRIPTION
In existing data importer, potential that column ID key does not exist in the dict.

This will [all be removed soon anyway](https://github.com/inventree/InvenTree/pull/6911)