### PR TITLE
Fix currency rendering in order tables

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,13 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 188
+INVENTREE_API_VERSION = 189
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v189 - 2024-04-19 : https://github.com/inventree/InvenTree/pull/7066
+    - Adds "currency" field to CompanyBriefSerializer class
 
 v188 - 2024-04-16 : https://github.com/inventree/InvenTree/pull/6970
     - Adds session authentication support for the API

--- a/src/backend/InvenTree/company/serializers.py
+++ b/src/backend/InvenTree/company/serializers.py
@@ -42,7 +42,9 @@ class CompanyBriefSerializer(InvenTreeModelSerializer):
         """Metaclass options."""
 
         model = Company
-        fields = ['pk', 'url', 'name', 'description', 'image', 'thumbnail']
+        fields = ['pk', 'url', 'name', 'description', 'image', 'thumbnail', 'currency']
+
+        read_only_fields = ['currency']
 
     url = serializers.CharField(source='get_absolute_url', read_only=True)
 

--- a/src/backend/InvenTree/templates/js/dynamic/nav.js
+++ b/src/backend/InvenTree/templates/js/dynamic/nav.js
@@ -21,12 +21,15 @@ function activatePanel(label, panel_name, options={}) {
     $('.panel-visible').hide();
     $('.panel-visible').removeClass('panel-visible');
 
+    // Remove illegal chars
+    panel_name = panel_name.replace('/', '');
+
     // Find the target panel
     var panel = `#panel-${panel_name}`;
     var select = `#select-${panel_name}`;
 
     // Check that the selected panel (and select) exist
-    if ($(panel).length && $(select).length) {
+    if ($(panel).exists() && $(panel).length && $(select).length) {
         // Yep, both are displayed
     } else {
         // Either the select or the panel are not displayed!

--- a/src/backend/InvenTree/templates/js/translated/purchase_order.js
+++ b/src/backend/InvenTree/templates/js/translated/purchase_order.js
@@ -1755,7 +1755,7 @@ function loadPurchaseOrderTable(table, options) {
                 sortable: true,
                 formatter: function(value, row) {
                     return formatCurrency(value, {
-                        currency: row.order_currency,
+                        currency: row.order_currency ?? row.supplier_detail?.currency,
                     });
                 },
             },

--- a/src/backend/InvenTree/templates/js/translated/return_order.js
+++ b/src/backend/InvenTree/templates/js/translated/return_order.js
@@ -300,7 +300,7 @@ function loadReturnOrderTable(table, options={}) {
                         return '{% trans "Invalid Customer" %}';
                     }
 
-                    return imageHoverIcon(row.customer_detail.image) + renderLink(row.customer_detail.name, `/company/${row.customer}/sales-orders/`);
+                    return imageHoverIcon(row.customer_detail.image) + renderLink(row.customer_detail.name, `/company/${row.customer}/?display=sales-orders/`);
                 }
             },
             {
@@ -384,7 +384,7 @@ function loadReturnOrderTable(table, options={}) {
                 visible: false,
                 formatter: function(value, row) {
                     return formatCurrency(value, {
-                        currency: row.order_currency
+                        currency: row.order_currency ?? row.customer_detail?.currency,
                     });
                 }
             }

--- a/src/backend/InvenTree/templates/js/translated/sales_order.js
+++ b/src/backend/InvenTree/templates/js/translated/sales_order.js
@@ -788,7 +788,7 @@ function loadSalesOrderTable(table, options) {
                         return '{% trans "Invalid Customer" %}';
                     }
 
-                    return imageHoverIcon(row.customer_detail.image) + renderLink(row.customer_detail.name, `/company/${row.customer}/sales-orders/`);
+                    return imageHoverIcon(row.customer_detail.image) + renderLink(row.customer_detail.name, `/company/${row.customer}/?display=sales-orders/`);
                 }
             },
             {
@@ -857,7 +857,7 @@ function loadSalesOrderTable(table, options) {
                 sortable: true,
                 formatter: function(value, row) {
                     return formatCurrency(value, {
-                        currency: row.order_currency,
+                        currency: row.order_currency ?? row.customer_detail?.currency,
                     });
                 }
             }

--- a/src/frontend/src/tables/purchasing/PurchaseOrderTable.tsx
+++ b/src/frontend/src/tables/purchasing/PurchaseOrderTable.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { AddItemButton } from '../../components/buttons/AddItemButton';
 import { Thumbnail } from '../../components/images/Thumbnail';
+import { formatCurrency } from '../../defaults/formatters';
 import { ApiEndpoints } from '../../enums/ApiEndpoints';
 import { ModelType } from '../../enums/ModelType';
 import { UserRoles } from '../../enums/Roles';
@@ -21,8 +22,7 @@ import {
   ReferenceColumn,
   ResponsibleColumn,
   StatusColumn,
-  TargetDateColumn,
-  TotalPriceColumn
+  TargetDateColumn
 } from '../ColumnRenderers';
 import {
   AssignedToMeFilter,
@@ -92,7 +92,16 @@ export function PurchaseOrderTable({
       ProjectCodeColumn(),
       CreationDateColumn(),
       TargetDateColumn(),
-      TotalPriceColumn(),
+      {
+        accessor: 'total_price',
+        title: t`Total Price`,
+        sortable: true,
+        render: (record: any) => {
+          return formatCurrency(record.total_price, {
+            currency: record.order_currency ?? record.supplier_detail?.currency
+          });
+        }
+      },
       ResponsibleColumn()
     ];
   }, []);

--- a/src/frontend/src/tables/sales/ReturnOrderTable.tsx
+++ b/src/frontend/src/tables/sales/ReturnOrderTable.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react';
 
 import { AddItemButton } from '../../components/buttons/AddItemButton';
 import { Thumbnail } from '../../components/images/Thumbnail';
+import { formatCurrency } from '../../defaults/formatters';
 import { ApiEndpoints } from '../../enums/ApiEndpoints';
 import { ModelType } from '../../enums/ModelType';
 import { UserRoles } from '../../enums/Roles';
@@ -18,8 +19,7 @@ import {
   ReferenceColumn,
   ResponsibleColumn,
   StatusColumn,
-  TargetDateColumn,
-  TotalPriceColumn
+  TargetDateColumn
 } from '../ColumnRenderers';
 import {
   AssignedToMeFilter,
@@ -81,7 +81,16 @@ export function ReturnOrderTable({ params }: { params?: any }) {
       CreationDateColumn(),
       TargetDateColumn(),
       ResponsibleColumn(),
-      TotalPriceColumn()
+      {
+        accessor: 'total_price',
+        title: t`Total Price`,
+        sortable: true,
+        render: (record: any) => {
+          return formatCurrency(record.total_price, {
+            currency: record.order_currency ?? record.customer_detail?.currency
+          });
+        }
+      }
     ];
   }, []);
 

--- a/src/frontend/src/tables/sales/SalesOrderTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderTable.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { AddItemButton } from '../../components/buttons/AddItemButton';
 import { Thumbnail } from '../../components/images/Thumbnail';
+import { formatCurrency } from '../../defaults/formatters';
 import { ApiEndpoints } from '../../enums/ApiEndpoints';
 import { ModelType } from '../../enums/ModelType';
 import { UserRoles } from '../../enums/Roles';
@@ -21,8 +22,7 @@ import {
   ReferenceColumn,
   ShipmentDateColumn,
   StatusColumn,
-  TargetDateColumn,
-  TotalPriceColumn
+  TargetDateColumn
 } from '../ColumnRenderers';
 import {
   AssignedToMeFilter,
@@ -117,7 +117,16 @@ export function SalesOrderTable({
       CreationDateColumn(),
       TargetDateColumn(),
       ShipmentDateColumn(),
-      TotalPriceColumn()
+      {
+        accessor: 'total_price',
+        title: t`Total Price`,
+        sortable: true,
+        render: (record: any) => {
+          return formatCurrency(record.total_price, {
+            currency: record.order_currency ?? record.customer_detail?.currency
+          });
+        }
+      }
     ];
   }, []);
 


### PR DESCRIPTION
If an order does not have a defined currency, the currency should fall back to the currency for the associated company.

This was *not* happening, but it is now!