### PR TITLE
Add contenttype model to API

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,13 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 190
+INVENTREE_API_VERSION = 191
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v191 - 2024-04-22 : https://github.com/inventree/InvenTree/pull/7079
+    - Adds API endpoints for Contenttype model
 
 v190 - 2024-04-19 : https://github.com/inventree/InvenTree/pull/7024
     - Adds "active" field to the Company API endpoints

--- a/src/backend/InvenTree/InvenTree/metadata.py
+++ b/src/backend/InvenTree/InvenTree/metadata.py
@@ -280,6 +280,8 @@ class InvenTreeMetadata(SimpleMetadata):
                 # Special case for 'user' model
                 if field_info['model'] == 'user':
                     field_info['api_url'] = '/api/user/'
+                elif field_info['model'] == 'contenttype':
+                    field_info['api_url'] = '/api/contenttype/'
                 else:
                     field_info['api_url'] = model.get_api_url()
 

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -818,7 +818,7 @@ common_api_urls = [
     ),
     # Contenttype
     path(
-        'contenttype',
+        'contenttype/',
         include([
             path(
                 '<int:pk>/', ContentTypeDetail.as_view(), name='api-contenttype-detail'

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -635,6 +635,11 @@ class ContentTypeDetail(RetrieveAPI):
     serializer_class = common.serializers.ContentTypeSerializer
     permission_classes = [permissions.IsAuthenticated]
 
+
+@extend_schema(operation_id='contenttype_retrieve_model')
+class ContentTypeModelDetail(ContentTypeDetail):
+    """Detail view for a ContentType model."""
+
     def get_object(self):
         """Attempt to find a ContentType object with the provided key."""
         model_ref = self.kwargs.get('model', None)
@@ -837,7 +842,7 @@ common_api_urls = [
             ),
             path(
                 '<str:model>/',
-                ContentTypeDetail.as_view(),
+                ContentTypeModelDetail.as_view(),
                 name='api-contenttype-detail-modelname',
             ),
             path('', ContentTypeList.as_view(), name='api-contenttype-list'),

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -635,6 +635,18 @@ class ContentTypeDetail(RetrieveAPI):
     serializer_class = common.serializers.ContentTypeSerializer
     permission_classes = [permissions.IsAuthenticated]
 
+    def get_object(self):
+        """Attempt to find a ContentType object with the provided key."""
+        model_ref = self.kwargs.get('model', None)
+        if model_ref:
+            qs = self.filter_queryset(self.get_queryset())
+            try:
+                return qs.get(model=model_ref)
+            except ContentType.DoesNotExist:
+                raise NotFound()
+
+        return super().get_object()
+
 
 settings_api_urls = [
     # User settings
@@ -822,6 +834,11 @@ common_api_urls = [
         include([
             path(
                 '<int:pk>/', ContentTypeDetail.as_view(), name='api-contenttype-detail'
+            ),
+            path(
+                '<str:model>/',
+                ContentTypeDetail.as_view(),
+                name='api-contenttype-detail-modelname',
             ),
             path('', ContentTypeList.as_view(), name='api-contenttype-list'),
         ]),

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -3,6 +3,7 @@
 import json
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.http.response import HttpResponse
 from django.urls import include, path, re_path
 from django.utils.decorators import method_decorator
@@ -619,6 +620,22 @@ class FlagDetail(RetrieveAPI):
         return {key: value}
 
 
+class ContentTypeList(ListAPI):
+    """List view for ContentTypes."""
+
+    queryset = ContentType.objects.all()
+    serializer_class = common.serializers.ContentTypeSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class ContentTypeDetail(RetrieveAPI):
+    """Detail view for a ContentType model."""
+
+    queryset = ContentType.objects.all()
+    serializer_class = common.serializers.ContentTypeSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
 settings_api_urls = [
     # User settings
     path(
@@ -797,6 +814,16 @@ common_api_urls = [
                 include([path('', StatusView.as_view(), name='api-status')]),
             ),
             path('', AllStatusViews.as_view(), name='api-status-all'),
+        ]),
+    ),
+    # Contenttype
+    path(
+        'contenttype',
+        include([
+            path(
+                '<int:pk>/', ContentTypeDetail.as_view(), name='api-contenttype-detail'
+            ),
+            path('', ContentTypeList.as_view(), name='api-contenttype-list'),
         ]),
     ),
 ]

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -649,8 +649,7 @@ class ContentTypeModelDetail(ContentTypeDetail):
                 return qs.get(model=model_ref)
             except ContentType.DoesNotExist:
                 raise NotFound()
-
-        return super().get_object()
+        raise NotFound()
 
 
 settings_api_urls = [

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -17,6 +17,7 @@ from InvenTree.serializers import (
     InvenTreeImageSerializerField,
     InvenTreeModelSerializer,
 )
+from plugin import registry as plugin_registry
 from users.serializers import OwnerSerializer
 
 
@@ -307,16 +308,21 @@ class FlagSerializer(serializers.Serializer):
 class ContentTypeSerializer(serializers.Serializer):
     """Serializer for ContentType models."""
 
+    pk = serializers.IntegerField(read_only=True)
     app_label = serializers.CharField(read_only=True)
     model = serializers.CharField(read_only=True)
     app_labeled_name = serializers.CharField(read_only=True)
-    natural_key = serializers.CharField(read_only=True)
+    is_plugin = serializers.SerializerMethodField('get_is_plugin', read_only=True)
 
     class Meta:
         """Meta options for ContentTypeSerializer."""
 
         model = ContentType
-        fields = '__all__'
+        fields = ['pk', 'app_label', 'model', 'app_labeled_name', 'is_plugin']
+
+    def get_is_plugin(self, obj) -> bool:
+        """Return True if the model is a plugin model."""
+        return obj.app_label in plugin_registry.installed_apps
 
 
 class CustomUnitSerializer(InvenTreeModelSerializer):

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -1,5 +1,6 @@
 """JSON serializers for common components."""
 
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import OuterRef, Subquery
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -301,6 +302,21 @@ class FlagSerializer(serializers.Serializer):
             data['conditions'] = self.instance[instance]
 
         return data
+
+
+class ContentTypeSerializer(serializers.Serializer):
+    """Serializer for ContentType models."""
+
+    app_label = serializers.CharField(read_only=True)
+    model = serializers.CharField(read_only=True)
+    app_labeled_name = serializers.CharField(read_only=True)
+    natural_key = serializers.CharField(read_only=True)
+
+    class Meta:
+        """Meta options for ContentTypeSerializer."""
+
+        model = ContentType
+        fields = '__all__'
 
 
 class CustomUnitSerializer(InvenTreeModelSerializer):

--- a/src/backend/InvenTree/common/tests.py
+++ b/src/backend/InvenTree/common/tests.py
@@ -1379,7 +1379,7 @@ class ContentTypeAPITest(InvenTreeAPITestCase):
         )
 
         # PK should not work on model name endpoint
-        response = self.get(
+        self.get(
             reverse('api-contenttype-detail-modelname', kwargs={'model': None}),
             expected_code=404,
         )


### PR DESCRIPTION
This adds APIs to access the contentype model. This is useful if you want to have a API form with a select that references models.

Closes #6755