### PR TITLE
Remove coveralls integration

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -290,16 +290,6 @@ jobs:
         run: python3 .github/scripts/check_migration_files.py
       - name: Coverage Tests
         run: invoke test --coverage
-      - name: Upload Coverage Report to Coveralls
-        if: always()
-        uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 # pin@v2.2.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: backend
-          file: coverage.xml
-          git-commit: ${{ github.sha }}
-          git-branch: ${{ github.ref }}
-          parallel: true
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # pin@v4.3.0
         if: always()
@@ -432,14 +422,6 @@ jobs:
           update: true
       - name: Run Tests
         run: invoke test --migrations --report --coverage
-      - name: Upload Coverage Report to Coveralls
-        if: always()
-        uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 # pin@v2.2.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: migrations
-          git-commit: ${{ github.sha }}
-          git-branch: ${{ github.ref }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # pin@v4.3.0
         if: always()
@@ -576,19 +558,3 @@ jobs:
         with:
           name: frontend-build
           path: src/backend/InvenTree/web/static/web
-
-  finish_coverage:
-    name: Finish Coverage
-    runs-on: ubuntu-20.04
-    needs: ["platform_ui", "coverage", "migration-tests", "paths-filter"]
-    if: (needs.paths-filter.outputs.server == 'true' || needs.paths-filter.outputs.frontend == 'true' || needs.paths-filter.outputs.force == 'true') && (needs.platform_ui.result == 'success' || needs.coverage.result == 'success' || needs.migration-tests.result == 'success')
-
-    steps:
-      - name: Finish coverage reporting
-        uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 # pin@v2.2.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          carryforward: "pui,backend,migrations"
-          parallel-finished: true
-          git-commit: ${{ github.sha }}
-          git-branch: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/9bbb2101-0a4d-41e7-ad56-b63fb6053094/deploy-status)](https://app.netlify.com/sites/inventree/deploys)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=inventree_InvenTree&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=inventree_InvenTree)
 
-[![Coveralls](https://img.shields.io/coveralls/github/inventree/InvenTree)](https://coveralls.io/github/inventree/InvenTree)
 [![codecov](https://codecov.io/gh/inventree/InvenTree/graph/badge.svg?token=9DZRGUUV7B)](https://codecov.io/gh/inventree/InvenTree)
 [![Crowdin](https://badges.crowdin.net/inventree/localized.svg)](https://crowdin.com/project/inventree)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/inventree/inventree)
@@ -95,7 +94,7 @@ InvenTree is designed to be **extensible**, and provides multiple options for **
   <ul>
     <li><a href="https://hub.docker.com/r/inventree/inventree">Docker</a></li>
     <li><a href="https://crowdin.com/project/inventree">Crowdin</a></li>
-    <li><a href="https://coveralls.io/github/inventree/InvenTree">Coveralls</a></li>
+    <li><a href="https://app.codecov.io/gh/inventree/InvenTree">Codecov</a></li>
     <li><a href="https://app.deepsource.com/gh/inventree/InvenTree">DeepSource</a></li>
     <li><a href="https://packager.io/gh/inventree/InvenTree">Packager.io</a></li>
   </ul>

--- a/docs/docs/credits.md
+++ b/docs/docs/credits.md
@@ -39,7 +39,6 @@ InvenTree relies on the following Python libraries:
 | [flake8](https://pypi.org/project/flake8/) | MIT | style checking |
 | [pep8-naming](https://pypi.org/project/pep8-naming/) | Expat | name checking |
 | [coverage](https://pypi.org/project/coverage/) | Apache-2.0 | coverage checking |
-| [coveralls](https://pypi.org/project/coveralls/) | MIT | coverage uploader |
 | [django-formtools](https://pypi.org/project/django-formtools/) | MIT | better forms / wizards |
 | [django-allauth](https://pypi.org/project/django-allauth/) | MIT | SSO for django |
 | [pint](https://pint.readthedocs.io/en/stable/) | [licence](https://github.com/hgrecco/pint/blob/master/LICENSE) | Physical unit conversion |

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -37,7 +37,7 @@ InvenTree is built using the Django framework, which has a strong focus on secur
 
 ### Test coverage
 
-We run coverage tests on our codebase to ensure that we have a high level of test coverage above 90%. This is public and can be found [here](https://coveralls.io/github/inventree/InvenTree).
+We run coverage tests on our codebase to ensure that we have a high level of test coverage above 90%. This is public and can be found [here](https://app.codecov.io/gh/inventree/InvenTree).
 
 ### Pinning dependencies
 

--- a/src/backend/requirements-dev.in
+++ b/src/backend/requirements-dev.in
@@ -1,7 +1,6 @@
 # Dev requirements for InvenTree
 -c requirements.txt
 coverage[toml]                          # Unit test coverage
-coveralls==2.1.2                        # Coveralls linking (for tracking coverage)  # PINNED 2022-06-28 - Old version needed for correct upload
 django-admin-shell                      # Remote shell access
 django-querycount                       # Display number of URL queries for requests
 django-slowtests                        # Show which unit tests are running slowly

--- a/src/backend/requirements-dev.txt
+++ b/src/backend/requirements-dev.txt
@@ -4,21 +4,15 @@ asgiref==3.8.1
     # via django
 build==1.2.1
     # via pip-tools
-certifi==2024.2.2
-    # via requests
 cffi==1.16.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.3.2
-    # via
-    #   pdfminer-six
-    #   requests
+    # via pdfminer-six
 click==8.1.7
     # via pip-tools
 coverage[toml]==5.5
-    # via coveralls
-coveralls==2.1.2
 cryptography==42.0.5
     # via pdfminer-six
 distlib==0.3.8
@@ -31,14 +25,10 @@ django-admin-shell==2.0.1
 django-querycount==0.8.3
 django-slowtests==1.1.1
 django-test-migrations==1.3.0
-docopt==0.6.2
-    # via coveralls
 filelock==3.13.3
     # via virtualenv
 identify==2.5.35
     # via pre-commit
-idna==3.6
-    # via requests
 importlib-metadata==7.0.0
     # via build
 isort==5.13.2
@@ -61,8 +51,6 @@ pyproject-hooks==1.0.0
     #   pip-tools
 pyyaml==6.0.1
     # via pre-commit
-requests==2.31.0
-    # via coveralls
 setuptools==69.5.1
     # via
     #   nodeenv
@@ -80,8 +68,6 @@ typing-extensions==4.11.0
     # via
     #   asgiref
     #   django-test-migrations
-urllib3==2.2.1
-    # via requests
 virtualenv==20.25.1
     # via pre-commit
 wheel==0.43.0


### PR DESCRIPTION
This PR removes coveralls now that codecov is working well.

- Closes https://github.com/inventree/InvenTree/issues/6966
- Closes https://github.com/inventree/InvenTree/pull/6986

Coveralls checks are now breaking a bunch of workflows:

- https://github.com/inventree/InvenTree/actions/runs/8789476903/job/24119663894?pr=7094
- https://github.com/inventree/InvenTree/actions/runs/8789400588/job/24119388223?pr=7092
- https://github.com/inventree/InvenTree/actions/runs/8789474926/job/24119585173?pr=7093
- https://github.com/inventree/InvenTree/actions/runs/8789477788/job/24119726308?pr=7095
- etc

@matmair I k now you wanted to wait a bit but our workflows are breaking now, what are your thoughts?