### PR TITLE
[FR] Increase Length of URL limit on import

### DIFF
--- a/src/backend/InvenTree/company/models.py
+++ b/src/backend/InvenTree/company/models.py
@@ -513,6 +513,7 @@ class ManufacturerPart(
         null=True,
         verbose_name=_('Link'),
         help_text=_('URL for external manufacturer part link'),
+        max_length=2000,
     )
 
     description = models.CharField(
@@ -829,6 +830,7 @@ class SupplierPart(
         null=True,
         verbose_name=_('Link'),
         help_text=_('URL for external supplier part link'),
+        max_length=2000,
     )
 
     description = models.CharField(


### PR DESCRIPTION
This increaes the max_length for links to 200 chars.
Why 2k? It seems reasonably long enough, the longest I could find on alibaba (not that I would use them as a supplier) is about 800ish - double it to be safe and this should be long enough.

Why not DB controllable? That would introduce a new surface to test for and make assumptions about the data model hard, which for me outweighs the possible gains.
Why not no limit? Opens us up to Denial of Service type of problems, we had that in the past and got according feedback from security researchers (see our Security Advisories).

Fixes #7118