### PR TITLE
Add field description to the currency_exchange_retrieve API call

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,13 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 193
+INVENTREE_API_VERSION = 194
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v194 - 2024-05-01 : https://github.com/inventree/InvenTree/pull/7147
+    -  Adds field description to the currency_exchange_retrieve API call
 
 v193 - 2024-04-30 : https://github.com/inventree/InvenTree/pull/7144
     - Adds "assigned_to" filter to PurchaseOrder / SalesOrder / ReturnOrder API endpoints

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -127,6 +127,7 @@ class CurrencyExchangeView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = None
 
+    @extend_schema(responses={200: common.serializers.CurrencyExchangeSerializer()})
     def get(self, request, format=None):
         """Return information on available currency conversions."""
         # Extract a list of all available rates

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -127,7 +127,7 @@ class CurrencyExchangeView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = None
 
-    @extend_schema(responses={200: common.serializers.CurrencyExchangeSerializer()})
+    @extend_schema(responses={200: common.serializers.CurrencyExchangeSerializer})
     def get(self, request, format=None):
         """Return information on available currency conversions."""
         # Extract a list of all available rates

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -125,6 +125,17 @@ class UserSettingsSerializer(SettingsSerializer):
     user = serializers.PrimaryKeyRelatedField(read_only=True)
 
 
+class CurrencyExchangeSerializer(serializers.Serializer):
+    """Serializer for a Currency Exchange request.
+
+    It's only purpose is describing the results correctly in the API schema right now.
+    """
+
+    base_currency = serializers.CharField(read_only=True)
+    exchange_rates = serializers.DictField(child=serializers.FloatField())
+    updated = serializers.DateTimeField(read_only=True)
+
+
 class GenericReferencedSettingSerializer(SettingsSerializer):
     """Serializer for a GenericReferencedSetting model.
 


### PR DESCRIPTION
While poking around with the OpenAPI codegen I ended up generating blank response from the currency/exchange endpoint. 

I fixed it with a custom serializer with the knowledge recently learned from wolflu05.

![kép](https://github.com/inventree/InvenTree/assets/1609182/a764ed48-53d9-498e-afd4-5951d1969a7c)
