### PR TITLE
Cookie mode

### DIFF
--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -97,10 +97,11 @@ Depending on how your InvenTree installation is configured, you will need to pay
 | INVENTREE_CORS_ORIGIN_ALLOW_ALL | cors.allow_all | Allow all remote URLS for CORS checks | False |
 | INVENTREE_CORS_ORIGIN_WHITELIST | cors.whitelist | List of whitelisted CORS URLs. Refer to the [django-cors-headers documentation](https://github.com/adamchainz/django-cors-headers#cors_allowed_origins-sequencestr) | Uses the *INVENTREE_SITE_URL* parameter, if set. Otherwise, an empty list. |
 | INVENTREE_CORS_ORIGIN_REGEX | cors.regex | List of regular expressions for CORS whitelisted URL patterns | *Empty list* |
+| INVENTREE_CORS_ALLOW_CREDENTIALS | cors.allow_credentials | Allow cookies in cross-site requests | True |
 | INVENTREE_USE_X_FORWARDED_HOST | use_x_forwarded_host | Use forwarded host header | False |
 | INVENTREE_USE_X_FORWARDED_PORT | use_x_forwarded_port | Use forwarded port header | False |
-| INVENTREE_CORS_ALLOW_CREDENTIALS | cors.allow_credentials | Allow cookies in cross-site requests | True |
-| INVENTREE_SESSION_COOKIE_SECURE | session_cookie_secure | Enforce secure session cookies | False |
+| INVENTREE_SESSION_COOKIE_SECURE | cookie.secure | Enforce secure session cookies | False |
+| INVENTREE_COOKIE_SAMESITE | cookie.samesite | Session cookie mode. Must be one of `None | "Strict" | "Lax"`. Refer to the [mozilla developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) for more information. | `"Lax"` |
 
 ### Proxy Settings
 

--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -101,7 +101,7 @@ Depending on how your InvenTree installation is configured, you will need to pay
 | INVENTREE_USE_X_FORWARDED_HOST | use_x_forwarded_host | Use forwarded host header | `False` |
 | INVENTREE_USE_X_FORWARDED_PORT | use_x_forwarded_port | Use forwarded port header | `False` |
 | INVENTREE_SESSION_COOKIE_SECURE | cookie.secure | Enforce secure session cookies | `False` |
-| INVENTREE_COOKIE_SAMESITE | cookie.samesite | Session cookie mode. Must be one of `Strict | Lax | None`. Refer to the [mozilla developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) for more information. | `Lax` |
+| INVENTREE_COOKIE_SAMESITE | cookie.samesite | Session cookie mode. Must be one of `Strict | Lax | None`. Refer to the [mozilla developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) for more information. | `None` |
 
 ### Proxy Settings
 

--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -94,14 +94,14 @@ Depending on how your InvenTree installation is configured, you will need to pay
 | --- | --- | --- | --- |
 | INVENTREE_ALLOWED_HOSTS | allowed_hosts | List of allowed hosts | `*` |
 | INVENTREE_TRUSTED_ORIGINS | trusted_origins | List of trusted origins. Refer to the [django documentation]({% include "django.html" %}/ref/settings/#csrf-trusted-origins) | Uses the *INVENTREE_SITE_URL* parameter, if set. Otherwise, an empty list. |
-| INVENTREE_CORS_ORIGIN_ALLOW_ALL | cors.allow_all | Allow all remote URLS for CORS checks | False |
+| INVENTREE_CORS_ORIGIN_ALLOW_ALL | cors.allow_all | Allow all remote URLS for CORS checks | `False` |
 | INVENTREE_CORS_ORIGIN_WHITELIST | cors.whitelist | List of whitelisted CORS URLs. Refer to the [django-cors-headers documentation](https://github.com/adamchainz/django-cors-headers#cors_allowed_origins-sequencestr) | Uses the *INVENTREE_SITE_URL* parameter, if set. Otherwise, an empty list. |
 | INVENTREE_CORS_ORIGIN_REGEX | cors.regex | List of regular expressions for CORS whitelisted URL patterns | *Empty list* |
-| INVENTREE_CORS_ALLOW_CREDENTIALS | cors.allow_credentials | Allow cookies in cross-site requests | True |
-| INVENTREE_USE_X_FORWARDED_HOST | use_x_forwarded_host | Use forwarded host header | False |
-| INVENTREE_USE_X_FORWARDED_PORT | use_x_forwarded_port | Use forwarded port header | False |
-| INVENTREE_SESSION_COOKIE_SECURE | cookie.secure | Enforce secure session cookies | False |
-| INVENTREE_COOKIE_SAMESITE | cookie.samesite | Session cookie mode. Must be one of `None | "Strict" | "Lax"`. Refer to the [mozilla developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) for more information. | `"Lax"` |
+| INVENTREE_CORS_ALLOW_CREDENTIALS | cors.allow_credentials | Allow cookies in cross-site requests | `True` |
+| INVENTREE_USE_X_FORWARDED_HOST | use_x_forwarded_host | Use forwarded host header | `False` |
+| INVENTREE_USE_X_FORWARDED_PORT | use_x_forwarded_port | Use forwarded port header | `False` |
+| INVENTREE_SESSION_COOKIE_SECURE | cookie.secure | Enforce secure session cookies | `False` |
+| INVENTREE_COOKIE_SAMESITE | cookie.samesite | Session cookie mode. Must be one of `Strict | Lax | None`. Refer to the [mozilla developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) for more information. | `Lax` |
 
 ### Proxy Settings
 

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1106,11 +1106,17 @@ if (
     )
     sys.exit(-1)
 
+COOKIE_MODE = get_setting('INVENTREE_COOKIE_MODE', 'cookie_mode', 'Lax')
+
+if COOKIE_MODE not in ['Lax', 'Strict', None]:
+    logger.error('Invalid cookie mode: %s', COOKIE_MODE)
+    sys.exit(-1)
+
 # Additional CSRF settings
 CSRF_HEADER_NAME = 'HTTP_X_CSRFTOKEN'
 CSRF_COOKIE_NAME = 'csrftoken'
-CSRF_COOKIE_SAMESITE = 'Lax'
-SESSION_COOKIE_SAMESITE = 'Lax'
+CSRF_COOKIE_SAMESITE = COOKIE_MODE
+SESSION_COOKIE_SAMESITE = COOKIE_MODE
 SESSION_COOKIE_SECURE = get_boolean_setting(
     'INVENTREE_SESSION_COOKIE_SECURE', 'session_cookie_secure', False
 )

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1106,11 +1106,19 @@ if (
     )
     sys.exit(-1)
 
-COOKIE_MODE = get_setting('INVENTREE_COOKIE_SAMESITE', 'cookie.samesite', 'Lax')
+COOKIE_MODE = (
+    str(get_setting('INVENTREE_COOKIE_SAMESITE', 'cookie.samesite', 'Lax'))
+    .lower()
+    .strip()
+)
 
-if COOKIE_MODE not in ['Lax', 'Strict', None]:
+valid_cookie_modes = {'lax': 'Lax', 'strict': 'Strict', 'none': None, 'null': None}
+
+if COOKIE_MODE not in valid_cookie_modes.keys():
     logger.error('Invalid cookie mode: %s', COOKIE_MODE)
     sys.exit(-1)
+
+COOKIE_MODE = valid_cookie_modes[COOKIE_MODE.lower()]
 
 # Additional CSRF settings
 CSRF_HEADER_NAME = 'HTTP_X_CSRFTOKEN'

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1106,7 +1106,7 @@ if (
     )
     sys.exit(-1)
 
-COOKIE_MODE = get_setting('INVENTREE_COOKIE_MODE', 'cookie_mode', 'Lax')
+COOKIE_MODE = get_setting('INVENTREE_COOKIE_SAMESITE', 'cookie.samesite', 'Lax')
 
 if COOKIE_MODE not in ['Lax', 'Strict', None]:
     logger.error('Invalid cookie mode: %s', COOKIE_MODE)
@@ -1118,7 +1118,7 @@ CSRF_COOKIE_NAME = 'csrftoken'
 CSRF_COOKIE_SAMESITE = COOKIE_MODE
 SESSION_COOKIE_SAMESITE = COOKIE_MODE
 SESSION_COOKIE_SECURE = get_boolean_setting(
-    'INVENTREE_SESSION_COOKIE_SECURE', 'session_cookie_secure', False
+    'INVENTREE_SESSION_COOKIE_SECURE', 'cookie.secure', False
 )
 
 USE_X_FORWARDED_HOST = get_boolean_setting(

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1107,7 +1107,7 @@ if (
     sys.exit(-1)
 
 COOKIE_MODE = (
-    str(get_setting('INVENTREE_COOKIE_SAMESITE', 'cookie.samesite', 'Lax'))
+    str(get_setting('INVENTREE_COOKIE_SAMESITE', 'cookie.samesite', 'None'))
     .lower()
     .strip()
 )

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1115,7 +1115,7 @@ COOKIE_MODE = (
 valid_cookie_modes = {'lax': 'Lax', 'strict': 'Strict', 'none': None, 'null': None}
 
 if COOKIE_MODE not in valid_cookie_modes.keys():
-    logger.error('Invalid cookie mode: %s', COOKIE_MODE)
+    logger.error('Invalid cookie samesite mode: %s', COOKIE_MODE)
     sys.exit(-1)
 
 COOKIE_MODE = valid_cookie_modes[COOKIE_MODE.lower()]

--- a/src/backend/InvenTree/config_template.yaml
+++ b/src/backend/InvenTree/config_template.yaml
@@ -184,7 +184,7 @@ use_x_forwarded_port: false
 # Cookie settings
 cookie:
   secure: false
-  samesite: 'Lax'
+  samesite: none
 
 # Cross Origin Resource Sharing (CORS) settings (see https://github.com/adamchainz/django-cors-headers)
 cors:

--- a/src/backend/InvenTree/config_template.yaml
+++ b/src/backend/InvenTree/config_template.yaml
@@ -181,6 +181,11 @@ use_x_forwarded_host: false
 # Override with the environment variable INVENTREE_USE_X_FORWARDED_PORT
 use_x_forwarded_port: false
 
+# Cookie settings
+cookie:
+  secure: false
+  samesite: 'Lax'
+
 # Cross Origin Resource Sharing (CORS) settings (see https://github.com/adamchainz/django-cors-headers)
 cors:
   allow_all: true


### PR DESCRIPTION
A follow-up to https://github.com/inventree/InvenTree/pull/6970

Now that we are using session auth, we need to be able to set the "cookie samesite" value to None (to allow the cookies to be sent as part of a CORS request). 

Without this, the netlify preview no longer works, among other things.