### PR TITLE
Mark as 0.16.0 dev version

### DIFF
--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -19,7 +19,7 @@ from dulwich.repo import NotGitRepository, Repo
 from .api_version import INVENTREE_API_TEXT, INVENTREE_API_VERSION
 
 # InvenTree software version
-INVENTREE_SW_VERSION = '0.15.0 dev'
+INVENTREE_SW_VERSION = '0.16.0 dev'
 
 # Discover git
 try:


### PR DESCRIPTION
Bump version from `0.15.0 dev` to `0.16.0 dev`