### PR TITLE
[PUI] Refactoring forms

### DIFF
--- a/src/frontend/src/components/forms/ApiForm.tsx
+++ b/src/frontend/src/components/forms/ApiForm.tsx
@@ -396,18 +396,14 @@ export function ApiForm({
           case 204:
             // Form was submitted successfully
 
-            // Optionally call the onFormSuccess callback
             if (props.onFormSuccess) {
+              // A custom callback hook is provided
               props.onFormSuccess(response.data);
-            }
-
-            // If we want to automatically follow the returned data
-            if (props.follow && props.modelType && response.data?.pk) {
+            } else if (props.follow && props.modelType && response.data?.pk) {
+              // If we want to automatically follow the returned data
               navigate(getDetailUrl(props.modelType, response.data?.pk));
-            }
-
-            // If we want to automatically update or reload a linked table
-            if (props.table) {
+            } else if (props.table) {
+              // If we want to automatically update or reload a linked table
               let pk_field = props.pk_field ?? 'pk';
               if (response?.data[pk_field]) {
                 props.table.updateRecord(response.data);

--- a/src/frontend/src/components/forms/ApiForm.tsx
+++ b/src/frontend/src/components/forms/ApiForm.tsx
@@ -399,13 +399,16 @@ export function ApiForm({
             if (props.onFormSuccess) {
               // A custom callback hook is provided
               props.onFormSuccess(response.data);
-            } else if (props.follow && props.modelType && response.data?.pk) {
+            }
+
+            if (props.follow && props.modelType && response.data?.pk) {
               // If we want to automatically follow the returned data
               navigate(getDetailUrl(props.modelType, response.data?.pk));
             } else if (props.table) {
               // If we want to automatically update or reload a linked table
               let pk_field = props.pk_field ?? 'pk';
-              if (response?.data[pk_field]) {
+
+              if (props.pk && response?.data[pk_field]) {
                 props.table.updateRecord(response.data);
               } else {
                 props.table.refreshTable();

--- a/src/frontend/src/components/forms/ApiForm.tsx
+++ b/src/frontend/src/components/forms/ApiForm.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../functions/forms';
 import { invalidResponse } from '../../functions/notifications';
 import { getDetailUrl } from '../../functions/urls';
+import { TableState } from '../../hooks/UseTable';
 import { PathParams } from '../../states/ApiState';
 import { Boundary } from '../Boundary';
 import {
@@ -54,6 +55,7 @@ export interface ApiFormAction {
  * Properties for the ApiForm component
  * @param url : The API endpoint to fetch the form data from
  * @param pk : Optional primary-key value when editing an existing object
+ * @param pk_field : Optional primary-key field name (default: pk)
  * @param pathParams : Optional path params for the url
  * @param method : Optional HTTP method to use when submitting the form (default: GET)
  * @param fields : The fields to render in the form
@@ -67,10 +69,12 @@ export interface ApiFormAction {
  * @param onFormError : A callback function to call when the form is submitted with errors.
  * @param modelType : Define a model type for this form
  * @param follow : Boolean, follow the result of the form (if possible)
+ * @param table : Table to update on success (if provided)
  */
 export interface ApiFormProps {
   url: ApiEndpoints | string;
   pk?: number | string | undefined;
+  pk_field?: string;
   pathParams?: PathParams;
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   fields?: ApiFormFieldSet;
@@ -87,6 +91,7 @@ export interface ApiFormProps {
   successMessage?: string;
   onFormSuccess?: (data: any) => void;
   onFormError?: () => void;
+  table?: TableState;
   modelType?: ModelType;
   follow?: boolean;
   actions?: ApiFormAction[];
@@ -396,9 +401,18 @@ export function ApiForm({
               props.onFormSuccess(response.data);
             }
 
-            if (props.follow) {
-              if (props.modelType && response.data?.pk) {
-                navigate(getDetailUrl(props.modelType, response.data?.pk));
+            // If we want to automatically follow the returned data
+            if (props.follow && props.modelType && response.data?.pk) {
+              navigate(getDetailUrl(props.modelType, response.data?.pk));
+            }
+
+            // If we want to automatically update or reload a linked table
+            if (props.table) {
+              let pk_field = props.pk_field ?? 'pk';
+              if (response?.data[pk_field]) {
+                props.table.updateRecord(response.data);
+              } else {
+                props.table.refreshTable();
               }
             }
 

--- a/src/frontend/src/components/settings/SettingItem.tsx
+++ b/src/frontend/src/components/settings/SettingItem.tsx
@@ -1,4 +1,3 @@
-import { t } from '@lingui/macro';
 import {
   Button,
   Group,
@@ -9,103 +8,25 @@ import {
   Text,
   useMantineColorScheme
 } from '@mantine/core';
-import { showNotification } from '@mantine/notifications';
 import { IconEdit } from '@tabler/icons-react';
 import { useMemo } from 'react';
 
-import { api } from '../../App';
-import { ModelType } from '../../enums/ModelType';
-import { openModalApiForm } from '../../functions/forms';
-import { apiUrl } from '../../states/ApiState';
 import { SettingsStateProps } from '../../states/SettingsState';
-import { Setting, SettingType } from '../../states/states';
+import { Setting } from '../../states/states';
 import { vars } from '../../theme';
-import { ApiFormFieldType } from '../forms/fields/ApiFormField';
 
 /**
  * Render a single setting value
  */
 function SettingValue({
-  settingsState,
   setting,
-  onChange
+  onEdit,
+  onToggle
 }: {
-  settingsState: SettingsStateProps;
   setting: Setting;
-  onChange?: () => void;
+  onEdit: (setting: Setting) => void;
+  onToggle: (setting: Setting, value: boolean) => void;
 }) {
-  // Callback function when a boolean value is changed
-  function onToggle(value: boolean) {
-    api
-      .patch(
-        apiUrl(settingsState.endpoint, setting.key, settingsState.pathParams),
-        { value: value }
-      )
-      .then(() => {
-        showNotification({
-          title: t`Setting updated`,
-          message: t`${setting?.name} updated successfully`,
-          color: 'green'
-        });
-        settingsState.fetchSettings();
-        onChange?.();
-      })
-      .catch((error) => {
-        showNotification({
-          title: t`Error editing setting`,
-          message: error.message,
-          color: 'red'
-        });
-      });
-  }
-
-  // Callback function to open the edit dialog (for non-boolean settings)
-  function onEditButton() {
-    const fieldDefinition: ApiFormFieldType = {
-      value: setting?.value ?? '',
-      field_type: setting?.type ?? 'string',
-      label: setting?.name,
-      description: setting?.description
-    };
-
-    // Match related field
-    if (
-      fieldDefinition.field_type === SettingType.Model &&
-      setting.api_url &&
-      setting.model_name
-    ) {
-      fieldDefinition.api_url = setting.api_url;
-
-      // TODO: improve this model matching mechanism
-      fieldDefinition.model = setting.model_name.split('.')[1] as ModelType;
-    } else if (setting.choices?.length > 0) {
-      // Match choices
-      fieldDefinition.field_type = SettingType.Choice;
-      fieldDefinition.choices = setting?.choices || [];
-    }
-
-    openModalApiForm({
-      url: settingsState.endpoint,
-      pk: setting.key,
-      pathParams: settingsState.pathParams,
-      method: 'PATCH',
-      title: t`Edit Setting`,
-      ignorePermissionCheck: true,
-      fields: {
-        value: fieldDefinition
-      },
-      onFormSuccess() {
-        showNotification({
-          title: t`Setting updated`,
-          message: t`${setting?.name} updated successfully`,
-          color: 'green'
-        });
-        settingsState.fetchSettings();
-        onChange?.();
-      }
-    });
-  }
-
   // Determine the text to display for the setting value
   const valueText: string = useMemo(() => {
     let value = setting.value;
@@ -130,7 +51,7 @@ function SettingValue({
           size="sm"
           radius="lg"
           checked={setting.value.toLowerCase() == 'true'}
-          onChange={(event) => onToggle(event.currentTarget.checked)}
+          onChange={(event) => onToggle(setting, event.currentTarget.checked)}
           style={{
             paddingRight: '20px'
           }}
@@ -140,12 +61,12 @@ function SettingValue({
       return valueText ? (
         <Group gap="xs" justify="right">
           <Space />
-          <Button variant="subtle" onClick={onEditButton}>
+          <Button variant="subtle" onClick={() => onEdit(setting)}>
             {valueText}
           </Button>
         </Group>
       ) : (
-        <Button variant="subtle" onClick={onEditButton}>
+        <Button variant="subtle" onClick={() => onEdit(setting)}>
           <IconEdit />
         </Button>
       );
@@ -159,12 +80,14 @@ export function SettingItem({
   settingsState,
   setting,
   shaded,
-  onChange
+  onEdit,
+  onToggle
 }: {
   settingsState: SettingsStateProps;
   setting: Setting;
   shaded: boolean;
-  onChange?: () => void;
+  onEdit: (setting: Setting) => void;
+  onToggle: (setting: Setting, value: boolean) => void;
 }) {
   const { colorScheme } = useMantineColorScheme();
 
@@ -184,11 +107,7 @@ export function SettingItem({
           </Text>
           <Text size="xs">{setting.description}</Text>
         </Stack>
-        <SettingValue
-          settingsState={settingsState}
-          setting={setting}
-          onChange={onChange}
-        />
+        <SettingValue setting={setting} onEdit={onEdit} onToggle={onToggle} />
       </Group>
     </Paper>
   );

--- a/src/frontend/src/components/settings/SettingItem.tsx
+++ b/src/frontend/src/components/settings/SettingItem.tsx
@@ -11,9 +11,9 @@ import {
 import { IconEdit } from '@tabler/icons-react';
 import { useMemo } from 'react';
 
-import { SettingsStateProps } from '../../states/SettingsState';
 import { Setting } from '../../states/states';
 import { vars } from '../../theme';
+import { Boundary } from '../Boundary';
 
 /**
  * Render a single setting value
@@ -77,13 +77,11 @@ function SettingValue({
  * Display a single setting item, and allow editing of the value
  */
 export function SettingItem({
-  settingsState,
   setting,
   shaded,
   onEdit,
   onToggle
 }: {
-  settingsState: SettingsStateProps;
   setting: Setting;
   shaded: boolean;
   onEdit: (setting: Setting) => void;
@@ -107,7 +105,9 @@ export function SettingItem({
           </Text>
           <Text size="xs">{setting.description}</Text>
         </Stack>
-        <SettingValue setting={setting} onEdit={onEdit} onToggle={onToggle} />
+        <Boundary label={`setting-value-${setting.key}`}>
+          <SettingValue setting={setting} onEdit={onEdit} onToggle={onToggle} />
+        </Boundary>
       </Group>
     </Paper>
   );

--- a/src/frontend/src/components/settings/SettingList.tsx
+++ b/src/frontend/src/components/settings/SettingList.tsx
@@ -1,8 +1,19 @@
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import { Stack, Text } from '@mantine/core';
-import React, { useEffect, useMemo, useRef } from 'react';
+import { notifications } from '@mantine/notifications';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { useStore } from 'zustand';
 
+import { api } from '../../App';
+import { ModelType } from '../../enums/ModelType';
+import { useEditApiFormModal } from '../../hooks/UseForm';
+import { apiUrl } from '../../states/ApiState';
 import {
   SettingsStateProps,
   createMachineSettingsState,
@@ -10,6 +21,8 @@ import {
   useGlobalSettingsState,
   useUserSettingsState
 } from '../../states/SettingsState';
+import { Setting } from '../../states/states';
+import { ApiFormFieldType } from '../forms/fields/ApiFormField';
 import { SettingItem } from './SettingItem';
 
 /**
@@ -33,8 +46,80 @@ export function SettingList({
     [settingsState?.settings]
   );
 
+  const [setting, setSetting] = useState<Setting | undefined>(undefined);
+
+  const editSettingModal = useEditApiFormModal({
+    url: settingsState.endpoint,
+    pk: setting?.key,
+    pathParams: settingsState.pathParams,
+    title: t`Edit Setting`,
+    fields: {
+      value: {
+        value: setting?.value ?? '',
+        field_type:
+          setting?.type ?? setting?.choices ?? 0 > 0 ? 'choice' : 'string',
+        label: setting?.name,
+        description: setting?.description,
+        api_url: setting?.api_url ?? '',
+        model: (setting?.model_name?.split('.')[1] as ModelType) ?? null,
+        choices: setting?.choices ?? undefined
+      }
+    },
+    successMessage: t`Setting ${setting?.key} updated successfully`,
+    onFormSuccess: () => {
+      settingsState.fetchSettings();
+      onChange?.();
+    }
+  });
+
+  // Callback for editing a single setting instance
+  const onValueEdit = useCallback(
+    (setting: Setting) => {
+      setSetting(setting);
+      editSettingModal.open();
+    },
+    [editSettingModal]
+  );
+
+  // Callback for toggling a single boolean setting instance
+  const onValueToggle = useCallback(
+    (setting: Setting, value: boolean) => {
+      api
+        .patch(
+          apiUrl(settingsState.endpoint, setting.key, settingsState.pathParams),
+          {
+            value: value
+          }
+        )
+        .then(() => {
+          notifications.hide('setting');
+          notifications.show({
+            title: t`Setting updated`,
+            message: t`Setting ${setting.key} updated successfully`,
+            color: 'green',
+            id: 'setting'
+          });
+          onChange?.();
+        })
+        .catch((error) => {
+          notifications.hide('setting');
+          notifications.show({
+            title: t`Error editing setting`,
+            message: error.message,
+            color: 'red',
+            id: 'setting'
+          });
+        })
+        .finally(() => {
+          settingsState.fetchSettings();
+        });
+    },
+    [settingsState]
+  );
+
   return (
     <>
+      {editSettingModal.modal}
       <Stack gap="xs">
         {(keys || allKeys).map((key, i) => {
           const setting = settingsState?.settings?.find(
@@ -48,7 +133,8 @@ export function SettingList({
                   settingsState={settingsState}
                   setting={setting}
                   shaded={i % 2 === 0}
-                  onChange={onChange}
+                  onEdit={onValueEdit}
+                  onToggle={onValueToggle}
                 />
               ) : (
                 <Text size="sm" style={{ fontStyle: 'italic' }} color="red">

--- a/src/frontend/src/components/settings/SettingList.tsx
+++ b/src/frontend/src/components/settings/SettingList.tsx
@@ -56,7 +56,9 @@ export function SettingList({
       value: {
         value: setting?.value ?? '',
         field_type:
-          setting?.type ?? setting?.choices ?? 0 > 0 ? 'choice' : 'string',
+          setting?.type ?? (setting?.choices?.length ?? 0) > 0
+            ? 'choice'
+            : 'string',
         label: setting?.name,
         description: setting?.description,
         api_url: setting?.api_url ?? '',

--- a/src/frontend/src/components/settings/SettingList.tsx
+++ b/src/frontend/src/components/settings/SettingList.tsx
@@ -130,7 +130,6 @@ export function SettingList({
             <React.Fragment key={key}>
               {setting ? (
                 <SettingItem
-                  settingsState={settingsState}
                   setting={setting}
                   shaded={i % 2 === 0}
                   onEdit={onValueEdit}

--- a/src/frontend/src/components/settings/SettingList.tsx
+++ b/src/frontend/src/components/settings/SettingList.tsx
@@ -22,7 +22,6 @@ import {
   useUserSettingsState
 } from '../../states/SettingsState';
 import { Setting } from '../../states/states';
-import { ApiFormFieldType } from '../forms/fields/ApiFormField';
 import { SettingItem } from './SettingItem';
 
 /**

--- a/src/frontend/src/forms/CompanyForms.tsx
+++ b/src/frontend/src/forms/CompanyForms.tsx
@@ -82,6 +82,9 @@ export function useManufacturerPartFields() {
 export function useManufacturerPartParameterFields() {
   return useMemo(() => {
     const fields: ApiFormFieldSet = {
+      manufacturer_part: {
+        disabled: true
+      },
       name: {},
       value: {},
       units: {}

--- a/src/frontend/src/pages/part/pricing/PriceBreakPanel.tsx
+++ b/src/frontend/src/pages/part/pricing/PriceBreakPanel.tsx
@@ -84,9 +84,7 @@ export default function PriceBreakPanel({
     url: tableUrl,
     pk: selectedPriceBreak,
     title: t`Delete Price Break`,
-    onFormSuccess: () => {
-      table.refreshTable();
-    }
+    table: table
   });
 
   const columns: TableColumn[] = useMemo(() => {

--- a/src/frontend/src/tables/bom/BomTable.tsx
+++ b/src/frontend/src/tables/bom/BomTable.tsx
@@ -312,7 +312,7 @@ export function BomTable({
       part: partId
     },
     successMessage: t`BOM item created`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const editBomItem = useEditApiFormModal({
@@ -321,7 +321,7 @@ export function BomTable({
     title: t`Edit BOM Item`,
     fields: bomItemFields(),
     successMessage: t`BOM item updated`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const deleteBomItem = useDeleteApiFormModal({
@@ -329,7 +329,7 @@ export function BomTable({
     pk: selectedBomItem,
     title: t`Delete BOM Item`,
     successMessage: t`BOM item deleted`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const rowActions = useCallback(

--- a/src/frontend/src/tables/build/BuildOutputTable.tsx
+++ b/src/frontend/src/tables/build/BuildOutputTable.tsx
@@ -113,9 +113,7 @@ export default function BuildOutputTable({ build }: { build: any }) {
     url: apiUrl(ApiEndpoints.build_output_create, buildId),
     title: t`Add Build Output`,
     fields: buildOutputFields,
-    onFormSuccess: () => {
-      table.refreshTable();
-    }
+    table: table
   });
 
   const [selectedOutputs, setSelectedOutputs] = useState<any[]>([]);

--- a/src/frontend/src/tables/company/AddressTable.tsx
+++ b/src/frontend/src/tables/company/AddressTable.tsx
@@ -124,7 +124,7 @@ export function AddressTable({
       company: companyId
     },
     successMessage: t`Address created`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const [selectedAddress, setSelectedAddress] = useState<number>(-1);
@@ -134,15 +134,15 @@ export function AddressTable({
     pk: selectedAddress,
     title: t`Edit Address`,
     fields: addressFields,
-    onFormSuccess: (record: any) => table.updateRecord(record)
+    table: table
   });
 
   const deleteAddress = useDeleteApiFormModal({
     url: ApiEndpoints.address_list,
     pk: selectedAddress,
     title: t`Delete Address`,
-    onFormSuccess: table.refreshTable,
-    preFormWarning: t`Are you sure you want to delete this address?`
+    preFormWarning: t`Are you sure you want to delete this address?`,
+    table: table
   });
 
   const rowActions = useCallback(

--- a/src/frontend/src/tables/company/ContactTable.tsx
+++ b/src/frontend/src/tables/company/ContactTable.tsx
@@ -80,14 +80,14 @@ export function ContactTable({
       company: companyId
     },
     fields: contactFields,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const deleteContact = useDeleteApiFormModal({
     url: ApiEndpoints.contact_list,
     pk: selectedContact,
     title: t`Delete Contact`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const rowActions = useCallback(

--- a/src/frontend/src/tables/part/PartCategoryTable.tsx
+++ b/src/frontend/src/tables/part/PartCategoryTable.tsx
@@ -79,13 +79,9 @@ export function PartCategoryTable({ parentId }: { parentId?: any }) {
     initialData: {
       parent: parentId
     },
-    onFormSuccess(data: any) {
-      if (data.pk) {
-        navigate(getDetailUrl(ModelType.partcategory, data.pk));
-      } else {
-        table.refreshTable();
-      }
-    }
+    follow: true,
+    modelType: ModelType.partcategory,
+    table: table
   });
 
   const [selectedCategory, setSelectedCategory] = useState<number>(-1);

--- a/src/frontend/src/tables/part/PartCategoryTable.tsx
+++ b/src/frontend/src/tables/part/PartCategoryTable.tsx
@@ -1,6 +1,5 @@
 import { t } from '@lingui/macro';
 import { useCallback, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { AddItemButton } from '../../components/buttons/AddItemButton';
 import { YesNoButton } from '../../components/buttons/YesNoButton';
@@ -8,7 +7,6 @@ import { ApiEndpoints } from '../../enums/ApiEndpoints';
 import { ModelType } from '../../enums/ModelType';
 import { UserRoles } from '../../enums/Roles';
 import { partCategoryFields } from '../../forms/PartForms';
-import { getDetailUrl } from '../../functions/urls';
 import {
   useCreateApiFormModal,
   useEditApiFormModal
@@ -26,8 +24,6 @@ import { RowEditAction } from '../RowActions';
  * PartCategoryTable - Displays a table of part categories
  */
 export function PartCategoryTable({ parentId }: { parentId?: any }) {
-  const navigate = useNavigate();
-
   const table = useTable('partcategory');
   const user = useUserState();
 

--- a/src/frontend/src/tables/part/PartCategoryTemplateTable.tsx
+++ b/src/frontend/src/tables/part/PartCategoryTemplateTable.tsx
@@ -37,7 +37,7 @@ export default function PartCategoryTemplateTable({}: {}) {
     url: ApiEndpoints.category_parameter_list,
     title: t`Add Category Parameter`,
     fields: formFields,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const editTemplate = useEditApiFormModal({
@@ -45,14 +45,14 @@ export default function PartCategoryTemplateTable({}: {}) {
     pk: selectedTemplate,
     title: t`Edit Category Parameter`,
     fields: formFields,
-    onFormSuccess: (record: any) => table.updateRecord(record)
+    table: table
   });
 
   const deleteTemplate = useDeleteApiFormModal({
     url: ApiEndpoints.category_parameter_list,
     pk: selectedTemplate,
     title: t`Delete Category Parameter`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const tableFilters: TableFilter[] = useMemo(() => {

--- a/src/frontend/src/tables/part/PartParameterTable.tsx
+++ b/src/frontend/src/tables/part/PartParameterTable.tsx
@@ -171,6 +171,7 @@ export function PartParameterTable({ partId }: { partId: any }) {
   const tableActions = useMemo(() => {
     return [
       <AddItemButton
+        key="add-parameter"
         hidden={!user.hasAddRole(UserRoles.part)}
         tooltip={t`Add parameter`}
         onClick={() => newParameter.open()}

--- a/src/frontend/src/tables/part/PartParameterTable.tsx
+++ b/src/frontend/src/tables/part/PartParameterTable.tsx
@@ -115,7 +115,7 @@ export function PartParameterTable({ partId }: { partId: any }) {
     initialData: {
       part: partId
     },
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const [selectedParameter, setSelectedParameter] = useState<
@@ -127,14 +127,14 @@ export function PartParameterTable({ partId }: { partId: any }) {
     pk: selectedParameter,
     title: t`Edit Part Parameter`,
     fields: partParameterFields,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const deleteParameter = useDeleteApiFormModal({
     url: ApiEndpoints.part_parameter_list,
     pk: selectedParameter,
     title: t`Delete Part Parameter`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   // Callback for row actions

--- a/src/frontend/src/tables/part/PartParameterTemplateTable.tsx
+++ b/src/frontend/src/tables/part/PartParameterTemplateTable.tsx
@@ -84,7 +84,7 @@ export default function PartParameterTemplateTable() {
     url: ApiEndpoints.part_parameter_template_list,
     title: t`Add Parameter Template`,
     fields: partParameterTemplateFields,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const [selectedTemplate, setSelectedTemplate] = useState<number | undefined>(
@@ -96,14 +96,14 @@ export default function PartParameterTemplateTable() {
     pk: selectedTemplate,
     title: t`Edit Parameter Template`,
     fields: partParameterTemplateFields,
-    onFormSuccess: (record: any) => table.updateRecord(record)
+    table: table
   });
 
   const deleteTemplate = useDeleteApiFormModal({
     url: ApiEndpoints.part_parameter_template_list,
     pk: selectedTemplate,
     title: t`Delete Parameter Template`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   // Callback for row actions

--- a/src/frontend/src/tables/part/PartTestTemplateTable.tsx
+++ b/src/frontend/src/tables/part/PartTestTemplateTable.tsx
@@ -128,7 +128,7 @@ export default function PartTestTemplateTable({ partId }: { partId: number }) {
     initialData: {
       part: partId
     },
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const [selectedTest, setSelectedTest] = useState<number>(-1);
@@ -138,7 +138,7 @@ export default function PartTestTemplateTable({ partId }: { partId: number }) {
     pk: selectedTest,
     title: t`Edit Test Template`,
     fields: partTestTemplateFields,
-    onFormSuccess: (record: any) => table.updateRecord(record)
+    table: table
   });
 
   const deleteTestTemplate = useDeleteApiFormModal({
@@ -154,7 +154,7 @@ export default function PartTestTemplateTable({ partId }: { partId: number }) {
         </Text>
       </Alert>
     ),
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const rowActions = useCallback(

--- a/src/frontend/src/tables/part/RelatedPartTable.tsx
+++ b/src/frontend/src/tables/part/RelatedPartTable.tsx
@@ -86,7 +86,7 @@ export function RelatedPartTable({ partId }: { partId: number }): ReactNode {
     initialData: {
       part_1: partId
     },
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const [selectedRelatedPart, setSelectedRelatedPart] = useState<
@@ -97,7 +97,7 @@ export function RelatedPartTable({ partId }: { partId: number }): ReactNode {
     url: ApiEndpoints.related_part_list,
     pk: selectedRelatedPart,
     title: t`Delete Related Part`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const tableActions: ReactNode[] = useMemo(() => {

--- a/src/frontend/src/tables/plugin/PluginListTable.tsx
+++ b/src/frontend/src/tables/plugin/PluginListTable.tsx
@@ -24,6 +24,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { api } from '../../App';
 import { ActionButton } from '../../components/buttons/ActionButton';
+import { YesNoButton } from '../../components/buttons/YesNoButton';
 import { InfoItem } from '../../components/items/InfoItem';
 import { DetailDrawer } from '../../components/nav/DetailDrawer';
 import { PluginSettingList } from '../../components/settings/SettingList';
@@ -72,16 +73,9 @@ export interface PluginI {
   >;
 }
 
-export function PluginDrawer({
-  pluginKey,
-  refreshTable
-}: {
-  pluginKey: string;
-  refreshTable: () => void;
-}) {
+export function PluginDrawer({ pluginKey }: { pluginKey: string }) {
   const {
     instance: plugin,
-    refreshInstance,
     instanceQuery: { isFetching, error }
   } = useInstance<PluginI>({
     endpoint: ApiEndpoints.plugin_list,
@@ -108,17 +102,18 @@ export function PluginDrawer({
 
   return (
     <Stack gap={'xs'}>
-      <Group justify="left">
-        <Box></Box>
+      <Card withBorder>
+        <Group justify="left">
+          <Box></Box>
 
-        <Group gap={'xs'}>
-          {plugin && <PluginIcon plugin={plugin} />}
-          <Title order={4}>
-            {plugin?.meta?.human_name ?? plugin?.name ?? '-'}
-          </Title>
+          <Group gap={'xs'}>
+            {plugin && <PluginIcon plugin={plugin} />}
+            <Title order={4}>
+              {plugin?.meta?.human_name ?? plugin?.name ?? '-'}
+            </Title>
+          </Group>
         </Group>
-      </Group>
-
+      </Card>
       <LoadingOverlay visible={isFetching} overlayProps={{ opacity: 0 }} />
 
       <Card withBorder>
@@ -126,64 +121,74 @@ export function PluginDrawer({
           <Title order={4}>
             <Trans>Plugin information</Trans>
           </Title>
-          <Stack pos="relative" gap="xs">
-            <InfoItem type="text" name={t`Name`} value={plugin?.name} />
-            <InfoItem
-              type="text"
-              name={t`Description`}
-              value={plugin?.meta.description}
-            />
-            <InfoItem
-              type="text"
-              name={t`Author`}
-              value={plugin?.meta.author}
-            />
-            <InfoItem
-              type="text"
-              name={t`Date`}
-              value={plugin?.meta.pub_date}
-            />
-            <InfoItem
-              type="text"
-              name={t`Version`}
-              value={plugin?.meta.version}
-            />
-            <InfoItem type="boolean" name={t`Active`} value={plugin?.active} />
-          </Stack>
+          {plugin.active ? (
+            <Stack pos="relative" gap="xs">
+              <InfoItem type="text" name={t`Name`} value={plugin?.name} />
+              <InfoItem
+                type="text"
+                name={t`Description`}
+                value={plugin?.meta.description}
+              />
+              <InfoItem
+                type="text"
+                name={t`Author`}
+                value={plugin?.meta.author}
+              />
+              <InfoItem
+                type="text"
+                name={t`Date`}
+                value={plugin?.meta.pub_date}
+              />
+              <InfoItem
+                type="text"
+                name={t`Version`}
+                value={plugin?.meta.version}
+              />
+              <InfoItem
+                type="boolean"
+                name={t`Active`}
+                value={plugin?.active}
+              />
+            </Stack>
+          ) : (
+            <Text color="red">{t`Plugin is not active`}</Text>
+          )}
         </Stack>
       </Card>
 
-      <Card withBorder>
-        <Stack gap="md">
-          <Title order={4}>
-            <Trans>Package information</Trans>
-          </Title>
-          <Stack pos="relative" gap="xs">
-            {plugin?.is_package && (
+      {plugin.active && (
+        <Card withBorder>
+          <Stack gap="md">
+            <Title order={4}>
+              <Trans>Package information</Trans>
+            </Title>
+            <Stack pos="relative" gap="xs">
+              {plugin?.is_package && (
+                <InfoItem
+                  type="text"
+                  name={t`Package Name`}
+                  value={plugin?.package_name}
+                />
+              )}
               <InfoItem
                 type="text"
-                name={t`Package Name`}
-                value={plugin?.package_name}
+                name={t`Installation Path`}
+                value={plugin?.meta.package_path}
               />
-            )}
-            <InfoItem
-              type="text"
-              name={t`Installation Path`}
-              value={plugin?.meta.package_path}
-            />
-            <InfoItem
-              type="boolean"
-              name={t`Builtin`}
-              value={plugin?.is_builtin}
-            />
-            <InfoItem
-              type="boolean"
-              name={t`Package`}
-              value={plugin?.is_package}
-            />
+              <InfoItem
+                type="boolean"
+                name={t`Builtin`}
+                value={plugin?.is_builtin}
+              />
+              <InfoItem
+                type="boolean"
+                name={t`Package`}
+                value={plugin?.is_package}
+              />
+            </Stack>
           </Stack>
-        </Stack>
-      </Card>
+        </Card>
+      )}
 
       {plugin && plugin?.active && (
         <Card withBorder>
@@ -259,6 +264,12 @@ export default function PluginListTable() {
             </Group>
           );
         }
+      },
+      {
+        accessor: 'active',
+        sortable: true,
+        title: t`Active`,
+        render: (record: any) => <YesNoButton value={record.active} />
       },
       {
         accessor: 'meta.description',
@@ -553,12 +564,7 @@ export default function PluginListTable() {
         size={'50%'}
         renderContent={(pluginKey) => {
           if (!pluginKey) return;
-          return (
-            <PluginDrawer
-              pluginKey={pluginKey}
-              refreshTable={table.refreshTable}
-            />
-          );
+          return <PluginDrawer pluginKey={pluginKey} />;
         }}
       />
       <InvenTreeTable

--- a/src/frontend/src/tables/plugin/PluginListTable.tsx
+++ b/src/frontend/src/tables/plugin/PluginListTable.tsx
@@ -73,7 +73,7 @@ export interface PluginI {
   >;
 }
 
-export function PluginDrawer({ pluginKey }: { pluginKey: string }) {
+export function PluginDrawer({ pluginKey }: { pluginKey: Readonly<string> }) {
   const {
     instance: plugin,
     instanceQuery: { isFetching, error }

--- a/src/frontend/src/tables/plugin/PluginListTable.tsx
+++ b/src/frontend/src/tables/plugin/PluginListTable.tsx
@@ -14,7 +14,6 @@ import { notifications, showNotification } from '@mantine/notifications';
 import {
   IconCircleCheck,
   IconCircleX,
-  IconDots,
   IconHelpCircle,
   IconInfoCircle,
   IconPlaylistAdd,
@@ -25,15 +24,10 @@ import { useNavigate } from 'react-router-dom';
 
 import { api } from '../../App';
 import { ActionButton } from '../../components/buttons/ActionButton';
-import {
-  ActionDropdown,
-  EditItemAction
-} from '../../components/items/ActionDropdown';
 import { InfoItem } from '../../components/items/InfoItem';
 import { DetailDrawer } from '../../components/nav/DetailDrawer';
 import { PluginSettingList } from '../../components/settings/SettingList';
 import { ApiEndpoints } from '../../enums/ApiEndpoints';
-import { openEditApiForm } from '../../functions/forms';
 import {
   useCreateApiFormModal,
   useDeleteApiFormModal,
@@ -96,11 +90,6 @@ export function PluginDrawer({
     throwError: true
   });
 
-  const refetch = useCallback(() => {
-    refreshTable();
-    refreshInstance();
-  }, [refreshTable, refreshInstance]);
-
   if (!pluginKey || isFetching) {
     return <LoadingOverlay visible={true} />;
   }
@@ -119,7 +108,7 @@ export function PluginDrawer({
 
   return (
     <Stack gap={'xs'}>
-      <Group justify="space-between">
+      <Group justify="left">
         <Box></Box>
 
         <Group gap={'xs'}>
@@ -128,33 +117,6 @@ export function PluginDrawer({
             {plugin?.meta?.human_name ?? plugin?.name ?? '-'}
           </Title>
         </Group>
-
-        <ActionDropdown
-          tooltip={t`Plugin Actions`}
-          icon={<IconDots />}
-          actions={[
-            EditItemAction({
-              tooltip: t`Edit plugin`,
-              onClick: () => {
-                openEditApiForm({
-                  title: t`Edit plugin`,
-                  url: ApiEndpoints.plugin_list,
-                  pathParams: { key: pluginKey },
-                  fields: {
-                    active: {}
-                  },
-                  onClose: refetch
-                });
-              }
-            }),
-            {
-              name: t`Reload`,
-              tooltip: t`Reload`,
-              icon: <IconRefresh />,
-              onClick: refreshInstance
-            }
-          ]}
-        />
       </Group>
 
       <LoadingOverlay visible={isFetching} overlayProps={{ opacity: 0 }} />

--- a/src/frontend/src/tables/plugin/PluginListTable.tsx
+++ b/src/frontend/src/tables/plugin/PluginListTable.tsx
@@ -10,7 +10,7 @@ import {
   Title,
   Tooltip
 } from '@mantine/core';
-import { notifications, showNotification } from '@mantine/notifications';
+import { showNotification } from '@mantine/notifications';
 import {
   IconCircleCheck,
   IconCircleX,

--- a/src/frontend/src/tables/plugin/PluginListTable.tsx
+++ b/src/frontend/src/tables/plugin/PluginListTable.tsx
@@ -346,9 +346,7 @@ export default function PluginListTable() {
         hidden: true
       }
     },
-    onFormSuccess: () => {
-      table.refreshTable();
-    }
+    table: table
   });
 
   // Determine available actions for a given plugin
@@ -451,17 +449,8 @@ export default function PluginListTable() {
     },
     closeOnClickOutside: false,
     submitText: t`Install`,
-    successMessage: undefined,
-    onFormSuccess: (data) => {
-      notifications.show({
-        title: t`Plugin installed successfully`,
-        message: data.result,
-        autoClose: 30000,
-        color: 'green'
-      });
-
-      table.refreshTable();
-    }
+    successMessage: t`Plugin installed successfully`,
+    table: table
   });
 
   const uninstallPluginModal = useEditApiFormModal({
@@ -485,24 +474,16 @@ export default function PluginListTable() {
         </Stack>
       </Alert>
     ),
-    onFormSuccess: (data) => {
-      notifications.show({
-        title: t`Plugin uninstalled successfully`,
-        message: data.result,
-        autoClose: 30000,
-        color: 'green'
-      });
-
-      table.refreshTable();
-    }
+    successMessage: t`Plugin uninstalled successfully`,
+    table: table
   });
 
   const deletePluginModal = useDeleteApiFormModal({
     url: ApiEndpoints.plugin_list,
     pathParams: { key: selectedPlugin },
     title: t`Delete Plugin`,
-    onFormSuccess: table.refreshTable,
-    preFormWarning: t`Deleting this plugin configuration will remove all associated settings and data. Are you sure you want to delete this plugin?`
+    preFormWarning: t`Deleting this plugin configuration will remove all associated settings and data. Are you sure you want to delete this plugin?`,
+    table: table
   });
 
   const reloadPlugins = useCallback(() => {

--- a/src/frontend/src/tables/purchasing/ManufacturerPartParameterTable.tsx
+++ b/src/frontend/src/tables/purchasing/ManufacturerPartParameterTable.tsx
@@ -104,6 +104,7 @@ export default function ManufacturerPartParameterTable({
   const tableActions = useMemo(() => {
     return [
       <AddItemButton
+        key="add-parameter"
         tooltip={t`Add Parameter`}
         onClick={() => {
           createParameter.open();

--- a/src/frontend/src/tables/purchasing/ManufacturerPartTable.tsx
+++ b/src/frontend/src/tables/purchasing/ManufacturerPartTable.tsx
@@ -62,7 +62,7 @@ export function ManufacturerPartTable({ params }: { params: any }): ReactNode {
     url: ApiEndpoints.manufacturer_part_list,
     title: t`Add Manufacturer Part`,
     fields: useManufacturerPartFields(),
-    onFormSuccess: table.refreshTable,
+    table: table,
     initialData: {
       manufacturer: params?.manufacturer
     }

--- a/src/frontend/src/tables/purchasing/ManufacturerPartTable.tsx
+++ b/src/frontend/src/tables/purchasing/ManufacturerPartTable.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import { ReactNode, useCallback, useMemo } from 'react';
+import { ReactNode, useCallback, useMemo, useState } from 'react';
 
 import { AddItemButton } from '../../components/buttons/AddItemButton';
 import { Thumbnail } from '../../components/images/Thumbnail';
@@ -7,8 +7,11 @@ import { ApiEndpoints } from '../../enums/ApiEndpoints';
 import { ModelType } from '../../enums/ModelType';
 import { UserRoles } from '../../enums/Roles';
 import { useManufacturerPartFields } from '../../forms/CompanyForms';
-import { openDeleteApiForm, openEditApiForm } from '../../functions/forms';
-import { useCreateApiFormModal } from '../../hooks/UseForm';
+import {
+  useCreateApiFormModal,
+  useDeleteApiFormModal,
+  useEditApiFormModal
+} from '../../hooks/UseForm';
 import { useTable } from '../../hooks/UseTable';
 import { apiUrl } from '../../states/ApiState';
 import { useUserState } from '../../states/UserState';
@@ -58,14 +61,35 @@ export function ManufacturerPartTable({ params }: { params: any }): ReactNode {
     ];
   }, [params]);
 
+  const manufacturerPartFields = useManufacturerPartFields();
+
+  const [selectedPart, setSelectedPart] = useState<number | undefined>(
+    undefined
+  );
+
   const createManufacturerPart = useCreateApiFormModal({
     url: ApiEndpoints.manufacturer_part_list,
     title: t`Add Manufacturer Part`,
-    fields: useManufacturerPartFields(),
+    fields: manufacturerPartFields,
     table: table,
     initialData: {
       manufacturer: params?.manufacturer
     }
+  });
+
+  const editManufacturerPart = useEditApiFormModal({
+    url: ApiEndpoints.manufacturer_part_list,
+    pk: selectedPart,
+    title: t`Edit Manufacturer Part`,
+    fields: manufacturerPartFields,
+    table: table
+  });
+
+  const deleteManufacturerPart = useDeleteApiFormModal({
+    url: ApiEndpoints.manufacturer_part_list,
+    pk: selectedPart,
+    title: t`Delete Manufacturer Part`,
+    table: table
   });
 
   const tableActions = useMemo(() => {
@@ -82,37 +106,21 @@ export function ManufacturerPartTable({ params }: { params: any }): ReactNode {
     ];
   }, [user]);
 
-  const editManufacturerPartFields = useManufacturerPartFields();
-
   const rowActions = useCallback(
     (record: any) => {
       return [
         RowEditAction({
           hidden: !user.hasChangeRole(UserRoles.purchase_order),
           onClick: () => {
-            record.pk &&
-              openEditApiForm({
-                url: ApiEndpoints.manufacturer_part_list,
-                pk: record.pk,
-                title: t`Edit Manufacturer Part`,
-                fields: editManufacturerPartFields,
-                onFormSuccess: table.refreshTable,
-                successMessage: t`Manufacturer part updated`
-              });
+            setSelectedPart(record.pk);
+            editManufacturerPart.open();
           }
         }),
         RowDeleteAction({
           hidden: !user.hasDeleteRole(UserRoles.purchase_order),
           onClick: () => {
-            record.pk &&
-              openDeleteApiForm({
-                url: ApiEndpoints.manufacturer_part_list,
-                pk: record.pk,
-                title: t`Delete Manufacturer Part`,
-                successMessage: t`Manufacturer part deleted`,
-                onFormSuccess: table.refreshTable,
-                preFormWarning: t`Are you sure you want to remove this manufacturer part?`
-              });
+            setSelectedPart(record.pk);
+            deleteManufacturerPart.open();
           }
         })
       ];
@@ -123,6 +131,8 @@ export function ManufacturerPartTable({ params }: { params: any }): ReactNode {
   return (
     <>
       {createManufacturerPart.modal}
+      {editManufacturerPart.modal}
+      {deleteManufacturerPart.modal}
       <InvenTreeTable
         url={apiUrl(ApiEndpoints.manufacturer_part_list)}
         tableState={table}

--- a/src/frontend/src/tables/purchasing/PurchaseOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/purchasing/PurchaseOrderLineItemTable.tsx
@@ -198,7 +198,7 @@ export function PurchaseOrderLineItemTable({
     title: t`Add Line Item`,
     fields: addPurchaseOrderFields,
     initialData: initialData,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const [selectedLine, setSelectedLine] = useState<number>(0);
@@ -214,14 +214,14 @@ export function PurchaseOrderLineItemTable({
     pk: selectedLine,
     title: t`Edit Line Item`,
     fields: editPurchaseOrderFields,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const deleteLine = useDeleteApiFormModal({
     url: ApiEndpoints.purchase_order_line_list,
     pk: selectedLine,
     title: t`Delete Line Item`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const rowActions = useCallback(

--- a/src/frontend/src/tables/purchasing/SupplierPartTable.tsx
+++ b/src/frontend/src/tables/purchasing/SupplierPartTable.tsx
@@ -166,7 +166,7 @@ export function SupplierPartTable({ params }: { params: any }): ReactNode {
       part: params?.part,
       supplier: params?.supplier
     },
-    onFormSuccess: table.refreshTable,
+    table: table,
     successMessage: t`Supplier part created`
   });
 
@@ -209,14 +209,14 @@ export function SupplierPartTable({ params }: { params: any }): ReactNode {
     pk: selectedSupplierPart,
     title: t`Edit Supplier Part`,
     fields: editSupplierPartFields,
-    onFormSuccess: () => table.refreshTable()
+    table: table
   });
 
   const deleteSupplierPart = useDeleteApiFormModal({
     url: ApiEndpoints.supplier_part_list,
     pk: selectedSupplierPart,
     title: t`Delete Supplier Part`,
-    onFormSuccess: () => table.refreshTable()
+    table: table
   });
 
   // Row action callback

--- a/src/frontend/src/tables/purchasing/SupplierPriceBreakTable.tsx
+++ b/src/frontend/src/tables/purchasing/SupplierPriceBreakTable.tsx
@@ -140,9 +140,7 @@ export default function SupplierPriceBreakTable({
     initialData: {
       part: supplierPartId
     },
-    onFormSuccess: (data: any) => {
-      table.refreshTable();
-    }
+    table: table
   });
 
   const editPriceBreak = useEditApiFormModal({
@@ -150,18 +148,14 @@ export default function SupplierPriceBreakTable({
     pk: selectedPriceBreak,
     title: t`Edit Price Break`,
     fields: supplierPriceBreakFields,
-    onFormSuccess: (data: any) => {
-      table.refreshTable();
-    }
+    table: table
   });
 
   const deletePriceBreak = useDeleteApiFormModal({
     url: apiUrl(ApiEndpoints.supplier_part_pricing_list),
     pk: selectedPriceBreak,
     title: t`Delete Price Break`,
-    onFormSuccess: () => {
-      table.refreshTable();
-    }
+    table: table
   });
 
   const tableActions = useMemo(() => {

--- a/src/frontend/src/tables/settings/CustomUnitsTable.tsx
+++ b/src/frontend/src/tables/settings/CustomUnitsTable.tsx
@@ -49,7 +49,7 @@ export default function CustomUnitsTable() {
     url: ApiEndpoints.custom_unit_list,
     title: t`Add Custom Unit`,
     fields: customUnitsFields(),
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const [selectedUnit, setSelectedUnit] = useState<number>(-1);
@@ -66,7 +66,7 @@ export default function CustomUnitsTable() {
     url: ApiEndpoints.custom_unit_list,
     pk: selectedUnit,
     title: t`Delete Custom Unit`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const rowActions = useCallback(

--- a/src/frontend/src/tables/settings/ErrorTable.tsx
+++ b/src/frontend/src/tables/settings/ErrorTable.tsx
@@ -53,9 +53,7 @@ export default function ErrorReportTable() {
       <Text c="red">{t`Are you sure you want to delete this error report?`}</Text>
     ),
     successMessage: t`Error report deleted`,
-    onFormSuccess: () => {
-      table.refreshTable();
-    }
+    table: table
   });
 
   const rowActions = useCallback((record: any): RowAction[] => {

--- a/src/frontend/src/tables/settings/ErrorTable.tsx
+++ b/src/frontend/src/tables/settings/ErrorTable.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { StylishText } from '../../components/items/StylishText';
 import { ApiEndpoints } from '../../enums/ApiEndpoints';
-import { openDeleteApiForm } from '../../functions/forms';
+import { useDeleteApiFormModal } from '../../hooks/UseForm';
 import { useTable } from '../../hooks/UseTable';
 import { apiUrl } from '../../states/ApiState';
 import { TableColumn } from '../Column';
@@ -41,18 +41,29 @@ export default function ErrorReportTable() {
     ];
   }, []);
 
+  const [selectedError, setSelectedError] = useState<number | undefined>(
+    undefined
+  );
+
+  const deleteErrorModal = useDeleteApiFormModal({
+    url: ApiEndpoints.error_report_list,
+    pk: selectedError,
+    title: t`Delete Error Report`,
+    preFormContent: (
+      <Text c="red">{t`Are you sure you want to delete this error report?`}</Text>
+    ),
+    successMessage: t`Error report deleted`,
+    onFormSuccess: () => {
+      table.refreshTable();
+    }
+  });
+
   const rowActions = useCallback((record: any): RowAction[] => {
     return [
       RowDeleteAction({
         onClick: () => {
-          openDeleteApiForm({
-            url: ApiEndpoints.error_report_list,
-            pk: record.pk,
-            title: t`Delete error report`,
-            onFormSuccess: table.refreshTable,
-            successMessage: t`Error report deleted`,
-            preFormWarning: t`Are you sure you want to delete this error report?`
-          });
+          setSelectedError(record.pk);
+          deleteErrorModal.open();
         }
       })
     ];
@@ -60,6 +71,7 @@ export default function ErrorReportTable() {
 
   return (
     <>
+      {deleteErrorModal.modal}
       <Drawer
         opened={opened}
         size="xl"

--- a/src/frontend/src/tables/settings/GroupTable.tsx
+++ b/src/frontend/src/tables/settings/GroupTable.tsx
@@ -125,7 +125,7 @@ export function GroupTable() {
     pk: selectedGroup,
     title: t`Delete group`,
     successMessage: t`Group deleted`,
-    onFormSuccess: table.refreshTable,
+    table: table,
     preFormWarning: t`Are you sure you want to delete this group?`
   });
 
@@ -133,7 +133,7 @@ export function GroupTable() {
     url: ApiEndpoints.group_list,
     title: t`Add group`,
     fields: { name: {} },
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const tableActions = useMemo(() => {

--- a/src/frontend/src/tables/settings/ProjectCodeTable.tsx
+++ b/src/frontend/src/tables/settings/ProjectCodeTable.tsx
@@ -41,7 +41,7 @@ export default function ProjectCodeTable() {
     url: ApiEndpoints.project_code_list,
     title: t`Add Project Code`,
     fields: projectCodeFields(),
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const [selectedProjectCode, setSelectedProjectCode] = useState<
@@ -53,14 +53,14 @@ export default function ProjectCodeTable() {
     pk: selectedProjectCode,
     title: t`Edit Project Code`,
     fields: projectCodeFields(),
-    onFormSuccess: (record: any) => table.updateRecord(record)
+    table: table
   });
 
   const deleteProjectCode = useDeleteApiFormModal({
     url: ApiEndpoints.project_code_list,
     pk: selectedProjectCode,
     title: t`Delete Project Code`,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const rowActions = useCallback(

--- a/src/frontend/src/tables/settings/TemplateTable.tsx
+++ b/src/frontend/src/tables/settings/TemplateTable.tsx
@@ -234,7 +234,7 @@ export function TemplateTable({
     pathParams: { variant },
     pk: selectedTemplate,
     title: t`Delete` + ' ' + templateTypeTranslation,
-    onFormSuccess: table.refreshTable
+    table: table
   });
 
   const newTemplate = useCreateApiFormModal({

--- a/src/frontend/src/tables/settings/UserTable.tsx
+++ b/src/frontend/src/tables/settings/UserTable.tsx
@@ -230,7 +230,7 @@ export function UserTable() {
     pk: selectedUser,
     title: t`Delete user`,
     successMessage: t`User deleted`,
-    onFormSuccess: table.refreshTable,
+    table: table,
     preFormWarning: t`Are you sure you want to delete this user?`
   });
 
@@ -244,7 +244,7 @@ export function UserTable() {
       first_name: {},
       last_name: {}
     },
-    onFormSuccess: table.refreshTable,
+    table: table,
     successMessage: t`Added user`
   });
 

--- a/src/frontend/src/tables/stock/StockItemTestResultTable.tsx
+++ b/src/frontend/src/tables/stock/StockItemTestResultTable.tsx
@@ -268,7 +268,7 @@ export default function StockItemTestResultTable({
       result: true
     },
     title: t`Add Test Result`,
-    onFormSuccess: () => table.refreshTable(),
+    table: table,
     successMessage: t`Test result added`
   });
 
@@ -279,7 +279,7 @@ export default function StockItemTestResultTable({
     pk: selectedTest,
     fields: resultFields,
     title: t`Edit Test Result`,
-    onFormSuccess: () => table.refreshTable(),
+    table: table,
     successMessage: t`Test result updated`
   });
 
@@ -287,7 +287,7 @@ export default function StockItemTestResultTable({
     url: ApiEndpoints.stock_test_result_list,
     pk: selectedTest,
     title: t`Delete Test Result`,
-    onFormSuccess: () => table.refreshTable(),
+    table: table,
     successMessage: t`Test result deleted`
   });
 

--- a/src/frontend/src/tables/stock/StockLocationTable.tsx
+++ b/src/frontend/src/tables/stock/StockLocationTable.tsx
@@ -1,13 +1,11 @@
 import { t } from '@lingui/macro';
 import { useCallback, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { AddItemButton } from '../../components/buttons/AddItemButton';
 import { ApiEndpoints } from '../../enums/ApiEndpoints';
 import { ModelType } from '../../enums/ModelType';
 import { UserRoles } from '../../enums/Roles';
 import { stockLocationFields } from '../../forms/StockForms';
-import { getDetailUrl } from '../../functions/urls';
 import {
   useCreateApiFormModal,
   useEditApiFormModal
@@ -27,8 +25,6 @@ import { RowEditAction } from '../RowActions';
 export function StockLocationTable({ parentId }: { parentId?: any }) {
   const table = useTable('stocklocation');
   const user = useUserState();
-
-  const navigate = useNavigate();
 
   const tableFilters: TableFilter[] = useMemo(() => {
     return [

--- a/src/frontend/src/tables/stock/StockLocationTable.tsx
+++ b/src/frontend/src/tables/stock/StockLocationTable.tsx
@@ -91,13 +91,9 @@ export function StockLocationTable({ parentId }: { parentId?: any }) {
     initialData: {
       parent: parentId
     },
-    onFormSuccess(data: any) {
-      if (data.pk) {
-        navigate(getDetailUrl(ModelType.stocklocation, data.pk));
-      } else {
-        table.refreshTable();
-      }
-    }
+    follow: true,
+    modelType: ModelType.stocklocation,
+    table: table
   });
 
   const [selectedLocation, setSelectedLocation] = useState<number>(-1);


### PR DESCRIPTION
Refactoring PUI forms to use the new forms approach which uses proper hooks.

- Fixes a number of buggy forms along the way
- Refactoring allows table state to be passed directly to form instance
- Refactors "settings" components also

The intent here is to remove entirely the following functions:

- `openCreateApiForm`
- `openEditApiForm`
- `openDeleteApiForm`

After this PR is merged (and https://github.com/inventree/InvenTree/pull/7232 is also merged) then the "machines" tables are the only ones left to go.

@wolffam do you think you could tackle those?