### PR TITLE
Fix for email template

### DIFF
--- a/src/backend/InvenTree/templates/email/build_order_required_stock.html
+++ b/src/backend/InvenTree/templates/email/build_order_required_stock.html
@@ -22,7 +22,7 @@
 {% for line in lines %}
 <tr style="height: 2.5rem; border-bottom: 1px solid">
     <td style='padding-left: 1em;'>
-        <a href='{{ line.link }}'>{{ line.part.full_name }}</a>{% if part.description %} - <em>{{ part.description }}</em>{% endif %}
+        <a href='{{ line.link }}'>{{ line.part.full_name }}</a>{% if line.part.description %} - <em>{{ line.part.description }}</em>{% endif %}
     </td>
     <td style="text-align: center;">
         {% decimal line.required %} {% include "part/part_units.html" with part=line.part %}


### PR DESCRIPTION
- Use `line.part` instead of `part`
- Fixes error in email notification when a build order requires stock