### PR TITLE
Use `UV_SYSTEM_PYTHON` to allow the system Python interpreter

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -50,9 +50,9 @@ runs:
         run: |
           python3 -m pip install -U pip
           pip3 install -U invoke wheel
-          pip3 install uv==0.1.45
-      - name: Set the VIRTUAL_ENV variable for uv to work
-        run: echo "VIRTUAL_ENV=${Python_ROOT_DIR}" >> $GITHUB_ENV
+          pip3 install 'uv<0.3.0'
+      - name: Allow uv to use the system Python by default
+        run: echo "UV_SYSTEM_PYTHON=1" >> $GITHUB_ENV
         shell: bash
       - name: Install Specific Python Dependencies
         if: ${{ inputs.pip-dependency }}
@@ -89,10 +89,8 @@ runs:
       - name: Run invoke install
         if: ${{ inputs.install == 'true' }}
         shell: bash
-        # run: invoke install --uv
-        run: invoke install
+        run: invoke install --uv
       - name: Run invoke update
         if: ${{ inputs.update == 'true' }}
         shell: bash
-        # run: invoke update --uv
-        run: invoke update
+        run: invoke update --uv


### PR DESCRIPTION
Hi!

I noticed this repository linked in https://github.com/astral-sh/uv/issues/3765 and see that you're having trouble with the breaking change we released. For some more context, you were using the `VIRTUAL_ENV` variable to point to a system installation which was a way to bypass our lack of system Python support. However, in the latest release we added stricter validation of virtual environments so if `VIRTUAL_ENV` points to a system Python interpreter, we will ignore it. Of course, in CI you don't care about virtual environments and it's totally fine to mutate the system Python — for that reason we added `--system` support a while ago.

I saw in #7309 you tried to thread through a `--system` flag to opt-in to using the system interpreter. That's the right idea, but it's easy to miss a case — which will cause uv to fail as it did there. Instead, you can use the [`UV_SYSTEM_PYTHON` flag](https://github.com/astral-sh/uv?tab=readme-ov-file#environment-variables) to opt-in without threading the argument anywhere. I think this should solve your problems, if it doesn't I'll definitely look into it. I've added an integration test for this pattern to be sure we have extra coverage of it https://github.com/astral-sh/uv/pull/3805. As a minor note, you could probably use `UV_PYTHON` with the path to the interpreter as well as we'll allow you to explicitly select the system interpreter that way.

In this pull request, I also add an upper bound to `uv` so you shouldn't encounter any breaking changes unless you opt-in to a later version. Note, you could avoid installing `pip` in CI at all and use our `curl` installer with a pinned uv version e.g. `curl -LsSf https://astral.sh/uv/0.2.2/install.sh | sh` but then you can't use version ranges so 🤷‍♀️ 

Of course, feel free to disregard this if you're not interested.