### PR TITLE
CUI: Don't load stock test results for non-trackable part

### DIFF
--- a/src/backend/InvenTree/stock/templates/stock/item.html
+++ b/src/backend/InvenTree/stock/templates/stock/item.html
@@ -233,6 +233,7 @@
 
     {% settings_value "TEST_STATION_DATA" as test_station_fields %}
 
+    {% if item.part.trackable %}
     loadStockTestResultsTable(
         $("#test-result-table"), {
             part: {{ item.part.id }},
@@ -244,6 +245,7 @@
     $("#test-report").click(function() {
         printReports('stockitem', [{{ item.pk }}]);
     });
+    {% endif %}
 
     {% if user.is_staff %}
     $("#delete-test-results").click(function() {


### PR DESCRIPTION
Fixes issue in legacy UI which caused a 400 request