### PR TITLE
Plugin reload fix

### DIFF
--- a/src/backend/InvenTree/plugin/base/event/events.py
+++ b/src/backend/InvenTree/plugin/base/event/events.py
@@ -60,6 +60,9 @@ def register_event(event, *args, **kwargs):
 
     # Determine if there are any plugins which are interested in responding
     if settings.PLUGIN_TESTING or InvenTreeSetting.get_setting('ENABLE_PLUGINS_EVENTS'):
+        # Check if the plugin registry needs to be reloaded
+        registry.check_reload()
+
         with transaction.atomic():
             for slug, plugin in registry.plugins.items():
                 if not plugin.mixin_enabled('events'):


### PR DESCRIPTION
- call registry.check_reload when registering an event
- ensure that latest versions of plugins are loaded