### PR TITLE
Fix click-through for purchase order line item table

### DIFF
--- a/src/frontend/src/tables/purchasing/PurchaseOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/purchasing/PurchaseOrderLineItemTable.tsx
@@ -307,7 +307,8 @@ export function PurchaseOrderLineItemTable({
           },
           rowActions: rowActions,
           tableActions: tableActions,
-          modelType: ModelType.supplierpart
+          modelType: ModelType.supplierpart,
+          modelField: 'part'
         }}
       />
     </>


### PR DESCRIPTION
- Use the 'part' field, not 'pk'