### PR TITLE
fix: add .vite folder in frontend releases (fixes #7476)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Zip frontend
         run: |
           cd src/backend/InvenTree/web/static/web
-          zip -r ../frontend-build.zip *
+          zip -r ../frontend-build.zip * .vite
       - uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # pin@2.9.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fixes #7476 

Cherry picked from https://github.com/Gigahawk/InvenTree/tree/24a314a1d948816b3bd157343da3430ed0881b1c

Tested working in https://github.com/Gigahawk/InvenTree/releases/tag/0.15.4-frontend-vite 