### PR TITLE
Fix fields for PurchaseOrderCancelSerializer

### DIFF
--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -270,7 +270,7 @@ class PurchaseOrderCancelSerializer(serializers.Serializer):
     class Meta:
         """Metaclass options."""
 
-        fields = ([],)
+        fields = []
 
     def get_context_data(self):
         """Return custom context information about the order."""

--- a/src/backend/InvenTree/order/test_api.py
+++ b/src/backend/InvenTree/order/test_api.py
@@ -484,6 +484,9 @@ class PurchaseOrderTest(OrderTest):
 
         url = reverse('api-po-cancel', kwargs={'pk': po.pk})
 
+        # Get an OPTIONS request from the endpoint
+        self.options(url, data={'context': True}, expected_code=200)
+
         # Try to cancel the PO, but without required permissions
         self.post(url, {}, expected_code=403)
 


### PR DESCRIPTION
- Bug fix for "fields" attribute in `PurchaseOrderCancel` serializer
- Throwing an error on an OPTIONS request