### PR TITLE
Fix non null field 'description'

### DIFF
--- a/src/backend/InvenTree/report/migrations/0026_auto_20240422_1301.py
+++ b/src/backend/InvenTree/report/migrations/0026_auto_20240422_1301.py
@@ -36,7 +36,7 @@ def convert_legacy_labels(table_name, model_name, template_model):
         'name', 'description', 'label', 'enabled', 'height', 'width', 'filename_pattern', 'filters'
     ]
 
-    non_null_fields = ['decription', 'filename_pattern', 'filters']
+    non_null_fields = ['description', 'filename_pattern', 'filters']
 
     fieldnames = ', '.join(fields)
 


### PR DESCRIPTION
Fix typo in migration '0026_auto_20240422_1301.py' to resolve error: `TypeError: LabelTemplate() got unexpected keyword arguments: 'decription'`