### PR TITLE
Display barcode text near qrcode

### DIFF
--- a/src/backend/InvenTree/common/models.py
+++ b/src/backend/InvenTree/common/models.py
@@ -1391,6 +1391,12 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'default': True,
             'validator': bool,
         },
+        'BARCODE_SHOW_TEXT': {
+            'name': _('Barcode Show Data'),
+            'description': _('Display barcode data in browser as text'),
+            'default': False,
+            'validator': bool,
+        },
         'PART_ENABLE_REVISION': {
             'name': _('Part Revisions'),
             'description': _('Enable revision field for Part'),

--- a/src/backend/InvenTree/templates/InvenTree/settings/barcode.html
+++ b/src/backend/InvenTree/templates/InvenTree/settings/barcode.html
@@ -15,7 +15,7 @@
         {% include "InvenTree/settings/setting.html" with key="BARCODE_ENABLE" icon="fa-qrcode" %}
         {% include "InvenTree/settings/setting.html" with key="BARCODE_INPUT_DELAY" icon="fa-hourglass-half" %}
         {% include "InvenTree/settings/setting.html" with key="BARCODE_WEBCAM_SUPPORT" icon="fa-video" %}
-        {% include "InvenTree/settings/setting.html" with key="BARCODE_SHOW_TEXT" icon="fa-text" %}
+        {% include "InvenTree/settings/setting.html" with key="BARCODE_SHOW_TEXT" icon="fa-closed-captioning" %}
     </tbody>
 </table>
 

--- a/src/backend/InvenTree/templates/InvenTree/settings/barcode.html
+++ b/src/backend/InvenTree/templates/InvenTree/settings/barcode.html
@@ -15,6 +15,7 @@
         {% include "InvenTree/settings/setting.html" with key="BARCODE_ENABLE" icon="fa-qrcode" %}
         {% include "InvenTree/settings/setting.html" with key="BARCODE_INPUT_DELAY" icon="fa-hourglass-half" %}
         {% include "InvenTree/settings/setting.html" with key="BARCODE_WEBCAM_SUPPORT" icon="fa-video" %}
+        {% include "InvenTree/settings/setting.html" with key="BARCODE_SHOW_TEXT" icon="fa-text" %}
     </tbody>
 </table>
 

--- a/src/backend/InvenTree/templates/js/translated/modals.js
+++ b/src/backend/InvenTree/templates/js/translated/modals.js
@@ -646,12 +646,12 @@ function showAlertDialog(title, content, options={}) {
 function showQRDialog(title, data, options={}) {
 
     let content = `
-    <div id='qrcode-container' style='margin: auto; width: 256px; padding: 25px;'>
+    <div id='qrcode-container' style='width: 256px; ' class='py-4 m-auto'>
         <div id='qrcode'></div>
     </div>`;
 
     if (global_settings.BARCODE_SHOW_TEXT) {
-        content += `<div style='text-align: center; margin-top: 10px;' id='qrcode-text'>${data}</div>`;
+        content += `<div class='text-center' id='qrcode-text'>${data}</div>`;
     }
 
     options.after_render = function(modal) {

--- a/src/backend/InvenTree/templates/js/translated/modals.js
+++ b/src/backend/InvenTree/templates/js/translated/modals.js
@@ -1,6 +1,7 @@
 {% load i18n %}
 
 /* globals
+    global_settings,
     inventreeGet,
     QRCode,
     showAlertOrCache,
@@ -648,6 +649,10 @@ function showQRDialog(title, data, options={}) {
     <div id='qrcode-container' style='margin: auto; width: 256px; padding: 25px;'>
         <div id='qrcode'></div>
     </div>`;
+
+    if (global_settings.BARCODE_SHOW_TEXT) {
+        content += `<div style='text-align: center; margin-top: 10px;' id='qrcode-text'>${data}</div>`;
+    }
 
     options.after_render = function(modal) {
         let qrcode = new QRCode('qrcode', {

--- a/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
+++ b/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
@@ -91,7 +91,8 @@ export default function SystemSettings() {
             keys={[
               'BARCODE_ENABLE',
               'BARCODE_INPUT_DELAY',
-              'BARCODE_WEBCAM_SUPPORT'
+              'BARCODE_WEBCAM_SUPPORT',
+              'BARCODE_SHOW_TEXT'
             ]}
           />
         )


### PR DESCRIPTION
This PR adds an optional display of the encoded barcode data underneath QR codes. Currently only in CUI - barcode modals are not implanted in PUI.
![grafik](https://github.com/inventree/InvenTree/assets/66015116/0efcd51a-c33d-461c-8f64-f30953acaf2d)
