### PR TITLE
Package is not checking for already existing installs

### DIFF
--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -344,7 +344,7 @@ function final_message() {
 
 function update_checks() {
   echo "# Running upgrade"
-  old_version = $2
+  old_version = $1
   old_version_rev = $(echo $old_version | cut -d' ' -f2)
   echo "# Old version is: ${old_version} - release: ${old_version_rev}"
 

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -343,12 +343,6 @@ function final_message() {
 
 
 function update_checks() {
-  # Check if we are updating
-  if [ -z "$2" ]; then
-    echo "# Normal install - no need for checks"
-    return
-  fi
-
   echo "# Running upgrade"
   old_version = $2
   old_version_rev = $(echo $old_version | cut -d' ' -f2)

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -355,10 +355,10 @@ function update_checks() {
     local name=$3
 
     local value=$(inventree config:get ${config_key})
-    if [ -z "${value}" ]; then
+    if [ -z "${value}" ] || [ "$value" == "null" ]; then
       value=$(jq -r ".[].${env_key}" <<< ${INVENTREE_CONF_DATA})
     fi
-    if [ -z "${value}" ]; then
+    if [ -z "${value}" ] || [ "$value" == "null" ]; then
       echo "# No setting for ${name} found - please set it manually either in ${INVENTREE_CONFIG_FILE} under '${config_key}' or with 'inventree config:set ${config_key}=value'"
       ABORT=true
     else

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -350,8 +350,8 @@ function update_checks() {
 
   local ABORT=false
   function check_config_value() {
-    local config_key=$1
-    local env_key=$2
+    local config_key=$2
+    local env_key=$1
     local name=$3
 
     local value=$(inventree config:get ${config_key})
@@ -361,6 +361,8 @@ function update_checks() {
     if [ -z "${value}" ]; then
       echo "# No setting for ${name} found - please set it manually either in ${INVENTREE_CONFIG_FILE} under '${config_key}' or with 'inventree config:set ${config_key}=value'"
       ABORT=true
+    else
+      echo "# Found setting for ${name} - ${value}"
     fi
   }
 

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -345,7 +345,7 @@ function final_message() {
 function update_checks() {
   echo "# Running upgrade"
   local old_version=$1
-  local old_version_rev=$(echo $old_version | cut -d' ' -f2)
+  local old_version_rev=$(echo ${old_version} | cut -d'-' -f1 | cut -d'.' -f2)
   echo "# Old version is: ${old_version} - release: ${old_version_rev}"
 
   local ABORT=false
@@ -356,7 +356,7 @@ function update_checks() {
 
     local value=$(inventree config:get ${config_key})
     if [ -z "${value}" ]; then
-      value=$(jq -r '.[].${env_key}' <<< ${INVENTREE_CONF_DATA})
+      value=$(jq -r ".[].${env_key}" <<< ${INVENTREE_CONF_DATA})
     fi
     if [ -z "${value}" ]; then
       echo "# No setting for ${name} found - please set it manually either in ${INVENTREE_CONFIG_FILE} under '${config_key}' or with 'inventree config:set ${config_key}=value'"
@@ -376,5 +376,6 @@ function update_checks() {
       echo "# Aborting - please set the missing values and run the update again"
       exit 1
     fi
+    echo "# All checks passed - continuing with the update"
   fi
 }

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -117,22 +117,22 @@ function detect_envs() {
     pip install --require-hashes -r ${APP_HOME}/contrib/dev_reqs/requirements.txt -q
 
     # Load config
-    local CONF=$(cat ${INVENTREE_CONFIG_FILE} | jc --yaml)
+    export INVENTREE_CONF_DATA=$(cat ${INVENTREE_CONFIG_FILE} | jc --yaml)
 
     # Parse the config file
-    export INVENTREE_MEDIA_ROOT=$(jq -r '.[].media_root' <<< ${CONF})
-    export INVENTREE_STATIC_ROOT=$(jq -r '.[].static_root' <<< ${CONF})
-    export INVENTREE_BACKUP_DIR=$(jq -r '.[].backup_dir' <<< ${CONF})
-    export INVENTREE_PLUGINS_ENABLED=$(jq -r '.[].plugins_enabled' <<< ${CONF})
-    export INVENTREE_PLUGIN_FILE=$(jq -r '.[].plugin_file' <<< ${CONF})
-    export INVENTREE_SECRET_KEY_FILE=$(jq -r '.[].secret_key_file' <<< ${CONF})
+    export INVENTREE_MEDIA_ROOT=$(jq -r '.[].media_root' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_STATIC_ROOT=$(jq -r '.[].static_root' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_BACKUP_DIR=$(jq -r '.[].backup_dir' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_PLUGINS_ENABLED=$(jq -r '.[].plugins_enabled' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_PLUGIN_FILE=$(jq -r '.[].plugin_file' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_SECRET_KEY_FILE=$(jq -r '.[].secret_key_file' <<< ${INVENTREE_CONF_DATA})
 
-    export INVENTREE_DB_ENGINE=$(jq -r '.[].database.ENGINE' <<< ${CONF})
-    export INVENTREE_DB_NAME=$(jq -r '.[].database.NAME' <<< ${CONF})
-    export INVENTREE_DB_USER=$(jq -r '.[].database.USER' <<< ${CONF})
-    export INVENTREE_DB_PASSWORD=$(jq -r '.[].database.PASSWORD' <<< ${CONF})
-    export INVENTREE_DB_HOST=$(jq -r '.[].database.HOST' <<< ${CONF})
-    export INVENTREE_DB_PORT=$(jq -r '.[].database.PORT' <<< ${CONF})
+    export INVENTREE_DB_ENGINE=$(jq -r '.[].database.ENGINE' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_DB_NAME=$(jq -r '.[].database.NAME' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_DB_USER=$(jq -r '.[].database.USER' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_DB_PASSWORD=$(jq -r '.[].database.PASSWORD' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_DB_HOST=$(jq -r '.[].database.HOST' <<< ${INVENTREE_CONF_DATA})
+    export INVENTREE_DB_PORT=$(jq -r '.[].database.PORT' <<< ${INVENTREE_CONF_DATA})
   else
     echo "# No config file found: ${INVENTREE_CONFIG_FILE}, using envs or defaults"
 

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -350,16 +350,16 @@ function update_checks() {
 
   local ABORT=false
   function check_config_value() {
-    local config_key=$2
     local env_key=$1
+    local config_key=$2
     local name=$3
 
-    local value=$(inventree config:get ${config_key})
+    local value=$(inventree config:get ${env_key})
     if [ -z "${value}" ] || [ "$value" == "null" ]; then
-      value=$(jq -r ".[].${env_key}" <<< ${INVENTREE_CONF_DATA})
+      value=$(jq -r ".[].${config_key}" <<< ${INVENTREE_CONF_DATA})
     fi
     if [ -z "${value}" ] || [ "$value" == "null" ]; then
-      echo "# No setting for ${name} found - please set it manually either in ${INVENTREE_CONFIG_FILE} under '${config_key}' or with 'inventree config:set ${config_key}=value'"
+      echo "# No setting for ${name} found - please set it manually either in ${INVENTREE_CONFIG_FILE} under '${config_key}' or with 'inventree config:set ${env_key}=value'"
       ABORT=true
     else
       echo "# Found setting for ${name} - ${value}"

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -344,8 +344,8 @@ function final_message() {
 
 function update_checks() {
   echo "# Running upgrade"
-  old_version = $1
-  old_version_rev = $(echo $old_version | cut -d' ' -f2)
+  local old_version = $1
+  local old_version_rev = $(echo $old_version | cut -d' ' -f2)
   echo "# Old version is: ${old_version} - release: ${old_version_rev}"
 
   local ABORT=false

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -344,8 +344,8 @@ function final_message() {
 
 function update_checks() {
   echo "# Running upgrade"
-  local old_version = $1
-  local old_version_rev = $(echo $old_version | cut -d' ' -f2)
+  local old_version=$1
+  local old_version_rev=$(echo $old_version | cut -d' ' -f2)
   echo "# Old version is: ${old_version} - release: ${old_version_rev}"
 
   local ABORT=false

--- a/contrib/packager.io/postinstall.sh
+++ b/contrib/packager.io/postinstall.sh
@@ -36,11 +36,10 @@ detect_ip
 detect_python
 
 # Check if we are updating and need to alert
-echo "$1" "$2"
 if [ -z "$2" ]; then
   echo "# Normal install - no need for checks"
 else
-  update_checks
+  update_checks $2
 
 # create processes
 create_initscripts

--- a/contrib/packager.io/postinstall.sh
+++ b/contrib/packager.io/postinstall.sh
@@ -36,10 +36,12 @@ detect_ip
 detect_python
 
 # Check if we are updating and need to alert
+echo "# Checking if update checks are needed"
 if [ -z "$2" ]; then
   echo "# Normal install - no need for checks"
 else
   update_checks $2
+fi
 
 # create processes
 create_initscripts

--- a/contrib/packager.io/postinstall.sh
+++ b/contrib/packager.io/postinstall.sh
@@ -36,7 +36,11 @@ detect_ip
 detect_python
 
 # Check if we are updating and need to alert
-update_checks
+echo "$1" "$2"
+if [ -z "$2" ]; then
+  echo "# Normal install - no need for checks"
+else
+  update_checks
 
 # create processes
 create_initscripts

--- a/contrib/packager.io/postinstall.sh
+++ b/contrib/packager.io/postinstall.sh
@@ -35,6 +35,9 @@ detect_initcmd
 detect_ip
 detect_python
 
+# Check if we are updating and need to alert
+update_checks
+
 # create processes
 create_initscripts
 create_admin


### PR DESCRIPTION
This PR adds logic to detect what version was installed before and initially ensures that updates from versions below 0.9.0 get SITE_URL and BACKUP_DIR set correctly.
If something is missing it is logged and the setup is exited with status_code 1

Fixes https://github.com/inventree/InvenTree/issues/6891
