### PR TITLE
Bump urllib3 to 2.2.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -545,9 +545,9 @@ typing-extensions==4.11.0 \
     # via
     #   anyio
     #   mkdocstrings
-urllib3==2.2.1 \
-    --hash=sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d \
-    --hash=sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19
+urllib3==2.2.2 \
+    --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \
+    --hash=sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168
     # via requests
 watchdog==4.0.0 \
     --hash=sha256:11e12fafb13372e18ca1bbf12d50f593e7280646687463dd47730fd4f4d5d257 \

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -1392,9 +1392,9 @@ uritemplate==4.1.1 \
     # via
     #   coreapi
     #   drf-spectacular
-urllib3==2.2.1 \
-    --hash=sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d \
-    --hash=sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19
+urllib3==2.2.2 \
+    --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \
+    --hash=sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168
     # via
     #   dulwich
     #   requests


### PR DESCRIPTION
Closes vulnerability disclosed in https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf