### PR TITLE
Move duplicate schema endpoint

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -7,7 +7,7 @@ INVENTREE_API_VERSION = 216
 
 
 INVENTREE_API_TEXT = """
-v216 - 2024-07-08 : https://github.com/inventree/InvenTree/pull/7002
+v216 - 2024-07-08 : https://github.com/inventree/InvenTree/pull/7595
     - Moves API endpoint for contenttype lookup by model name
 
 v215 - 2024-07-09 : https://github.com/inventree/InvenTree/pull/7591

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,15 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 213
+INVENTREE_API_VERSION = 214
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+v214 - 2024-07-08 : https://github.com/inventree/InvenTree/pull/7002
+    - Moves API endpoint for contenttype lookup by model name
+
 v213 - 2024-07-06 : https://github.com/inventree/InvenTree/pull/7527
     - Adds 'locked' field to Part API
 

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -950,7 +950,7 @@ common_api_urls = [
                 '<int:pk>/', ContentTypeDetail.as_view(), name='api-contenttype-detail'
             ),
             path(
-                '<str:model>/',
+                'model/<str:model>/',
                 ContentTypeModelDetail.as_view(),
                 name='api-contenttype-detail-modelname',
             ),


### PR DESCRIPTION
There are currently 2 different endpoints with the pattern /api/contenttype/###/ that lead to different endpoints depending on the type of input. That is impossible/hard to understand for OpenAPI clients so this PR moves one of the 2 endpoints.