### PR TITLE
Fix "Scan barcode" modal input

### DIFF
--- a/src/backend/InvenTree/templates/js/translated/barcode.js
+++ b/src/backend/InvenTree/templates/js/translated/barcode.js
@@ -315,8 +315,32 @@ function barcodeDialog(title, options={}) {
 
         var barcode = $(modal + ' #barcode');
 
+        // The control characters that are used in barcodes.
+        const controlKeys = {
+            "BracketRight": String.fromCharCode(29), // Group separator
+            "Digit6": String.fromCharCode(30), // Record separator
+        }
+        let altValue = 0;
+
         barcode.keydown(function(event) {
-            event.preventDefault();
+            if (event.ctrlKey) {
+                // Prevent most of the keyboard shortcuts.
+                // Not all of them will be blocked, browser don't allow this:
+                // https://stackoverflow.com/questions/59952382/using-preventdefault-to-override-opening-new-tab
+                event.preventDefault();
+                if (event.originalEvent.code in controlKeys) {
+                    event.target.value += controlKeys[event.originalEvent.code];
+                }
+            }
+            else if (event.altKey && event.key != "Alt") {
+                let val = parseInt(event.key, 10);
+                if (Number.isNaN(val) || val < 0 || val > 9) {
+                    altValue = 0;
+                    return;
+                }
+                altValue *= 10;
+                altValue += val;
+            }
         });
 
         // Handle 'enter' key on barcode
@@ -326,6 +350,9 @@ function barcodeDialog(title, options={}) {
             if (event.which == 10 || event.which == 13) {
                 clearTimeout(barcodeInputTimer);
                 sendBarcode();
+            } else if (event.key == "Alt" && altValue > 0) {
+                event.target.value += String.fromCharCode(altValue);
+                altValue = 0;
             } else {
                 // Start a timer to automatically send barcode after input is complete
                 clearTimeout(barcodeInputTimer);

--- a/src/backend/InvenTree/templates/js/translated/barcode.js
+++ b/src/backend/InvenTree/templates/js/translated/barcode.js
@@ -315,6 +315,10 @@ function barcodeDialog(title, options={}) {
 
         var barcode = $(modal + ' #barcode');
 
+        barcode.keydown(function(event) {
+            event.preventDefault();
+        });
+
         // Handle 'enter' key on barcode
         barcode.keyup(function(event) {
             event.preventDefault();


### PR DESCRIPTION
Fixes #7529.
I've taken another look, and although `event.preventDefault()` stops some shortcuts from being executed by the browser, things like `ctrl`+`T` and `ctrl`+`Tab` are still captured and executed[^1]. However, as far as I know no barcodes contain characters that collide with these shortcuts. It of course also depends on the barcode reader.

I've also addressed the issue of receiving the "alt key codes" by pressing `alt`+`<some numbers>`. Our barcode scanner can be set to only emit these codes which avoids the shortcut problem from above, but it takes way longer to input a barcode this way.

[^1]: https://stackoverflow.com/questions/59952382/using-preventdefault-to-override-opening-new-tab