### PR TITLE
Correct tooltips

### DIFF
--- a/src/backend/InvenTree/templates/js/translated/part.js
+++ b/src/backend/InvenTree/templates/js/translated/part.js
@@ -2951,8 +2951,8 @@ function loadPartTestTemplateTable(table, options) {
                     if (row.part == part) {
                         let html = '';
 
-                        html += makeEditButton('button-test-edit', pk, '{% trans "Edit test result" %}');
-                        html += makeDeleteButton('button-test-delete', pk, '{% trans "Delete test result" %}');
+                        html += makeEditButton('button-test-edit', pk, '{% trans "Edit test template" %}');
+                        html += makeDeleteButton('button-test-delete', pk, '{% trans "Delete test template" %}');
 
                         return wrapButtons(html);
                     } else {


### PR DESCRIPTION
In the test templates list there are two actions where the tooltip says test result, however it relates to test template: 
![kép](https://github.com/inventree/InvenTree/assets/1609182/f6e54358-8b8e-4d36-9c2f-2192f2b6a897)

