### PR TITLE
Fix location icon field

### DIFF
--- a/src/frontend/src/forms/StockForms.tsx
+++ b/src/frontend/src/forms/StockForms.tsx
@@ -860,7 +860,7 @@ export function stockLocationFields({}: {}): ApiFormFieldSet {
     description: {},
     structural: {},
     external: {},
-    icon: {},
+    custom_icon: {},
     location_type: {}
   };
 


### PR DESCRIPTION
The API uses the `custom_icon` field for setting an icon directly for the location. The `icon` field is only a getter that first tries to resolve with the `location.icon` and if not defined with `location.location_type.icon`.