### PR TITLE
Fix rendering bug with company image

### DIFF
--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -180,7 +180,7 @@ export function RenderInlineModel({
   return (
     <Group gap="xs" justify="space-between" wrap="nowrap">
       <Group gap="xs" justify="left" wrap="nowrap">
-        {image && Thumbnail({ src: image, size: 18 })}
+        {image && <Thumbnail src={image} size={18} />}
         {url ? (
           <Anchor href={url} onClick={(event: any) => onClick(event)}>
             <Text size="sm">{primary}</Text>


### PR DESCRIPTION
Fixed rendering bug when switching from a company that has an image and one that hasn't in a related model field due to the number of rendered hooks changes, because Thumbnail is not used as a component here, but a normal function.

![image](https://github.com/user-attachments/assets/c05f43b1-bd43-4ac4-acb0-698eb2b5089f)
