### PR TITLE
Bump node to 20

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   python_version: 3.9
-  node_version: 18
+  node_version: 20
   # The OS version must be set per job
   server_start_sleep: 60
 

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   python_version: 3.9
-  node_version: 18
+  node_version: 20
 
 permissions:
   contents: read

--- a/docs/docs/develop/contributing.md
+++ b/docs/docs/develop/contributing.md
@@ -125,7 +125,7 @@ The core software modules are targeting the following versions:
 | Python | {{ config.extra.min_python_version }} | Minimum required version |
 | Invoke | {{ config.extra.min_invoke_version }} | Minimum required version |
 | Django | {{ config.extra.django_version }} | Pinned version |
-| Node | 18 | Only needed for frontend development |
+| Node | 20 | Only needed for frontend development |
 
 Any other software dependencies are handled by the project package config.
 


### PR DESCRIPTION
Bump the minimum node version to 20, the current LTS. The GitHub CI is consistently complaining about this.