### PR TITLE
try to fix tests

### DIFF
--- a/src/backend/InvenTree/part/test_migrations.py
+++ b/src/backend/InvenTree/part/test_migrations.py
@@ -110,7 +110,6 @@ class TestParameterMigrations(MigratorTestCase):
         t2 = PartParameterTemlate.objects.create(name='Template 2', units='AMPERE')
 
         # Create some parameter values
-        print('===>', repr(Part), repr(a), repr(PartParameter), repr(t1))
         PartParameter.objects.create(part=a, template=t1, data='1.0')
         PartParameter.objects.create(part=a, template=t2, data='-2mA')
 

--- a/src/backend/InvenTree/part/test_migrations.py
+++ b/src/backend/InvenTree/part/test_migrations.py
@@ -110,6 +110,7 @@ class TestParameterMigrations(MigratorTestCase):
         t2 = PartParameterTemlate.objects.create(name='Template 2', units='AMPERE')
 
         # Create some parameter values
+        print('===>', repr(Part), repr(a), repr(PartParameter), repr(t1))
         PartParameter.objects.create(part=a, template=t1, data='1.0')
         PartParameter.objects.create(part=a, template=t2, data='-2mA')
 

--- a/src/backend/requirements-dev.txt
+++ b/src/backend/requirements-dev.txt
@@ -279,9 +279,9 @@ django-querycount==0.8.3 \
 django-slowtests==1.1.1 \
     --hash=sha256:3c6936d420c9df444ac03625b41d97de043c662bbde61fbcd33e4cd407d0c247
     # via -r src/backend/requirements-dev.in
-django-test-migrations==1.3.0 \
-    --hash=sha256:b42edb1af481e08c9d91c95aa9b373e76e905a931bc19c086ec00a6cb936876e \
-    --hash=sha256:b52b29475f9a1bcaa4512f2ec8fad08b5f470cf1cf522e86b7d950252fb6fbf1
+django-test-migrations==1.4.0 \
+    --hash=sha256:294dff98f6d43d020d4046b971bac5339e7c71458a35e9ad6450c388fe16ed6b \
+    --hash=sha256:f0c9c92864ed27d0c9a582e92056637e91227f54bd868a50cb9a1726668c563e
     # via -r src/backend/requirements-dev.in
 filelock==3.15.4 \
     --hash=sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb \
@@ -291,12 +291,6 @@ identify==2.5.36 \
     --hash=sha256:37d93f380f4de590500d9dba7db359d0d3da95ffe7f9de1753faa159e71e7dfa \
     --hash=sha256:e5e00f54165f9047fbebeb4a560f9acfb8af4c88232be60a488e9b68d122745d
     # via pre-commit
-importlib-metadata==7.1.0 \
-    --hash=sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570 \
-    --hash=sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2
-    # via
-    #   -c src/backend/requirements.txt
-    #   build
 isort==5.13.2 \
     --hash=sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109 \
     --hash=sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6
@@ -411,19 +405,11 @@ sqlparse==0.5.0 \
     # via
     #   -c src/backend/requirements.txt
     #   django
-tomli==2.0.1 \
-    --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
-    --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
-    # via
-    #   build
-    #   coverage
-    #   pip-tools
 typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
     # via
     #   -c src/backend/requirements.txt
-    #   asgiref
     #   django-test-migrations
 virtualenv==20.26.3 \
     --hash=sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a \
@@ -433,9 +419,3 @@ wheel==0.43.0 \
     --hash=sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85 \
     --hash=sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81
     # via pip-tools
-zipp==3.19.2 \
-    --hash=sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19 \
-    --hash=sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c
-    # via
-    #   -c src/backend/requirements.txt
-    #   importlib-metadata

--- a/src/backend/requirements-dev.txt
+++ b/src/backend/requirements-dev.txt
@@ -291,6 +291,12 @@ identify==2.5.36 \
     --hash=sha256:37d93f380f4de590500d9dba7db359d0d3da95ffe7f9de1753faa159e71e7dfa \
     --hash=sha256:e5e00f54165f9047fbebeb4a560f9acfb8af4c88232be60a488e9b68d122745d
     # via pre-commit
+importlib-metadata==7.1.0 \
+    --hash=sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570 \
+    --hash=sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2
+    # via
+    #   -c src/backend/requirements.txt
+    #   build
 isort==5.13.2 \
     --hash=sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109 \
     --hash=sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6
@@ -405,11 +411,19 @@ sqlparse==0.5.0 \
     # via
     #   -c src/backend/requirements.txt
     #   django
+tomli==2.0.1 \
+    --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
+    --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
+    # via
+    #   build
+    #   coverage
+    #   pip-tools
 typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
     # via
     #   -c src/backend/requirements.txt
+    #   asgiref
     #   django-test-migrations
 virtualenv==20.26.3 \
     --hash=sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a \
@@ -419,3 +433,9 @@ wheel==0.43.0 \
     --hash=sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85 \
     --hash=sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81
     # via pip-tools
+zipp==3.19.2 \
+    --hash=sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19 \
+    --hash=sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c
+    # via
+    #   -c src/backend/requirements.txt
+    #   importlib-metadata


### PR DESCRIPTION
This PR fixes the failing migrations tests first discovered after the merge of #7684 in: https://github.com/inventree/InvenTree/actions/runs/10069548588/job/27836706327
https://github.com/inventree/InvenTree/actions/runs/10069548597/job/27838227324 

Somehow this seems to not be directly related to that PR, but was first caught after that merge. It may be related to https://github.com/wemake-services/django-test-migrations/pull/294 ? Because when upgrading to 1.4.0 from 1.3.0 the issue is gone.