### PR TITLE
fix path to CI dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     directories:
     - /contrib/container
     - /docs
-    - /.github
+    - /contrib/dev_reqs
     - /src/backend
     schedule:
       interval: weekly


### PR DESCRIPTION
The currently configured dependabot path is wrong