### PR TITLE
Add option to disable MFA

### DIFF
--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -297,6 +297,10 @@ Alternatively this location can be specified with the `INVENTREE_BACKUP_DIR` env
 
 InvenTree provides allowance for additional sign-in options. The following options are not enabled by default, and care must be taken by the system administrator when configuring these settings.
 
+| Environment Variable | Configuration File | Description | Default |
+| --- | --- | --- | --- |
+| INVENTREE_MFA_ENABLED | mfa_enabled | Enable or disable multi-factor authentication support for the InvenTree server | True |
+
 ### Single Sign On
 
 Single Sign On (SSO) allows users to sign in to InvenTree using a third-party authentication provider. This functionality is provided by the [django-allauth](https://docs.allauth.org/en/latest/) package.

--- a/src/backend/InvenTree/InvenTree/forms.py
+++ b/src/backend/InvenTree/InvenTree/forms.py
@@ -15,6 +15,7 @@ from allauth.account.forms import LoginForm, SignupForm, set_form_field_order
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth_2fa.adapter import OTPAdapter
+from allauth_2fa.forms import TOTPDeviceForm
 from allauth_2fa.utils import user_has_valid_totp_device
 from crispy_forms.bootstrap import AppendedText, PrependedAppendedText, PrependedText
 from crispy_forms.helper import FormHelper
@@ -209,6 +210,16 @@ class CustomSignupForm(SignupForm):
                 self.add_error('email2', _('You must type the same email each time.'))
 
         return cleaned_data
+
+
+class CustomTOTPDeviceForm(TOTPDeviceForm):
+    """Ensure that db registration is enabled."""
+
+    def __init__(self, user, metadata=None, **kwargs):
+        """Override to check if registration is open."""
+        if not settings.INVENTREE_MFA_ENABLED:
+            raise forms.ValidationError(_('MFA Registration is disabled.'))
+        super().__init__(user, metadata, **kwargs)
 
 
 def registration_enabled():

--- a/src/backend/InvenTree/InvenTree/forms.py
+++ b/src/backend/InvenTree/InvenTree/forms.py
@@ -217,7 +217,7 @@ class CustomTOTPDeviceForm(TOTPDeviceForm):
 
     def __init__(self, user, metadata=None, **kwargs):
         """Override to check if registration is open."""
-        if not settings.INVENTREE_MFA_ENABLED:
+        if not settings.MFA_ENABLED:
             raise forms.ValidationError(_('MFA Registration is disabled.'))
         super().__init__(user, metadata, **kwargs)
 

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1210,6 +1210,10 @@ ACCOUNT_FORMS = {
     'reset_password_from_key': 'allauth.account.forms.ResetPasswordKeyForm',
     'disconnect': 'allauth.socialaccount.forms.DisconnectForm',
 }
+# Determine if multi-factor authentication is enabled for this server (default = True)
+INVENTREE_MFA_ENABLED = get_boolean_setting(
+    'INVENTREE_MFA_ENABLED', 'mfa_enabled', True
+)
 
 SOCIALACCOUNT_ADAPTER = 'InvenTree.forms.CustomSocialAccountAdapter'
 ACCOUNT_ADAPTER = 'InvenTree.forms.CustomAccountAdapter'

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1212,9 +1212,7 @@ ACCOUNT_FORMS = {
 }
 ALLAUTH_2FA_FORMS = {'setup': 'InvenTree.forms.CustomTOTPDeviceForm'}
 # Determine if multi-factor authentication is enabled for this server (default = True)
-INVENTREE_MFA_ENABLED = get_boolean_setting(
-    'INVENTREE_MFA_ENABLED', 'mfa_enabled', True
-)
+MFA_ENABLED = get_boolean_setting('INVENTREE_MFA_ENABLED', 'mfa_enabled', True)
 
 SOCIALACCOUNT_ADAPTER = 'InvenTree.forms.CustomSocialAccountAdapter'
 ACCOUNT_ADAPTER = 'InvenTree.forms.CustomAccountAdapter'

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1210,6 +1210,7 @@ ACCOUNT_FORMS = {
     'reset_password_from_key': 'allauth.account.forms.ResetPasswordKeyForm',
     'disconnect': 'allauth.socialaccount.forms.DisconnectForm',
 }
+ALLAUTH_2FA_FORMS = {'setup': 'InvenTree.forms.CustomTOTPDeviceForm'}
 # Determine if multi-factor authentication is enabled for this server (default = True)
 INVENTREE_MFA_ENABLED = get_boolean_setting(
     'INVENTREE_MFA_ENABLED', 'mfa_enabled', True

--- a/src/backend/InvenTree/InvenTree/social_auth_urls.py
+++ b/src/backend/InvenTree/InvenTree/social_auth_urls.py
@@ -178,9 +178,9 @@ class SocialProviderListView(ListAPI):
         data = {
             'sso_enabled': InvenTree.sso.login_enabled(),
             'sso_registration': InvenTree.sso.registration_enabled(),
-            'mfa_required': settings.INVENTREE_MFA_ENABLED
+            'mfa_required': settings.MFA_ENABLED
             and get_global_setting('LOGIN_ENFORCE_MFA'),
-            'mfa_enabled': settings.INVENTREE_MFA_ENABLED,
+            'mfa_enabled': settings.MFA_ENABLED,
             'providers': provider_list,
             'registration_enabled': get_global_setting('LOGIN_ENABLE_REG'),
             'password_forgotten_enabled': get_global_setting('LOGIN_ENABLE_PWD_FORGOT'),

--- a/src/backend/InvenTree/InvenTree/social_auth_urls.py
+++ b/src/backend/InvenTree/InvenTree/social_auth_urls.py
@@ -3,6 +3,7 @@
 import logging
 from importlib import import_module
 
+from django.conf import settings
 from django.urls import NoReverseMatch, include, path, reverse
 
 from allauth.account.models import EmailAddress
@@ -177,7 +178,9 @@ class SocialProviderListView(ListAPI):
         data = {
             'sso_enabled': InvenTree.sso.login_enabled(),
             'sso_registration': InvenTree.sso.registration_enabled(),
-            'mfa_required': get_global_setting('LOGIN_ENFORCE_MFA'),
+            'mfa_required': settings.INVENTREE_MFA_ENABLED
+            and get_global_setting('LOGIN_ENFORCE_MFA'),
+            'mfa_enabled': settings.INVENTREE_MFA_ENABLED,
             'providers': provider_list,
             'registration_enabled': get_global_setting('LOGIN_ENABLE_REG'),
             'password_forgotten_enabled': get_global_setting('LOGIN_ENABLE_PWD_FORGOT'),


### PR DESCRIPTION
This PR adds a installation level option to disable MFA entirely. MFA is kept enabled by default but can be turned off via `config.yaml` or environment variable.

Replaces https://github.com/inventree/InvenTree/pull/7747
See https://github.com/inventree/InvenTree/discussions/7746