### PR TITLE
Removed obsoleted version element from docker-compose examples

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db:
     image: postgres:13

--- a/contrib/container/dev-docker-compose.yml
+++ b/contrib/container/dev-docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # Docker compose recipe for InvenTree development server
 # - Runs PostgreSQL as the database backend
 # - Uses built-in django webserver

--- a/contrib/container/docker-compose.yml
+++ b/contrib/container/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # Docker compose recipe for a production-ready InvenTree setup, with the following containers:
 # - PostgreSQL as the database backend
 # - gunicorn as the InvenTree web server


### PR DESCRIPTION
Fixes issue #7759 (Docker compose version top-level element has been obsoleted)

Closes https://github.com/inventree/InvenTree/issues/7759