### PR TITLE
Plugin static files

### DIFF
--- a/src/backend/InvenTree/InvenTree/ready.py
+++ b/src/backend/InvenTree/InvenTree/ready.py
@@ -115,6 +115,7 @@ def canAppAccessDatabase(
         'makemessages',
         'compilemessages',
         'spectactular',
+        'collectstatic',
     ]
 
     if not allow_shell:
@@ -125,7 +126,7 @@ def canAppAccessDatabase(
         excluded_commands.append('test')
 
     if not allow_plugins:
-        excluded_commands.extend(['collectstatic', 'collectplugins'])
+        excluded_commands.extend(['collectplugins'])
 
     for cmd in excluded_commands:
         if cmd in sys.argv:

--- a/src/backend/InvenTree/plugin/staticfiles.py
+++ b/src/backend/InvenTree/plugin/staticfiles.py
@@ -1,7 +1,6 @@
 """Static files management for InvenTree plugins."""
 
 import logging
-from pathlib import Path
 
 from django.contrib.staticfiles.storage import staticfiles_storage
 
@@ -23,12 +22,15 @@ def clear_static_dir(path, recursive=True):
     dirs, files = staticfiles_storage.listdir(path)
 
     for f in files:
-        staticfiles_storage.delete(f'{path}/{f}')
+        staticfiles_storage.delete(f'{path}{f}')
 
     if recursive:
         for d in dirs:
-            clear_static_dir(f'{path}/{d}', recursive=True)
-            staticfiles_storage.delete(d)
+            clear_static_dir(f'{path}{d}/', recursive=True)
+            staticfiles_storage.delete(f'{path}{d}')
+
+    # Finally, delete the directory itself to remove orphan folders when uninstalling a plugin
+    staticfiles_storage.delete(path)
 
 
 def collect_plugins_static_files():

--- a/src/backend/InvenTree/plugin/templatetags/plugin_extras.py
+++ b/src/backend/InvenTree/plugin/templatetags/plugin_extras.py
@@ -2,6 +2,7 @@
 
 from django import template
 from django.conf import settings as djangosettings
+from django.templatetags.static import static
 from django.urls import reverse
 
 from common.notifications import storage
@@ -96,3 +97,27 @@ def notification_list(context, *args, **kwargs):
         }
         for a in storage.liste
     ]
+
+
+@register.simple_tag(takes_context=True)
+def plugin_static(context, file: str, **kwargs):
+    """Return the URL for a static file within a plugin.
+
+    Arguments:
+        file: The path to the file within the plugin static directory
+
+    Keyword Arguments:
+        plugin: The plugin slug (optional, will be inferred from the context if not provided)
+
+    """
+    plugin = context.get('plugin', None)
+
+    if plugin:
+        plugin = plugin.slug
+    else:
+        plugin = kwargs.get('plugin', None)
+
+    if not plugin:
+        return file
+
+    return static(f'plugins/{plugin}/{file}')


### PR DESCRIPTION
This PR fixes issue 1 and 4 from https://github.com/inventree/InvenTree/issues/7709#issuecomment-2244844925

This PR is marked as breaking to appear at the top of the changelog. Something like the following text should be added to the changelog for users to explain the change:

---

### ⚠️ Plugin static files (#7425) (#7763)

Previously if a plugin had the `AppMixin` and contained a `static` folder, static files where collected as part of `invoke static` like a normal django app directly in the `static` folder (e.g. `my-plugin/static/test.js` was accessible by `/static/test.js`). Now plugin static files are collected from every plugin that contains a `my-plugin/static` folder (No need for the `AppMixin` anymore) in `/static/plugins/<plugin-slug>/` meaning the `test.js` in the static folder from the previous example is now accessible from `/static/plugins/<plugin-slug>/test.js`.

The `{% plugin_static "test.js" %}` template tag from `{% load plugin_extras %}` can be used to get the correct path for a static file provided by a plugin. It is also backported to 0.15.x (#7764) and acts as a proxy to the normal `static` tag there. 

---

