### PR TITLE
Add provenance to releases and publish SBOMs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Create SBOM for frontend
         uses: anchore/sbom-action@v0
         with:
-          artifact-name: frontend.spdx
+          artifact-name: frontend-build.spdx
           path: src/frontend
       - name: Write version file - SHA
         run: cd src/backend/InvenTree/web/static/web/.vite && echo "$GITHUB_SHA" > sha.txt
@@ -62,14 +62,22 @@ jobs:
           cd src/backend/InvenTree/web/static/web
           zip -r ../frontend-build.zip * .vite
       - name: Attest Build Provenance
+        id: attest
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: "${{ github.workspace }}/src/backend/InvenTree/web/static/frontend-build.zip"
+      - name: Upload Provenance
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # pin@v4.3.4
+        with:
+          name: frontend-build.intoto.jsonl
+          path: ${{ steps.attest.outputs.bundle-path}}
+          retention-days: 5
       - name: Upload frontend
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # pin@v4.3.4
         with:
           name: frontend-build
           path: src/backend/InvenTree/web/static/frontend-build.zip
+          retention-days: 5
 
   publish:
     runs-on: ubuntu-latest
@@ -79,15 +87,15 @@ jobs:
       pull-requests: write
     name: Publish frontend
     steps:
-      - name: Download frontend
+      - name: Download Artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: frontend-build
+          path: artifacts
       - name: Upload to release
         uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # pin@2.9.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: frontend-build.zip
-          asset_name: frontend-build.zip
+          file: artifacts/*
+          file_glob: true
           tag: ${{ github.ref }}
           overwrite: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,11 +29,11 @@ jobs:
           branch: stable
           force: true
 
-  publish-build:
+  build:
     runs-on: ubuntu-latest
+    name: Build frontend
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4.1.7
       - name: Environment Setup
@@ -52,10 +52,28 @@ jobs:
         run: |
           cd src/backend/InvenTree/web/static/web
           zip -r ../frontend-build.zip * .vite
-      - uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # pin@2.9.0
+      - name: Upload frontend
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # pin@v4.3.4
+        with:
+          name: frontend-build
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: ["build"]
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Publish frontend
+    steps:
+      - name: Download frontend
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: frontend-build
+      - name: Upload to release
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # pin@2.9.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: src/backend/InvenTree/web/static/frontend-build.zip
+          file: frontend-build.zip
           asset_name: frontend-build.zip
           tag: ${{ github.ref }}
           overwrite: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,36 +66,20 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: "${{ github.workspace }}/src/backend/InvenTree/web/static/frontend-build.zip"
-      - name: Upload Provenance
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # pin@v4.3.4
-        with:
-          name: frontend-build.intoto.jsonl
-          path: ${{ steps.attest.outputs.bundle-path}}
-          retention-days: 5
-      - name: Upload frontend
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # pin@v4.3.4
-        with:
-          name: frontend-build
-          path: src/backend/InvenTree/web/static/frontend-build.zip
-          retention-days: 5
 
-  publish:
-    runs-on: ubuntu-latest
-    needs: ["build"]
-    permissions:
-      contents: write
-      pull-requests: write
-    name: Publish frontend
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-        with:
-          path: artifacts
-      - name: Upload to release
+      - name: Upload frontend
         uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # pin@2.9.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: artifacts/*
-          file_glob: true
+          file: src/backend/InvenTree/web/static/frontend-build.zip
+          asset_name: frontend-build.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+      - name: Upload Attestation
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # pin@2.9.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          asset_name: frontend-build.intoto.jsonl
+          file: ${{ steps.attest.outputs.bundle-path}}
           tag: ${{ github.ref }}
           overwrite: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: '${{ github.workspace }}/src/backend/InvenTree/web/static/frontend-build.zip'
+          subject-path: "${{ github.workspace }}/src/backend/InvenTree/web/static/frontend-build.zip"
       - name: Create SBOM for frontend
         uses: anchore/sbom-action@v0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 # Runs on releases
 
-name: Publish release notes
+name: Publish release
 on:
   release:
     types: [published]
@@ -8,6 +8,7 @@ on:
 jobs:
   stable:
     runs-on: ubuntu-latest
+    name: Write release to stable branch
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,10 +48,6 @@ jobs:
         run: cd src/frontend && yarn install
       - name: Build frontend
         run: cd src/frontend && npm run compile && npm run build
-      - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: "${{ github.workspace }}/src/backend/InvenTree/web/static/frontend-build.zip"
       - name: Create SBOM for frontend
         uses: anchore/sbom-action@v0
         with:
@@ -65,6 +61,10 @@ jobs:
         run: |
           cd src/backend/InvenTree/web/static/web
           zip -r ../frontend-build.zip * .vite
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "${{ github.workspace }}/src/backend/InvenTree/web/static/frontend-build.zip"
       - name: Upload frontend
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # pin@v4.3.4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,11 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    name: Build frontend
+    name: Build and attest frontend
     permissions:
-      contents: read
+      id-token: write
+      contents: write
+      attestations: write
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4.1.7
       - name: Environment Setup
@@ -44,6 +46,15 @@ jobs:
         run: cd src/frontend && yarn install
       - name: Build frontend
         run: cd src/frontend && npm run compile && npm run build
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{ github.workspace }}/src/backend/InvenTree/web/static/frontend-build.zip'
+      - name: Create SBOM for frontend
+        uses: anchore/sbom-action@v0
+        with:
+          artifact-name: frontend.spdx
+          path: src/frontend
       - name: Write version file - SHA
         run: cd src/backend/InvenTree/web/static/web/.vite && echo "$GITHUB_SHA" > sha.txt
       - name: Write version file - TAG

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ name: Publish release
 on:
   release:
     types: [published]
+permissions:
+  contents: read
 
 jobs:
   stable:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # pin@v4.3.4
         with:
           name: frontend-build
+          path: src/backend/InvenTree/web/static/frontend-build.zip
 
   publish:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,4 +87,4 @@ known_django="django"
 sections=["FUTURE","STDLIB","DJANGO","THIRDPARTY","FIRSTPARTY","LOCALFOLDER"]
 
 [tool.codespell]
-ignore-words-list = ["assertIn","SME"]
+ignore-words-list = ["assertIn","SME","intoto"]


### PR DESCRIPTION
This PR:
- Adds nicer names to the release workflow
- Adds build attestation to the release objects
- Create SBOM for frontend

Ref #7774 