### PR TITLE
[Bug]  Attachment permissions

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,16 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 236
+INVENTREE_API_VERSION = 237
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+
+v237 - 2024-08-13 : https://github.com/inventree/InvenTree/pull/7863
+    - Reimplement "bulk delete" operation for Attachment model
+    - Fix permission checks for Attachment API endpoints
 
 v236 - 2024-08-10 : https://github.com/inventree/InvenTree/pull/7844
     - Adds "supplier_name" to the PurchaseOrder API serializer

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -707,38 +707,12 @@ class AttachmentFilter(rest_filters.FilterSet):
         return queryset.filter(Q(attachment=None) | Q(attachment='')).distinct()
 
 
-class AttachmentPermission(permissions.BasePermission):
-    """Permission class for the Attachment API endpoints.
-
-    As the 'Attachment' class references other models,
-    we need to check that the user has the permissions required
-    for the model that the attachment is attached to.
-    """
-
-    def has_permission(self, request, view):
-        """Check if the user has permission to access the Attachment API."""
-        print('AttachmentPermission.has_permission:', request.user, request.method)
-
-        return super().has_permission(request, view)
-
-    def has_object_permission(self, request, view, obj):
-        """Check if the user has permission to access the Attachment object."""
-        print(
-            'AttachmentPermission.has_object_permission:',
-            request.user,
-            request.method,
-            obj,
-        )
-
-        return super().has_object_permission(request, view, obj)
-
-
 class AttachmentList(BulkDeleteMixin, ListCreateAPI):
     """List API endpoint for Attachment objects."""
 
     queryset = common.models.Attachment.objects.all()
     serializer_class = common.serializers.AttachmentSerializer
-    permission_classes = [permissions.IsAuthenticated, AttachmentPermission]
+    permission_classes = [permissions.IsAuthenticated]
 
     filter_backends = SEARCH_ORDER_FILTER
     filterset_class = AttachmentFilter

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -543,7 +543,7 @@ class AttachmentSerializer(InvenTreeModelSerializer):
     def save(self):
         """Override the save method to handle the model_type field."""
         from InvenTree.models import InvenTreeAttachmentMixin
-        from users.models import check_user_permissions
+        from users.models import check_user_permission
 
         model_type = self.validated_data.get('model_type', None)
 
@@ -557,7 +557,7 @@ class AttachmentSerializer(InvenTreeModelSerializer):
         if not issubclass(target_model_class, InvenTreeAttachmentMixin):
             raise PermissionDenied(_('Invalid model type specified for attachment'))
 
-        if not check_user_permissions(user, target_model_class, 'change'):
+        if not check_user_permission(user, target_model_class, 'change'):
             raise PermissionDenied(
                 _('User does not have permission to attach files against this model')
             )

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -540,12 +540,16 @@ class AttachmentSerializer(InvenTreeModelSerializer):
         allow_null=False,
     )
 
-    def save(self):
+    def save(self, **kwargs):
         """Override the save method to handle the model_type field."""
         from InvenTree.models import InvenTreeAttachmentMixin
         from users.models import check_user_permission
 
         model_type = self.validated_data.get('model_type', None)
+
+        if model_type is None:
+            if self.instance:
+                model_type = self.instance.model_type
 
         # Ensure that the user has permission to attach files to the specified model
         user = self.context.get('request').user
@@ -570,7 +574,7 @@ class AttachmentSerializer(InvenTreeModelSerializer):
                 )
             )
 
-        return super().save()
+        return super().save(**kwargs)
 
 
 class IconSerializer(serializers.Serializer):

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -543,6 +543,7 @@ class AttachmentSerializer(InvenTreeModelSerializer):
     def save(self):
         """Override the save method to handle the model_type field."""
         from InvenTree.models import InvenTreeAttachmentMixin
+        from users.models import check_user_permissions
 
         model_type = self.validated_data.get('model_type', None)
 
@@ -555,6 +556,11 @@ class AttachmentSerializer(InvenTreeModelSerializer):
 
         if not issubclass(target_model_class, InvenTreeAttachmentMixin):
             raise PermissionDenied(_('Invalid model type specified for attachment'))
+
+        if not check_user_permissions(user, target_model_class, 'change'):
+            raise PermissionDenied(
+                _('User does not have permission to attach files against this model')
+            )
 
         # Check that the user has the required permissions to attach files to the target model
         if not target_model_class.check_attachment_permission('change', user):

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -561,18 +561,16 @@ class AttachmentSerializer(InvenTreeModelSerializer):
         if not issubclass(target_model_class, InvenTreeAttachmentMixin):
             raise PermissionDenied(_('Invalid model type specified for attachment'))
 
+        permission_error_msg = _(
+            'User does not have permission to create or edit attachments for this model'
+        )
+
         if not check_user_permission(user, target_model_class, 'change'):
-            raise PermissionDenied(
-                _('User does not have permission to attach files against this model')
-            )
+            raise PermissionDenied(permission_error_msg)
 
         # Check that the user has the required permissions to attach files to the target model
         if not target_model_class.check_attachment_permission('change', user):
-            raise PermissionDenied(
-                _(
-                    'User does not have permission to create or edit attachments for this model'
-                )
-            )
+            raise PermissionDenied(_(permission_error_msg))
 
         return super().save(**kwargs)
 

--- a/src/backend/InvenTree/common/tests.py
+++ b/src/backend/InvenTree/common/tests.py
@@ -157,6 +157,29 @@ class AttachmentTest(InvenTreeAPITestCase):
         # Upload should now work!
         response = self.post(url, data, expected_code=201)
 
+        pk = response.data['pk']
+
+        # Edit the attachment via API
+        response = self.patch(
+            reverse('api-attachment-detail', kwargs={'pk': pk}),
+            {'comment': 'New comment'},
+            expected_code=200,
+        )
+
+        self.assertEqual(response.data['comment'], 'New comment')
+
+        attachment = Attachment.objects.get(pk=pk)
+        self.assertEqual(attachment.comment, 'New comment')
+
+        # And check that we cannot edit the attachment without the correct permissions
+        self.clearRoles()
+
+        self.patch(
+            reverse('api-attachment-detail', kwargs={'pk': pk}),
+            {'comment': 'New comment 2'},
+            expected_code=403,
+        )
+
         # Try to delete the attachment via API (should fail)
         attachment = part.attachments.first()
         url = reverse('api-attachment-detail', kwargs={'pk': attachment.pk})

--- a/src/backend/InvenTree/users/models.py
+++ b/src/backend/InvenTree/users/models.py
@@ -682,6 +682,18 @@ def clear_user_role_cache(user: User):
             cache.delete(key)
 
 
+def check_user_permission(user: User, model, permission):
+    """Check if the user has a particular permission against a given model type.
+
+    Arguments:
+        user: The user object to check
+        model: The model class to check (e.g. Part)
+        permission: The permission to check (e.g. 'view' / 'delete')
+    """
+    permission_name = f'{model._meta.app_label}.{permission}_{model._meta.model_name}'
+    return user.has_perm(permission_name)
+
+
 def check_user_role(user: User, role, permission):
     """Check if a user has a particular role:permission combination.
 


### PR DESCRIPTION
- Fixes a bug where attachments cannot be deleted via the API, due to incorrect permission checks.
- Re-enable bulk delete of attachments
- Validation for attachment bulk delete