### PR TITLE
Update default fonts for docker image

### DIFF
--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -75,7 +75,7 @@ RUN apk add --no-cache \
     mariadb-client mariadb-connector-c \
     && \
     # font support
-    apk --update --upgrade --no-cache add fontconfig ttf-freefont font-terminus font-inconsolata font-dejavu font-noto font-noto-cjk font-noto-extra \
+    apk --update --upgrade --no-cache add fontconfig ttf-freefont font-terminus font-noto font-noto-cjk font-noto-extra \
     && fc-cache -f
 
 EXPOSE 8000

--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -74,8 +74,9 @@ RUN apk add --no-cache \
     # MySQL / MariaDB client
     mariadb-client mariadb-connector-c \
     && \
-    # fonts
-    apk --update --upgrade --no-cache add fontconfig ttf-freefont font-noto terminus-font && fc-cache -f
+    # font support
+    apk --update --upgrade --no-cache add fontconfig ttf-freefont font-terminus font-inconsolata font-dejavu font-noto font-noto-cjk font-noto-extra \
+    && fc-cache -f
 
 EXPOSE 8000
 


### PR DESCRIPTION
- Closes https://github.com/inventree/InvenTree/issues/7737
- Adds more comprehensive font support for back-end operations (e.g. printing)