### PR TITLE
[PUI] fix missing key in currency table

### DIFF
--- a/src/frontend/src/tables/settings/CurrencyTable.tsx
+++ b/src/frontend/src/tables/settings/CurrencyTable.tsx
@@ -66,6 +66,7 @@ export default function CurrencyTable() {
       tableState={table}
       columns={columns}
       props={{
+        idAccessor: 'currency',
         tableActions: tableActions,
         dataFormatter: (data: any) => {
           let rates = data.exchange_rates ?? {};


### PR DESCRIPTION
The currency table in the AdminCenter is missing an accessor - this sometimes throws errors when returning to the tab after a while.