### PR TITLE
Reset page offset when changing page size

### DIFF
--- a/src/frontend/src/tables/InvenTreeTable.tsx
+++ b/src/frontend/src/tables/InvenTreeTable.tsx
@@ -590,6 +590,7 @@ export function InvenTreeTable<T = any>({
   // pagination refresth table if pageSize changes
   function updatePageSize(newData: number) {
     tableState.setPageSize(newData);
+    tableState.setPage(1);
     tableState.refreshTable();
   }
 


### PR DESCRIPTION
- Prevents table rendering an "empty" page