### PR TITLE
fix translatable string

### DIFF
--- a/src/frontend/src/components/items/QRCode.tsx
+++ b/src/frontend/src/components/items/QRCode.tsx
@@ -97,7 +97,7 @@ export const InvenTreeQRCode = ({
   return (
     <Stack>
       {mdl_prop.hash ? (
-        <Alert variant="outline" color="red" title={t`Custom bascode`}>
+        <Alert variant="outline" color="red" title={t`Custom barcode`}>
           <Trans>
             A custom barcode is registered for this item. The shown code is not
             that custom barcode.

--- a/src/frontend/src/tables/TableHoverCard.tsx
+++ b/src/frontend/src/tables/TableHoverCard.tsx
@@ -32,7 +32,7 @@ export function TableHoverCard({
       return (
         <Stack gap="xs">
           {extra.map((item, idx) => (
-            <div key={t`item-${idx}`}>{item}</div>
+            <div key={`item-${idx}`}>{item}</div>
           ))}
         </Stack>
       );


### PR DESCRIPTION
Fixes a typo in a translatable string and remove a translation of a component key (never shown to user)