### PR TITLE
Change target branch for translation

### DIFF
--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -60,7 +60,7 @@ jobs:
           create_pull_request: true
           pull_request_title: 'New Crowdin updates'
           pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
-          pull_request_base_branch_name: 'l10'
+          pull_request_base_branch_name: 'master'
           pull_request_labels: 'translations'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ var/
 # Django stuff:
 *.log
 local_settings.py
+*.sqlite
 *.sqlite3
 *.sqlite3-journal
 *.backup


### PR DESCRIPTION
Change target branch for translation updates to "master"

- Previous `l10` branch is a holdover from the old way of managing translation PRs
- Currently the translation update process is broken