### PR TITLE
Fix "sales_order" filter for build table

### DIFF
--- a/src/frontend/src/pages/build/BuildDetail.tsx
+++ b/src/frontend/src/pages/build/BuildDetail.tsx
@@ -309,10 +309,7 @@ export default function BuildDetail() {
         label: t`Child Build Orders`,
         icon: <IconSitemap />,
         content: build.pk ? (
-          <BuildOrderTable
-            parentBuildId={build.pk}
-            salesOrderId={build.sales_order}
-          />
+          <BuildOrderTable parentBuildId={build.pk} />
         ) : (
           <Skeleton />
         )

--- a/src/frontend/src/tables/build/BuildOrderTable.tsx
+++ b/src/frontend/src/tables/build/BuildOrderTable.tsx
@@ -194,6 +194,7 @@ export function BuildOrderTable({
           params: {
             part: partId,
             ancestor: parentBuildId,
+            sales_order: salesOrderId,
             part_detail: true
           },
           tableActions: tableActions,


### PR DESCRIPTION
Previous patch had incorrectly removed the ability to filter by sales order ID