### PR TITLE
Add option for controlling test result uploads

### DIFF
--- a/docs/docs/settings/global.md
+++ b/docs/docs/settings/global.md
@@ -188,6 +188,7 @@ Configuration of stock item options
 {{ globalsetting("STOCK_ENFORCE_BOM_INSTALLATION") }}
 {{ globalsetting("STOCK_ALLOW_OUT_OF_STOCK_TRANSFER") }}
 {{ globalsetting("TEST_STATION_DATA") }}
+{{ globalsetting("TEST_UPLOAD_CREATE_TEMPLATE") }}
 
 ### Build Orders
 

--- a/src/backend/InvenTree/common/models.py
+++ b/src/backend/InvenTree/common/models.py
@@ -2160,6 +2160,14 @@ class InvenTreeSetting(BaseInvenTreeSetting):
             'default': False,
             'validator': bool,
         },
+        'TEST_UPLOAD_CREATE_TEMPLATE': {
+            'name': _('Create Template on Upload'),
+            'description': _(
+                'Create a new test template when uploading test data which does not match an existing template'
+            ),
+            'default': True,
+            'validator': bool,
+        },
     }
 
     typ = 'inventree'

--- a/src/backend/InvenTree/stock/serializers.py
+++ b/src/backend/InvenTree/stock/serializers.py
@@ -274,7 +274,7 @@ class StockItemTestResultSerializer(
                     test_name,
                 )
 
-                # Create a new test template based on the provided dasta
+                # Create a new test template based on the provided data
                 data['template'] = part_models.PartTestTemplate.objects.create(
                     part=stock_item.part, test_name=test_name
                 )

--- a/src/backend/InvenTree/stock/serializers.py
+++ b/src/backend/InvenTree/stock/serializers.py
@@ -268,7 +268,7 @@ class StockItemTestResultSerializer(
             ).first():
                 data['template'] = template
 
-            else:
+            elif get_global_setting('TEST_UPLOAD_CREATE_TEMPLATE', False):
                 logger.debug(
                     "No matching test template found for '%s' - creating a new template",
                     test_name,

--- a/src/backend/InvenTree/stock/test_api.py
+++ b/src/backend/InvenTree/stock/test_api.py
@@ -1716,6 +1716,14 @@ class StockTestResultTest(StockAPITestCase):
             'notes': 'I guess there was just too much pressure?',
         }
 
+        # First, test with TEST_UPLOAD_CREATE_TEMPLATE set to False
+        InvenTreeSetting.set_setting('TEST_UPLOAD_CREATE_TEMPLATE', False, self.user)
+
+        response = self.post(url, data, expected_code=400)
+
+        # Again, with the setting enabled
+        InvenTreeSetting.set_setting('TEST_UPLOAD_CREATE_TEMPLATE', True, self.user)
+
         response = self.post(url, data, expected_code=201)
 
         # Check that a new test template has been created

--- a/src/backend/InvenTree/templates/InvenTree/settings/stock.html
+++ b/src/backend/InvenTree/templates/InvenTree/settings/stock.html
@@ -25,6 +25,7 @@
         {% include "InvenTree/settings/setting.html" with key="STOCK_ENFORCE_BOM_INSTALLATION" icon="fa-check-circle" %}
         {% include "InvenTree/settings/setting.html" with key="STOCK_ALLOW_OUT_OF_STOCK_TRANSFER" icon="fa-dolly" %}
         {% include "InvenTree/settings/setting.html" with key="TEST_STATION_DATA" icon="fa-network-wired" %}
+        {% include "InvenTree/settings/setting.html" with key="TEST_UPLOAD_CREATE_TEMPLATE" %}
 
     </tbody>
 </table>

--- a/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
+++ b/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
@@ -221,7 +221,8 @@ export default function SystemSettings() {
               'STOCK_SHOW_INSTALLED_ITEMS',
               'STOCK_ENFORCE_BOM_INSTALLATION',
               'STOCK_ALLOW_OUT_OF_STOCK_TRANSFER',
-              'TEST_STATION_DATA'
+              'TEST_STATION_DATA',
+              'TEST_UPLOAD_CREATE_TEMPLATE'
             ]}
           />
         )


### PR DESCRIPTION
Currently (due to legacy behaviour), uploading a test result which does not match a "test template" can create a *new* template automatically.

While I don't want to remove this functionality for anyone who makes use of it or has integrations with external API callers, this PR introduces a new global setting to optionally disable this functionality.