### PR TITLE
Revert int.worker to worker

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
     {
       "label": "worker",
       "type": "shell",
-      "command": "invoke int.worker",
+      "command": "invoke worker",
       "problemMatcher": [],
     },
     {

--- a/contrib/container/dev-docker-compose.yml
+++ b/contrib/container/dev-docker-compose.yml
@@ -56,7 +56,7 @@ services:
     inventree-dev-worker:
         image: inventree-dev-image
         build: *build_config
-        command: invoke int.worker
+        command: invoke worker
         depends_on:
             - inventree-dev-server
         volumes:

--- a/contrib/container/docker-compose.yml
+++ b/contrib/container/docker-compose.yml
@@ -83,7 +83,7 @@ services:
         # If you wish to specify a particular InvenTree version, do so here
         image: inventree/inventree:${INVENTREE_TAG:-stable}
         container_name: inventree-worker
-        command: invoke int.worker
+        command: invoke worker
         depends_on:
             - inventree-server
         env_file:

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -107,7 +107,7 @@ The background worker process must be started separately to the web-server appli
 From the top-level source directory, run the following command from a separate terminal, while the server is already running:
 
 ```
-invoke int.worker
+invoke worker
 ```
 
 !!! info "Supervisor"

--- a/docs/docs/start/bare_dev.md
+++ b/docs/docs/start/bare_dev.md
@@ -52,7 +52,7 @@ source ./env/bin/activate
 ### Start Background Worker
 
 ```
-(env) invoke int.worker
+(env) invoke worker
 ```
 
 This will start the background process manager in the current shell.

--- a/docs/docs/start/docker_install.md
+++ b/docs/docs/start/docker_install.md
@@ -247,7 +247,7 @@ index 8adee63..dc3993c 100644
 -        image: inventree/inventree:${INVENTREE_TAG:-stable}
 +        image: inventree/inventree:${INVENTREE_TAG:-stable}-custom
 +        pull_policy: never
-         command: invoke int.worker
+         command: invoke worker
          depends_on:
              - inventree-server
 ```

--- a/tasks.py
+++ b/tasks.py
@@ -1473,7 +1473,6 @@ internal = Collection(
     rebuild_thumbnails,
     showmigrations,
     translate_stats,
-    worker,
 )
 
 ns = Collection(
@@ -1491,6 +1490,7 @@ ns = Collection(
     update,
     version,
     wait,
+    worker,
 )
 
 ns.add_collection(development, 'dev')


### PR DESCRIPTION
- Prevent existing docker compose installs from breaking
- Ref: https://github.com/inventree/InvenTree/issues/8103

This PR reverts the "worker" task to simply being called "worker" (not "int.worker"). Otherwise, when we push the new changes to stable, anyone running on a docker setup will find that their "worker" task will not start any more. Their (existing) docker compose file will reference the "worker" task