### PR TITLE
Bug: Remove old setting

### DIFF
--- a/docs/docs/settings/global.md
+++ b/docs/docs/settings/global.md
@@ -121,7 +121,6 @@ Configuration of report generation:
 {{ globalsetting("REPORT_DEFAULT_PAGE_SIZE") }}
 {{ globalsetting("REPORT_DEBUG_MODE") }}
 {{ globalsetting("REPORT_LOG_ERRORS") }}
-{{ globalsetting("REPORT_ENABLE_TEST_REPORT") }}
 {{ globalsetting("REPORT_ATTACH_TEST_REPORT") }}
 
 ### Parts

--- a/docs/docs/settings/global.md
+++ b/docs/docs/settings/global.md
@@ -121,7 +121,6 @@ Configuration of report generation:
 {{ globalsetting("REPORT_DEFAULT_PAGE_SIZE") }}
 {{ globalsetting("REPORT_DEBUG_MODE") }}
 {{ globalsetting("REPORT_LOG_ERRORS") }}
-{{ globalsetting("REPORT_ATTACH_TEST_REPORT") }}
 
 ### Parts
 


### PR DESCRIPTION
The setting REPORT_ENABLE_TEST_REPORT was removed and is blocking docs builds - see https://readthedocs.org/projects/inventree/builds/25647002/