### PR TITLE
[PUI] Panels plugin fix

### DIFF
--- a/docs/docs/extend/plugins/ui.md
+++ b/docs/docs/extend/plugins/ui.md
@@ -18,9 +18,9 @@ When rendering certain content in the user interface, the rendering functions ar
 
 ## Custom Panels
 
-Many of the pages in the InvenTree web interface are built using a series of "panels" which are displayed on the page. Custom panels can be added to these pages, by implementing the `get_custom_panels` method:
+Many of the pages in the InvenTree web interface are built using a series of "panels" which are displayed on the page. Custom panels can be added to these pages, by implementing the `ui_panels` method:
 
-::: plugin.base.integration.UserInterfaceMixin.UserInterfaceMixin.get_custom_panels
+::: plugin.base.integration.UserInterfaceMixin.UserInterfaceMixin.ui_panels
     options:
       show_bases: False
       show_root_heading: False

--- a/docs/docs/extend/plugins/ui.md
+++ b/docs/docs/extend/plugins/ui.md
@@ -18,9 +18,9 @@ When rendering certain content in the user interface, the rendering functions ar
 
 ## Custom Panels
 
-Many of the pages in the InvenTree web interface are built using a series of "panels" which are displayed on the page. Custom panels can be added to these pages, by implementing the `ui_panels` method:
+Many of the pages in the InvenTree web interface are built using a series of "panels" which are displayed on the page. Custom panels can be added to these pages, by implementing the `get_ui_panels` method:
 
-::: plugin.base.integration.UserInterfaceMixin.UserInterfaceMixin.ui_panels
+::: plugin.base.integration.UserInterfaceMixin.UserInterfaceMixin.get_ui_panels
     options:
       show_bases: False
       show_root_heading: False

--- a/src/backend/InvenTree/plugin/api.py
+++ b/src/backend/InvenTree/plugin/api.py
@@ -436,9 +436,7 @@ class PluginPanelList(APIView):
             for _plugin in registry.with_mixin('ui', active=True):
                 try:
                     # Allow plugins to fill this data out
-                    plugin_panels = _plugin.get_ui_panels(
-                        target_model, target_id, request
-                    )
+                    plugin_panels = _plugin.ui_panels(target_model, target_id, request)
 
                     if plugin_panels and type(plugin_panels) is list:
                         for panel in plugin_panels:
@@ -449,7 +447,7 @@ class PluginPanelList(APIView):
                 except Exception:
                     # Custom panels could not load
                     # Log the error and continue
-                    log_error(f'{_plugin.slug}.get_ui_panels')
+                    log_error(f'{_plugin.slug}.ui_panels')
 
         return Response(PluginSerializers.PluginPanelSerializer(panels, many=True).data)
 

--- a/src/backend/InvenTree/plugin/api.py
+++ b/src/backend/InvenTree/plugin/api.py
@@ -436,7 +436,9 @@ class PluginPanelList(APIView):
             for _plugin in registry.with_mixin('ui', active=True):
                 try:
                     # Allow plugins to fill this data out
-                    plugin_panels = _plugin.ui_panels(target_model, target_id, request)
+                    plugin_panels = _plugin.get_ui_panels(
+                        target_model, target_id, request
+                    )
 
                     if plugin_panels and type(plugin_panels) is list:
                         for panel in plugin_panels:
@@ -447,7 +449,7 @@ class PluginPanelList(APIView):
                 except Exception:
                     # Custom panels could not load
                     # Log the error and continue
-                    log_error(f'{_plugin.slug}.ui_panels')
+                    log_error(f'{_plugin.slug}.get_ui_panels')
 
         return Response(PluginSerializers.PluginPanelSerializer(panels, many=True).data)
 

--- a/src/backend/InvenTree/plugin/base/integration/UserInterfaceMixin.py
+++ b/src/backend/InvenTree/plugin/base/integration/UserInterfaceMixin.py
@@ -36,7 +36,7 @@ class UserInterfaceMixin:
     - This means that content can be dynamically generated, based on the current state of the system.
 
     The following custom UI methods are available:
-    - get_ui_panels: Return a list of custom panels to be injected into the UI
+    - ui_panels: Return a list of custom panels to be injected into the UI
 
     """
 
@@ -50,7 +50,7 @@ class UserInterfaceMixin:
         super().__init__()
         self.add_mixin('ui', True, __class__)
 
-    def get_ui_panels(
+    def ui_panels(
         self, instance_type: str, instance_id: int, request: Request, **kwargs
     ) -> list[CustomPanel]:
         """Return a list of custom panels to be injected into the UI.

--- a/src/backend/InvenTree/plugin/base/integration/UserInterfaceMixin.py
+++ b/src/backend/InvenTree/plugin/base/integration/UserInterfaceMixin.py
@@ -36,7 +36,7 @@ class UserInterfaceMixin:
     - This means that content can be dynamically generated, based on the current state of the system.
 
     The following custom UI methods are available:
-    - ui_panels: Return a list of custom panels to be injected into the UI
+    - get_ui_panels: Return a list of custom panels to be injected into the UI
 
     """
 
@@ -50,7 +50,7 @@ class UserInterfaceMixin:
         super().__init__()
         self.add_mixin('ui', True, __class__)
 
-    def ui_panels(
+    def get_ui_panels(
         self, instance_type: str, instance_id: int, request: Request, **kwargs
     ) -> list[CustomPanel]:
         """Return a list of custom panels to be injected into the UI.

--- a/src/backend/InvenTree/plugin/base/integration/UserInterfaceMixin.py
+++ b/src/backend/InvenTree/plugin/base/integration/UserInterfaceMixin.py
@@ -34,6 +34,10 @@ class UserInterfaceMixin:
 
     - All content is accessed via the API, as requested by the user interface.
     - This means that content can be dynamically generated, based on the current state of the system.
+
+    The following custom UI methods are available:
+    - get_ui_panels: Return a list of custom panels to be injected into the UI
+
     """
 
     class MixinMeta:

--- a/src/backend/InvenTree/plugin/base/integration/UserInterfaceMixin.py
+++ b/src/backend/InvenTree/plugin/base/integration/UserInterfaceMixin.py
@@ -46,8 +46,8 @@ class UserInterfaceMixin:
         super().__init__()
         self.add_mixin('ui', True, __class__)
 
-    def get_custom_panels(
-        self, instance_type: str, instance_id: int, request: Request
+    def get_ui_panels(
+        self, instance_type: str, instance_id: int, request: Request, **kwargs
     ) -> list[CustomPanel]:
         """Return a list of custom panels to be injected into the UI.
 

--- a/src/backend/InvenTree/plugin/samples/integration/user_interface_sample.py
+++ b/src/backend/InvenTree/plugin/samples/integration/user_interface_sample.py
@@ -44,7 +44,7 @@ class SampleUserInterfacePlugin(SettingsMixin, UserInterfaceMixin, InvenTreePlug
         },
     }
 
-    def get_custom_panels(self, instance_type: str, instance_id: int, request):
+    def get_ui_panels(self, instance_type: str, instance_id: int, request, **kwargs):
         """Return a list of custom panels to be injected into the UI."""
         panels = []
 

--- a/src/backend/InvenTree/plugin/samples/integration/user_interface_sample.py
+++ b/src/backend/InvenTree/plugin/samples/integration/user_interface_sample.py
@@ -44,7 +44,7 @@ class SampleUserInterfacePlugin(SettingsMixin, UserInterfaceMixin, InvenTreePlug
         },
     }
 
-    def ui_panels(self, instance_type: str, instance_id: int, request, **kwargs):
+    def get_ui_panels(self, instance_type: str, instance_id: int, request, **kwargs):
         """Return a list of custom panels to be injected into the UI."""
         panels = []
 

--- a/src/backend/InvenTree/plugin/samples/integration/user_interface_sample.py
+++ b/src/backend/InvenTree/plugin/samples/integration/user_interface_sample.py
@@ -44,7 +44,7 @@ class SampleUserInterfacePlugin(SettingsMixin, UserInterfaceMixin, InvenTreePlug
         },
     }
 
-    def get_ui_panels(self, instance_type: str, instance_id: int, request, **kwargs):
+    def ui_panels(self, instance_type: str, instance_id: int, request, **kwargs):
         """Return a list of custom panels to be injected into the UI."""
         panels = []
 


### PR DESCRIPTION
This is a follow up to https://github.com/inventree/InvenTree/pull/7470

Realized after the fact that the CUI and PUI plugin mixins use the same method name for delivering custom panels. This means that a plugin cannot bridge the gap and support both CUI and PUI.

To address this, the method name in the `UserInterfaceMixin` class has been changed.