### PR TITLE
Exception handling for BulkDeleteMixin

### DIFF
--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -379,11 +379,26 @@ class BulkDeleteMixin:
 
             # Filter by provided item ID values
             if items:
-                queryset = queryset.filter(id__in=items)
+                try:
+                    queryset = queryset.filter(id__in=items)
+                except Exception:
+                    raise ValidationError({
+                        'non_field_errors': _('Invalid items list provided')
+                    })
 
             # Filter by provided filters
             if filters:
-                queryset = queryset.filter(**filters)
+                try:
+                    queryset = queryset.filter(**filters)
+                except Exception:
+                    raise ValidationError({
+                        'non_field_errors': _('Invalid filters provided')
+                    })
+
+            if queryset.count() == 0:
+                raise ValidationError({
+                    'non_field_errors': _('No items found to delete')
+                })
 
             # Run a final validation step (should raise an error if the deletion should not proceed)
             self.validate_delete(queryset, request)

--- a/src/backend/InvenTree/stock/test_api.py
+++ b/src/backend/InvenTree/stock/test_api.py
@@ -1874,7 +1874,7 @@ class StockTestResultTest(StockAPITestCase):
         # Now, let's delete all the newly created items with a single API request
         # However, we will provide incorrect filters
         response = self.delete(
-            url, {'items': tests, 'filters': {'stock_item': 10}}, expected_code=204
+            url, {'items': tests, 'filters': {'stock_item': 10}}, expected_code=400
         )
 
         self.assertEqual(StockItemTestResult.objects.count(), n + 50)


### PR DESCRIPTION
Handle cases where id values or filters passed to bulk delete are invalid.

Based on exception reported by sentry.io for demo server