### PR TITLE
Shipment Attachments

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,15 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 263
+INVENTREE_API_VERSION = 264
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+
+264 - 2024-10-03 : https://github.com/inventree/InvenTree/pull/8231
+    - Adds Sales Order Shipment attachment model type
 
 263 - 2024-09-30 : https://github.com/inventree/InvenTree/pull/8194
     - Adds Sales Order Shipment report

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1738,6 +1738,7 @@ class SalesOrderLineItem(OrderLineItem):
 
 
 class SalesOrderShipment(
+    InvenTree.models.InvenTreeAttachmentMixin,
     InvenTree.models.InvenTreeNotesMixin,
     report.mixins.InvenTreeReportMixin,
     InvenTree.models.MetadataMixin,
@@ -1920,6 +1921,13 @@ class SalesOrderShipment(
         self.save()
 
         trigger_event('salesordershipment.completed', id=self.pk)
+
+    def create_attachment(self, *args, **kwargs):
+        """Create an attachment / link on parent order.
+
+        This will only be called when a generated report should be attached to this instance.
+        """
+        return self.order.create_attachment(*args, **kwargs)
 
 
 class SalesOrderExtraLine(OrderExtraLine):


### PR DESCRIPTION
This pull request updates `SalesOrderShipment` to support attachments by overriding `create_attachment` to instead create them on the parent `SalesOrder` instance. The remaining functions provided by `InvenTreeAttachmentMixin` have been intentionally left as is and no attachments will be returned or deleted on the `SalesOrderShipment` model.

![Sales Order](https://github.com/user-attachments/assets/0f6d106d-5bbf-4aa4-bdb7-59637716d17f)
