### PR TITLE
Fix build item over-allocation checks

### DIFF
--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -1606,12 +1606,19 @@ class BuildItem(InvenTree.models.InvenTreeMetadataModel):
                     'quantity': _(f'Allocated quantity ({q}) must not exceed available stock quantity ({a})')
                 })
 
-            # Allocated quantity cannot cause the stock item to be over-allocated
+            # Ensure that we do not 'over allocate' a stock item
             available = decimal.Decimal(self.stock_item.quantity)
-            allocated = decimal.Decimal(self.stock_item.allocation_count())
             quantity = decimal.Decimal(self.quantity)
+            build_allocation_count = decimal.Decimal(self.stock_item.build_allocation_count(
+                exclude_allocations={'pk': self.pk}
+            ))
+            sales_allocation_count = decimal.Decimal(self.stock_item.sales_order_allocation_count())
 
-            if available - allocated + quantity < quantity:
+            total_allocation = (
+                build_allocation_count + sales_allocation_count + quantity
+            )
+
+            if total_allocation > available:
                 raise ValidationError({
                     'quantity': _('Stock item is over-allocated')
                 })

--- a/src/backend/InvenTree/stock/models.py
+++ b/src/backend/InvenTree/stock/models.py
@@ -1190,9 +1190,17 @@ class StockItem(
 
         return self.sales_order_allocations.count() > 0
 
-    def build_allocation_count(self):
-        """Return the total quantity allocated to builds."""
-        query = self.allocations.aggregate(q=Coalesce(Sum('quantity'), Decimal(0)))
+    def build_allocation_count(self, **kwargs):
+        """Return the total quantity allocated to builds, with optional filters."""
+        query = self.allocations.all()
+
+        if filter_allocations := kwargs.get('filter_allocations'):
+            query = query.filter(**filter_allocations)
+
+        if exclude_allocations := kwargs.get('exclude_allocations'):
+            query = query.exclude(**exclude_allocations)
+
+        query = query.aggregate(q=Coalesce(Sum('quantity'), Decimal(0)))
 
         total = query['q']
 


### PR DESCRIPTION
This pull request fixes an issue with `BuildItem` over-allocation checks which prevent allocation changes to over-allocated items. Looking a bit closer at related code it appears `SalesOrderAllocation` already handled this correctly, and I've aligned these changes with that implementation.

---------------

Not sure if this is a concern but I noticed the quantity checks between `BuildItem` and `SalesOrderAllocation` don't appear to be aligned with one casting to `decimal.Decimal` and the other not. Not sure if this is breaking anything, but it doesn't look quite right to me.

https://github.com/inventree/InvenTree/blob/f8c7635a8d42f8860dc39198d7962f5286bcd853/src/backend/InvenTree/build/models.py#L1609-L1617
https://github.com/inventree/InvenTree/blob/f8c7635a8d42f8860dc39198d7962f5286bcd853/src/backend/InvenTree/order/models.py#L2014-L2025