### PR TITLE
Add missing namespaces to contributing page

### DIFF
--- a/docs/docs/develop/contributing.md
+++ b/docs/docs/develop/contributing.md
@@ -23,7 +23,7 @@ To setup a development environment using [docker](../start/docker.md), run the f
 ```bash
 git clone https://github.com/inventree/InvenTree.git && cd InvenTree
 docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run --rm inventree-dev-server invoke install
-docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run --rm inventree-dev-server invoke setup-test --dev
+docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run --rm inventree-dev-server invoke dev.setup-test --dev
 docker compose --project-directory . -f contrib/container/dev-docker-compose.yml up -d
 ```
 
@@ -34,8 +34,8 @@ A "bare metal" development setup can be installed as follows:
 ```bash
 git clone https://github.com/inventree/InvenTree.git && cd InvenTree
 python3 -m venv env && source env/bin/activate
-pip install invoke && invoke
-pip install invoke && invoke setup-dev --tests
+pip install django invoke && invoke
+invoke dev.setup-dev --tests
 ```
 
 Read the [InvenTree setup documentation](../start/intro.md) for a complete installation reference guide.
@@ -45,7 +45,7 @@ Read the [InvenTree setup documentation](../start/intro.md) for a complete insta
 Run the following command to set up all toolsets for development.
 
 ```bash
-invoke setup-dev
+invoke dev.setup-dev
 ```
 
 *We recommend you run this command before starting to contribute. This will install and set up `pre-commit` to run some checks before each commit and help reduce errors.*
@@ -170,18 +170,18 @@ The various github actions can be found in the `./github/workflows` directory
 
 To run test locally, use:
 ```
-invoke test
+invoke dev.test
 ```
 
 To run only partial tests, for example for a module use:
 ```
-invoke test --runtest order
+invoke dev.test --runtest order
 ```
 
 To see all the available options:
 
 ```
-invoke test --help
+invoke dev.test --help
 ```
 
 ## Code Style


### PR DESCRIPTION
I was rebuilding my dev environment and the instructions in the docs didn't work as listed.

1. Without django installed in my environment `invoke` wouldn't run.
2. The `dev` namespace was missing from the invoke arguments.

It looks like this page was largely missed in PR #7904. I didn't find any other pages that didn't have the namespace specified where necessary.