### PR TITLE
Translation fixes

### DIFF
--- a/.github/scripts/check_source_strings.py
+++ b/.github/scripts/check_source_strings.py
@@ -56,14 +56,14 @@ def compare_source_strings(sources, threshold):
 
     for i, source in enumerate(sources):
         for other in sources[i + 1 :]:
-            ratio = rapidfuzz.fuzz.ratio(source, other)
-
             if other.lower() == source.lower():
                 print(f'- Duplicate: {source} ~ {other}')
                 issues += 1
+                continue
 
-            elif ratio > threshold:
-                print(f'- Close match: {source} ~ {other} ({ratio}%)')
+            ratio = rapidfuzz.fuzz.ratio(source, other)
+            if ratio > threshold:
+                print(f'- Close match: {source} ~ {other} ({ratio:.1f}%)')
                 issues += 1
 
     if issues:

--- a/.github/scripts/check_source_strings.py
+++ b/.github/scripts/check_source_strings.py
@@ -52,15 +52,22 @@ def extract_source_strings(file_path):
 
 def compare_source_strings(sources, threshold):
     """Compare source strings to find duplicates (or close matches)."""
+    issues = 0
+
     for i, source in enumerate(sources):
         for other in sources[i + 1 :]:
             ratio = rapidfuzz.fuzz.ratio(source, other)
 
             if other.lower() == source.lower():
                 print(f'- Duplicate: {source} ~ {other}')
+                issues += 1
 
             elif ratio > threshold:
                 print(f'- Close match: {source} ~ {other} ({ratio}%)')
+                issues += 1
+
+    if issues:
+        print(f' - Found {issues} issues.')
 
 
 if __name__ == '__main__':

--- a/.github/scripts/check_source_strings.py
+++ b/.github/scripts/check_source_strings.py
@@ -50,13 +50,16 @@ def extract_source_strings(file_path):
     return sources
 
 
-def compare_source_strings(sources, threshold=95):
+def compare_source_strings(sources, threshold):
     """Compare source strings to find duplicates (or close matches)."""
     for i, source in enumerate(sources):
         for other in sources[i + 1 :]:
             ratio = rapidfuzz.fuzz.ratio(source, other)
 
-            if ratio > threshold:
+            if other.lower() == source.lower():
+                print(f'- Duplicate: {source} ~ {other}')
+
+            elif ratio > threshold:
                 print(f'- Close match: {source} ~ {other} ({ratio}%)')
 
 
@@ -74,7 +77,7 @@ if __name__ == '__main__':
         '--threshold',
         type=int,
         help='Set the threshold for string comparison',
-        default=95,
+        default=99,
     )
 
     args = parser.parse_args()

--- a/.github/scripts/check_source_strings.py
+++ b/.github/scripts/check_source_strings.py
@@ -1,5 +1,6 @@
 """Script to check source strings for translations."""
 
+import argparse
 import os
 
 import rapidfuzz
@@ -49,24 +50,41 @@ def extract_source_strings(file_path):
     return sources
 
 
-def compare_source_strings(sources):
+def compare_source_strings(sources, threshold=95):
     """Compare source strings to find duplicates (or close matches)."""
-    THRESHOLD = 98
-
     for i, source in enumerate(sources):
         for other in sources[i + 1 :]:
             ratio = rapidfuzz.fuzz.ratio(source, other)
 
-            if ratio > THRESHOLD:
+            if ratio > threshold:
                 print(f'- Close match: {source} ~ {other} ({ratio}%)')
 
 
 if __name__ == '__main__':
-    backend_sources = extract_source_strings(BACKEND_SOURCE_FILE)
-    frontend_sources = extract_source_strings(FRONTEND_SOURCE_FILE)
+    parser = argparse.ArgumentParser(
+        description='Check source strings for translations.'
+    )
+    parser.add_argument(
+        '--backend', action='store_true', help='Check backend source strings'
+    )
+    parser.add_argument(
+        '--frontend', action='store_true', help='Check frontend source strings'
+    )
+    parser.add_argument(
+        '--threshold',
+        type=int,
+        help='Set the threshold for string comparison',
+        default=95,
+    )
 
-    print('Backend source strings:', len(backend_sources))
-    compare_source_strings(backend_sources)
+    args = parser.parse_args()
 
-    print('Frontend source strings:', len(frontend_sources))
-    compare_source_strings(frontend_sources)
+    if args.backend:
+        backend_sources = extract_source_strings(BACKEND_SOURCE_FILE)
+        print('Backend source strings:', len(backend_sources))
+        compare_source_strings(backend_sources, args.threshold)
+
+    if args.frontend:
+        frontend_sources = extract_source_strings(FRONTEND_SOURCE_FILE)
+        print('Frontend source strings:', len(frontend_sources))
+        compare_source_strings(frontend_sources, args.threshold)

--- a/.github/scripts/check_source_strings.py
+++ b/.github/scripts/check_source_strings.py
@@ -1,0 +1,72 @@
+"""Script to check source strings for translations."""
+
+import os
+
+import rapidfuzz
+
+BACKEND_SOURCE_FILE = [
+    '..',
+    '..',
+    'src',
+    'backend',
+    'InvenTree',
+    'locale',
+    'en',
+    'LC_MESSAGES',
+    'django.po',
+]
+
+FRONTEND_SOURCE_FILE = [
+    '..',
+    '..',
+    'src',
+    'frontend',
+    'src',
+    'locales',
+    'en',
+    'messages.po',
+]
+
+
+def extract_source_strings(file_path):
+    """Extract source strings from the provided file."""
+    here = os.path.abspath(os.path.dirname(__file__))
+    abs_file_path = os.path.abspath(os.path.join(here, *file_path))
+
+    sources = []
+
+    with open(abs_file_path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith('msgid '):
+                msgid = line[6:].strip()
+
+                if msgid in sources:
+                    print(f'Duplicate source string: {msgid}')
+                else:
+                    sources.append(msgid)
+
+    return sources
+
+
+def compare_source_strings(sources):
+    """Compare source strings to find duplicates (or close matches)."""
+    THRESHOLD = 98
+
+    for i, source in enumerate(sources):
+        for other in sources[i + 1 :]:
+            ratio = rapidfuzz.fuzz.ratio(source, other)
+
+            if ratio > THRESHOLD:
+                print(f'- Close match: {source} ~ {other} ({ratio}%)')
+
+
+if __name__ == '__main__':
+    backend_sources = extract_source_strings(BACKEND_SOURCE_FILE)
+    frontend_sources = extract_source_strings(FRONTEND_SOURCE_FILE)
+
+    print('Backend source strings:', len(backend_sources))
+    compare_source_strings(backend_sources)
+
+    print('Frontend source strings:', len(frontend_sources))
+    compare_source_strings(frontend_sources)

--- a/.github/workflows/check_translations.yaml
+++ b/.github/workflows/check_translations.yaml
@@ -38,5 +38,8 @@ jobs:
           apt-dependency: gettext
       - name: Test Translations
         run: invoke dev.translate
+      - name: Check for Duplicates
+        run: |
+          python ./.github/scripts/check_source_strings.py --frontend --backend
       - name: Check Migration Files
         run: python3 .github/scripts/check_migration_files.py

--- a/src/backend/InvenTree/InvenTree/conversion.py
+++ b/src/backend/InvenTree/InvenTree/conversion.py
@@ -158,7 +158,7 @@ def convert_physical_value(value: str, unit: Optional[str] = None, strip_units=T
             valid = False
 
         if not valid:
-            raise ValidationError(_('Invalid unit provided ({unit})'))
+            raise ValidationError(_(f'Invalid unit provided ({unit})'))
 
     original = str(value).strip()
 

--- a/src/backend/InvenTree/InvenTree/conversion.py
+++ b/src/backend/InvenTree/InvenTree/conversion.py
@@ -158,7 +158,7 @@ def convert_physical_value(value: str, unit: Optional[str] = None, strip_units=T
             valid = False
 
         if not valid:
-            raise ValidationError(_('Invalid unit provided') + f': ({unit})')
+            raise ValidationError(_('Invalid unit provided ({unit})'))
 
     original = str(value).strip()
 

--- a/src/backend/InvenTree/InvenTree/conversion.py
+++ b/src/backend/InvenTree/InvenTree/conversion.py
@@ -158,7 +158,7 @@ def convert_physical_value(value: str, unit: Optional[str] = None, strip_units=T
             valid = False
 
         if not valid:
-            raise ValidationError(_(f'Invalid unit provided ({unit})'))
+            raise ValidationError(_('Invalid unit provided') + f': ({unit})')
 
     original = str(value).strip()
 
@@ -204,7 +204,7 @@ def convert_physical_value(value: str, unit: Optional[str] = None, strip_units=T
         if unit:
             raise ValidationError(_(f'Could not convert {original} to {unit}'))
         else:
-            raise ValidationError(_('Invalid quantity supplied'))
+            raise ValidationError(_('Invalid quantity provided'))
 
     # Calculate the "magnitude" of the value, as a float
     # If the value is specified strangely (e.g. as a fraction or a dozen), this can cause issues
@@ -218,7 +218,7 @@ def convert_physical_value(value: str, unit: Optional[str] = None, strip_units=T
 
         magnitude = float(ureg.Quantity(magnitude).to_base_units().magnitude)
     except Exception as exc:
-        raise ValidationError(_(f'Invalid quantity supplied ({exc})'))
+        raise ValidationError(_('Invalid quantity provided') + f': ({exc})')
 
     if strip_units:
         return magnitude

--- a/src/backend/InvenTree/InvenTree/helpers.py
+++ b/src/backend/InvenTree/InvenTree/helpers.py
@@ -551,7 +551,7 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
 
                 if a == b:
                     # Invalid group
-                    add_error(_('Invalid group') + f': {group}')
+                    add_error(_(f'Invalid group: {group}'))
                     continue
 
                 group_items = []
@@ -594,7 +594,7 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
                     for item in group_items:
                         add_serial(item)
                 else:
-                    add_error(_('Invalid group') + f': {group}')
+                    add_error(_(f'Invalid group: {group}'))
 
             else:
                 # In the case of a different number of hyphens, simply add the entire group
@@ -612,14 +612,14 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
             sequence_count = max(0, expected_quantity - len(serials))
 
             if len(items) > 2 or len(items) == 0:
-                add_error(_('Invalid group') + f': {group}')
+                add_error(_(f'Invalid group: {group}'))
                 continue
             elif len(items) == 2:
                 try:
                     if items[1]:
                         sequence_count = int(items[1]) + 1
                 except ValueError:
-                    add_error(_('Invalid group') + f': {group}')
+                    add_error(_(f'Invalid group: {group}'))
                     continue
 
             value = items[0]
@@ -638,7 +638,7 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
                 for item in sequence_items:
                     add_serial(item)
             else:
-                add_error(_('Invalid group') + f': {group}')
+                add_error(_(f'Invalid group: {group}'))
 
         else:
             # At this point, we assume that the 'group' is just a single serial value

--- a/src/backend/InvenTree/InvenTree/helpers.py
+++ b/src/backend/InvenTree/InvenTree/helpers.py
@@ -551,7 +551,7 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
 
                 if a == b:
                     # Invalid group
-                    add_error(_(f'Invalid group range: {group}'))
+                    add_error(_('Invalid group') + f': {group}')
                     continue
 
                 group_items = []
@@ -594,7 +594,7 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
                     for item in group_items:
                         add_serial(item)
                 else:
-                    add_error(_(f'Invalid group range: {group}'))
+                    add_error(_('Invalid group') + f': {group}')
 
             else:
                 # In the case of a different number of hyphens, simply add the entire group
@@ -612,14 +612,14 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
             sequence_count = max(0, expected_quantity - len(serials))
 
             if len(items) > 2 or len(items) == 0:
-                add_error(_(f'Invalid group sequence: {group}'))
+                add_error(_('Invalid group') + f': {group}')
                 continue
             elif len(items) == 2:
                 try:
                     if items[1]:
                         sequence_count = int(items[1]) + 1
                 except ValueError:
-                    add_error(_(f'Invalid group sequence: {group}'))
+                    add_error(_('Invalid group') + f': {group}')
                     continue
 
             value = items[0]
@@ -638,7 +638,7 @@ def extract_serial_numbers(input_string, expected_quantity: int, starting_value=
                 for item in sequence_items:
                     add_serial(item)
             else:
-                add_error(_(f'Invalid group sequence: {group}'))
+                add_error(_('Invalid group') + f': {group}')
 
         else:
             # At this point, we assume that the 'group' is just a single serial value

--- a/src/backend/InvenTree/InvenTree/magic_login.py
+++ b/src/backend/InvenTree/InvenTree/magic_login.py
@@ -25,7 +25,7 @@ def send_simple_login_email(user, link):
     )
 
     send_mail(
-        _(f'[{site_name}] Log in to the app'),
+        f'[{site_name}]' + _('Log in to the app'),
         email_plaintext_message,
         settings.DEFAULT_FROM_EMAIL,
         [user.email],

--- a/src/backend/InvenTree/InvenTree/magic_login.py
+++ b/src/backend/InvenTree/InvenTree/magic_login.py
@@ -25,7 +25,7 @@ def send_simple_login_email(user, link):
     )
 
     send_mail(
-        f'[{site_name}]' + _('Log in to the app'),
+        f'[{site_name}] ' + _('Log in to the app'),
         email_plaintext_message,
         settings.DEFAULT_FROM_EMAIL,
         [user.email],

--- a/src/backend/InvenTree/InvenTree/serializers.py
+++ b/src/backend/InvenTree/InvenTree/serializers.py
@@ -835,7 +835,7 @@ class DataFileExtractSerializer(serializers.Serializer):
             # Check for missing required columns
             if required and name not in self.columns:
                 raise serializers.ValidationError(
-                    _('Missing required column') + f': {name}'
+                    _('Missing required column') + f": '{name}'"
                 )
 
         for col in self.columns:

--- a/src/backend/InvenTree/InvenTree/serializers.py
+++ b/src/backend/InvenTree/InvenTree/serializers.py
@@ -835,7 +835,7 @@ class DataFileExtractSerializer(serializers.Serializer):
             # Check for missing required columns
             if required and name not in self.columns:
                 raise serializers.ValidationError(
-                    _('Missing required column') + f": '{name}'"
+                    _(f"Missing required column: '{name}'")
                 )
 
         for col in self.columns:
@@ -844,7 +844,7 @@ class DataFileExtractSerializer(serializers.Serializer):
 
             # Check for duplicated columns
             if col in cols_seen:
-                raise serializers.ValidationError(_('Duplicate column') + f': {col}')
+                raise serializers.ValidationError(_(f"Duplicate column: '{col}'"))
 
             cols_seen.add(col)
 

--- a/src/backend/InvenTree/InvenTree/serializers.py
+++ b/src/backend/InvenTree/InvenTree/serializers.py
@@ -624,7 +624,7 @@ class DataFileUploadSerializer(serializers.Serializer):
         accepted_file_types = ['xls', 'xlsx', 'csv', 'tsv', 'xml']
 
         if ext not in accepted_file_types:
-            raise serializers.ValidationError(_('Unsupported file type'))
+            raise serializers.ValidationError(_('Unsupported file format'))
 
         # Impose a 50MB limit on uploaded BOM files
         max_upload_file_size = 50 * 1024 * 1024
@@ -835,7 +835,7 @@ class DataFileExtractSerializer(serializers.Serializer):
             # Check for missing required columns
             if required and name not in self.columns:
                 raise serializers.ValidationError(
-                    _(f"Missing required column: '{name}'")
+                    _('Missing required column') + f': {name}'
                 )
 
         for col in self.columns:
@@ -844,7 +844,7 @@ class DataFileExtractSerializer(serializers.Serializer):
 
             # Check for duplicated columns
             if col in cols_seen:
-                raise serializers.ValidationError(_(f"Duplicate column: '{col}'"))
+                raise serializers.ValidationError(_('Duplicate column') + f': {col}')
 
             cols_seen.add(col)
 

--- a/src/backend/InvenTree/common/files.py
+++ b/src/backend/InvenTree/common/files.py
@@ -60,7 +60,7 @@ class FileManager:
                 file.seek(0)
             else:
                 fmt = ext.upper()
-                raise ValidationError(_(f'Unsupported file format: {fmt}'))
+                raise ValidationError(_('Unsupported file format') + f': {fmt}')
         except UnicodeEncodeError:
             raise ValidationError(_('Error reading file (invalid encoding)'))
 

--- a/src/backend/InvenTree/common/forms.py
+++ b/src/backend/InvenTree/common/forms.py
@@ -22,8 +22,8 @@ class UploadFileForm(forms.Form):
 
         if name:
             # Update label and help_text with file name
-            self.fields['file'].label = _(f'{name.title()} File')
-            self.fields['file'].help_text = _(f'Select {name} file to upload')
+            self.fields['file'].label = name.title() + ' ' + _('File')
+            self.fields['file'].help_text = _('Select file to upload')
 
     def clean_file(self):
         """Run tabular file validation.

--- a/src/backend/InvenTree/common/migrations/0005_auto_20190915_1256.py
+++ b/src/backend/InvenTree/common/migrations/0005_auto_20190915_1256.py
@@ -18,6 +18,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='inventreesetting',
             name='key',
-            field=models.CharField(help_text='Settings key (must be unique - case insensitive', max_length=50, unique=True),
+            field=models.CharField(help_text='Settings key', max_length=50, unique=True),
         ),
     ]

--- a/src/backend/InvenTree/common/migrations/0011_auto_20210722_2114.py
+++ b/src/backend/InvenTree/common/migrations/0011_auto_20210722_2114.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('value', models.CharField(blank=True, help_text='Settings value', max_length=200)),
-                ('key', models.CharField(help_text='Settings key (must be unique - case insensitive', max_length=50)),
+                ('key', models.CharField(help_text='Settings key', max_length=50)),
                 ('user', models.ForeignKey(blank=True, help_text='User', null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL, verbose_name='User')),
             ],
             options={

--- a/src/backend/InvenTree/common/models.py
+++ b/src/backend/InvenTree/common/models.py
@@ -780,10 +780,7 @@ class BaseInvenTreeSetting(models.Model):
             )
 
     key = models.CharField(
-        max_length=50,
-        blank=False,
-        unique=False,
-        help_text=_('Settings key (must be unique - case insensitive)'),
+        max_length=50, blank=False, unique=False, help_text=_('Settings key')
     )
 
     value = models.CharField(
@@ -2179,10 +2176,7 @@ class InvenTreeSetting(BaseInvenTreeSetting):
     typ = 'inventree'
 
     key = models.CharField(
-        max_length=50,
-        blank=False,
-        unique=True,
-        help_text=_('Settings key (must be unique - case insensitive'),
+        max_length=50, blank=False, unique=True, help_text=_('Settings key')
     )
 
     def to_native_value(self):
@@ -2559,10 +2553,7 @@ class InvenTreeUserSetting(BaseInvenTreeSetting):
     extra_unique_fields = ['user']
 
     key = models.CharField(
-        max_length=50,
-        blank=False,
-        unique=False,
-        help_text=_('Settings key (must be unique - case insensitive'),
+        max_length=50, blank=False, unique=False, help_text=_('Settings key')
     )
 
     user = models.ForeignKey(

--- a/src/backend/InvenTree/common/validators.py
+++ b/src/backend/InvenTree/common/validators.py
@@ -104,7 +104,7 @@ def validate_email_domains(setting):
         if not domain:
             raise ValidationError(_('An empty domain is not allowed.'))
         if not re.match(r'^@[a-zA-Z0-9\.\-_]+$', domain):
-            raise ValidationError(_('Invalid domain name') + f': {domain}')
+            raise ValidationError(_(f'Invalid domain name: {domain}'))
 
 
 def validate_icon(name: Union[str, None]):

--- a/src/backend/InvenTree/common/validators.py
+++ b/src/backend/InvenTree/common/validators.py
@@ -104,7 +104,7 @@ def validate_email_domains(setting):
         if not domain:
             raise ValidationError(_('An empty domain is not allowed.'))
         if not re.match(r'^@[a-zA-Z0-9\.\-_]+$', domain):
-            raise ValidationError(_(f'Invalid domain name: {domain}'))
+            raise ValidationError(_('Invalid domain name') + f': {domain}')
 
 
 def validate_icon(name: Union[str, None]):

--- a/src/backend/InvenTree/locale/he/LC_MESSAGES/django.po
+++ b/src/backend/InvenTree/locale/he/LC_MESSAGES/django.po
@@ -40,7 +40,7 @@ msgstr "למשתמש אין הרשאה לצפות במוזל הזה"
 #: InvenTree/conversion.py:161
 #, python-brace-format
 msgid "Invalid unit provided ({unit})"
-msgstr "סופקה יחידה שלא קיימת"
+msgstr "סופקה יחידה שלא קיימת ({unit})"
 
 #: InvenTree/conversion.py:178
 msgid "No value provided"

--- a/src/backend/InvenTree/locale/he/LC_MESSAGES/django.po
+++ b/src/backend/InvenTree/locale/he/LC_MESSAGES/django.po
@@ -49,7 +49,7 @@ msgstr "לא צוין ערך"
 #: InvenTree/conversion.py:205
 #, python-brace-format
 msgid "Could not convert {original} to {unit}"
-msgstr "לא ניתן להמיר מקור ליחידה"
+msgstr ""
 
 #: InvenTree/conversion.py:207
 msgid "Invalid quantity supplied"

--- a/src/backend/InvenTree/machine/migrations/0001_initial.py
+++ b/src/backend/InvenTree/machine/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
             name='MachineSetting',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('key', models.CharField(help_text='Settings key (must be unique - case insensitive)', max_length=50)),
+                ('key', models.CharField(help_text='Settings key', max_length=50)),
                 ('value', models.CharField(blank=True, help_text='Settings value', max_length=2000)),
                 ('config_type', models.CharField(choices=[('M', 'Machine'), ('D', 'Driver')], max_length=1, verbose_name='Config type')),
                 ('machine_config', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='settings', to='machine.machineconfig', verbose_name='Machine Config')),

--- a/src/backend/InvenTree/order/templates/order/order_base.html
+++ b/src/backend/InvenTree/order/templates/order/order_base.html
@@ -143,7 +143,7 @@ src="{% static 'img/blank_image.png' %}"
             {% if order.supplier %}
             <a href="{% url 'company-detail' order.supplier.id %}">{{ order.supplier.name }}</a>{% include "clip.html" %}
             {% else %}
-            <em>{% trans "No suppplier information available" %}</em>
+            <em>{% trans "No supplier information available" %}</em>
             {% endif %}
         </td>
     </tr>

--- a/src/backend/InvenTree/part/models.py
+++ b/src/backend/InvenTree/part/models.py
@@ -687,7 +687,9 @@ class Part(
             match = re.search(pattern, self.IPN)
 
             if match is None:
-                raise ValidationError(_(f'IPN must match regex pattern {pattern}'))
+                raise ValidationError(
+                    _('IPN must match regex pattern') + f': {pattern}'
+                )
 
     def validate_revision(self):
         """Check the 'revision' and 'revision_of' fields."""

--- a/src/backend/InvenTree/part/models.py
+++ b/src/backend/InvenTree/part/models.py
@@ -687,9 +687,7 @@ class Part(
             match = re.search(pattern, self.IPN)
 
             if match is None:
-                raise ValidationError(
-                    _('IPN must match regex pattern') + f': {pattern}'
-                )
+                raise ValidationError(_(f'IPN must match regex pattern {pattern}'))
 
     def validate_revision(self):
         """Check the 'revision' and 'revision_of' fields."""

--- a/src/backend/InvenTree/part/test_bom_import.py
+++ b/src/backend/InvenTree/part/test_bom_import.py
@@ -82,7 +82,7 @@ class BomUploadTest(InvenTreeAPITestCase):
         """POST with an unsupported file type."""
         response = self.post_bom('sample.txt', b'hello world', expected_code=400)
 
-        self.assertIn('Unsupported file type', str(response.data['data_file']))
+        self.assertIn('Unsupported file format', str(response.data['data_file']))
 
     def test_broken_file(self):
         """Test upload with broken (corrupted) files."""

--- a/src/backend/InvenTree/plugin/migrations/0003_pluginsetting.py
+++ b/src/backend/InvenTree/plugin/migrations/0003_pluginsetting.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             name='PluginSetting',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('key', models.CharField(help_text='Settings key (must be unique - case insensitive', max_length=50)),
+                ('key', models.CharField(help_text='Settings key', max_length=50)),
                 ('value', models.CharField(blank=True, help_text='Settings value', max_length=200)),
                 ('plugin', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='settings', to='plugin.pluginconfig', verbose_name='Plugin')),
             ],

--- a/src/backend/InvenTree/plugin/migrations/0004_alter_pluginsetting_key.py
+++ b/src/backend/InvenTree/plugin/migrations/0004_alter_pluginsetting_key.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='pluginsetting',
             name='key',
-            field=models.CharField(help_text='Settings key (must be unique - case insensitive)', max_length=50),
+            field=models.CharField(help_text='Settings key', max_length=50),
         ),
     ]

--- a/src/backend/InvenTree/plugin/migrations/0005_notificationusersetting.py
+++ b/src/backend/InvenTree/plugin/migrations/0005_notificationusersetting.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name='NotificationUserSetting',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('key', models.CharField(help_text='Settings key (must be unique - case insensitive)', max_length=50)),
+                ('key', models.CharField(help_text='Settings key', max_length=50)),
                 ('value', models.CharField(blank=True, help_text='Settings value', max_length=200)),
                 ('method', models.CharField(max_length=255, verbose_name='Method')),
                 ('user', models.ForeignKey(blank=True, help_text='User', null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL, verbose_name='User')),

--- a/src/backend/InvenTree/templates/js/translated/sales_order.js
+++ b/src/backend/InvenTree/templates/js/translated/sales_order.js
@@ -2046,7 +2046,7 @@ function loadSalesOrderLineItemTable(table, options={}) {
 
                 if (options.allow_edit && (row.shipped < row.quantity)) {
                     if (part.trackable) {
-                        buttons += makeIconButton('fa-hashtag icon-green', 'button-add-by-sn', pk, '{% trans "Allocate serial numbers" %}');
+                        buttons += makeIconButton('fa-hashtag icon-green', 'button-add-by-sn', pk, '{% trans "Allocate Serial Numbers" %}');
                     }
                     buttons += makeIconButton('fa-sign-in-alt icon-green', 'button-add', pk, '{% trans "Allocate stock" %}');
                     if (part.purchaseable) {

--- a/src/backend/InvenTree/templates/js/translated/stock.js
+++ b/src/backend/InvenTree/templates/js/translated/stock.js
@@ -617,7 +617,7 @@ function findStockItemBySerialNumber(part_id) {
                 handleFormErrors(
                     {
                         'serial': [
-                            '{% trans "Enter a serial number" %}',
+                            '{% trans "Enter serial number" %}',
                         ]
                     }, fields, opts
                 );
@@ -1445,14 +1445,14 @@ function removeStockRow(e) {
 function passFailBadge(result) {
 
     if (result) {
-        return `<span class='badge badge-right rounded-pill bg-success'>{% trans "PASS" %}</span>`;
+        return `<span class='badge badge-right rounded-pill bg-success'>{% trans "Pass" %}</span>`;
     } else {
-        return `<span class='badge badge-right rounded-pill bg-danger'>{% trans "FAIL" %}</span>`;
+        return `<span class='badge badge-right rounded-pill bg-danger'>{% trans "Fail" %}</span>`;
     }
 }
 
 function noResultBadge() {
-    return `<span class='badge badge-right rounded-pill bg-info'>{% trans "NO RESULT" %}</span>`;
+    return `<span class='badge badge-right rounded-pill bg-info'>{% trans "No result" %}</span>`;
 }
 
 function formatDate(row, date, options={}) {

--- a/src/backend/InvenTree/templates/socialaccount/authentication_error.html
+++ b/src/backend/InvenTree/templates/socialaccount/authentication_error.html
@@ -10,7 +10,7 @@
 <p>
     {% trans "An error occurred while attempting to login via your social network account." %}
     <br>
-    {% trans "Contact your system administrator for further information." %}
+    {% trans "Contact your system administrator for further information" %}
 </p>
 
 <hr>

--- a/src/frontend/src/components/importer/ImporterImportProgress.tsx
+++ b/src/frontend/src/components/importer/ImporterImportProgress.tsx
@@ -36,7 +36,7 @@ export default function ImporterImportProgress({
           <StylishText size="lg">{t`Importing Records`}</StylishText>
           <Loader />
           <Text size="lg">
-            {t`Imported rows`}: {session.sessionData.row_count}
+            {t`Imported Rows`}: {session.sessionData.row_count}
           </Text>
         </Stack>
       </Container>

--- a/src/frontend/src/components/items/GettingStartedCarousel.tsx
+++ b/src/frontend/src/components/items/GettingStartedCarousel.tsx
@@ -24,7 +24,7 @@ function StartedCard({
       </div>
       <Anchor href={link} target="_blank">
         <Button>
-          <Trans>Read more</Trans>
+          <Trans>Read More</Trans>
         </Button>
       </Anchor>
     </Paper>

--- a/src/frontend/src/components/nav/MainMenu.tsx
+++ b/src/frontend/src/components/nav/MainMenu.tsx
@@ -56,7 +56,7 @@ export function MainMenu() {
           component={Link}
           to="/settings/user"
         >
-          <Trans>Account settings</Trans>
+          <Trans>Account Settings</Trans>
         </Menu.Item>
         {user?.is_staff && (
           <Menu.Item

--- a/src/frontend/src/components/nav/SearchDrawer.tsx
+++ b/src/frontend/src/components/nav/SearchDrawer.tsx
@@ -459,7 +459,7 @@ export function SearchDrawer({
               color="blue"
               radius="sm"
               variant="light"
-              title={t`No results`}
+              title={t`No Results`}
               icon={<IconSearch size="1rem" />}
             >
               <Trans>No results available for search query</Trans>

--- a/src/frontend/src/components/widgets/GetStartedWidget.tsx
+++ b/src/frontend/src/components/widgets/GetStartedWidget.tsx
@@ -8,7 +8,7 @@ export default function GetStartedWidget() {
   return (
     <span>
       <Title order={5}>
-        <Trans>Getting started</Trans>
+        <Trans>Getting Started</Trans>
       </Title>
       <GettingStartedCarousel items={navDocLinks} />
     </span>

--- a/src/frontend/src/defaults/menuItems.tsx
+++ b/src/frontend/src/defaults/menuItems.tsx
@@ -12,7 +12,7 @@ export const menuItems: menuItemsCollection = {
   },
   profile: {
     id: 'profile',
-    text: <Trans>Account settings</Trans>,
+    text: <Trans>Account Settings</Trans>,
     link: '/settings/user',
     doctext: <Trans>User attributes and design settings.</Trans>
   },

--- a/src/frontend/src/functions/notifications.tsx
+++ b/src/frontend/src/functions/notifications.tsx
@@ -21,7 +21,7 @@ export function notYetImplemented() {
  */
 export function permissionDenied() {
   notifications.show({
-    title: t`Permission denied`,
+    title: t`Permission Denied`,
     message: t`You do not have permission to perform this action`,
     color: 'red'
   });

--- a/src/frontend/src/pages/Auth/Reset.tsx
+++ b/src/frontend/src/pages/Auth/Reset.tsx
@@ -38,7 +38,7 @@ export default function Reset() {
               type="submit"
               onClick={() => handleReset(navigate, simpleForm.values)}
             >
-              <Trans>Send mail</Trans>
+              <Trans>Send Email</Trans>
             </Button>
           </Stack>
         </Container>

--- a/src/frontend/src/pages/Auth/Set-Password.tsx
+++ b/src/frontend/src/pages/Auth/Set-Password.tsx
@@ -45,12 +45,7 @@ export default function Set_Password() {
   useEffect(() => {
     // make sure we have a token
     if (!token || !uid) {
-      notifications.show({
-        title: t`No token provided`,
-        message: t`You need to provide a token to set a new password. Check your inbox for a reset link.`,
-        color: 'red'
-      });
-      navigate('/login');
+      invalidToken();
     }
   }, [token]);
 
@@ -109,7 +104,7 @@ export default function Set_Password() {
               />
             </Stack>
             <Button type="submit" onClick={handleSet}>
-              <Trans>Send mail</Trans>
+              <Trans>Send Email</Trans>
             </Button>
           </Stack>
         </Container>

--- a/src/frontend/src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx
+++ b/src/frontend/src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx
@@ -32,7 +32,7 @@ export default function TaskManagementPanel() {
   return (
     <>
       {taskInfo?.is_running == false && (
-        <Alert title={t`Background Worker Not Running`} color="red">
+        <Alert title={t`Background worker not running`} color="red">
           <Text>{t`The background task manager service is not running. Contact your system administrator.`}</Text>
         </Alert>
       )}

--- a/src/frontend/src/pages/Index/Settings/AdminCenter/UserManagementPanel.tsx
+++ b/src/frontend/src/pages/Index/Settings/AdminCenter/UserManagementPanel.tsx
@@ -34,7 +34,7 @@ export default function UserManagementPanel() {
             </Trans>
           </Text>
           <Anchor component={Link} to={'/settings/system'}>
-            <Trans>System settings</Trans>
+            <Trans>System Settings</Trans>
           </Anchor>
         </Group>
       </Stack>

--- a/src/frontend/src/pages/part/pricing/SaleHistoryPanel.tsx
+++ b/src/frontend/src/pages/part/pricing/SaleHistoryPanel.tsx
@@ -21,7 +21,7 @@ export default function SaleHistoryPanel({
     return [
       {
         accessor: 'order',
-        title: t`Sale Order`,
+        title: t`Sales Order`,
         render: (record: any) => record?.order_detail?.reference,
         sortable: true,
         switchable: false

--- a/src/frontend/src/pages/sales/ReturnOrderDetail.tsx
+++ b/src/frontend/src/pages/sales/ReturnOrderDetail.tsx
@@ -346,7 +346,7 @@ export default function ReturnOrderDetail() {
     title: t`Cancel Return Order`,
     onFormSuccess: refreshInstance,
     preFormWarning: t`Cancel this order`,
-    successMessage: t`Order canceled`
+    successMessage: t`Order cancelled`
   });
 
   const holdOrder = useCreateApiFormModal({

--- a/src/frontend/src/pages/stock/StockDetail.tsx
+++ b/src/frontend/src/pages/stock/StockDetail.tsx
@@ -668,7 +668,7 @@ export default function StockDetail() {
           },
           {
             name: t`Add`,
-            tooltip: t`Add stock`,
+            tooltip: t`Add Stock`,
             hidden: serialized,
             icon: <InvenTreeIcon icon="add" iconProps={{ color: 'green' }} />,
             onClick: () => {
@@ -677,7 +677,7 @@ export default function StockDetail() {
           },
           {
             name: t`Remove`,
-            tooltip: t`Remove stock`,
+            tooltip: t`Remove Stock`,
             hidden: serialized,
             icon: <InvenTreeIcon icon="remove" iconProps={{ color: 'red' }} />,
             onClick: () => {
@@ -695,7 +695,7 @@ export default function StockDetail() {
           },
           {
             name: t`Transfer`,
-            tooltip: t`Transfer stock`,
+            tooltip: t`Transfer Stock`,
             icon: (
               <InvenTreeIcon icon="transfer" iconProps={{ color: 'blue' }} />
             ),

--- a/src/frontend/src/tables/ColumnRenderers.tsx
+++ b/src/frontend/src/tables/ColumnRenderers.tsx
@@ -38,7 +38,7 @@ export function PartColumn({
           </Tooltip>
         )}
         {part?.locked && (
-          <Tooltip label={t`Part is locked`}>
+          <Tooltip label={t`Part is Locked`}>
             <IconLock size={16} />
           </Tooltip>
         )}

--- a/src/frontend/src/tables/InvenTreeTable.tsx
+++ b/src/frontend/src/tables/InvenTreeTable.tsx
@@ -652,8 +652,8 @@ export function InvenTreeTable<T extends Record<string, any>>({
                 <ButtonMenu
                   key="barcode-actions"
                   icon={<IconBarcode />}
-                  label={t`Barcode actions`}
-                  tooltip={t`Barcode actions`}
+                  label={t`Barcode Actions`}
+                  tooltip={t`Barcode Actions`}
                   actions={tableProps.barcodeActions ?? []}
                 />
               )}

--- a/src/frontend/src/tables/InvenTreeTable.tsx
+++ b/src/frontend/src/tables/InvenTreeTable.tsx
@@ -549,7 +549,7 @@ export function InvenTreeTable<T extends Record<string, any>>({
         color="red"
         title={t`Are you sure you want to delete the selected items?`}
       >
-        {t`This action cannot be undone!`}
+        {t`This action cannot be undone`}
       </Alert>
     ),
     initialData: {
@@ -709,7 +709,7 @@ export function InvenTreeTable<T extends Record<string, any>>({
                     variant="transparent"
                     aria-label="table-select-filters"
                   >
-                    <Tooltip label={t`Table filters`}>
+                    <Tooltip label={t`Table Filters`}>
                       <IconFilter
                         onClick={() => setFiltersVisible(!filtersVisible)}
                       />

--- a/src/frontend/src/tables/bom/BomTable.tsx
+++ b/src/frontend/src/tables/bom/BomTable.tsx
@@ -539,7 +539,7 @@ export function BomTable({
       <Stack gap="xs">
         {partLocked && (
           <Alert
-            title={t`Part is Locked`}
+            title={t`Part is locked`}
             color="orange"
             icon={<IconLock />}
             p="xs"

--- a/src/frontend/src/tables/bom/BomTable.tsx
+++ b/src/frontend/src/tables/bom/BomTable.tsx
@@ -539,7 +539,7 @@ export function BomTable({
       <Stack gap="xs">
         {partLocked && (
           <Alert
-            title={t`Part is locked`}
+            title={t`Part is Locked`}
             color="orange"
             icon={<IconLock />}
             p="xs"

--- a/src/frontend/src/tables/build/BuildLineTable.tsx
+++ b/src/frontend/src/tables/build/BuildLineTable.tsx
@@ -56,7 +56,7 @@ export default function BuildLineTable({
       {
         name: 'available',
         label: t`Available`,
-        description: t`Show lines with available stock`
+        description: t`Show items with available stock`
       },
       {
         name: 'consumable',

--- a/src/frontend/src/tables/build/BuildOutputTable.tsx
+++ b/src/frontend/src/tables/build/BuildOutputTable.tsx
@@ -301,7 +301,7 @@ export default function BuildOutputTable({
           }
         },
         RowEditAction({
-          tooltip: t`Edit build output`,
+          tooltip: t`Edit Build Output`,
           onClick: () => {
             setSelectedOutputs([record]);
             editBuildOutput.open();

--- a/src/frontend/src/tables/part/PartParameterTemplateTable.tsx
+++ b/src/frontend/src/tables/part/PartParameterTemplateTable.tsx
@@ -138,7 +138,7 @@ export default function PartParameterTemplateTable() {
   const tableActions = useMemo(() => {
     return [
       <AddItemButton
-        tooltip={t`Add parameter template`}
+        tooltip={t`Add Parameter Template`}
         onClick={() => newTemplate.open()}
         hidden={!user.hasAddRole(UserRoles.part)}
       />

--- a/src/frontend/src/tables/part/RelatedPartTable.tsx
+++ b/src/frontend/src/tables/part/RelatedPartTable.tsx
@@ -106,7 +106,7 @@ export function RelatedPartTable({
     return [
       <AddItemButton
         key="add-related-part"
-        tooltip={t`Add related part`}
+        tooltip={t`Add Related Part`}
         hidden={!user.hasAddRole(UserRoles.part)}
         onClick={() => newRelatedPart.open()}
       />

--- a/src/frontend/src/tables/plugin/PluginListTable.tsx
+++ b/src/frontend/src/tables/plugin/PluginListTable.tsx
@@ -305,7 +305,7 @@ export default function PluginListTable() {
       >
         <Stack gap="xs">
           <Text>{t`The selected plugin will be uninstalled.`}</Text>
-          <Text>{t`This action cannot be undone.`}</Text>
+          <Text>{t`This action cannot be undone`}</Text>
         </Stack>
       </Alert>
     ),

--- a/src/frontend/src/tables/purchasing/PurchaseOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/purchasing/PurchaseOrderLineItemTable.tsx
@@ -341,7 +341,7 @@ export function PurchaseOrderLineItemTable({
       />,
       <AddItemButton
         key="add-line-item"
-        tooltip={t`Add line item`}
+        tooltip={t`Add Line Item`}
         onClick={() => {
           setInitialData({
             order: orderId

--- a/src/frontend/src/tables/sales/ReturnOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/sales/ReturnOrderLineItemTable.tsx
@@ -157,7 +157,7 @@ export default function ReturnOrderLineItemTable({
     return [
       <AddItemButton
         key="add-line-item"
-        tooltip={t`Add line item`}
+        tooltip={t`Add Line Item`}
         hidden={!user.hasAddRole(UserRoles.return_order)}
         onClick={() => {
           newLine.open();

--- a/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
@@ -255,7 +255,7 @@ export default function SalesOrderLineItemTable({
     return [
       <AddItemButton
         key="add-line-item"
-        tooltip={t`Add line item`}
+        tooltip={t`Add Line Item`}
         onClick={() => {
           setInitialData({
             order: orderId

--- a/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
@@ -277,7 +277,7 @@ export default function SalesOrderLineItemTable({
             allocated ||
             !editable ||
             !user.hasChangeRole(UserRoles.sales_order),
-          title: t`Allocate stock`,
+          title: t`Allocate Stock`,
           icon: <IconSquareArrowRight />,
           color: 'green',
           onClick: notYetImplemented

--- a/src/frontend/src/tables/settings/CustomStateTable.tsx
+++ b/src/frontend/src/tables/settings/CustomStateTable.tsx
@@ -112,7 +112,7 @@ export default function CustomStateTable() {
     return [
       <AddItemButton
         onClick={() => newCustomState.open()}
-        tooltip={t`Add state`}
+        tooltip={t`Add State`}
       />
     ];
   }, []);

--- a/src/frontend/src/tables/stock/StockItemTable.tsx
+++ b/src/frontend/src/tables/stock/StockItemTable.tsx
@@ -449,7 +449,7 @@ export function StockItemTable({
         disabled={table.selectedRecords.length === 0}
         actions={[
           {
-            name: t`Add stock`,
+            name: t`Add Stock`,
             icon: <InvenTreeIcon icon="add" iconProps={{ color: 'green' }} />,
             tooltip: t`Add a new stock item`,
             disabled: !can_add_stock,
@@ -458,7 +458,7 @@ export function StockItemTable({
             }
           },
           {
-            name: t`Remove stock`,
+            name: t`Remove Stock`,
             icon: <InvenTreeIcon icon="remove" iconProps={{ color: 'red' }} />,
             tooltip: t`Remove some quantity from a stock item`,
             disabled: !can_add_stock,
@@ -478,7 +478,7 @@ export function StockItemTable({
             }
           },
           {
-            name: t`Transfer stock`,
+            name: t`Transfer Stock`,
             icon: (
               <InvenTreeIcon icon="transfer" iconProps={{ color: 'blue' }} />
             ),

--- a/src/frontend/src/tables/stock/StockItemTable.tsx
+++ b/src/frontend/src/tables/stock/StockItemTable.tsx
@@ -525,7 +525,7 @@ export function StockItemTable({
           {
             name: t`Delete stock`,
             icon: <InvenTreeIcon icon="delete" iconProps={{ color: 'red' }} />,
-            tooltip: t`Delete stock items`,
+            tooltip: t`Delete Stock Items`,
             disabled: !can_delete_stock,
             onClick: () => {
               deleteStock.open();


### PR DESCRIPTION
- Simplifies translations strings
- Removes some similar duplicate strings
- Reduces passing of tokens into translation
- Fixes bug in translated string

Additionally, adds a helper script (in `./github/scripts/`) which can detect duplicate (or close match) translated strings. For now, this script is just used to manually detect similar strings - but could easily be used in the future as part of CI 

Note: The bad string has also been corrected on Crowdin

### Future Work

There are a lot of strings which are "identical" except for the case sensitivity. Might be worth looking into using a common style for these strings, and then implementing a `titleCase` function where necessary, rather than requiring translation for two versions of the same string.