### PR TITLE
[Breaking] Samesite Cookie Fix

### DIFF
--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -107,7 +107,18 @@ Depending on how your InvenTree installation is configured, you will need to pay
 | INVENTREE_USE_X_FORWARDED_HOST | use_x_forwarded_host | Use forwarded host header | `False` |
 | INVENTREE_USE_X_FORWARDED_PORT | use_x_forwarded_port | Use forwarded port header | `False` |
 | INVENTREE_SESSION_COOKIE_SECURE | cookie.secure | Enforce secure session cookies | `False` |
-| INVENTREE_COOKIE_SAMESITE | cookie.samesite | Session cookie mode. Must be one of `Strict | Lax | None`. Refer to the [mozilla developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) for more information. | `None` |
+| INVENTREE_COOKIE_SAMESITE | cookie.samesite | Session cookie mode. Must be one of `Strict | Lax | None | False`. Refer to the [mozilla developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) and the [django documentation]({% include "django.html" %}/ref/settings/#std-setting-SESSION_COOKIE_SAMESITE) for more information. | False |
+
+### Debug Mode
+
+Note that in [debug mode](./intro.md#debug-mode), some of the above settings are automatically adjusted to allow for easier development:
+
+| Setting | Value in Debug Mode | Description |
+| --- | --- | --- |
+| `INVENTREE_ALLOWED_HOSTS` | `*` | Allow all host in debug mode |
+| `CSRF_TRUSTED_ORIGINS` | Value is appended to allow `http://*.localhost:*` | Allow all connections from localhost, for development purposes |
+| `INVENTREE_COOKIE_SAMESITE` | `False` | Disable all same-site cookie checks in debug mode |
+| `INVENTREE_SESSION_COOKIE_SECURE` | `False` | Disable secure session cookies in debug mode (allow non-https cookies) |
 
 ### Proxy Settings
 

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1093,22 +1093,32 @@ if (
     sys.exit(-1)
 
 COOKIE_MODE = (
-    str(get_setting('INVENTREE_COOKIE_SAMESITE', 'cookie.samesite', 'None'))
+    str(get_setting('INVENTREE_COOKIE_SAMESITE', 'cookie.samesite', 'False'))
     .lower()
     .strip()
 )
 
-valid_cookie_modes = {'lax': 'Lax', 'strict': 'Strict', 'none': 'None', 'null': 'None'}
+# Valid modes (as per the django settings documentation)
+valid_cookie_modes = ['lax', 'strict', 'none']
 
-COOKIE_MODE = valid_cookie_modes.get(COOKIE_MODE.lower(), 'None')
+if not DEBUG and COOKIE_MODE in valid_cookie_modes:
+    # Set the cookie mode (in production mode only)
+    COOKIE_MODE = COOKIE_MODE.capitalize()
+else:
+    # Default to False, as per the Django settings
+    COOKIE_MODE = False
 
 # Additional CSRF settings
 CSRF_HEADER_NAME = 'HTTP_X_CSRFTOKEN'
 CSRF_COOKIE_NAME = 'csrftoken'
+
 CSRF_COOKIE_SAMESITE = COOKIE_MODE
 SESSION_COOKIE_SAMESITE = COOKIE_MODE
-SESSION_COOKIE_SECURE = get_boolean_setting(
-    'INVENTREE_SESSION_COOKIE_SECURE', 'cookie.secure', False
+
+SESSION_COOKIE_SECURE = (
+    False
+    if DEBUG
+    else get_boolean_setting('INVENTREE_SESSION_COOKIE_SECURE', 'cookie.secure', True)
 )
 
 USE_X_FORWARDED_HOST = get_boolean_setting(

--- a/src/backend/InvenTree/config_template.yaml
+++ b/src/backend/InvenTree/config_template.yaml
@@ -117,7 +117,7 @@ use_x_forwarded_port: false
 # Cookie settings
 cookie:
   secure: false
-  samesite: none
+  samesite: false
 
 # Cross Origin Resource Sharing (CORS) settings (see https://github.com/adamchainz/django-cors-headers)
 cors:


### PR DESCRIPTION
A [previous PR](https://github.com/inventree/InvenTree/pull/8262) which was well-intentioned to solve [this issue](https://github.com/inventree/InvenTree/issues/8254) has resulted in problems with session authentication.

PR #8262 changed the default value of `CSRF_COOKIE_SAMESITE` and `SESSION_COOKIE_SAMESITE` from `None (boolean value)` to `'None' (string value). This is in accordance with the [django documentation](https://docs.djangoproject.com/en/5.1/ref/settings/#std-setting-SESSION_COOKIE_SAMESITE) which specifies that these values must be *strings* and not `None`:

![image](https://github.com/user-attachments/assets/1036c7dc-07b8-4e04-8195-b7c0d579653b)

**However**, note that the boolean value `False` is allowed, which disables the cookie checks entirely.

Our previous literal value `None` (disallowed) was resulting a boolean check to evaluate the same as if the value was set to `False` (allowed):

```python
>>> not 'None'
False
>>> not None
True
>>> not False
True
```

This means that (prior to this patch), the samesite cookie session was effectively set to `False` (disabled), and not `'None'` - which has different implications in operation. However, this value was causing a downstream error in the [allauth](https://docs.allauth.org/en/latest/) package.

### Changes

So, this PR makes the following adjustments:

- Cookie-Samesite options are stringified appropriately (or, set to the `False` boolean literal)
- The default value is changed from `'None'` to `False`
- Value is forced to `False` in `DEBUG` mode (to aid in easy development)

### Breaking

This is considered a "breaking" change because any production installation which has the samesite set to `None` will now evaluate to `'None'` instead of `False` - resulting in different behaviour.

Users in this predicament should change the value of `INVENTREE_COOKIE_SAMESITE` from `None` to `False` to disable the checks.