### PR TITLE
Order table variants

### DIFF
--- a/src/backend/InvenTree/build/api.py
+++ b/src/backend/InvenTree/build/api.py
@@ -35,7 +35,6 @@ class BuildFilter(rest_filters.FilterSet):
         model = Build
         fields = [
             'sales_order',
-            'part',
         ]
 
     status = rest_filters.NumberFilter(label='Status')
@@ -53,6 +52,39 @@ class BuildFilter(rest_filters.FilterSet):
         label=_('Parent Build'),
         field_name='parent',
     )
+
+    include_variants = rest_filters.BooleanFilter(label='Include Variants', method='filter_include_variants')
+
+    def filter_include_variants(self, queryset, name, value):
+        """Filter by whether or not to include variants of the selected part.
+
+        Note:
+        - This filter does nothing by itself, and requires the 'part' filter to be set.
+        - Refer to the 'filter_part' method for more information.
+        """
+
+        return queryset
+
+    part = rest_filters.ModelChoiceFilter(
+        queryset=part.models.Part.objects.all(),
+        field_name='part',
+        method='filter_part'
+    )
+
+    def filter_part(self, queryset, name, part):
+        """Filter by 'part' which is being built.
+
+        Note:
+        - If "include_variants" is True, include all variants of the selected part.
+        - Otherwise, just filter by the selected part.
+        """
+
+        include_variants = str2bool(self.data.get('include_variants', False))
+
+        if include_variants:
+            return queryset.filter(part__in=part.get_descendants(include_self=True))
+        else:
+            return queryset.filter(part=part)
 
     ancestor = rest_filters.ModelChoiceFilter(
         queryset=Build.objects.all(),

--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -270,8 +270,6 @@ class Build(
         related_name='builds',
         limit_choices_to={
             'assembly': True,
-            'active': True,
-            'virtual': False,
         },
         help_text=_('Select part to build'),
     )

--- a/src/frontend/src/tables/build/BuildOrderTable.tsx
+++ b/src/frontend/src/tables/build/BuildOrderTable.tsx
@@ -160,7 +160,7 @@ export function BuildOrderTable({
         name: 'include_variants',
         type: 'boolean',
         label: t`Include Variants`,
-        description: t`Include variant build orders`
+        description: t`Include build orders for part variants`
       });
     }
 

--- a/src/frontend/src/tables/build/BuildOrderTable.tsx
+++ b/src/frontend/src/tables/build/BuildOrderTable.tsx
@@ -38,6 +38,8 @@ export function BuildOrderTable({
   parentBuildId?: number;
   salesOrderId?: number;
 }>) {
+  const table = useTable(!!partId ? 'buildorder-part' : 'buildorder-index');
+
   const tableColumns = useMemo(() => {
     return [
       ReferenceColumn({}),
@@ -102,7 +104,7 @@ export function BuildOrderTable({
   const ownerFilters = useOwnerFilters();
 
   const tableFilters: TableFilter[] = useMemo(() => {
-    return [
+    let filters: TableFilter[] = [
       {
         name: 'active',
         type: 'boolean',
@@ -151,11 +153,21 @@ export function BuildOrderTable({
         choices: ownerFilters.choices
       }
     ];
-  }, [parentBuildId, projectCodeFilters.choices, ownerFilters.choices]);
+
+    // If we are filtering on a specific part, we can include the "include variants" filter
+    if (!!partId) {
+      filters.push({
+        name: 'include_variants',
+        type: 'boolean',
+        label: t`Include Variants`,
+        description: t`Include variant build orders`
+      });
+    }
+
+    return filters;
+  }, [partId, projectCodeFilters.choices, ownerFilters.choices]);
 
   const user = useUserState();
-
-  const table = useTable('buildorder');
 
   const buildOrderFields = useBuildOrderFields({ create: true });
 

--- a/src/frontend/src/tables/build/BuildOrderTable.tsx
+++ b/src/frontend/src/tables/build/BuildOrderTable.tsx
@@ -160,7 +160,7 @@ export function BuildOrderTable({
         name: 'include_variants',
         type: 'boolean',
         label: t`Include Variants`,
-        description: t`Include build orders for part variants`
+        description: t`Include orders for part variants`
       });
     }
 

--- a/src/frontend/src/tables/part/PartPurchaseOrdersTable.tsx
+++ b/src/frontend/src/tables/part/PartPurchaseOrdersTable.tsx
@@ -123,6 +123,12 @@ export default function PartPurchaseOrdersTable({
         label: t`Order Status`,
         description: t`Filter by order status`,
         choiceFunction: StatusFilterOptions(ModelType.purchaseorder)
+      },
+      {
+        name: 'include_variants',
+        type: 'boolean',
+        label: t`Include Variants`,
+        description: t`Include orders for part variants`
       }
     ];
   }, []);

--- a/src/frontend/src/tables/sales/SalesOrderTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderTable.tsx
@@ -40,14 +40,14 @@ export function SalesOrderTable({
   partId?: number;
   customerId?: number;
 }>) {
-  const table = useTable('sales-order');
+  const table = useTable(!!partId ? 'salesorder-part' : 'salesorder-index');
   const user = useUserState();
 
   const projectCodeFilters = useProjectCodeFilters();
   const responsibleFilters = useOwnerFilters();
 
   const tableFilters: TableFilter[] = useMemo(() => {
-    return [
+    let filters: TableFilter[] = [
       {
         name: 'status',
         label: t`Status`,
@@ -75,7 +75,18 @@ export function SalesOrderTable({
         choices: responsibleFilters.choices
       }
     ];
-  }, [projectCodeFilters.choices, responsibleFilters.choices]);
+
+    if (!!partId) {
+      filters.push({
+        name: 'include_variants',
+        type: 'boolean',
+        label: t`Include Variants`,
+        description: t`Include sales orders for part variants`
+      });
+    }
+
+    return filters;
+  }, [partId, projectCodeFilters.choices, responsibleFilters.choices]);
 
   const salesOrderFields = useSalesOrderFields({});
 

--- a/src/frontend/src/tables/sales/SalesOrderTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderTable.tsx
@@ -81,7 +81,7 @@ export function SalesOrderTable({
         name: 'include_variants',
         type: 'boolean',
         label: t`Include Variants`,
-        description: t`Include sales orders for part variants`
+        description: t`Include orders for part variants`
       });
     }
 


### PR DESCRIPTION
Adds API filtering for "include_variants" when viewing orders based on a part.

e.g. Allows the BuildOrderTable to optionally display build orders for all variants of a selected part, or just the selected part 