### PR TITLE
Clear allocations when manually returning an item into stock

### DIFF
--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -2328,7 +2328,7 @@ class ReturnOrder(TotalPriceMixin, Order):
     # endregion
 
     @transaction.atomic
-    def receive_line_item(self, line, location, user, note=''):
+    def receive_line_item(self, line, location, user, note='', **kwargs):
         """Receive a line item against this ReturnOrder.
 
         Rules:
@@ -2354,7 +2354,7 @@ class ReturnOrder(TotalPriceMixin, Order):
             deltas['customer'] = stock_item.customer.pk
 
         # Update the StockItem
-        stock_item.status = StockStatus.QUARANTINED.value
+        stock_item.status = kwargs.get('status', StockStatus.QUARANTINED.value)
         stock_item.location = location
         stock_item.customer = None
         stock_item.sales_order = None

--- a/src/backend/InvenTree/stock/models.py
+++ b/src/backend/InvenTree/stock/models.py
@@ -1238,10 +1238,12 @@ class StockItem(
             location=location,
         )
 
+        # Clear out allocation information for the stock item
         self.customer = None
         self.belongs_to = None
         self.sales_order = None
         self.location = location
+        self.clearAllocations()
 
         trigger_event('stockitem.returnedfromcustomer', id=self.id)
 


### PR DESCRIPTION
Fixes bug where the sales order allocations would still exist, meaning the stock item is still effectively "out of stock"