### PR TITLE
Bug fix for auto-allocation against build order

### DIFF
--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -887,7 +887,6 @@ class Build(
 
                 # Auto-allocate stock based on serial number
                 if auto_allocate:
-                    allocations = []
 
                     for bom_item in trackable_parts:
                         valid_part_ids = valid_parts.get(bom_item.pk, [])


### PR DESCRIPTION
- Only the 'last' line item was being correctly allocated
- Variable scoping issue