### PR TITLE
[Bug] Fix issue with build order lines table

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,15 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 272
+INVENTREE_API_VERSION = 273
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+
+v273 - 2024-10-28 : https://github.com/inventree/InvenTree/pull/8376
+    - Fixes for the BuildLine API endpoint
 
 v272 - 2024-10-25 : https://github.com/inventree/InvenTree/pull/8343
     - Adjustments to BuildLine API serializers

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -1409,6 +1409,7 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
         queryset = queryset.prefetch_related(
             'allocations',
             'allocations__stock_item',
+            'allocations__stock_item__part',
             'allocations__stock_item__location',
 
             'bom_item__sub_part__stock_items',

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -1307,6 +1307,9 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
             'available_variant_stock',
             'external_stock',
 
+            # Related fields
+            'allocations',
+
             # Extra fields only for data export
             'part_description',
             'part_category_name',
@@ -1329,6 +1332,8 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
     part_description = serializers.CharField(source='bom_item.sub_part.description', label=_('Part Description'), read_only=True)
     part_category_id = serializers.PrimaryKeyRelatedField(source='bom_item.sub_part.category', label=_('Part Category ID'), read_only=True)
     part_category_name = serializers.CharField(source='bom_item.sub_part.category.name', label=_('Part Category Name'), read_only=True)
+
+    allocations = BuildItemSerializer(many=True, read_only=True)
 
     # BOM item info fields
     reference = serializers.CharField(source='bom_item.reference', label=_('Reference'), read_only=True)
@@ -1403,6 +1408,8 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
         # Pre-fetch related fields
         queryset = queryset.prefetch_related(
             'allocations',
+            'allocations__stock_item',
+            'allocations__stock_item__location',
 
             'bom_item__sub_part__stock_items',
             'bom_item__sub_part__stock_items__allocations',

--- a/src/frontend/src/tables/build/BuildOutputTable.tsx
+++ b/src/frontend/src/tables/build/BuildOutputTable.tsx
@@ -153,7 +153,7 @@ export default function BuildOutputTable({
 
           // Find all allocations which match the build output
           let allocations = item.allocations.filter(
-            (allocation: any) => (allocation.install_into = record.pk)
+            (allocation: any) => allocation.install_into == record.pk
           );
 
           allocations.forEach((allocation: any) => {


### PR DESCRIPTION
- Bug introduced in https://github.com/inventree/InvenTree/pull/8343
- Inadvertently removed the "allocations" field
- Is crucial for displaying the "allocations" in the build order tables!
