### PR TITLE
[PUI] Build allocation sub tables

### DIFF
--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -1301,7 +1301,6 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
 
             # Annotated fields
             'allocated',
-            'allocated_items',
             'in_production',
             'on_order',
             'available_stock',
@@ -1368,12 +1367,6 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
     # Total quantity of allocated stock
     allocated = serializers.FloatField(
         label=_('Allocated Stock'),
-        read_only=True
-    )
-
-    # Total number of individual allocations
-    allocated_items = serializers.IntegerField(
-        label=_('Allocated Items'),
         read_only=True
     )
 
@@ -1486,10 +1479,6 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
             allocated=Coalesce(
                 Sum('allocations__quantity'), 0,
                 output_field=models.DecimalField()
-            ),
-            allocated_items=Coalesce(
-                Count('allocations'), 0,
-                output_field=models.IntegerField()
             )
         )
 

--- a/src/backend/InvenTree/templates/js/translated/build.js
+++ b/src/backend/InvenTree/templates/js/translated/build.js
@@ -2734,6 +2734,15 @@ function loadBuildLineTable(table, build_id, options={}) {
                 }
             },
             {
+                field: 'trackable',
+                title: '{% trans "Trackable" %}',
+                sortable: true,
+                switchable: true,
+                formatter: function(value, row) {
+                    return yesNoLabel(row.part_detail.trackable);
+                }
+            },
+            {
                 field: 'unit_quantity',
                 sortable: true,
                 title: '{% trans "Unit Quantity" %}',

--- a/src/backend/InvenTree/templates/js/translated/build.js
+++ b/src/backend/InvenTree/templates/js/translated/build.js
@@ -2505,6 +2505,7 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
         url: '{% url "api-build-item-list" %}',
         queryParams: {
             build_line: build_line.pk,
+            output: options.output ?? undefined,
         },
         showHeader: false,
         columns: [
@@ -2609,9 +2610,10 @@ function renderBuildLineAllocationTable(element, build_line, options={}) {
  */
 function loadBuildLineTable(table, build_id, options={}) {
 
+    const params = options.params || {};
+    const output = options.output;
+
     let name = 'build-lines';
-    let params = options.params || {};
-    let output = options.output;
 
     params.build = build_id;
 
@@ -2647,6 +2649,7 @@ function loadBuildLineTable(table, build_id, options={}) {
         detailFormatter: function(_index, row, element) {
             renderBuildLineAllocationTable(element, row, {
                 parent_table: table,
+                output: output,
             });
         },
         formatNoMatches: function() {

--- a/src/frontend/src/components/forms/fields/TableField.tsx
+++ b/src/frontend/src/components/forms/fields/TableField.tsx
@@ -1,7 +1,7 @@
 import { Trans, t } from '@lingui/macro';
-import { Alert, Container, Group, Table } from '@mantine/core';
+import { Alert, Container, Group, Stack, Table, Text } from '@mantine/core';
 import { IconExclamationCircle } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo } from 'react';
 import { FieldValues, UseControllerReturn } from 'react-hook-form';
 
 import { identifierString } from '../../../functions/conversion';
@@ -16,6 +16,69 @@ export interface TableFieldRowProps {
   control: UseControllerReturn<FieldValues, any>;
   changeFn: (idx: number, key: string, value: any) => void;
   removeFn: (idx: number) => void;
+}
+
+function TableFieldRow({
+  item,
+  idx,
+  errors,
+  definition,
+  control,
+  changeFn,
+  removeFn
+}: {
+  item: any;
+  idx: number;
+  errors: any;
+  definition: ApiFormFieldType;
+  control: UseControllerReturn<FieldValues, any>;
+  changeFn: (idx: number, key: string, value: any) => void;
+  removeFn: (idx: number) => void;
+}) {
+  // Table fields require render function
+  if (!definition.modelRenderer) {
+    return (
+      <Table.Tr key="table-row-no-renderer">
+        <Table.Td colSpan={definition.headers?.length}>
+          <Alert color="red" title={t`Error`} icon={<IconExclamationCircle />}>
+            {`modelRenderer entry required for tables`}
+          </Alert>
+        </Table.Td>
+      </Table.Tr>
+    );
+  }
+
+  return definition.modelRenderer({
+    item: item,
+    idx: idx,
+    rowErrors: errors,
+    control: control,
+    changeFn: changeFn,
+    removeFn: removeFn
+  });
+}
+
+export function TableFieldErrorWrapper({
+  props,
+  errorKey,
+  children
+}: {
+  props: TableFieldRowProps;
+  errorKey: string;
+  children: ReactNode;
+}) {
+  const msg = props?.rowErrors && props.rowErrors[errorKey];
+
+  return (
+    <Stack gap="xs">
+      {children}
+      {msg && (
+        <Text size="xs" c="red">
+          {msg.message}
+        </Text>
+      )}
+    </Stack>
+  );
 }
 
 export function TableField({
@@ -47,7 +110,7 @@ export function TableField({
   };
 
   // Extract errors associated with the current row
-  const rowErrors = useCallback(
+  const rowErrors: any = useCallback(
     (idx: number) => {
       if (Array.isArray(error)) {
         return error[idx];
@@ -74,31 +137,18 @@ export function TableField({
       <Table.Tbody>
         {value.length > 0 ? (
           value.map((item: any, idx: number) => {
-            // Table fields require render function
-            if (!definition.modelRenderer) {
-              return (
-                <Table.Tr key="table-row-no-renderer">
-                  <Table.Td colSpan={definition.headers?.length}>
-                    <Alert
-                      color="red"
-                      title={t`Error`}
-                      icon={<IconExclamationCircle />}
-                    >
-                      {`modelRenderer entry required for tables`}
-                    </Alert>
-                  </Table.Td>
-                </Table.Tr>
-              );
-            }
-
-            return definition.modelRenderer({
-              item: item,
-              idx: idx,
-              rowErrors: rowErrors(idx),
-              control: control,
-              changeFn: onRowFieldChange,
-              removeFn: removeRow
-            });
+            return (
+              <TableFieldRow
+                key={`table-row-${idx}`}
+                item={item}
+                idx={idx}
+                errors={rowErrors(idx)}
+                control={control}
+                definition={definition}
+                changeFn={onRowFieldChange}
+                removeFn={removeRow}
+              />
+            );
           })
         ) : (
           <Table.Tr key="table-row-no-entries">

--- a/src/frontend/src/forms/BuildForms.tsx
+++ b/src/frontend/src/forms/BuildForms.tsx
@@ -17,7 +17,10 @@ import {
   ApiFormFieldSet,
   ApiFormFieldType
 } from '../components/forms/fields/ApiFormField';
-import { TableFieldRowProps } from '../components/forms/fields/TableField';
+import {
+  TableFieldErrorWrapper,
+  TableFieldRowProps
+} from '../components/forms/fields/TableField';
 import { ProgressBar } from '../components/items/ProgressBar';
 import { StatusRenderer } from '../components/render/StatusRenderer';
 import { ApiEndpoints } from '../enums/ApiEndpoints';
@@ -210,7 +213,11 @@ function BuildOutputFormRow({
         <Table.Td>
           <PartColumn part={record.part_detail} />
         </Table.Td>
-        <Table.Td>{serial}</Table.Td>
+        <Table.Td>
+          <TableFieldErrorWrapper props={props} errorKey="output">
+            {serial}
+          </TableFieldErrorWrapper>
+        </Table.Td>
         <Table.Td>{record.batch}</Table.Td>
         <Table.Td>
           <StatusRenderer status={record.status} type={ModelType.stockitem} />{' '}
@@ -259,7 +266,7 @@ export function useCompleteBuildOutputsForm({
             <BuildOutputFormRow props={row} record={record} key={record.pk} />
           );
         },
-        headers: [t`Part`, t`Stock Item`, t`Batch`, t`Status`]
+        headers: [t`Part`, t`Build Output`, t`Batch`, t`Status`]
       },
       status_custom_key: {},
       location: {

--- a/src/frontend/src/forms/BuildForms.tsx
+++ b/src/frontend/src/forms/BuildForms.tsx
@@ -461,8 +461,8 @@ function BuildAllocateLineRow({
       </Table.Td>
       <Table.Td>
         <ProgressBar
-          value={record.allocated}
-          maximum={record.quantity}
+          value={record.allocatedQuantity}
+          maximum={record.requiredQuantity}
           progressLabel
         />
       </Table.Td>
@@ -573,7 +573,7 @@ export function useAllocateStockToBuildForm({
         return {
           build_line: item.pk,
           stock_item: undefined,
-          quantity: Math.max(0, item.quantity - item.allocated),
+          quantity: Math.max(0, item.requiredQuantity - item.allocatedQuantity),
           output: outputId
         };
       })

--- a/src/frontend/src/forms/BuildForms.tsx
+++ b/src/frontend/src/forms/BuildForms.tsx
@@ -512,6 +512,7 @@ export function useAllocateStockToBuildForm({
             lineItems.find((item) => item.pk == row.item.build_line) ?? {};
           return (
             <BuildAllocateLineRow
+              key={row.idx}
               props={row}
               record={record}
               sourceLocation={sourceLocation}
@@ -566,7 +567,7 @@ export function useAllocateStockToBuildForm({
           build_line: item.pk,
           stock_item: undefined,
           quantity: Math.max(0, item.quantity - item.allocated),
-          output: null
+          output: outputId
         };
       })
     },

--- a/src/frontend/src/hooks/UseTable.tsx
+++ b/src/frontend/src/hooks/UseTable.tsx
@@ -23,6 +23,7 @@ export type TableState = {
   clearActiveFilters: () => void;
   expandedRecords: any[];
   setExpandedRecords: (records: any[]) => void;
+  isRowExpanded: (pk: number) => boolean;
   selectedRecords: any[];
   selectedIds: number[];
   hasSelectedRecords: boolean;
@@ -78,6 +79,14 @@ export function useTable(tableName: string): TableState {
 
   // Array of expanded records
   const [expandedRecords, setExpandedRecords] = useState<any[]>([]);
+
+  // Function to determine if a record is expanded
+  const isRowExpanded = useCallback(
+    (pk: number) => {
+      return expandedRecords.includes(pk);
+    },
+    [expandedRecords]
+  );
 
   // Array of selected records
   const [selectedRecords, setSelectedRecords] = useState<any[]>([]);
@@ -148,6 +157,7 @@ export function useTable(tableName: string): TableState {
     clearActiveFilters,
     expandedRecords,
     setExpandedRecords,
+    isRowExpanded,
     selectedRecords,
     selectedIds,
     setSelectedRecords,

--- a/src/frontend/src/pages/build/BuildDetail.tsx
+++ b/src/frontend/src/pages/build/BuildDetail.tsx
@@ -251,11 +251,7 @@ export default function BuildDetail() {
         name: 'line-items',
         label: t`Line Items`,
         icon: <IconListNumbers />,
-        content: build?.pk ? (
-          <BuildLineTable build={build} buildId={build.pk} />
-        ) : (
-          <Skeleton />
-        )
+        content: build?.pk ? <BuildLineTable build={build} /> : <Skeleton />
       },
       {
         name: 'incomplete-outputs',

--- a/src/frontend/src/tables/InvenTreeTable.tsx
+++ b/src/frontend/src/tables/InvenTreeTable.tsx
@@ -20,6 +20,7 @@ import { useQuery } from '@tanstack/react-query';
 import {
   DataTable,
   DataTableCellClickHandler,
+  DataTableRowExpansionProps,
   DataTableSortStatus
 } from 'mantine-datatable';
 import React, {
@@ -103,7 +104,7 @@ export type InvenTreeTableProps<T = any> = {
   barcodeActions?: React.ReactNode[];
   tableFilters?: TableFilter[];
   tableActions?: React.ReactNode[];
-  rowExpansion?: any;
+  rowExpansion?: DataTableRowExpansionProps<T>;
   idAccessor?: string;
   dataFormatter?: (data: any) => any;
   rowActions?: (record: T) => RowAction[];
@@ -633,6 +634,33 @@ export function InvenTreeTable<T extends Record<string, any>>({
     tableState.refreshTable();
   }
 
+  /**
+   * Memoize row expansion options:
+   * - If rowExpansion is not provided, return undefined
+   * - Otherwise, return the rowExpansion object
+   * - Utilize the useTable hook to track expanded rows
+   */
+  const rowExpansion: DataTableRowExpansionProps<T> | undefined =
+    useMemo(() => {
+      if (!props.rowExpansion) {
+        return undefined;
+      }
+
+      return {
+        ...props.rowExpansion,
+        expanded: {
+          recordIds: tableState.expandedRecords,
+          onRecordIdsChange: (ids: any[]) => {
+            tableState.setExpandedRecords(ids);
+          }
+        }
+      };
+    }, [
+      tableState.expandedRecords,
+      tableState.setExpandedRecords,
+      props.rowExpansion
+    ]);
+
   const optionalParams = useMemo(() => {
     let optionalParamsa: Record<string, any> = {};
     if (tableProps.enablePagination) {
@@ -779,7 +807,7 @@ export function InvenTreeTable<T extends Record<string, any>>({
               onSelectedRecordsChange={
                 enableSelection ? onSelectedRecordsChange : undefined
               }
-              rowExpansion={tableProps.rowExpansion}
+              rowExpansion={rowExpansion}
               rowStyle={tableProps.rowStyle}
               fetching={isFetching}
               noRecordsText={missingRecordsText}

--- a/src/frontend/src/tables/build/BuildAllocatedStockTable.tsx
+++ b/src/frontend/src/tables/build/BuildAllocatedStockTable.tsx
@@ -161,8 +161,11 @@ export default function BuildAllocatedStockTable({
   const editItem = useEditApiFormModal({
     pk: selectedItem,
     url: ApiEndpoints.build_item_list,
-    title: t`Edit Build Item`,
+    title: t`Edit Stock Allocation`,
     fields: {
+      stock_item: {
+        disabled: true
+      },
       quantity: {}
     },
     table: table
@@ -171,7 +174,7 @@ export default function BuildAllocatedStockTable({
   const deleteItem = useDeleteApiFormModal({
     pk: selectedItem,
     url: ApiEndpoints.build_item_list,
-    title: t`Delete Build Item`,
+    title: t`Delete Stock Allocation`,
     table: table
   });
 

--- a/src/frontend/src/tables/build/BuildLineTable.tsx
+++ b/src/frontend/src/tables/build/BuildLineTable.tsx
@@ -25,7 +25,11 @@ import {
 import { navigateToLink } from '../../functions/navigation';
 import { notYetImplemented } from '../../functions/notifications';
 import { getDetailUrl } from '../../functions/urls';
-import { useCreateApiFormModal } from '../../hooks/UseForm';
+import {
+  useCreateApiFormModal,
+  useDeleteApiFormModal,
+  useEditApiFormModal
+} from '../../hooks/UseForm';
 import useStatusCodes from '../../hooks/UseStatusCodes';
 import { useTable } from '../../hooks/UseTable';
 import { apiUrl } from '../../states/ApiState';
@@ -121,6 +125,7 @@ function BuildLineSubTable({
     <Paper p="md">
       <Stack gap="xs">
         <DataTable
+          minHeight={50}
           withTableBorder
           withColumnBorders
           striped
@@ -287,7 +292,7 @@ export default function BuildLineTable({
     return [
       {
         accessor: 'bom_item',
-        title: t`Component Part`,
+        title: t`Component`,
         ordering: 'part',
         sortable: true,
         switchable: false,
@@ -491,6 +496,28 @@ export default function BuildLineTable({
     table: table
   });
 
+  const [selectedAllocation, setSelectedAllocation] = useState<number>(0);
+
+  const editAllocation = useEditApiFormModal({
+    url: ApiEndpoints.build_item_list,
+    pk: selectedAllocation,
+    title: t`Edit Stock Allocation`,
+    fields: {
+      stock_item: {
+        disabled: true
+      },
+      quantity: {}
+    },
+    table: table
+  });
+
+  const deleteAllocation = useDeleteApiFormModal({
+    url: ApiEndpoints.build_item_list,
+    pk: selectedAllocation,
+    title: t`Delete Stock Allocation`,
+    table: table
+  });
+
   const rowActions = useCallback(
     (record: any): RowAction[] => {
       let part = record.part_detail ?? {};
@@ -653,10 +680,12 @@ export default function BuildLineTable({
           <BuildLineSubTable
             lineItem={record}
             onEditAllocation={(pk: number) => {
-              // TODO
+              setSelectedAllocation(pk);
+              editAllocation.open();
             }}
             onDeleteAllocation={(pk: number) => {
-              // TODO
+              setSelectedAllocation(pk);
+              deleteAllocation.open();
             }}
           />
         );
@@ -670,6 +699,8 @@ export default function BuildLineTable({
       {newBuildOrder.modal}
       {allocateStock.modal}
       {deallocateStock.modal}
+      {editAllocation.modal}
+      {deleteAllocation.modal}
       <InvenTreeTable
         url={apiUrl(ApiEndpoints.build_line_list)}
         tableState={table}

--- a/src/frontend/src/tables/build/BuildLineTable.tsx
+++ b/src/frontend/src/tables/build/BuildLineTable.tsx
@@ -330,16 +330,14 @@ export default function BuildLineTable({
   // Calculate the total number of allocations against a particular build line and output
   const getRowAllocationCount = useCallback(
     (record: any) => {
-      const output_id = output?.pk ?? undefined;
+      let allocations = filterAllocationsForOutput(record.allocations, output);
 
       let count = 0;
 
       // Allocations matching the output ID, or all allocations if no output ID is specified
-      record.allocations
-        ?.filter((a: any) => a.install_into == output_id || !output_id)
-        .forEach((a: any) => {
-          count += a.quantity;
-        });
+      allocations.forEach((a: any) => {
+        count += a.quantity;
+      });
 
       return count;
     },

--- a/src/frontend/src/tables/build/BuildLineTable.tsx
+++ b/src/frontend/src/tables/build/BuildLineTable.tsx
@@ -1,12 +1,17 @@
 import { t } from '@lingui/macro';
-import { Alert, Group, Text } from '@mantine/core';
+import { ActionIcon, Alert, Group, Space, Text } from '@mantine/core';
 import {
   IconArrowRight,
+  IconChevronCompactDown,
+  IconChevronCompactRight,
+  IconChevronDown,
+  IconChevronRight,
   IconCircleMinus,
   IconShoppingCart,
   IconTool,
   IconWand
 } from '@tabler/icons-react';
+import { DataTableRowExpansionProps } from 'mantine-datatable';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -184,10 +189,30 @@ export default function BuildLineTable({
     return [
       {
         accessor: 'bom_item',
+        title: t`Component Part`,
         ordering: 'part',
         sortable: true,
         switchable: false,
-        render: (record: any) => PartColumn({ part: record.part_detail })
+        render: (record: any) => {
+          const hasAllocatedItems = record?.allocated_items > 0;
+
+          return (
+            <Group wrap="nowrap">
+              <ActionIcon
+                size="sm"
+                variant="transparent"
+                disabled={!hasAllocatedItems}
+              >
+                {table.isRowExpanded(record.pk) ? (
+                  <IconChevronDown />
+                ) : (
+                  <IconChevronRight />
+                )}
+              </ActionIcon>
+              <PartColumn part={record.part_detail} />
+            </Group>
+          );
+        }
       },
       {
         accessor: 'part_detail.IPN',
@@ -280,7 +305,7 @@ export default function BuildLineTable({
         }
       }
     ];
-  }, [isActive]);
+  }, [isActive, table]);
 
   const buildOrderFields = useBuildOrderFields({ create: true });
 
@@ -517,6 +542,20 @@ export default function BuildLineTable({
     table.selectedRecords
   ]);
 
+  // Control row expansion
+  const rowExpansion: DataTableRowExpansionProps<any> = useMemo(() => {
+    return {
+      allowMultiple: true,
+      expandable: ({ record }: { record: any }) => {
+        // Only items with allocated stock can be expanded
+        return record?.allocated_items > 0;
+      },
+      content: ({ record }: { record: any }) => {
+        return <div>hello world: {record.pk}</div>;
+      }
+    };
+  }, []);
+
   return (
     <>
       {autoAllocateStock.modal}
@@ -537,7 +576,8 @@ export default function BuildLineTable({
           tableFilters: tableFilters,
           rowActions: rowActions,
           enableDownload: true,
-          enableSelection: true
+          enableSelection: true,
+          rowExpansion: rowExpansion
         }}
       />
     </>

--- a/src/frontend/src/tables/build/BuildOutputTable.tsx
+++ b/src/frontend/src/tables/build/BuildOutputTable.tsx
@@ -1,18 +1,8 @@
 import { t } from '@lingui/macro';
-import {
-  Divider,
-  Drawer,
-  Group,
-  Loader,
-  Paper,
-  Space,
-  Stack,
-  Text
-} from '@mantine/core';
+import { Divider, Drawer, Group, Paper, Space, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconCircleCheck, IconCircleX } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
-import { DataTableRowExpansionProps } from 'mantine-datatable';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { api } from '../../App';
@@ -520,15 +510,6 @@ export default function BuildOutputTable({
   const [drawerOpen, { open: openDrawer, close: closeDrawer }] =
     useDisclosure(false);
 
-  const rowExpansion: DataTableRowExpansionProps<any> = useMemo(() => {
-    return {
-      allowMultiple: true,
-      content: ({ record }: { record: any }) => {
-        return <BuildLineTable build={build} output={record} />;
-      }
-    };
-  }, [buildId]);
-
   return (
     <>
       {addBuildOutput.modal}
@@ -555,11 +536,9 @@ export default function BuildOutputTable({
           },
           enableLabels: true,
           enableReports: true,
-          // modelType: ModelType.stockitem,
           dataFormatter: formatRecords,
           tableActions: tableActions,
           rowActions: rowActions,
-          // rowExpansion: rowExpansion,
           enableSelection: true,
           onRowClick: (record: any) => {
             if (hasTrackedItems && !!record.serial) {

--- a/src/frontend/src/tables/build/BuildOutputTable.tsx
+++ b/src/frontend/src/tables/build/BuildOutputTable.tsx
@@ -361,13 +361,18 @@ export default function BuildOutputTable({
           title: t`Allocate`,
           tooltip: t`Allocate stock to build output`,
           color: 'blue',
+          hidden: !hasTrackedItems || !user.hasChangeRole(UserRoles.build),
           icon: <InvenTreeIcon icon="plus" />,
-          onClick: notYetImplemented
+          onClick: () => {
+            setSelectedOutputs([record]);
+            openDrawer();
+          }
         },
         {
           title: t`Deallocate`,
           tooltip: t`Deallocate stock from build output`,
           color: 'red',
+          hidden: !hasTrackedItems || !user.hasChangeRole(UserRoles.build),
           icon: <InvenTreeIcon icon="minus" />,
           onClick: notYetImplemented
         },
@@ -410,7 +415,7 @@ export default function BuildOutputTable({
         }
       ];
     },
-    [user, partId]
+    [user, partId, hasTrackedItems]
   );
 
   const tableColumns: TableColumn[] = useMemo(() => {


### PR DESCRIPTION
Implements (most of) the remaining build order stock allocation functionality, from CUI to PUI.


### Future Development

- Work on similar tables for showing allocated stock in sales orders / shipment tables
- Update documentation / screenshots showing new user interface

### Screenshots

| Description | Screenshot |
| --- | --- |
| Sub tables showing allocations against individual lines | ![image](https://github.com/user-attachments/assets/d703a7f7-b5e4-4b7b-adc3-f11bcdf18b1d) |
| Expanded drawer view for tracked build output | ![image](https://github.com/user-attachments/assets/7ad501ea-976f-4fbc-b1cf-2d46ca826b32)  |
