### PR TITLE
[Bug] Fix for create_child_builds

### DIFF
--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -194,6 +194,7 @@ class BuildSerializer(NotesFieldMixin, DataImportExportSerializerMixin, InvenTre
                 build.tasks.create_child_builds,
                 build_order.pk,
                 group='build',
+                force_async=True
             )
 
         return build_order

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -180,6 +180,7 @@ class BuildSerializer(NotesFieldMixin, DataImportExportSerializerMixin, InvenTre
 
         return reference
 
+    @transaction.atomic
     def create(self, validated_data):
         """Save the Build object."""
 

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -193,8 +193,7 @@ class BuildSerializer(NotesFieldMixin, DataImportExportSerializerMixin, InvenTre
             InvenTree.tasks.offload_task(
                 build.tasks.create_child_builds,
                 build_order.pk,
-                group='build',
-                force_async=True
+                group='build'
             )
 
         return build_order

--- a/src/backend/InvenTree/build/tasks.py
+++ b/src/backend/InvenTree/build/tasks.py
@@ -202,6 +202,9 @@ def create_child_builds(build_id: int) -> None:
 
     assembly_items = build_order.part.get_bom_items().filter(sub_part__assembly=True)
 
+    # Random delay, to reduce likelihood of race conditions from multiple build orders being created simultaneously
+    time.sleep(random.random())
+
     with transaction.atomic():
         # Atomic transaction to ensure that all child build orders are created together, or not at all
         # This is critical to prevent duplicate child build orders being created (e.g. if the task is re-run)
@@ -211,8 +214,6 @@ def create_child_builds(build_id: int) -> None:
         for item in assembly_items:
             quantity = item.quantity * build_order.quantity
 
-            # Random delay, to reduce likelihood of race conditions from multiple build orders being created simultaneously
-            time.sleep(random.random())
 
             # Check if the child build order has already been created
             if build_models.Build.objects.filter(
@@ -244,9 +245,6 @@ def create_child_builds(build_id: int) -> None:
                 pk,
                 group='build'
             )
-
-            # Random delay, to reduce likelihood of race conditions from multiple build orders being created simultaneously
-            time.sleep(random.random())
 
 
 def notify_overdue_build_order(bo: build_models.Build):

--- a/src/backend/InvenTree/build/tasks.py
+++ b/src/backend/InvenTree/build/tasks.py
@@ -214,6 +214,15 @@ def create_child_builds(build_id: int) -> None:
             # Random delay, to reduce likelihood of race conditions from multiple build orders being created simultaneously
             time.sleep(random.random())
 
+            # Check if the child build order has already been created
+            if build_models.Build.objects.filter(
+                part=item.sub_part,
+                parent=build_order,
+                quantity=quantity,
+                status__in=BuildStatusGroups.ACTIVE_CODES
+            ).exists():
+                continue
+
             sub_order = build_models.Build.objects.create(
                 part=item.sub_part,
                 quantity=quantity,

--- a/src/backend/InvenTree/build/tasks.py
+++ b/src/backend/InvenTree/build/tasks.py
@@ -1,11 +1,15 @@
 """Background task definitions for the BuildOrder app."""
 
 import logging
+import random
+import time
+
 from datetime import timedelta
 from decimal import Decimal
 
 from django.contrib.auth.models import User
 from django.template.loader import render_to_string
+from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 
 from allauth.account.models import EmailAddress
@@ -198,27 +202,42 @@ def create_child_builds(build_id: int) -> None:
 
     assembly_items = build_order.part.get_bom_items().filter(sub_part__assembly=True)
 
-    for item in assembly_items:
-        quantity = item.quantity * build_order.quantity
+    with transaction.atomic():
+        # Atomic transaction to ensure that all child build orders are created together, or not at all
+        # This is critical to prevent duplicate child build orders being created (e.g. if the task is re-run)
 
-        sub_order = build_models.Build.objects.create(
-            part=item.sub_part,
-            quantity=quantity,
-            title=build_order.title,
-            batch=build_order.batch,
-            parent=build_order,
-            target_date=build_order.target_date,
-            sales_order=build_order.sales_order,
-            issued_by=build_order.issued_by,
-            responsible=build_order.responsible,
-        )
+        sub_build_ids = []
 
-        # Offload the child build order creation to the background task queue
-        InvenTree.tasks.offload_task(
-            create_child_builds,
-            sub_order.pk,
-            group='build'
-        )
+        for item in assembly_items:
+            quantity = item.quantity * build_order.quantity
+
+            # Random delay, to reduce likelihood of race conditions from multiple build orders being created simultaneously
+            time.sleep(random.random())
+
+            sub_order = build_models.Build.objects.create(
+                part=item.sub_part,
+                quantity=quantity,
+                title=build_order.title,
+                batch=build_order.batch,
+                parent=build_order,
+                target_date=build_order.target_date,
+                sales_order=build_order.sales_order,
+                issued_by=build_order.issued_by,
+                responsible=build_order.responsible,
+            )
+
+            sub_build_ids.append(sub_order.pk)
+
+        for pk in sub_build_ids:
+            # Offload the child build order creation to the background task queue
+            InvenTree.tasks.offload_task(
+                create_child_builds,
+                pk,
+                group='build'
+            )
+
+            # Random delay, to reduce likelihood of race conditions from multiple build orders being created simultaneously
+            time.sleep(random.random())
 
 
 def notify_overdue_build_order(bo: build_models.Build):


### PR DESCRIPTION
This PR fixes an issue with the background worker creating child builds automatically. When multiple background worker processes are running, duplicate build orders can be created. Additionally, (before this PR), the task could fail part-way through, which would cause further duplication when the task is attempted again.

- Account for concurrency between multiple worker processes
- Ensure db transactions are atomic
- Add random delays between build creation