### PR TITLE
Importer permissions

### DIFF
--- a/src/backend/InvenTree/importer/models.py
+++ b/src/backend/InvenTree/importer/models.py
@@ -124,6 +124,14 @@ class DataImportSession(models.Model):
         return mapping
 
     @property
+    def model_class(self):
+        """Return the model class for this importer."""
+        serializer = self.serializer_class
+
+        if serializer:
+            return serializer.Meta.model
+
+    @property
     def serializer_class(self):
         """Return the serializer class for this importer."""
         from importer.registry import supported_models

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1487,10 +1487,9 @@ class PurchaseOrderLineItem(OrderLineItem):
 
     def __str__(self):
         """Render a string representation of a PurchaseOrderLineItem instance."""
-        return '{n} x {part} from {supplier} (for {po})'.format(
+        return '{n} x {part} - {po}'.format(
             n=decimal2string(self.quantity),
             part=self.part.SKU if self.part else 'unknown part',
-            supplier=self.order.supplier.name if self.order.supplier else _('deleted'),
             po=self.order,
         )
 

--- a/src/backend/InvenTree/order/tests.py
+++ b/src/backend/InvenTree/order/tests.py
@@ -50,7 +50,7 @@ class OrderTest(TestCase):
             self.assertEqual(order.reference, f'PO-{pk:04d}')
 
         line = PurchaseOrderLineItem.objects.get(pk=1)
-        self.assertEqual(str(line), '100 x ACME0001 from ACME (for PO-0001 - ACME)')
+        self.assertEqual(str(line), '100 x ACME0001 - PO-0001 - ACME')
 
     def test_rebuild_reference(self):
         """Test that the reference_int field is correctly updated when the model is saved."""

--- a/src/backend/InvenTree/users/models.py
+++ b/src/backend/InvenTree/users/models.py
@@ -687,6 +687,9 @@ def check_user_permission(user: User, model, permission):
         model: The model class to check (e.g. Part)
         permission: The permission to check (e.g. 'view' / 'delete')
     """
+    if user.is_superuser:
+        return True
+
     permission_name = f'{model._meta.app_label}.{permission}_{model._meta.model_name}'
     return user.has_perm(permission_name)
 

--- a/src/frontend/src/components/forms/fields/DateField.tsx
+++ b/src/frontend/src/components/forms/fields/DateField.tsx
@@ -39,11 +39,18 @@ export default function DateField({
     [field.onChange, definition]
   );
 
-  const dateValue = useMemo(() => {
+  const dateValue: Date | null = useMemo(() => {
+    let dv: Date | null = null;
+
     if (field.value) {
-      return new Date(field.value);
+      dv = new Date(field.value) ?? null;
+    }
+
+    // Ensure that the date is valid
+    if (dv instanceof Date && !isNaN(dv.getTime())) {
+      return dv;
     } else {
-      return undefined;
+      return null;
     }
   }, [field.value]);
 


### PR DESCRIPTION
- Fixes permission checks for importing data
- Non-superuser ran into 403 errors due to incorrect permission checks
- Now, perform checks on the type of model being imported, not the ImportSession instance