### PR TITLE
fix: Narrow scope of cleanup

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1443,14 +1443,14 @@ def docs_server(c, address='localhost:8080', compile_schema=False):
 def clear_generated(c):
     """Clear generated files from `invoke update`."""
     # pyc/pyo files
-    run(c, 'find . -name "*.pyc" -exec rm -f {} +')
-    run(c, 'find . -name "*.pyo" -exec rm -f {} +')
+    run(c, 'find src -name "*.pyc" -exec rm -f {} +')
+    run(c, 'find src -name "*.pyo" -exec rm -f {} +')
     # cache folders
-    run(c, 'find . -name "__pycache__" -exec rm -rf {} +')
+    run(c, 'find src -name "__pycache__" -exec rm -rf {} +')
 
     # Generated translations
-    run(c, 'find . -name "django.mo" -exec rm -f {} +')
-    run(c, 'find . -name "messages.mo" -exec rm -f {} +')
+    run(c, 'find src -name "django.mo" -exec rm -f {} +')
+    run(c, 'find src -name "messages.mo" -exec rm -f {} +')
 
 
 # Collection sorting


### PR DESCRIPTION
This fixes the `clear-generated` task. It was previously too widely scoped and had the potential to brick users envs if they were under /opt/inventree (which is the default).
This fix narrows the scope to the "src" directory - which is always guaranteed to be InvenTree internal stuff.

Fixes https://github.com/inventree/InvenTree/issues/8252 https://github.com/inventree/InvenTree/issues/8155