### PR TITLE
Fix for useReturnOrderLineItemFields

### DIFF
--- a/src/frontend/src/forms/ReturnOrderForms.tsx
+++ b/src/frontend/src/forms/ReturnOrderForms.tsx
@@ -115,13 +115,7 @@ export function useReturnOrderLineItemFields({
       price_currency: {},
       target_date: {},
       notes: {},
-      link: {},
-      responsible: {
-        filters: {
-          is_active: true
-        },
-        icon: <IconUsers />
-      }
+      link: {}
     };
   }, [create, orderId, customerId]);
 }


### PR DESCRIPTION
- Remove 'responsible' field from form-set
- Not actually available on the endpoint