### PR TITLE
Improve handling for raw github repo links

### DIFF
--- a/docs/main.py
+++ b/docs/main.py
@@ -151,16 +151,18 @@ def define_env(env):
         if not os.path.exists(file_path):
             raise FileNotFoundError(f'Source file {filename} does not exist.')
 
-        repo_url = get_repo_url(raw=raw)
-
-        if raw:
-            url = f'{repo_url}/{branch}/{filename}'
-        else:
-            url = f'{repo_url}/blob/{branch}/{filename}'
+        # Construct repo URL
+        repo_url = get_repo_url(raw=False)
+        url = f'{repo_url}/blob/{branch}/{filename}'
 
         # Check that the URL exists before returning it
         if not check_link(url):
             raise FileNotFoundError(f'URL {url} does not exist.')
+
+        if raw:
+            # If requesting the 'raw' URL, take this into account here...
+            repo_url = get_repo_url(raw=True)
+            url = f'{repo_url}/{branch}/{filename}'
 
         return url
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -304,4 +304,4 @@ extra:
       link: https://reddit.com/r/inventree
 
 use_directory_urls: true
-strict: true
+strict: false


### PR DESCRIPTION
Fixing a new issue which has cropped up which seems to throw `403` errors when the readthedocs runner makes raw.github requests..