### PR TITLE
Docker venv

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       INVENTREE_PLUGINS_ENABLED: True
       INVENTREE_SITE_URL: http://localhost:8000
       INVENTREE_CORS_ORIGIN_ALLOW_ALL: True
-      INVENTREE_PY_ENV: /home/inventree/dev/venv
 
     depends_on:
       - db

--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -37,7 +37,7 @@ ENV INVENTREE_PLUGIN_DIR="${INVENTREE_DATA_DIR}/plugins"
 # Location for python virtual environment
 # This will be created on the host system to persist *certain* packages
 # Note: *base* packages are installed into the docker image
-ENV INVENTREE_PY_ENV="${INVENTREE_DATA_DIR}/env"
+ENV INVENTREE_PY_ENV="${INVENTREE_DATA_DIR}/venv"
 
 ENV INVENTREE_BACKEND_DIR="${INVENTREE_HOME}/src/backend"
 

--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -34,6 +34,11 @@ ENV INVENTREE_MEDIA_ROOT="${INVENTREE_DATA_DIR}/media"
 ENV INVENTREE_BACKUP_DIR="${INVENTREE_DATA_DIR}/backup"
 ENV INVENTREE_PLUGIN_DIR="${INVENTREE_DATA_DIR}/plugins"
 
+# Location for python virtual environment
+# This will be created on the host system to persist *certain* packages
+# Note: *base* packages are installed into the docker image
+ENV INVENTREE_PY_ENV="${INVENTREE_DATA_DIR}/env"
+
 ENV INVENTREE_BACKEND_DIR="${INVENTREE_HOME}/src/backend"
 
 # InvenTree configuration files
@@ -160,10 +165,6 @@ RUN yarn config set network-timeout 600000 -g
 # So from here, we don't actually "do" anything, apart from some file management
 
 ENV INVENTREE_DEBUG=True
-
-# Location for python virtual environment
-# If the INVENTREE_PY_ENV variable is set, the entrypoint script will use it!
-ENV INVENTREE_PY_ENV="${INVENTREE_DATA_DIR}/env"
 
 WORKDIR ${INVENTREE_HOME}
 


### PR DESCRIPTION
This PR changes behavior under docker, using the python virtual environment even in "production" mode.

The purpose for this is to ensure that any extra python packages that get installed (i.e. plugins) persist between container runs, and across the webserver and worker containers.

### The Problem

Ref: https://github.com/inventree/InvenTree/issues/7709

The webserver and background worker processes run on separate container instances - meaning that they have different python package installation environments.

Thus, if a plugin is installed via the webserver (in the admin interface), it gets *installed* into the webserver container instance, but the background worker instance does not have a copy of the newly installed plugin code. When it tries to find it, it fails, and can result in some different subtle bugs (as well as the obvious "plugin does not work" issue).

As an added complication, if the background worker process is restarted, it *may* successfully result in the plugin being correctly installed inside that container, due to the auto-install behaviour of `plugins.txt` - however, this is kinda flaky and the static files don't get copied across reliably in this scenario.

### The Solution

In the `init.sh` entrypoint script for both containers, active a python virtual environment which points to a subdirectory on the externally mounted volume. This means that:

A) Installed plugin packages persist on the host machine (via mounted volume)
B) Installed plugin packages are shared between the webserver and background worker containers

### Testing

You can test that this works on an existing docker installation by adding the following line to the `.env` file:

```python
# Enable python virtual environment
INVENTREE_PY_ENV=/home/inventree/data/venv
```

Then, restart the docker containers.

Install a new plugin and verify that the plugin has been installed in the `<data>/venv/` subdirectory in the mounted volume

### Base Packages

Base python packages (that is, everything in `requirements.txt` needed for core InvenTree functionality) is installed *inside the container image* - when the container is built. Thus, only secondary packages (user installed plugins, etc) will persist in the external venv.