### PR TITLE
github/workflows: fix missing dotfiles in frontend-build.zip

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -584,3 +584,4 @@ jobs:
         with:
           name: frontend-build
           path: src/backend/InvenTree/web/static/web
+          include-hidden-files: true


### PR DESCRIPTION
This should fix #7476 once again
