### PR TITLE
Fix spelling of InvenTree in code base

### DIFF
--- a/contrib/container/Caddyfile
+++ b/contrib/container/Caddyfile
@@ -1,7 +1,7 @@
-# Example Caddyfile for Inventree
+# Example Caddyfile for InvenTree
 # The following environment variables may be used:
-# - INVENTREE_SITE_URL: The upstream URL of the Inventree site (default: inventree.localhost)
-# - INVENTREE_SERVER: The internal URL of the Inventree container (default: http://inventree-server:8000)
+# - INVENTREE_SITE_URL: The upstream URL of the InvenTree site (default: inventree.localhost)
+# - INVENTREE_SERVER: The internal URL of the InvenTree container (default: http://inventree-server:8000)
 #
 # Note that while this file is a good starting point, it may need to be modified to suit your specific requirements
 

--- a/docs/docs/features.md
+++ b/docs/docs/features.md
@@ -39,7 +39,7 @@ InvenTree allows you to upload simple BOM files in multiple formats, and downloa
 
 ## Build Parts
 
-Inventree features a build management system to help you track the progress of your builds.
+InvenTree features a build management system to help you track the progress of your builds.
 Builds consume stock items to make new parts, you can decide to automatically or manually allocate parts from your current inventory.
 
 [Read more...](./build/build.md)

--- a/docs/docs/order/company.md
+++ b/docs/docs/order/company.md
@@ -61,7 +61,7 @@ A *contact* can be assigned to orders, (such as [purchase orders](./purchase_ord
 
 A company can have multiple registered addresses for use with all types of orders.
 An address is broken down to internationally recognised elements that are designed to allow for formatting an address according to user needs.
-Addresses are composed differently across the world, and Inventree reflects this by splitting addresses into components:
+Addresses are composed differently across the world, and InvenTree reflects this by splitting addresses into components:
 - Line 1: Main street address
 - Line 2: Extra street address line
 - Postal Code: Also known as ZIP code, this is normally a number 3-5 digits in length

--- a/docs/docs/releases/0.7.0.md
+++ b/docs/docs/releases/0.7.0.md
@@ -81,7 +81,7 @@ Multiple improvements have been made to the docker installation process, most no
 
 ### QR code scanner
 
-[#2779](https://github.com/inventree/InvenTree/pull/2779) provides a QR code scanner which can be used to quickly scan Inventree generated QR codes using webcams or mobile devices. This feature requires secure (HTTPS) connection to the server.
+[#2779](https://github.com/inventree/InvenTree/pull/2779) provides a QR code scanner which can be used to quickly scan InvenTree generated QR codes using webcams or mobile devices. This feature requires secure (HTTPS) connection to the server.
 
 ### Order, Order
 

--- a/docs/docs/start/advanced.md
+++ b/docs/docs/start/advanced.md
@@ -63,7 +63,7 @@ Next you can start configuring the connection. Either use the config file or set
 | `ldap.user_dn_template` | `INVENTREE_LDAP_USER_DN_TEMPLATE` | use direct bind as auth user, `ldap.bind_dn` and `ldap.bin_password` is not necessary then, e.g. `uid=%(user)s,dc=example,dc=org` |
 | `ldap.global_options` | `INVENTREE_LDAP_GLOBAL_OPTIONS` | set advanced options as dict, e.g. TLS settings. For a list of all available options, see [python-ldap docs](https://www.python-ldap.org/en/latest/reference/ldap.html#ldap-options). (keys and values starting with OPT_ get automatically converted to `python-ldap` keys) |
 | `ldap.search_filter_str`| `INVENTREE_LDAP_SEARCH_FILTER_STR` | LDAP search filter str, default: `uid=%(user)s` |
-| `ldap.user_attr_map` | `INVENTREE_LDAP_USER_ATTR_MAP` | LDAP <-> Inventree user attribute map, can be json if used as env, in yml directly specify the object. default: `{"first_name": "givenName", "last_name": "sn", "email": "mail"}` |
+| `ldap.user_attr_map` | `INVENTREE_LDAP_USER_ATTR_MAP` | LDAP <-> InvenTree user attribute map, can be json if used as env, in yml directly specify the object. default: `{"first_name": "givenName", "last_name": "sn", "email": "mail"}` |
 | `ldap.always_update_user` | `INVENTREE_LDAP_ALWAYS_UPDATE_USER` | Always update the user on each login, default: `true` |
 | `ldap.cache_timeout` | `INVENTREE_LDAP_CACHE_TIMEOUT` | cache timeout to reduce traffic with LDAP server, default: `3600` (1h) |
 | `ldap.group_search` | `INVENTREE_LDAP_GROUP_SEARCH` | Base LDAP DN for group searching; required to enable group features |

--- a/docs/docs/start/installer.md
+++ b/docs/docs/start/installer.md
@@ -31,7 +31,7 @@ The installer creates the following directories:
 | --- | --- |
 | `/etc/inventree/` | Configuration files |
 | `/opt/inventree/` | InvenTree application files |
-| `/opt/inventree/data/` | Inventree data files |
+| `/opt/inventree/data/` | InvenTree data files |
 
 #### Performed steps
 

--- a/docs/docs/start/intro.md
+++ b/docs/docs/start/intro.md
@@ -68,7 +68,7 @@ python3 -m venv env
 
 The virtual environment needs to be activated to ensure the correct python binaries and libraries are used. The InvenTree instructions assume that the virtual environment is always correctly activated.
 
-To configure Inventree inside a virtual environment, ``cd`` into the inventree base directory and run the following command:
+To configure InvenTree inside a virtual environment, ``cd`` into the inventree base directory and run the following command:
 
 ```
 source env/bin/activate

--- a/docs/docs/start/processes.md
+++ b/docs/docs/start/processes.md
@@ -100,4 +100,4 @@ InvenTree uses the [Redis](https://redis.io/) cache server to manage cache data.
     To optimize and configure your redis deployment follow the [official docker guide](https://redis.io/docs/getting-started/install-stack/docker/#configuration).
 
 !!! tip "Enable Cache"
-    While a redis container is provided in the default configuration, by default it is not enabled in the Inventree server. You can enable redis cache support by following the [caching configuration guide](./config.md#caching)
+    While a redis container is provided in the default configuration, by default it is not enabled in the InvenTree server. You can enable redis cache support by following the [caching configuration guide](./config.md#caching)

--- a/src/backend/InvenTree/InvenTree/helpers_mixin.py
+++ b/src/backend/InvenTree/InvenTree/helpers_mixin.py
@@ -99,7 +99,7 @@ class ClassProviderMixin:
 
     @classmethod
     def get_is_builtin(cls):
-        """Is this Class build in the Inventree source code?"""
+        """Is this Class build in the InvenTree source code?"""
         try:
             Path(cls.get_provider_file()).relative_to(settings.BASE_DIR)
             return True

--- a/src/backend/InvenTree/plugin/builtin/suppliers/digikey.py
+++ b/src/backend/InvenTree/plugin/builtin/suppliers/digikey.py
@@ -1,4 +1,4 @@
-"""The DigiKeyPlugin is meant to integrate the DigiKey API into Inventree.
+"""The DigiKeyPlugin is meant to integrate the DigiKey API into InvenTree.
 
 This plugin can currently only match DigiKey barcodes to supplier parts.
 """
@@ -10,7 +10,7 @@ from plugin.mixins import SettingsMixin, SupplierBarcodeMixin
 
 
 class DigiKeyPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):
-    """Plugin to integrate the DigiKey API into Inventree."""
+    """Plugin to integrate the DigiKey API into InvenTree."""
 
     NAME = 'DigiKeyPlugin'
     TITLE = _('Supplier Integration - DigiKey')

--- a/src/backend/InvenTree/plugin/builtin/suppliers/lcsc.py
+++ b/src/backend/InvenTree/plugin/builtin/suppliers/lcsc.py
@@ -1,4 +1,4 @@
-"""The LCSCPlugin is meant to integrate the LCSC API into Inventree.
+"""The LCSCPlugin is meant to integrate the LCSC API into InvenTree.
 
 This plugin can currently only match LCSC barcodes to supplier parts.
 """
@@ -12,7 +12,7 @@ from plugin.mixins import SettingsMixin, SupplierBarcodeMixin
 
 
 class LCSCPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):
-    """Plugin to integrate the LCSC API into Inventree."""
+    """Plugin to integrate the LCSC API into InvenTree."""
 
     NAME = 'LCSCPlugin'
     TITLE = _('Supplier Integration - LCSC')

--- a/src/backend/InvenTree/plugin/builtin/suppliers/mouser.py
+++ b/src/backend/InvenTree/plugin/builtin/suppliers/mouser.py
@@ -1,4 +1,4 @@
-"""The MouserPlugin is meant to integrate the Mouser API into Inventree.
+"""The MouserPlugin is meant to integrate the Mouser API into InvenTree.
 
 This plugin currently only match Mouser barcodes to supplier parts.
 """
@@ -10,7 +10,7 @@ from plugin.mixins import SettingsMixin, SupplierBarcodeMixin
 
 
 class MouserPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):
-    """Plugin to integrate the Mouser API into Inventree."""
+    """Plugin to integrate the Mouser API into InvenTree."""
 
     NAME = 'MouserPlugin'
     TITLE = _('Supplier Integration - Mouser')

--- a/src/backend/InvenTree/plugin/builtin/suppliers/tme.py
+++ b/src/backend/InvenTree/plugin/builtin/suppliers/tme.py
@@ -1,4 +1,4 @@
-"""The TMEPlugin is meant to integrate the TME API into Inventree.
+"""The TMEPlugin is meant to integrate the TME API into InvenTree.
 
 This plugin can currently only match TME barcodes to supplier parts.
 """
@@ -12,7 +12,7 @@ from plugin.mixins import SettingsMixin, SupplierBarcodeMixin
 
 
 class TMEPlugin(SupplierBarcodeMixin, SettingsMixin, InvenTreePlugin):
-    """Plugin to integrate the TME API into Inventree."""
+    """Plugin to integrate the TME API into InvenTree."""
 
     NAME = 'TMEPlugin'
     TITLE = _('Supplier Integration - TME')

--- a/src/frontend/src/defaults/actions.tsx
+++ b/src/frontend/src/defaults/actions.tsx
@@ -38,7 +38,7 @@ export function getActions(navigate: NavigateFunction) {
     {
       id: 'server-info',
       label: t`Server Information`,
-      description: t`About this Inventree instance`,
+      description: t`About this InvenTree instance`,
       onClick: () => serverInfo(),
       leftSection: <IconLink size='1.2rem' />
     },

--- a/src/frontend/src/defaults/links.tsx
+++ b/src/frontend/src/defaults/links.tsx
@@ -115,7 +115,7 @@ export function AboutLinks(): MenuLinkItem[] {
     {
       id: 'instance',
       title: t`System Information`,
-      description: t`About this Inventree instance`,
+      description: t`About this InvenTree instance`,
       icon: 'info',
       action: serverInfo
     },

--- a/src/frontend/src/states/states.tsx
+++ b/src/frontend/src/states/states.tsx
@@ -92,7 +92,7 @@ export interface SettingChoice {
 }
 
 export enum SettingTyp {
-  Inventree = 'inventree',
+  InvenTree = 'inventree',
   Plugin = 'plugin',
   User = 'user',
   Notification = 'notification'

--- a/src/frontend/tests/modals.spec.ts
+++ b/src/frontend/tests/modals.spec.ts
@@ -8,7 +8,7 @@ test('Modals as admin', async ({ page }) => {
   await page.getByLabel('open-spotlight').click();
   await page
     .getByRole('button', {
-      name: 'Server Information About this Inventree instance'
+      name: 'Server Information About this InvenTree instance'
     })
     .click();
   await page.getByRole('cell', { name: 'Instance Name' }).waitFor();

--- a/src/frontend/tests/pui_command.spec.ts
+++ b/src/frontend/tests/pui_command.spec.ts
@@ -49,7 +49,7 @@ test('Quick Command - No Keys', async ({ page }) => {
   await page.getByLabel('open-spotlight').click();
   await page
     .getByRole('button', {
-      name: 'Server Information About this Inventree instance'
+      name: 'Server Information About this InvenTree instance'
     })
     .click();
   await page.getByRole('cell', { name: 'Instance Name' }).waitFor();


### PR DESCRIPTION
Some places in the docs and code refer to InvenTree using the wrong spelling.