### PR TITLE
Add location when creating multiple serials

### DIFF
--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -871,6 +871,7 @@ class Build(
                 part=self.part,
                 build=self,
                 batch=batch,
+                location=location,
                 is_building=True
             )
 


### PR DESCRIPTION
Previously missing location information when creating items