### PR TITLE
Set null location on stock item:

### DIFF
--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -1749,6 +1749,7 @@ class BuildItem(InvenTree.models.InvenTreeMetadataModel):
         else:
             # Mark the item as "consumed" by the build order
             item.consumed_by = self.build
+            item.location = None
             item.save(add_note=False)
 
             item.add_tracking_entry(

--- a/src/backend/InvenTree/stock/models.py
+++ b/src/backend/InvenTree/stock/models.py
@@ -1403,6 +1403,7 @@ class StockItem(
         # Assign the other stock item into this one
         stock_item.belongs_to = self
         stock_item.consumed_by = build
+        stock_item.location = None
         stock_item.save(add_note=False)
 
         deltas = {'stockitem': self.pk}


### PR DESCRIPTION
- When consumed by a build order
- When shipped to a customer

This ensures that the behaviour is in-line with other "transformative" stock operations. The item is no longer consider to be "in" a specific location, so the `location` field is set to `None`