### PR TITLE
Bug fix: record shipment date

### DIFF
--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1177,8 +1177,9 @@ class SalesOrder(TotalPriceMixin, Order):
         else:
             self.status = SalesOrderStatus.SHIPPED.value
 
-        self.shipped_by = user
-        self.shipment_date = InvenTree.helpers.current_date()
+        if self.shipment_date is None:
+            self.shipped_by = user
+            self.shipment_date = InvenTree.helpers.current_date()
 
         self.save()
 

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1176,8 +1176,9 @@ class SalesOrder(TotalPriceMixin, Order):
             self.status = SalesOrderStatus.COMPLETE.value
         else:
             self.status = SalesOrderStatus.SHIPPED.value
-            self.shipped_by = user
-            self.shipment_date = InvenTree.helpers.current_date()
+
+        self.shipped_by = user
+        self.shipment_date = InvenTree.helpers.current_date()
 
         self.save()
 

--- a/src/backend/InvenTree/order/test_api.py
+++ b/src/backend/InvenTree/order/test_api.py
@@ -1633,6 +1633,8 @@ class SalesOrderTest(OrderTest):
 
         so.refresh_from_db()
         self.assertEqual(so.status, SalesOrderStatus.SHIPPED.value)
+        self.assertIsNotNone(so.shipment_date)
+        self.assertIsNotNone(so.shipped_by)
 
         # Now, let's try to "complete" the shipment again
         # This time it should get marked as "COMPLETE"
@@ -1648,9 +1650,14 @@ class SalesOrderTest(OrderTest):
 
         # Next, we'll change the setting so that the order status jumps straight to "complete"
         so.status = SalesOrderStatus.PENDING.value
+        so.shipment_date = None
+        so.shipped_by = None
         so.save()
         so.refresh_from_db()
+
         self.assertEqual(so.status, SalesOrderStatus.PENDING.value)
+        self.assertIsNone(so.shipped_by)
+        self.assertIsNone(so.shipment_date)
 
         InvenTreeSetting.set_setting('SALESORDER_SHIP_COMPLETE', True)
 
@@ -1659,6 +1666,9 @@ class SalesOrderTest(OrderTest):
         # The orders status should now be "complete" (not "shipped")
         so.refresh_from_db()
         self.assertEqual(so.status, SalesOrderStatus.COMPLETE.value)
+
+        self.assertIsNotNone(so.shipment_date)
+        self.assertIsNotNone(so.shipped_by)
 
 
 class SalesOrderLineItemTest(OrderTest):


### PR DESCRIPTION
- Ref: https://github.com/inventree/InvenTree/pull/6449
- Fixes issue where "shipment date" is not recorded for a sales order
- Only if "bypass_shipped" setting is enabled
- @tsimonq2 FYI