### PR TITLE
Allow settings value to be nullified

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,15 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 290
+INVENTREE_API_VERSION = 291
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+
+v291 - 2024-11-30 : https://github.com/inventree/InvenTree/pull/8596
+    - Allow null / empty values for plugin settings
 
 v290 - 2024-11-29 : https://github.com/inventree/InvenTree/pull/8590
     - Adds "quantity" field to ReturnOrderLineItem model and API

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -41,11 +41,19 @@ class SettingsValueField(serializers.Field):
 
         Protected settings are returned as '***'
         """
-        return '***' if instance.protected else str(instance.value or '')
+        if instance.protected:
+            return '***'
+        elif instance.value is None:
+            return ''
+        else:
+            return str(instance.value)
 
     def to_internal_value(self, data):
         """Return the internal value of the setting."""
-        return str(data or '')
+        if data is None:
+            return ''
+        else:
+            return str(data)
 
 
 class SettingsSerializer(InvenTreeModelSerializer):
@@ -69,7 +77,9 @@ class SettingsSerializer(InvenTreeModelSerializer):
 
     def validate_value(self, value):
         """Validate the value of the setting."""
-        return str(value or '')
+        if value is None:
+            return ''
+        return str(value)
 
     units = serializers.CharField(read_only=True)
 
@@ -191,7 +201,9 @@ class GenericReferencedSettingSerializer(SettingsSerializer):
 
     def validate_value(self, value):
         """Validate the value of the setting."""
-        return str(value or '')
+        if value is None:
+            return ''
+        return str(value)
 
 
 class NotificationMessageSerializer(InvenTreeModelSerializer):

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -41,7 +41,7 @@ class SettingsValueField(serializers.Field):
 
         Protected settings are returned as '***'
         """
-        return '***' if instance.protected else str(instance.value)
+        return '***' if instance.protected else str(instance.value or '')
 
     def to_internal_value(self, data):
         """Return the internal value of the setting."""

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -45,7 +45,7 @@ class SettingsValueField(serializers.Field):
 
     def to_internal_value(self, data):
         """Return the internal value of the setting."""
-        return str(data)
+        return str(data or '')
 
 
 class SettingsSerializer(InvenTreeModelSerializer):
@@ -65,7 +65,11 @@ class SettingsSerializer(InvenTreeModelSerializer):
 
     api_url = serializers.CharField(read_only=True)
 
-    value = SettingsValueField()
+    value = SettingsValueField(allow_null=True)
+
+    def validate_value(self, value):
+        """Validate the value of the setting."""
+        return str(value or '')
 
     units = serializers.CharField(read_only=True)
 
@@ -184,6 +188,10 @@ class GenericReferencedSettingSerializer(SettingsSerializer):
 
         # resume operations
         super().__init__(*args, **kwargs)
+
+    def validate_value(self, value):
+        """Validate the value of the setting."""
+        return str(value or '')
 
 
 class NotificationMessageSerializer(InvenTreeModelSerializer):

--- a/src/frontend/src/components/settings/SettingList.tsx
+++ b/src/frontend/src/components/settings/SettingList.tsx
@@ -68,6 +68,7 @@ export function SettingList({
     fields: {
       value: {
         field_type: fieldType,
+        required: setting?.required ?? false,
         label: setting?.name,
         description: setting?.description,
         api_url: setting?.api_url ?? '',


### PR DESCRIPTION
- Settings values should be able to be "nulled" via UI and API
- Allow "null" values on the field (to prevent API errors)
- Convert any null values to empty string