### PR TITLE
[PUI] Make dashboard header look less like a widget

### DIFF
--- a/src/frontend/src/components/dashboard/DashboardLayout.tsx
+++ b/src/frontend/src/components/dashboard/DashboardLayout.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import { Alert, Card, Center, Divider, Loader, Text } from '@mantine/core';
+import { Alert, Card, Center, Loader, Text } from '@mantine/core';
 import { useDisclosure, useHotkeys } from '@mantine/hooks';
 import { IconInfoCircle } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -275,7 +275,6 @@ export default function DashboardLayout() {
         editing={editing}
         removing={removing}
       />
-      <Divider p='xs' />
       {layouts && loaded && availableWidgets.loaded ? (
         <>
           {widgetLabels.length == 0 ? (

--- a/src/frontend/src/components/dashboard/DashboardMenu.tsx
+++ b/src/frontend/src/components/dashboard/DashboardMenu.tsx
@@ -76,7 +76,7 @@ export default function DashboardMenu({
             <Menu.Target>
               <Indicator
                 color='red'
-                position='bottom-start'
+                position='bottom-center'
                 processing
                 disabled={!editing}
               >

--- a/src/frontend/src/components/dashboard/DashboardMenu.tsx
+++ b/src/frontend/src/components/dashboard/DashboardMenu.tsx
@@ -50,7 +50,7 @@ export default function DashboardMenu({
   }, [user, instanceName]);
 
   return (
-    <Paper p='sm' shadow='xs'>
+    <Paper p='sm' pr={0}>
       <Group justify='space-between' wrap='nowrap'>
         {title}
 


### PR DESCRIPTION
This PR changed the header of the dashboard from
![grafik](https://github.com/user-attachments/assets/11ea1dff-aaf1-4b01-b1a1-6931cd66ae6e)

to
![grafik](https://github.com/user-attachments/assets/f5c73bc3-911b-4798-aa63-0b7554cf3231)

and moves the editing indicator
![grafik](https://github.com/user-attachments/assets/b5e20e78-ae44-43a3-8eb0-d9a386a4ebba)
