### PR TITLE
Add separate dialog for 'Ship Order' button

### DIFF
--- a/src/frontend/src/pages/sales/SalesOrderDetail.tsx
+++ b/src/frontend/src/pages/sales/SalesOrderDetail.tsx
@@ -399,6 +399,17 @@ export default function SalesOrderDetail() {
     successMessage: t`Order placed on hold`
   });
 
+  const shipOrder = useCreateApiFormModal({
+    url: apiUrl(ApiEndpoints.sales_order_complete, order.pk),
+    title: t`Ship Sales Order`,
+    onFormSuccess: refreshInstance,
+    preFormWarning: t`Ship this order?`,
+    successMessage: t`Order shipped`,
+    fields: {
+      accept_incomplete: {}
+    }
+  });
+
   const completeOrder = useCreateApiFormModal({
     url: apiUrl(ApiEndpoints.sales_order_complete, order.pk),
     title: t`Complete Sales Order`,
@@ -444,7 +455,7 @@ export default function SalesOrderDetail() {
         icon='deliver'
         hidden={!canShip}
         color='blue'
-        onClick={completeOrder.open}
+        onClick={shipOrder.open}
       />,
       <PrimaryActionButton
         title={t`Complete Order`}
@@ -510,6 +521,7 @@ export default function SalesOrderDetail() {
       {issueOrder.modal}
       {cancelOrder.modal}
       {holdOrder.modal}
+      {shipOrder.modal}
       {completeOrder.modal}
       {editSalesOrder.modal}
       {duplicateSalesOrder.modal}


### PR DESCRIPTION
When trying to use the PUI, I found it rather confusing that clicking the "Ship Order" button to move the order to the `SHIPPED` state opened the "Complete Order" dialog. The "Complete Order" dialog performed as I expected "Ship Order" to do, based on the CUI, but all the text indicated the wrong action was taking place.

I created a new dialog with the "Complete Order" functionality but the text from the CUI version of the "Ship Order" dialog.