### PR TITLE
Fix missing permission for push schema action

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -209,7 +209,7 @@ jobs:
         with:
           repository: inventree/schema
           token: ${{ secrets.SCHEMA_PAT }}
-          persist-credentials: false
+          persist-credentials: true
       - name: Download schema artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v4.1.8
         with:


### PR DESCRIPTION
This PR fixes an error introduced by me when restricting the permissions of all flows. In this specific case we need to keep the credentials persistent.