### PR TITLE
Fix default value for SESSION_COOKIE_SECURE

### DIFF
--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1177,7 +1177,9 @@ SESSION_COOKIE_SECURE = (
     if DEBUG
     else (
         SESSION_COOKIE_SAMESITE == 'None'
-        or get_boolean_setting('INVENTREE_SESSION_COOKIE_SECURE', 'cookie.secure', True)
+        or get_boolean_setting(
+            'INVENTREE_SESSION_COOKIE_SECURE', 'cookie.secure', False
+        )
     )
 )
 

--- a/src/backend/InvenTree/config_template.yaml
+++ b/src/backend/InvenTree/config_template.yaml
@@ -124,9 +124,9 @@ use_x_forwarded_host: false
 use_x_forwarded_port: false
 
 # Cookie settings (nominally the default settings should be fine)
-#cookie:
-#  secure: false
-#  samesite: false
+cookie:
+  secure: false
+  samesite: false
 
 # Cross Origin Resource Sharing (CORS) settings (see https://github.com/adamchainz/django-cors-headers)
 cors:


### PR DESCRIPTION
- Default value was previously `True`
- Documentation indicated that it was `False`
- Value in config_template.yaml was `False` (but commented out)
- Closes https://github.com/inventree/InvenTree/issues/8761