### PR TITLE
Update dependabot settings for python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,16 +16,33 @@ updates:
 
   - package-ecosystem: pip
     directories:
-    - /contrib/container
     - /docs
     - /contrib/dev_reqs
-    - /src/backend
     schedule:
       interval: weekly
+      day: friday
     groups:
       dependencies:
         patterns:
           - "*" # Include all dependencies
+    assignees:
+      - "matmair"
+    versioning-strategy: increase
+
+  - package-ecosystem: pip
+    directories:
+    - /contrib/container
+    - /src/backend
+    schedule:
+      interval: weekly
+      day: friday
+    groups:
+      dependencies:
+        patterns:
+          - "*" # Include all dependencies
+    assignees:
+      - "matmair"
+    versioning-strategy: increase
 
   - package-ecosystem: npm
     directories:


### PR DESCRIPTION
Several changes to dependabot behaviour:
- Splits backend and helper dependency updates
- schedules them for Friday
- changes version bumping schema
- adds me as an assignee as they need to be fixed by hand