### PR TITLE
Fix package install in envs using python lower than 3.12 on debian like OSs

### DIFF
--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -292,6 +292,7 @@ function stop_inventree() {
 }
 
 function update_or_install() {
+  set -e
 
   # Set permissions so app user can write there
   chown ${APP_USER}:${APP_GROUP} ${APP_HOME} -R

--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -298,8 +298,8 @@ function update_or_install() {
 
   # Run update as app user
   echo "# POI12| Updating InvenTree"
-  sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && pip install uv wheel"
-  sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && invoke update --uv | sed -e 's/^/# POI12| u | /;'"
+  sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && pip install wheel"
+  sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && invoke update | sed -e 's/^/# POI12| u | /;'"
 
   # Make sure permissions are correct again
   echo "# POI12| Set permissions for data dir and media: ${DATA_DIR}"


### PR DESCRIPTION
This fixes issues where uv installs the wrong version of a package. It might be wise to use the uv lockfile in the future to ensure this does not happen again, that requires more work though