### PR TITLE
Remove admin shell

### DIFF
--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -93,7 +93,6 @@ The following debugging / logging options are available:
 | --- | --- | --- | --- |
 | INVENTREE_DEBUG | debug | Enable [debug mode](./intro.md#debug-mode) | False |
 | INVENTREE_DEBUG_QUERYCOUNT | debug_querycount | Enable [query count logging](https://github.com/bradmontgomery/django-querycount) in the terminal | False |
-| INVENTREE_DEBUG_SHELL | debug_shell | Enable [administrator shell](https://github.com/djk2/django-admin-shell) (only in debug mode) | False |
 | INVENTREE_DB_LOGGING | db_logging | Enable logging of database messages | False |
 | INVENTREE_LOG_LEVEL | log_level | Set level of logging to terminal | WARNING |
 | INVENTREE_JSON_LOG | json_log | log as json | False |
@@ -106,10 +105,6 @@ Enabling the `INVENTREE_DEBUG` setting will turn on [Django debug mode]({% inclu
 ### Query Count Logging
 
 Enabling the `INVENTREE_DEBUG_QUERYCOUNT` setting will log the number of database queries executed for each page load. This can be useful for identifying performance bottlenecks in the InvenTree server. Note that this setting is only available if `INVENTREE_DEBUG` is also enabled.
-
-### Debug Shell
-
-Enabling the `INVENTREE_DEBUG_SHELL` setting will allow the use of the [administrator shell](https://github.com/djk2/django-admin-shell). Note that this setting is only available if `INVENTREE_DEBUG` is also enabled, and is only accessible to superuser accounts.
 
 ### Database Logging
 

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -353,29 +353,6 @@ QUERYCOUNT = {
     'RESPONSE_HEADER': 'X-Django-Query-Count',
 }
 
-ADMIN_SHELL_ENABLE = False
-ADMIN_SHELL_IMPORT_DJANGO = False
-ADMIN_SHELL_IMPORT_MODELS = False
-
-# In DEBUG mode, add support for django-admin-shell
-# Ref: https://github.com/djk2/django-admin-shell
-if (
-    DEBUG
-    and INVENTREE_ADMIN_ENABLED
-    and not TESTING
-    and get_boolean_setting('INVENTREE_DEBUG_SHELL', 'debug_shell', False)
-):
-    try:
-        import django_admin_shell  # noqa: F401
-
-        INSTALLED_APPS.append('django_admin_shell')
-        ADMIN_SHELL_ENABLE = True
-
-        logger.warning('Admin shell is enabled')
-    except ModuleNotFoundError:
-        logger.warning(
-            'django-admin-shell is not installed - Admin shell is not enabled'
-        )
 
 AUTHENTICATION_BACKENDS = CONFIG.get(
     'authentication_backends',

--- a/src/backend/InvenTree/InvenTree/urls.py
+++ b/src/backend/InvenTree/InvenTree/urls.py
@@ -188,9 +188,6 @@ urlpatterns = []
 if settings.INVENTREE_ADMIN_ENABLED:
     admin_url = settings.INVENTREE_ADMIN_URL
 
-    if settings.ADMIN_SHELL_ENABLE:
-        urlpatterns += [path(f'{admin_url}/shell/', include('django_admin_shell.urls'))]
-
     urlpatterns += [
         path(f'{admin_url}/error_log/', include('error_report.urls')),
         path(f'{admin_url}/', admin.site.urls, name='inventree-admin'),

--- a/src/backend/requirements-dev.in
+++ b/src/backend/requirements-dev.in
@@ -1,7 +1,6 @@
 # Dev requirements for InvenTree
 -c requirements.txt
 coverage[toml]                          # Unit test coverage
-django-admin-shell                      # Remote shell access
 django-querycount                       # Display number of URL queries for requests
 django-slowtests                        # Show which unit tests are running slowly
 django-test-migrations                  # Unit testing for database migrations

--- a/src/backend/requirements-dev.txt
+++ b/src/backend/requirements-dev.txt
@@ -302,12 +302,7 @@ django==4.2.17 \
     --hash=sha256:6b56d834cc94c8b21a8f4e775064896be3b4a4ca387f2612d4406a5927cd2fdc
     # via
     #   -c src/backend/requirements.txt
-    #   django-admin-shell
     #   django-slowtests
-django-admin-shell==2.0.1 \
-    --hash=sha256:334a651e53ae4f59d0d279d7ede7dc5ed7a7733d4d093765b447dca5274c7b30 \
-    --hash=sha256:b129e282ebd581c2099c0504edf081259728b3a504b40c5784d0457b8cb41470
-    # via -r src/backend/requirements-dev.in
 django-querycount==0.8.3 \
     --hash=sha256:0782484e8a1bd29498fa0195a67106e47cdcc98fafe80cebb1991964077cb694
     # via -r src/backend/requirements-dev.in


### PR DESCRIPTION
This removes the integration for djnago-admin-shell, which is not recommended in the docs anymore.