### PR TITLE
fix: remove structlog from invoke internal paths

### DIFF
--- a/src/backend/InvenTree/InvenTree/config.py
+++ b/src/backend/InvenTree/InvenTree/config.py
@@ -2,6 +2,7 @@
 
 import datetime
 import json
+import logging
 import os
 import random
 import shutil
@@ -12,9 +13,7 @@ from pathlib import Path
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 
-import structlog
-
-logger = structlog.get_logger('inventree')
+logger = logging.getLogger('inventree')
 CONFIG_DATA = None
 CONFIG_LOOKUPS = {}
 

--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -3,6 +3,7 @@
 Provides information on the current InvenTree version
 """
 
+import logging
 import os
 import pathlib
 import platform
@@ -20,9 +21,7 @@ from .api_version import INVENTREE_API_TEXT, INVENTREE_API_VERSION
 INVENTREE_SW_VERSION = '0.18.0 dev'
 
 
-import structlog
-
-logger = structlog.get_logger('inventree')
+logger = logging.getLogger('inventree')
 
 
 # Discover git


### PR DESCRIPTION
This is not really a fix but a path that should re-enable running most tests and invoke commands. https://github.com/inventree/InvenTree/pull/8835 is still required.

Follow up to https://github.com/inventree/InvenTree/pull/8747