### PR TITLE
Add Expiry Date on Receive Line Item

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     -   id: check-yaml
     -   id: mixed-line-ending
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.9.0
     hooks:
     - id: ruff-format
       args: [--preview]
@@ -28,7 +28,7 @@ repos:
         --preview
       ]
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.1
+    rev: 0.5.16
     hooks:
       - id: pip-compile
         name: pip-compile requirements-dev.in

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     -   id: check-yaml
     -   id: mixed-line-ending
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.0
+    rev: v0.7.3
     hooks:
     - id: ruff-format
       args: [--preview]
@@ -28,7 +28,7 @@ repos:
         --preview
       ]
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.16
+    rev: 0.5.1
     hooks:
       - id: pip-compile
         name: pip-compile requirements-dev.in

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -10,6 +10,7 @@ INVENTREE_API_TEXT = """
 
 v299 - 2025-01-10 - https://github.com/inventree/InvenTree/pull/8867
     - Adds 'expiry_date' field to the PurchaseOrderReceive API endpoint
+    - Adds 'default_expiry` field to the PartBriefSerializer, affecting API endpoints which use it
 
 v298 - 2025-01-07 - https://github.com/inventree/InvenTree/pull/8848
     - Adds 'created_by' field to PurchaseOrder API endpoints

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,15 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 298
+INVENTREE_API_VERSION = 299
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+
+v299 - 2025-01-10 - https://github.com/inventree/InvenTree/pull/8867
+    - Adds 'expiry_date' field to the PurchaseOrderReceive API endpoint
 
 v298 - 2025-01-07 - https://github.com/inventree/InvenTree/pull/8848
     - Adds 'created_by' field to PurchaseOrder API endpoints

--- a/src/backend/InvenTree/order/api.py
+++ b/src/backend/InvenTree/order/api.py
@@ -410,6 +410,7 @@ class PurchaseOrderReceive(PurchaseOrderContextMixin, CreateAPI):
         - supplier_part: pk value of the supplier part
         - quantity: quantity to receive
         - status: stock item status
+        - expiry_date: stock item expiry date (optional)
         - location: destination for stock item (optional)
         - batch_code: the batch code for this stock item
         - serial_numbers: serial numbers for this stock item

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -800,8 +800,8 @@ class PurchaseOrder(TotalPriceMixin, Order):
         # Extract optional batch code for the new stock item
         batch_code = kwargs.get('batch_code', '')
 
-        # Extract optional expiry data for the new stock item
-        expiry_date = kwargs.get('expiry_date', '')
+        # Extract optional expiry date for the new stock item
+        expiry_date = kwargs.get('expiry_date')
 
         # Extract optional list of serial numbers
         serials = kwargs.get('serials')

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -800,6 +800,9 @@ class PurchaseOrder(TotalPriceMixin, Order):
         # Extract optional batch code for the new stock item
         batch_code = kwargs.get('batch_code', '')
 
+        # Extract optional expiry data for the new stock item
+        expiry_date = kwargs.get('expiry_date', '')
+
         # Extract optional list of serial numbers
         serials = kwargs.get('serials')
 
@@ -863,6 +866,7 @@ class PurchaseOrder(TotalPriceMixin, Order):
                     purchase_order=self,
                     status=status,
                     batch=batch_code,
+                    expiry_date=expiry_date,
                     packaging=packaging,
                     serial=sn,
                     purchase_price=unit_purchase_price,

--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -717,6 +717,7 @@ class PurchaseOrderLineItemReceiveSerializer(serializers.Serializer):
             'quantity',
             'status',
             'batch_code',
+            'expiry_date',
             'serial_numbers',
             'packaging',
             'note',
@@ -763,6 +764,13 @@ class PurchaseOrderLineItemReceiveSerializer(serializers.Serializer):
         required=False,
         default='',
         allow_blank=True,
+    )
+
+    expiry_date = serializers.DateField(
+        label=_('Expiry Date'),
+        help_text=_('Enter expiry date for incoming stock items'),
+        required=False,
+        default=None,
     )
 
     serial_numbers = serializers.CharField(
@@ -967,6 +975,7 @@ class PurchaseOrderReceiveSerializer(serializers.Serializer):
                         status=item['status'],
                         barcode=item.get('barcode', ''),
                         batch_code=item.get('batch_code', ''),
+                        expiry_date=item.get('expiry_date', ''),
                         packaging=item.get('packaging', ''),
                         serials=item.get('serials', None),
                         notes=item.get('note', None),

--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -975,7 +975,7 @@ class PurchaseOrderReceiveSerializer(serializers.Serializer):
                         status=item['status'],
                         barcode=item.get('barcode', ''),
                         batch_code=item.get('batch_code', ''),
-                        expiry_date=item.get('expiry_date', ''),
+                        expiry_date=item.get('expiry_date', None),
                         packaging=item.get('packaging', ''),
                         serials=item.get('serials', None),
                         notes=item.get('note', None),

--- a/src/backend/InvenTree/order/test_api.py
+++ b/src/backend/InvenTree/order/test_api.py
@@ -3,7 +3,7 @@
 import base64
 import io
 import json
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 from django.core.exceptions import ValidationError
 from django.db import connection
@@ -1061,12 +1061,20 @@ class PurchaseOrderReceiveTest(OrderTest):
         self.assertEqual(line_1.received, 0)
         self.assertEqual(line_2.received, 50)
 
+        one_week_from_today = date.today() + timedelta(days=7)
+
         valid_data = {
             'items': [
-                {'line_item': 1, 'quantity': 50, 'barcode': 'MY-UNIQUE-BARCODE-123'},
+                {
+                    'line_item': 1,
+                    'quantity': 50,
+                    'expiry_date': one_week_from_today.strftime(r'%Y-%m-%d'),
+                    'barcode': 'MY-UNIQUE-BARCODE-123',
+                },
                 {
                     'line_item': 2,
                     'quantity': 200,
+                    'expiry_date': one_week_from_today.strftime(r'%Y-%m-%d'),
                     'location': 2,  # Explicit location
                     'barcode': 'MY-UNIQUE-BARCODE-456',
                 },
@@ -1110,6 +1118,10 @@ class PurchaseOrderReceiveTest(OrderTest):
         # Check received locations
         self.assertEqual(stock_1.last().location.pk, 1)
         self.assertEqual(stock_2.last().location.pk, 2)
+
+        # Expiry dates should be set
+        self.assertEqual(stock_1.last().expiry_date, one_week_from_today)
+        self.assertEqual(stock_2.last().expiry_date, one_week_from_today)
 
         # Barcodes should have been assigned to the stock items
         self.assertTrue(

--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -352,6 +352,7 @@ class PartBriefSerializer(InvenTree.serializers.InvenTreeModelSerializer):
             'barcode_hash',
             'category_default_location',
             'default_location',
+            'default_expiry',
             'name',
             'revision',
             'full_name',

--- a/src/frontend/src/forms/PurchaseOrderForms.tsx
+++ b/src/frontend/src/forms/PurchaseOrderForms.tsx
@@ -25,6 +25,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 
+import { IconCalendarExclamation } from '@tabler/icons-react';
 import { api } from '../App';
 import { ActionButton } from '../components/buttons/ActionButton';
 import RemoveRowButton from '../components/buttons/RemoveRowButton';
@@ -49,7 +50,6 @@ import {
   useSerialNumberGenerator
 } from '../hooks/UseGenerator';
 import { apiUrl } from '../states/ApiState';
-
 /*
  * Construct a set of fields for creating / editing a PurchaseOrderLineItem instance
  */
@@ -298,6 +298,12 @@ function LineItemFormRow({
     }
   });
 
+  const [expiryDateOpen, expiryDateHandlers] = useDisclosure(false, {
+    onClose: () => {
+      props.changeFn(props.idx, 'expiry_date', undefined);
+    }
+  });
+
   // Status value
   const [statusOpen, statusHandlers] = useDisclosure(false, {
     onClose: () => props.changeFn(props.idx, 'status', undefined)
@@ -439,6 +445,14 @@ function LineItemFormRow({
               tooltip={batchToolTip}
               tooltipAlignment='top'
               variant={batchOpen ? 'filled' : 'transparent'}
+            />
+            <ActionButton
+              size='sm'
+              onClick={() => expiryDateHandlers.toggle()}
+              icon={<IconCalendarExclamation />}
+              tooltip={t`Set Expiry Date`}
+              tooltipAlignment='top'
+              variant={expiryDateOpen ? 'filled' : 'transparent'}
             />
             <ActionButton
               size='sm'
@@ -587,6 +601,19 @@ function LineItemFormRow({
         error={props.rowErrors?.serial_numbers?.message}
       />
       <TableFieldExtraRow
+        visible={expiryDateOpen}
+        onValueChange={(value) =>
+          props.changeFn(props.idx, 'expiry_date', value)
+        }
+        fieldDefinition={{
+          field_type: 'date',
+          label: t`Expiry Date`,
+          description: t`Enter an expiry date for received items`,
+          value: props.item.expiry_date
+        }}
+        error={props.rowErrors?.expiry_date?.message}
+      />
+      <TableFieldExtraRow
         visible={packagingOpen}
         onValueChange={(value) => props.changeFn(props.idx, 'packaging', value)}
         fieldDefinition={{
@@ -672,6 +699,7 @@ export function useReceiveLineItems(props: LineItemsForm) {
           line_item: elem.pk,
           location: elem.destination ?? elem.destination_detail?.pk ?? null,
           quantity: elem.quantity - elem.received,
+          expiry_date: null,
           batch_code: '',
           serial_numbers: '',
           status: 10,

--- a/src/frontend/src/forms/PurchaseOrderForms.tsx
+++ b/src/frontend/src/forms/PurchaseOrderForms.tsx
@@ -50,6 +50,7 @@ import {
   useSerialNumberGenerator
 } from '../hooks/UseGenerator';
 import { apiUrl } from '../states/ApiState';
+import { useGlobalSettingsState } from '../states/SettingsState';
 /*
  * Construct a set of fields for creating / editing a PurchaseOrderLineItem instance
  */
@@ -245,6 +246,8 @@ function LineItemFormRow({
     () => record.part_detail?.trackable ?? false,
     [record]
   );
+
+  const settings = useGlobalSettingsState();
 
   useEffect(() => {
     if (!!record.destination) {
@@ -446,14 +449,16 @@ function LineItemFormRow({
               tooltipAlignment='top'
               variant={batchOpen ? 'filled' : 'transparent'}
             />
-            <ActionButton
-              size='sm'
-              onClick={() => expiryDateHandlers.toggle()}
-              icon={<IconCalendarExclamation />}
-              tooltip={t`Set Expiry Date`}
-              tooltipAlignment='top'
-              variant={expiryDateOpen ? 'filled' : 'transparent'}
-            />
+            {settings.isSet('STOCK_ENABLE_EXPIRY') && (
+              <ActionButton
+                size='sm'
+                onClick={() => expiryDateHandlers.toggle()}
+                icon={<IconCalendarExclamation />}
+                tooltip={t`Set Expiry Date`}
+                tooltipAlignment='top'
+                variant={expiryDateOpen ? 'filled' : 'transparent'}
+              />
+            )}
             <ActionButton
               size='sm'
               icon={<InvenTreeIcon icon='packaging' />}
@@ -600,19 +605,21 @@ function LineItemFormRow({
         }}
         error={props.rowErrors?.serial_numbers?.message}
       />
-      <TableFieldExtraRow
-        visible={expiryDateOpen}
-        onValueChange={(value) =>
-          props.changeFn(props.idx, 'expiry_date', value)
-        }
-        fieldDefinition={{
-          field_type: 'date',
-          label: t`Expiry Date`,
-          description: t`Enter an expiry date for received items`,
-          value: props.item.expiry_date
-        }}
-        error={props.rowErrors?.expiry_date?.message}
-      />
+      {settings.isSet('STOCK_ENABLE_EXPIRY') && (
+        <TableFieldExtraRow
+          visible={expiryDateOpen}
+          onValueChange={(value) =>
+            props.changeFn(props.idx, 'expiry_date', value)
+          }
+          fieldDefinition={{
+            field_type: 'date',
+            label: t`Expiry Date`,
+            description: t`Enter an expiry date for received items`,
+            value: props.item.expiry_date
+          }}
+          error={props.rowErrors?.expiry_date?.message}
+        />
+      )}
       <TableFieldExtraRow
         visible={packagingOpen}
         onValueChange={(value) => props.changeFn(props.idx, 'packaging', value)}

--- a/src/frontend/src/forms/PurchaseOrderForms.tsx
+++ b/src/frontend/src/forms/PurchaseOrderForms.tsx
@@ -26,6 +26,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 
 import { IconCalendarExclamation } from '@tabler/icons-react';
+import dayjs from 'dayjs';
 import { api } from '../App';
 import { ActionButton } from '../components/buttons/ActionButton';
 import RemoveRowButton from '../components/buttons/RemoveRowButton';
@@ -306,13 +307,11 @@ function LineItemFormRow({
       // check the default part expiry. Assume expiry is relative to today
       const defaultExpiry = record.part_detail?.default_expiry;
       if (defaultExpiry !== undefined && defaultExpiry > 0) {
-        const defaultExpiryDate = new Date();
-        defaultExpiryDate.setDate(defaultExpiryDate.getDate() + defaultExpiry);
-        const year = defaultExpiryDate.getFullYear();
-        const month = String(defaultExpiryDate.getMonth() + 1).padStart(2, '0'); // January is 0!
-        const day = String(defaultExpiryDate.getDate()).padStart(2, '0');
-        const defaultExpiryDateString = `${year}-${month}-${day}`;
-        props.changeFn(props.idx, 'expiry_date', defaultExpiryDateString);
+        props.changeFn(
+          props.idx,
+          'expiry_date',
+          dayjs().add(defaultExpiry, 'day').format('YYYY-MM-DD')
+        );
       }
     },
     onClose: () => {

--- a/src/frontend/src/forms/PurchaseOrderForms.tsx
+++ b/src/frontend/src/forms/PurchaseOrderForms.tsx
@@ -302,6 +302,19 @@ function LineItemFormRow({
   });
 
   const [expiryDateOpen, expiryDateHandlers] = useDisclosure(false, {
+    onOpen: () => {
+      // check the default part expiry. Assume expiry is relative to today
+      const defaultExpiry = record.part_detail?.default_expiry;
+      if (defaultExpiry !== undefined && defaultExpiry > 0) {
+        const defaultExpiryDate = new Date();
+        defaultExpiryDate.setDate(defaultExpiryDate.getDate() + defaultExpiry);
+        const year = defaultExpiryDate.getFullYear();
+        const month = String(defaultExpiryDate.getMonth() + 1).padStart(2, '0'); // January is 0!
+        const day = String(defaultExpiryDate.getDate()).padStart(2, '0');
+        const defaultExpiryDateString = `${year}-${month}-${day}`;
+        props.changeFn(props.idx, 'expiry_date', defaultExpiryDateString);
+      }
+    },
     onClose: () => {
       props.changeFn(props.idx, 'expiry_date', undefined);
     }


### PR DESCRIPTION
Addresses #6176

Add option in PUI receive line item form for adding an expiry. 
Update test `PurchaseOrderReceive.test_valid` to include an `expiry_date`

