### PR TITLE
Allow null value for expiry_date field

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,15 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 299
+INVENTREE_API_VERSION = 300
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+
+v300 - 2025-01-13 - https://github.com/inventree/InvenTree/pull/8886
+    - Allow null value for 'expiry_date' field introduced in #8867
 
 v299 - 2025-01-10 - https://github.com/inventree/InvenTree/pull/8867
     - Adds 'expiry_date' field to the PurchaseOrderReceive API endpoint

--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -770,6 +770,7 @@ class PurchaseOrderLineItemReceiveSerializer(serializers.Serializer):
         label=_('Expiry Date'),
         help_text=_('Enter expiry date for incoming stock items'),
         required=False,
+        allow_null=True,
         default=None,
     )
 


### PR DESCRIPTION
- Follow-up to https://github.com/inventree/InvenTree/pull/8867
- Allow specifying null value against `expiry_date` field