### PR TITLE
feat: Add setting for controling console logs

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -285,6 +285,7 @@ jobs:
       INVENTREE_DB_NAME: ./inventree.sqlite
       INVENTREE_DB_ENGINE: sqlite3
       INVENTREE_PLUGINS_ENABLED: true
+      INVENTREE_CONSOLE_LOG: false
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       python_version: ${{ matrix.python_version }}
 
@@ -328,6 +329,7 @@ jobs:
       INVENTREE_DB_PORT: 5432
       INVENTREE_DEBUG: true
       INVENTREE_LOG_LEVEL: INFO
+      INVENTREE_CONSOLE_LOG: false
       INVENTREE_CACHE_HOST: localhost
       INVENTREE_PLUGINS_ENABLED: true
 
@@ -377,6 +379,7 @@ jobs:
       INVENTREE_DB_PORT: 3306
       INVENTREE_DEBUG: true
       INVENTREE_LOG_LEVEL: INFO
+      INVENTREE_CONSOLE_LOG: false
       INVENTREE_PLUGINS_ENABLED: true
 
     services:

--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -97,6 +97,7 @@ The following debugging / logging options are available:
 | INVENTREE_LOG_LEVEL | log_level | Set level of logging to terminal | WARNING |
 | INVENTREE_JSON_LOG | json_log | log as json | False |
 | INVENTREE_WRITE_LOG | write_log | Enable writing of log messages to file at config base | False |
+| INVENTREE_CONSOLE_LOG | console_log | Enable logging to console | True |
 
 ### Debug Mode
 

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -89,6 +89,7 @@ logging.basicConfig(level=LOG_LEVEL, format='%(asctime)s %(levelname)s %(message
 
 if LOG_LEVEL not in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
     LOG_LEVEL = 'WARNING'  # pragma: no cover
+DEFAULT_LOG_HANDLER = ['console'] if CONSOLE_LOG else []
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -119,8 +120,8 @@ LOGGING = {
     if CONSOLE_LOG
     else {},
     'loggers': {
-        'django_structlog': {'handlers': ['console'], 'level': LOG_LEVEL},
-        'inventree': {'handlers': ['console'], 'level': LOG_LEVEL},
+        'django_structlog': {'handlers': DEFAULT_LOG_HANDLER, 'level': LOG_LEVEL},
+        'inventree': {'handlers': DEFAULT_LOG_HANDLER, 'level': LOG_LEVEL},
     },
 }
 
@@ -132,14 +133,14 @@ if WRITE_LOG and JSON_LOG:  # pragma: no cover
         'filename': str(BASE_DIR.joinpath('logs.json')),
         'formatter': 'json_formatter',
     }
-    LOGGING['loggers']['django_structlog']['handlers'] += ['log_file']
+    DEFAULT_LOG_HANDLER.append('log_file')
 elif WRITE_LOG:  # pragma: no cover
     LOGGING['handlers']['log_file'] = {
         'class': 'logging.handlers.WatchedFileHandler',
         'filename': str(BASE_DIR.joinpath('logs.log')),
         'formatter': 'key_value',
     }
-    LOGGING['loggers']['django_structlog']['handlers'] += ['log_file']
+    DEFAULT_LOG_HANDLER.append('log_file')
 
 structlog.configure(
     processors=[
@@ -380,7 +381,7 @@ if LDAP_AUTH:
             LOGGING['loggers'] = {}
         LOGGING['loggers']['django_auth_ldap'] = {
             'level': 'DEBUG',
-            'handlers': ['console'],
+            'handlers': DEFAULT_LOG_HANDLER,
         }
 
     # get global options from dict and use ldap.OPT_* as keys and values

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -83,6 +83,7 @@ DEBUG = get_boolean_setting('INVENTREE_DEBUG', 'debug', False)
 LOG_LEVEL = get_setting('INVENTREE_LOG_LEVEL', 'log_level', 'WARNING')
 JSON_LOG = get_boolean_setting('INVENTREE_JSON_LOG', 'json_log', False)
 WRITE_LOG = get_boolean_setting('INVENTREE_WRITE_LOG', 'write_log', False)
+CONSOLE_LOG = get_boolean_setting('INVENTREE_CONSOLE_LOG', 'console_log', True)
 
 logging.basicConfig(level=LOG_LEVEL, format='%(asctime)s %(levelname)s %(message)s')
 

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -115,7 +115,9 @@ LOGGING = {
     },
     'handlers': {
         'console': {'class': 'logging.StreamHandler', 'formatter': 'plain_console'}
-    },
+    }
+    if CONSOLE_LOG
+    else {},
     'loggers': {
         'django_structlog': {'handlers': ['console'], 'level': LOG_LEVEL},
         'inventree': {'handlers': ['console'], 'level': LOG_LEVEL},

--- a/src/backend/InvenTree/config_template.yaml
+++ b/src/backend/InvenTree/config_template.yaml
@@ -55,6 +55,9 @@ db_logging: False
 # Enable writing a log file, or use the environment variable INVENTREE_WRITE_LOG
 write_log: False
 
+# Enable writing logs to the console (stdout), or use the environment variable INVENTREE_CONSOLE_LOG
+console_log: True
+
 # Select default system language , or use the environment variable INVENTREE_LANGUAGE
 language: en-us
 


### PR DESCRIPTION
This adds the option to turn off console logging and also does that in the long-running backend tests to reduce storage footprint and GitHub action log viewer performance.