### PR TITLE
Plugin reload fix

### DIFF
--- a/src/backend/InvenTree/.gitignore
+++ b/src/backend/InvenTree/.gitignore
@@ -1,0 +1,2 @@
+# Files generated during unit testing
+_testfolder/

--- a/src/backend/InvenTree/plugin/models.py
+++ b/src/backend/InvenTree/plugin/models.py
@@ -142,7 +142,7 @@ class PluginConfig(InvenTree.models.MetadataMixin, models.Model):
 
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
         """Extend save method to reload plugins if the 'active' status changes."""
-        reload = kwargs.pop('no_reload', False)  # check if no_reload flag is set
+        no_reload = kwargs.pop('no_reload', False)  # check if no_reload flag is set
 
         super().save(force_insert, force_update, *args, **kwargs)
 
@@ -150,10 +150,10 @@ class PluginConfig(InvenTree.models.MetadataMixin, models.Model):
             # Force active if builtin
             self.active = True
 
-        if not reload and self.active != self.__org_active:
+        if not no_reload and self.active != self.__org_active:
             if settings.PLUGIN_TESTING:
-                warnings.warn('A reload was triggered', stacklevel=2)
-            registry.reload_plugins()
+                warnings.warn('A plugin registry reload was triggered', stacklevel=2)
+            registry.reload_plugins(full_reload=True, force_reload=True, collect=True)
 
     @admin.display(boolean=True, description=_('Installed'))
     def is_installed(self) -> bool:

--- a/src/backend/InvenTree/plugin/test_api.py
+++ b/src/backend/InvenTree/plugin/test_api.py
@@ -205,7 +205,7 @@ class PluginDetailAPITest(PluginMixin, InvenTreeAPITestCase):
 
             plg_inactive.active = True
             plg_inactive.save()
-        self.assertEqual(cm.warning.args[0], 'A reload was triggered')
+        self.assertEqual(cm.warning.args[0], 'A plugin registry reload was triggered')
 
     def test_check_plugin(self):
         """Test check_plugin function."""

--- a/src/backend/InvenTree/plugin/test_plugin.py
+++ b/src/backend/InvenTree/plugin/test_plugin.py
@@ -4,9 +4,11 @@ import os
 import shutil
 import subprocess
 import tempfile
+import textwrap
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 
@@ -17,6 +19,9 @@ from plugin.samples.integration.another_sample import (
     WrongIntegrationPlugin,
 )
 from plugin.samples.integration.sample import SampleIntegrationPlugin
+
+# Directory for testing plugins during CI
+PLUGIN_TEST_DIR = '_testfolder/test_plugins'
 
 
 class PluginTagTests(TestCase):
@@ -287,3 +292,111 @@ class RegistryTests(TestCase):
         self.assertEqual(
             registry.errors.get('init')[0]['broken_sample'], "'This is a dummy error'"
         )
+
+    @override_settings(PLUGIN_TESTING=True, PLUGIN_TESTING_SETUP=True)
+    @patch.dict(os.environ, {'INVENTREE_PLUGIN_TEST_DIR': PLUGIN_TEST_DIR})
+    def test_registry_reload(self):
+        """Test that the registry correctly reloads plugin modules.
+
+        - Create a simple plugin which we can change the version
+        - Ensure that the "hash" of the plugin registry changes
+        """
+        dummy_file = os.path.join(PLUGIN_TEST_DIR, 'dummy_ci_plugin.py')
+
+        # Ensure the plugin dir exists
+        os.makedirs(PLUGIN_TEST_DIR, exist_ok=True)
+
+        # Create an __init__.py file
+        init_file = os.path.join(PLUGIN_TEST_DIR, '__init__.py')
+        if not os.path.exists(init_file):
+            with open(os.path.join(init_file), 'w', encoding='utf-8') as f:
+                f.write('')
+
+        def plugin_content(version):
+            """Return the content of the plugin file."""
+            content = f"""
+            from plugin import InvenTreePlugin
+
+            PLG_VERSION = "{version}"
+
+            print(">>> LOADING DUMMY PLUGIN v" + PLG_VERSION + " <<<")
+
+            class DummyCIPlugin(InvenTreePlugin):
+
+                NAME = "DummyCIPlugin"
+                SLUG = "dummyci"
+                TITLE = "Dummy plugin for CI testing"
+
+                VERSION = PLG_VERSION
+
+            """
+
+            return textwrap.dedent(content)
+
+        def create_plugin_file(
+            version: str, enabled: bool = True, reload: bool = True
+        ) -> str:
+            """Create a plugin file with the given version.
+
+            Arguments:
+                version: The version string to use for the plugin file
+                enabled: Whether the plugin should be enabled or not
+
+            Returns:
+                str: The plugin registry hash
+            """
+            import time
+
+            content = plugin_content(version)
+
+            with open(dummy_file, 'w', encoding='utf-8') as f:
+                f.write(content)
+
+            # Wait for the file to be written
+            time.sleep(2)
+
+            if reload:
+                # Ensure the plugin is activated
+                registry.set_plugin_state('dummyci', enabled)
+                registry.reload_plugins(
+                    full_reload=True, collect=True, force_reload=True
+                )
+
+            registry.update_plugin_hash()
+
+            return registry.registry_hash
+
+        # Initial hash, with plugin disabled
+        hash_disabled = create_plugin_file('0.0.1', enabled=False, reload=False)
+
+        # Perform initial registry reload
+        registry.reload_plugins(full_reload=True, collect=True, force_reload=True)
+
+        # Start plugin in known state
+        registry.set_plugin_state('dummyci', False)
+
+        hash_disabled = create_plugin_file('0.0.1', enabled=False)
+
+        # Enable the plugin
+        hash_enabled = create_plugin_file('0.1.0', enabled=True)
+
+        # Hash must be different!
+        self.assertNotEqual(hash_disabled, hash_enabled)
+
+        plugin_hash = hash_enabled
+
+        for v in ['0.1.1', '7.1.2', '1.2.1', '4.0.1']:
+            h = create_plugin_file(v, enabled=True)
+            self.assertNotEqual(plugin_hash, h)
+            plugin_hash = h
+
+        # Revert back to original 'version'
+        h = create_plugin_file('0.1.0', enabled=True)
+        self.assertEqual(hash_enabled, h)
+
+        # Disable the plugin
+        h = create_plugin_file('0.0.1', enabled=False)
+        self.assertEqual(hash_disabled, h)
+
+        # Finally, ensure that the plugin file is removed after testing
+        os.remove(dummy_file)

--- a/tasks.py
+++ b/tasks.py
@@ -911,13 +911,28 @@ def gunicorn(c, address='0.0.0.0:8000', workers=None):
     run(c, cmd, pty=True)
 
 
-@task(pre=[wait], help={'address': 'Server address:port (default=127.0.0.1:8000)'})
-def server(c, address='127.0.0.1:8000'):
+@task(
+    pre=[wait],
+    help={
+        'address': 'Server address:port (default=127.0.0.1:8000)',
+        'no_reload': 'Do not automatically reload the server in response to code changes',
+        'no_threading': 'Disable multi-threading for the development server',
+    },
+)
+def server(c, address='127.0.0.1:8000', no_reload=False, no_threading=False):
     """Launch a (development) server using Django's in-built webserver.
 
     Note: This is *not* sufficient for a production installation.
     """
-    manage(c, f'runserver {address}', pty=True)
+    cmd = f'runserver {address}'
+
+    if no_reload:
+        cmd += ' --noreload'
+
+    if no_threading:
+        cmd += ' --nothreading'
+
+    manage(c, cmd, pty=True)
 
 
 @task(pre=[wait])


### PR DESCRIPTION
This PR fixes another piece of the plugin puzzle.

When updating an existing plugin, which is already installed and has been loaded by the InvenTree server (or worker) process, the plugin module is not *reloaded* - as it is already loaded into `sys.modules`.

Thus, updating the plugin does not actually *reload* it correctly. This can mean that the "in memory" code does not match the "on disk" code. The problem is compounded further when it comes to synchronizing the plugin code between the `server` and `worker` processes - even if they point to the same code "on disk", the processes are not guaranteed to have the same code "in memory".

Thus, this PR forces any active third-party plugin modules to reload right at the point of mounting. This ensures that the "on disk" and "in memory" code is the same.

### Local Testing

I have tested this locally, by running the worker and server processes separately:

- `invoke dev.server`
- `invoke worker`

Then, installing a debug plugin with `-e` option (for editable install) and making live changes to the plugin code.

*Before this fix* the *server* process would reload the new code - but the *worker* process would attempt a reload (due to changed plugin hash) but just reload the *old* code from memory.

*After this fix* the *worker* process loads the correct (new) code when the reload is triggered.

### CI Testing

I am struggling to think of a way to test this in production / CI - but it would be a very good step.... @matmair @wolflu05 any thoughts here?