### PR TITLE
[Enhancement] Request cache

### DIFF
--- a/src/backend/InvenTree/InvenTree/cache.py
+++ b/src/backend/InvenTree/InvenTree/cache.py
@@ -112,6 +112,11 @@ def get_cache_config(global_cache: bool) -> dict:
     return {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
 
 
+def clear_session_cache() -> None:
+    """Reset the session cache."""
+    thread_data.request_cache = {}
+
+
 def get_session_cache(key: str) -> any:
     """Return a cached value from the session cache."""
     request_cache = getattr(thread_data, 'request_cache', None)

--- a/src/backend/InvenTree/InvenTree/cache.py
+++ b/src/backend/InvenTree/InvenTree/cache.py
@@ -110,3 +110,18 @@ def get_cache_config(global_cache: bool) -> dict:
 
     # Default: Use django local memory cache
     return {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
+
+
+def get_session_cache(key: str) -> any:
+    """Return a cached value from the session cache."""
+    request_cache = getattr(thread_data, 'request_cache', None)
+    if request_cache is not None:
+        return request_cache.get(key, None)
+
+
+def set_session_cache(key: str, value: any) -> None:
+    """Set a cached value in the session cache."""
+    request_cache = getattr(thread_data, 'request_cache', None)
+
+    if request_cache is not None:
+        request_cache[key] = value

--- a/src/backend/InvenTree/InvenTree/cache.py
+++ b/src/backend/InvenTree/InvenTree/cache.py
@@ -1,6 +1,7 @@
 """Configuration options for InvenTree external cache."""
 
 import socket
+import threading
 
 import structlog
 
@@ -9,9 +10,18 @@ import InvenTree.ready
 
 logger = structlog.get_logger('inventree')
 
+# Thread-local cache for caching data against the request object
+thread_data = threading.local()
+
 
 def cache_setting(name, default=None, **kwargs):
-    """Return a cache setting."""
+    """Return the value of a particular cache setting.
+
+    Arguments:
+        name: The name of the cache setting
+        default: The default value to return if the setting is not found
+        kwargs: Additional arguments to pass to the cache setting request
+    """
     return InvenTree.config.get_setting(
         f'INVENTREE_CACHE_{name.upper()}', f'cache.{name.lower()}', default, **kwargs
     )
@@ -22,12 +32,12 @@ def cache_host():
     return cache_setting('host', None)
 
 
-def cache_port():
+def cache_port() -> int:
     """Return the cache port."""
     return cache_setting('port', '6379', typecast=int)
 
 
-def is_global_cache_enabled():
+def is_global_cache_enabled() -> bool:
     """Check if the global cache is enabled.
 
     - Test if the user has enabled and configured global cache

--- a/src/backend/InvenTree/InvenTree/middleware.py
+++ b/src/backend/InvenTree/InvenTree/middleware.py
@@ -233,15 +233,11 @@ class InvenTreeRequestCacheMiddleware(MiddlewareMixin):
         """Create a request-specific cache object."""
         # Create a new cache object for this request
         thread_data.request_cache = {}
-        print('CREATING CACHE:')
 
     def process_response(self, request, response):
         """Clear the cache object."""
         # Remove the cache object from the request once the response has been generated
         if hasattr(thread_data, 'request_cache'):
-            print('CLEARING CACHE:')
-            for k, v in thread_data.request_cache.items():
-                print(f'  {k} -> {v}')
             del thread_data.request_cache
 
         return response

--- a/src/backend/InvenTree/InvenTree/middleware.py
+++ b/src/backend/InvenTree/InvenTree/middleware.py
@@ -14,7 +14,7 @@ from allauth_2fa.middleware import AllauthTwoFactorMiddleware, BaseRequire2FAMid
 from error_report.middleware import ExceptionProcessor
 
 from common.settings import get_global_setting
-from InvenTree.cache import clear_session_cache
+from InvenTree.cache import create_session_cache, delete_session_cache
 from InvenTree.urls import frontendpatterns
 from users.models import ApiToken
 
@@ -231,9 +231,9 @@ class InvenTreeRequestCacheMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """Create a request-specific cache object."""
-        clear_session_cache()
+        create_session_cache(request)
 
     def process_response(self, request, response):
         """Clear the cache object."""
-        clear_session_cache()
+        delete_session_cache()
         return response

--- a/src/backend/InvenTree/InvenTree/middleware.py
+++ b/src/backend/InvenTree/InvenTree/middleware.py
@@ -14,7 +14,7 @@ from allauth_2fa.middleware import AllauthTwoFactorMiddleware, BaseRequire2FAMid
 from error_report.middleware import ExceptionProcessor
 
 from common.settings import get_global_setting
-from InvenTree.cache import thread_data
+from InvenTree.cache import clear_session_cache
 from InvenTree.urls import frontendpatterns
 from users.models import ApiToken
 
@@ -231,13 +231,9 @@ class InvenTreeRequestCacheMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """Create a request-specific cache object."""
-        # Create a new cache object for this request
-        thread_data.request_cache = {}
+        clear_session_cache()
 
     def process_response(self, request, response):
         """Clear the cache object."""
-        # Remove the cache object from the request once the response has been generated
-        if hasattr(thread_data, 'request_cache'):
-            del thread_data.request_cache
-
+        clear_session_cache()
         return response

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -330,6 +330,7 @@ MIDDLEWARE = CONFIG.get(
         'InvenTree.middleware.Check2FAMiddleware',  # Check if the user should be forced to use MFA
         'maintenance_mode.middleware.MaintenanceModeMiddleware',
         'InvenTree.middleware.InvenTreeExceptionProcessor',  # Error reporting
+        'InvenTree.middleware.InvenTreeRequestCacheMiddleware',  # Request caching
         'django_structlog.middlewares.RequestMiddleware',  # Structured logging
     ],
 )

--- a/src/backend/InvenTree/common/models.py
+++ b/src/backend/InvenTree/common/models.py
@@ -157,6 +157,9 @@ class BaseInvenTreeSetting(models.Model):
         if do_cache:
             self.save_to_cache()
 
+        # Remove the setting from the request cache
+        set_session_cache(self.cache_key, None)
+
         # Execute after_save action
         self._call_settings_function('after_save', args, kwargs)
 

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -26,6 +26,7 @@ from django.utils.translation import gettext_lazy as _
 
 import structlog
 
+import InvenTree.cache
 from common.settings import get_global_setting, set_global_setting
 from InvenTree.config import get_plugin_dir
 from InvenTree.ready import canAppAccessDatabase
@@ -835,6 +836,12 @@ class PluginsRegistry:
         if not canAppAccessDatabase(allow_shell=True):
             # Skip check if database cannot be accessed
             return
+
+        if InvenTree.cache.get_session_cache('plugin_registry_checked'):
+            # Return early if the registry has already been checked (for this request)
+            return
+
+        InvenTree.cache.set_session_cache('plugin_registry_checked', True)
 
         logger.debug('Checking plugin registry hash')
 


### PR DESCRIPTION
This PR adds an ephemeral cache which exists for the duration of a single web request.

The benefit of this is that external cache access (e.g. Redis), while being faster than a database hit, is still kinda slow. There are a number of cache checks which may be performed multiple times per single request - e.g. lookup for the `_PLUGIN_REGISTRY_HASH` key or the `PART_NAME_FORMAT` setting.

### Functionality 

- The first time a setting is accessed (within the context of a request), the setting object is cached. 
- Any subsequent access hits (within the same request) will return the cached value
- The cached values are cleared at the end of the request
- Cache is specific to its owning thread (i.e. does not cache across processes)
- This new cache is **not** automatically used - it has to be called manually
- Manually calling means we can be careful about where we apply it

### Performance

Some rough performance numbers, performing an API request for all items in the demo dataset:

| Model | Without Cache | With Cache | Improvement |
| --- | --- | --- | --- |
| Part | 0.891s | 0.725s | 19% |
| Stock Item | 2.332s | 2.0s | 14% |
| Build Order | 0.07s | 0.06s | 14% |
| BOM Item | 0.98s | 0.83s | 15% |

### Related Issues

- Discovered as part of profiling for https://github.com/inventree/InvenTree/pull/8950