### PR TITLE
Update docker build workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -163,11 +163,14 @@ jobs:
             inventree/inventree
             ghcr.io/${{ github.repository }}
 
+      - uses: depot/setup-action@v1
+
       - name: Push Docker Images
         id: push-docker
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # pin@v6.10.0
+        uses: depot/build-push-action@v1
         with:
+          project: jczzbjkk68
           context: .
           file: ./contrib/container/Dockerfile
           platforms: linux/amd64,linux/arm64

--- a/tasks.py
+++ b/tasks.py
@@ -45,7 +45,7 @@ def checkInvokeVersion():
     MIN_INVOKE_VERSION = '2.0.0'
 
     min_version = tuple(map(int, MIN_INVOKE_VERSION.split('.')))
-    invoke_version = tuple(map(int, invoke.__version__.split('.')))  # noqa: RUF048
+    invoke_version = tuple(map(int, invoke.__version__.split('.')))
 
     if invoke_version < min_version:
         error(f'The installed invoke version ({invoke.__version__}) is not supported!')


### PR DESCRIPTION
Backport the docker workflow changes to the 0.17.x branch, so that the docker image build does not timeout on GH actions.

Ref: https://github.com/inventree/InvenTree/actions/runs/12988816563/attempts/1