### PR TITLE
Fix user role caching issues

### DIFF
--- a/src/backend/InvenTree/stock/api.py
+++ b/src/backend/InvenTree/stock/api.py
@@ -321,7 +321,7 @@ class StockLocationFilter(rest_filters.FilterSet):
     def filter_parent(self, queryset, name, value):
         """Filter by parent location.
 
-        Note that the filtering behaviour here varies,
+        Note that the filtering behavior here varies,
         depending on whether the 'cascade' value is set.
 
         So, we have to check the "cascade" value here.

--- a/src/backend/InvenTree/stock/models.py
+++ b/src/backend/InvenTree/stock/models.py
@@ -328,12 +328,12 @@ def default_delete_on_deplete():
     """Return a default value for the 'delete_on_deplete' field.
 
     Prior to 2022-12-24, this field was set to True by default.
-    Now, there is a user-configurable setting to govern default behaviour.
+    Now, there is a user-configurable setting to govern default behavior.
     """
     try:
         return get_global_setting('STOCK_DELETE_DEPLETED_DEFAULT', True)
     except (IntegrityError, OperationalError):
-        # Revert to original default behaviour
+        # Revert to original default behavior
         return True
 
 

--- a/src/backend/InvenTree/stock/test_api.py
+++ b/src/backend/InvenTree/stock/test_api.py
@@ -561,7 +561,7 @@ class StockItemListTest(StockAPITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Return JSON-ified data
+        # Return JSON data
         return response.data
 
     def test_top_level_filtering(self):
@@ -1305,7 +1305,7 @@ class StockItemTest(StockAPITestCase):
             expected_code=201,
         )
 
-    def test_stock_item_create_withsupplierpart(self):
+    def test_stock_item_create_with_supplier_part(self):
         """Test creation of a StockItem via the API, including SupplierPart data."""
         # POST with non-existent supplier part
         response = self.post(
@@ -1543,7 +1543,7 @@ class StockItemTest(StockAPITestCase):
         self.assertEqual(data['purchase_price_currency'], 'NZD')
 
     def test_install(self):
-        """Test that stock item can be installed into antoher item, via the API."""
+        """Test that stock item can be installed into another item, via the API."""
         # Select the "parent" stock item
         parent_part = part.models.Part.objects.get(pk=100)
 

--- a/src/backend/InvenTree/users/models.py
+++ b/src/backend/InvenTree/users/models.py
@@ -666,14 +666,20 @@ def update_group_roles(group, debug=False):
                         )
 
 
-def check_user_permission(user: User, model, permission):
+def check_user_permission(user: User, model, permission) -> bool:
     """Check if the user has a particular permission against a given model type.
 
     Arguments:
         user: The user object to check
-        model: The model class to check (e.g. Part)
+        model: The model class to check (e.g. 'part')
         permission: The permission to check (e.g. 'view' / 'delete')
+
+    Returns:
+        bool: True if the user has the specified permission
     """
+    if not user:
+        return False
+
     if user.is_superuser:
         return True
 
@@ -681,11 +687,20 @@ def check_user_permission(user: User, model, permission):
     return user.has_perm(permission_name)
 
 
-def check_user_role(user: User, role, permission):
+def check_user_role(user: User, role, permission) -> bool:
     """Check if a user has a particular role:permission combination.
 
-    If the user is a superuser, this will return True
+    Arguments:
+        user: The user object to check
+        role: The role to check (e.g. 'part' / 'stock')
+        permission: The permission to check (e.g. 'view' / 'delete')
+
+    Returns:
+        bool: True if the user has the specified role:permission combination
     """
+    if not user:
+        return False
+
     if user.is_superuser:
         return True
 

--- a/src/backend/InvenTree/users/test_api.py
+++ b/src/backend/InvenTree/users/test_api.py
@@ -206,7 +206,7 @@ class UserTokenTests(InvenTreeAPITestCase):
 
         self.client.get(me, expected_code=200)
 
-    def test_buildin_token(self):
+    def test_builtin_token(self):
         """Test the built-in token authentication."""
         response = self.post(
             reverse('rest_login'),


### PR DESCRIPTION
Significant simplification and improvements for the "caching" of user role checks.

### Problem Description

- Caching first introduced in https://github.com/inventree/InvenTree/pull/3185 (June 2022)
- Intented to reduce DB hits when rendering templates
- Relied on a simplistic caching mechanism
- Cache invalidation does not transfer between worker processes (unless global cache is enabled)
- Cache is valid for 3600s (one hour!!)
- Weird things can occur if a user's roles are changed

### Solution

- As UI is now rendered on the frontend, we check the user's roles minimally
- Simplify the caching to utilize the new "request cache"
- Ensure first request is always made to the DB
- Any subsequent checks (if any) hit the request cache