### PR TITLE
[UI] Part pricing breaks

### DIFF
--- a/src/frontend/src/pages/part/PartPricingPanel.tsx
+++ b/src/frontend/src/pages/part/PartPricingPanel.tsx
@@ -106,9 +106,6 @@ export default function PartPricingPanel({ part }: Readonly<{ part: any }>) {
             label={panelOptions.internal}
             title={t`Internal Pricing`}
             visible={internalPricing}
-            disabled={
-              !pricing?.internal_cost_min || !pricing?.internal_cost_max
-            }
           />
           <PricingPanel
             content={<SupplierPricingPanel part={part} />}
@@ -143,7 +140,6 @@ export default function PartPricingPanel({ part }: Readonly<{ part: any }>) {
             label={panelOptions.sale_pricing}
             title={t`Sale Pricing`}
             visible={salesOrderPricing}
-            disabled={!pricing?.sale_price_min || !pricing?.sale_price_max}
           />
           <PricingPanel
             content={<SaleHistoryPanel part={part} />}

--- a/src/frontend/src/pages/part/pricing/PricingOverviewPanel.tsx
+++ b/src/frontend/src/pages/part/pricing/PricingOverviewPanel.tsx
@@ -169,6 +169,20 @@ export default function PricingOverviewPanel({
   const overviewData: PricingOverviewEntry[] = useMemo(() => {
     return [
       {
+        name: panelOptions.override,
+        title: t`Override Pricing`,
+        icon: <IconExclamationCircle />,
+        min_value: pricing?.override_min,
+        max_value: pricing?.override_max
+      },
+      {
+        name: panelOptions.overall,
+        title: t`Overall Pricing`,
+        icon: <IconReportAnalytics />,
+        min_value: pricing?.overall_min,
+        max_value: pricing?.overall_max
+      },
+      {
         name: panelOptions.internal,
         title: t`Internal Pricing`,
         icon: <IconList />,
@@ -216,20 +230,6 @@ export default function PricingOverviewPanel({
         icon: <IconTriangleSquareCircle />,
         min_value: pricing?.sale_history_min,
         max_value: pricing?.sale_history_max
-      },
-      {
-        name: panelOptions.override,
-        title: t`Override Pricing`,
-        icon: <IconExclamationCircle />,
-        min_value: pricing?.override_min,
-        max_value: pricing?.override_max
-      },
-      {
-        name: panelOptions.overall,
-        title: t`Overall Pricing`,
-        icon: <IconReportAnalytics />,
-        min_value: pricing?.overall_min,
-        max_value: pricing?.overall_max
       }
     ].filter((entry) => {
       return !(entry.min_value == null || entry.max_value == null);

--- a/src/frontend/tests/login.ts
+++ b/src/frontend/tests/login.ts
@@ -36,6 +36,10 @@ export const doQuickLogin = async (
 
   await page.getByLabel('navigation-menu').waitFor();
   await page.getByText(/InvenTree Demo Server -/).waitFor();
+
+  // Wait for the dashboard to load
+  await page.getByText('No widgets selected').waitFor();
+  await page.waitForTimeout(250);
 };
 
 export const doLogout = async (page) => {

--- a/src/frontend/tests/pages/pui_part.spec.ts
+++ b/src/frontend/tests/pages/pui_part.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../baseFixtures';
 import { baseUrl } from '../defaults';
-import { getRowFromCell } from '../helpers';
+import { clearTableFilters, getRowFromCell } from '../helpers';
 import { doQuickLogin } from '../login';
 
 /**
@@ -9,12 +9,17 @@ import { doQuickLogin } from '../login';
 test('Parts - Tabs', async ({ page }) => {
   await doQuickLogin(page);
 
-  await page.goto(`${baseUrl}/home`);
   await page.getByRole('tab', { name: 'Parts' }).click();
+  await page
+    .getByLabel('panel-tabs-partcategory')
+    .getByRole('tab', { name: 'Parts' })
+    .click();
 
-  await page.waitForURL('**/platform/part/category/index/details');
-  await page.goto(`${baseUrl}/part/category/index/parts`);
+  // Select a particular part from the table
+  await clearTableFilters(page);
+  await page.getByPlaceholder('Search').fill('1551');
   await page.getByText('1551ABK').click();
+
   await page.getByRole('tab', { name: 'Allocations' }).click();
   await page.getByRole('tab', { name: 'Used In' }).click();
   await page.getByRole('tab', { name: 'Pricing' }).click();
@@ -30,11 +35,12 @@ test('Parts - Tabs', async ({ page }) => {
   await page.getByText('1551ACLR').click();
   await page.getByRole('tab', { name: 'Part Details' }).click();
   await page.getByRole('tab', { name: 'Parameters' }).click();
+
   await page
-    .getByRole('tab', { name: 'Part Details' })
-    .locator('xpath=..')
+    .getByLabel('panel-tabs-part')
     .getByRole('tab', { name: 'Stock', exact: true })
     .click();
+
   await page.getByRole('tab', { name: 'Allocations' }).click();
   await page.getByRole('tab', { name: 'Used In' }).click();
   await page.getByRole('tab', { name: 'Pricing' }).click();

--- a/src/frontend/tests/pages/pui_purchase_order.spec.ts
+++ b/src/frontend/tests/pages/pui_purchase_order.spec.ts
@@ -1,14 +1,19 @@
 import { test } from '../baseFixtures.ts';
 import { baseUrl } from '../defaults.ts';
-import { clickButtonIfVisible, openFilterDrawer } from '../helpers.ts';
+import {
+  clearTableFilters,
+  clickButtonIfVisible,
+  openFilterDrawer
+} from '../helpers.ts';
 import { doQuickLogin } from '../login.ts';
 
 test('Purchase Orders', async ({ page }) => {
   await doQuickLogin(page);
 
-  await page.goto(`${baseUrl}/home`);
   await page.getByRole('tab', { name: 'Purchasing' }).click();
   await page.getByRole('tab', { name: 'Purchase Orders' }).click();
+
+  await clearTableFilters(page);
 
   // Check for expected values
   await page.getByRole('cell', { name: 'PO0014' }).waitFor();


### PR DESCRIPTION
Fixes issue with price breaks on the "part pricing" panel.

Both the "internal price break" and "sale price break" sub-panels are hidden if there are no price breaks available. Thus, it prevents the user from ever actually entering data here...