### PR TITLE
Sales Order Barcode Allocate

### DIFF
--- a/src/backend/InvenTree/plugin/base/barcodes/api.py
+++ b/src/backend/InvenTree/plugin/base/barcodes/api.py
@@ -654,7 +654,7 @@ class BarcodeSOAllocate(BarcodeView):
             return shipment
 
         shipments = order.models.SalesOrderShipment.objects.filter(
-            order=sales_order, delivery_date=None
+            order=sales_order, shipment_date=None
         )
 
         if shipments.count() == 1:


### PR DESCRIPTION
I discovered that when allocating items to a sales order by scanning stock item barcodes, once you complete the first shipment and move to another shipment, no stock items can be allocated to the new shipment.

As can be seen in the commit, previously with the `delivery_date` filter completed shipments would need a delivery date added before items could be allocated to a new shipment. Changing this to `shipment_date` enables multiple shipments to be allocated and shipped together easily.

-----------

Looking at the app, there probably should be a way to allocate into specific shipments. I might be able to take a look when I have some time, happen to use Dart + Flutter myself in a couple of production apps.