### PR TITLE
fix missing template tag

### DIFF
--- a/src/backend/InvenTree/InvenTree/templatetags/inventree_extras.py
+++ b/src/backend/InvenTree/InvenTree/templatetags/inventree_extras.py
@@ -118,6 +118,12 @@ def inventree_commit_hash(*args, **kwargs):
 
 
 @register.simple_tag()
+def inventree_installer(*args, **kwargs):
+    """Return InvenTree package installer string."""
+    return version.inventreeInstaller()
+
+
+@register.simple_tag()
 def inventree_commit_date(*args, **kwargs):
     """Return InvenTree git commit date string."""
     return version.inventreeCommitDate()


### PR DESCRIPTION
#8932 has removed a bunch of tags, now the default page cannot be rendered because this tag is missing.