### PR TITLE
Clean up deprecated module removed in python 3.13

### DIFF
--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -1,6 +1,5 @@
 """DRF data serializers for Part app."""
 
-import imghdr
 import io
 import os
 from decimal import Decimal
@@ -295,13 +294,6 @@ class PartThumbSerializerUpdate(InvenTree.serializers.InvenTreeModelSerializer):
 
         model = Part
         fields = ['image']
-
-    def validate_image(self, value):
-        """Check that file is an image."""
-        validate = imghdr.what(value)
-        if not validate:
-            raise serializers.ValidationError('File is not an image')
-        return value
 
     image = InvenTree.serializers.InvenTreeAttachmentSerializerField(required=True)
 

--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -299,7 +299,7 @@ class PartThumbSerializerUpdate(InvenTree.serializers.InvenTreeModelSerializer):
         """Check that file is an image."""
         validate = InvenTree.helpers.TestIfImage(value)
         if not validate:
-            raise serializers.ValidationError('File is not an image')
+            raise serializers.ValidationError(_('File is not an image'))
         return value
 
     image = InvenTree.serializers.InvenTreeAttachmentSerializerField(required=True)

--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -295,6 +295,13 @@ class PartThumbSerializerUpdate(InvenTree.serializers.InvenTreeModelSerializer):
         model = Part
         fields = ['image']
 
+    def validate_image(self, value):
+        """Check that file is an image."""
+        validate = InvenTree.helpers.TestIfImage(value)
+        if not validate:
+            raise serializers.ValidationError('File is not an image')
+        return value
+
     image = InvenTree.serializers.InvenTreeAttachmentSerializerField(required=True)
 
 


### PR DESCRIPTION
Module `imghdr` is deprecated in python 3.11 and removed in python 3.13: https://peps.python.org/pep-0594/

I removed the validation function because I couldn't find a way to trigger it: I didn't see a call in `inventree-python` and all of the platform ui image update paths I tried rejected non-image files but didn't call the function in question to do so.

If anyone can give me a way to hit the validation function then I'd be happy to put together a replacement using one of the libraries mentioned in the link above.