### PR TITLE
Uncomment site_url in default config

### DIFF
--- a/src/backend/InvenTree/config_template.yaml
+++ b/src/backend/InvenTree/config_template.yaml
@@ -26,7 +26,7 @@ database:
   # PORT: Database host port (if required)
 
 # Base URL for the InvenTree server (or use the environment variable INVENTREE_SITE_URL)
-# site_url: 'http://localhost:8000'
+site_url: 'http://localhost:8000'
 
 # Set debug to False to run in production mode, or use the environment variable INVENTREE_DEBUG
 debug: False


### PR DESCRIPTION
- Re-enable default value for site_url
- Fixes some CI steps which require this to be set