### PR TITLE
Debounce `checkLoginState` (testing reliability)

### DIFF
--- a/src/frontend/src/pages/Auth/Logged-In.tsx
+++ b/src/frontend/src/pages/Auth/Logged-In.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/macro';
 import { Card, Container, Group, Loader, Stack, Text } from '@mantine/core';
+import { useDebouncedCallback } from '@mantine/hooks';
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -9,8 +10,10 @@ export default function Logged_In() {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const checkLoginStateDebounced = useDebouncedCallback(checkLoginState, 300);
+
   useEffect(() => {
-    checkLoginState(navigate, location?.state);
+    checkLoginStateDebounced(navigate, location?.state);
   }, [navigate]);
 
   return (


### PR DESCRIPTION
Had a closer look at the issue I was experiencing with tests stalling in #8992 and tracked it down to a redirection issue during login. I'm not sure if this is the best way to go about fixing this issue, ideally fixing this without a time delay would probably be better. Let me know what you think.

As displayed in the screenshots below: two `checkLoginState` calls are being fired as of 1b5019ba529df4e8a9d17117d4071f5b99d22aab, this can intermittently cause an unexpected redirection back to /home after playwright has clicked a tab on the header which in-turn stalls the test until timeout.

-----------

**master / 1b5019ba529df4e8a9d17117d4071f5b99d22aab** *(test successful)*

![2025-02-02 23_45_51-DevTools - localhost_5173_platform_home](https://github.com/user-attachments/assets/c2f65854-7e49-4edf-ac9c-e995bdebad6d)


**master / 1b5019ba529df4e8a9d17117d4071f5b99d22aab** *(test stalled)*

![2025-02-02 23_44_44-DevTools - localhost_5173_platform_home](https://github.com/user-attachments/assets/892c72e6-02ec-4050-a350-d4be1911fde3)

--------------

**PR / c1804696392897e627a6d4be2d109201cc490029** *(test successful)*

![2025-02-02 23_53_26-DevTools - localhost_5173_platform_home](https://github.com/user-attachments/assets/90ea281d-9fd4-4349-846c-3d63688b470f)
