### PR TITLE
Enhance creation of default settings

### DIFF
--- a/src/backend/InvenTree/common/models.py
+++ b/src/backend/InvenTree/common/models.py
@@ -169,15 +169,6 @@ class BaseInvenTreeSetting(models.Model):
 
         If a particular setting is not present, create it with the default value
         """
-        cache_key = f'BUILD_DEFAULT_VALUES:{cls.__name__!s}'
-
-        try:
-            if InvenTree.helpers.str2bool(cache.get(cache_key, False)):
-                # Already built default values
-                return
-        except Exception:
-            pass
-
         try:
             existing_keys = cls.objects.filter(**kwargs).values_list('key', flat=True)
             settings_keys = cls.SETTINGS.keys()
@@ -197,11 +188,6 @@ class BaseInvenTreeSetting(models.Model):
             logger.exception(
                 'Failed to build default values for %s (%s)', str(cls), str(type(exc))
             )
-
-        try:
-            cache.set(cache_key, True, timeout=3600)
-        except Exception:
-            pass
 
     def _call_settings_function(self, reference: str, args, kwargs):
         """Call a function associated with a particular setting.


### PR DESCRIPTION
- Remove cache requirement
- Replaces https://github.com/inventree/InvenTree/pull/9021

Caching the calculation introduces a lot of complexity especially with regard to sync between processes.

The actual code to ensure all settings are in the DB takes less than a millisecond to execute (if there are no settings to build), and the API endpoints are not called often anyway. So the code can be simplified dramatically.