### PR TITLE
[0.17.x] feat(backend): Improve error with missing manifest  (#8957)

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -26,7 +26,12 @@ Refer to the [invoke guide](./start/invoke.md#cant-find-any-collection-named-tas
 
 If the installed version of invoke is too old, users may see error messages during the installation procedure. Refer to the [invoke guide](./start/invoke.md#minimum-version) for more information.
 
-### No module named 'django'
+### INVE-E1 - No frontend included
+
+Make sure you are running a stable or production release of InvenTree. The frontend panel is not included in development releases.
+More Information: [Error Codes - INVE-E1](./settings/error_codes.md#inve-e1)
+
+### No module named <xxx>
 
 During the install or update process, you may be presented with an error like:
 

--- a/docs/docs/settings/error_codes.md
+++ b/docs/docs/settings/error_codes.md
@@ -1,0 +1,26 @@
+## Error Codes
+
+InvenTree is starting to use error codes to help identify and diagnose issues. These are increasingly being added to the codebase. Error messages missing an error code should be reported on GitHub.
+Error codes are prefixed with `INVE-` and are followed by a letter to indicate the type of error and a number to indicate the specific error. Once a code is used it might not be reassigned to a different error, it can be marked as stricken from the list.
+
+### INVE-E (InvenTree Error)
+Errors - These are critical errors which should be addressed as soon as possible.
+
+#### INVE-E1
+**No frontend included - Backend/web**
+
+Only stable / production releases of InvenTree include the frontend panel. This is both a measure of resource-saving and attack surface reduction. If you want to use the frontend panel, you can either:″
+- use a docker image that is version-tagged or the stable version
+- use a package version that is from the stable or version stream
+- install node and yarn on the server to build the frontend with the [invoke](../start/invoke.md) task `int.frontend-build`
+
+Raise an issue if none of these options work.
+
+### INVE-W (InvenTree Warning)
+Warnings - These are non-critical errors which should be addressed when possible.
+
+### INVE-I (InvenTree Information)
+Information — These are not errors but information messages. They might point out potential issues or just provide information.
+
+### INVE-M (InvenTree Miscellaneous)
+Miscellaneous — These are information messages that might be used to mark debug information or other messages helpful for the InvenTree team to understand behaviour.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -153,15 +153,18 @@ nav:
     - User Settings: settings/user.md
     - Reference Patterns: settings/reference.md
     - Admin Interface: settings/admin.md
-    - User Permissions: settings/permissions.md
-    - Single Sign on: settings/SSO.md
-    - Multi Factor Authentication: settings/MFA.md
+    - Setup:
+      - User Permissions: settings/permissions.md
+      - Single Sign on: settings/SSO.md
+      - Multi Factor Authentication: settings/MFA.md
+      - Email: settings/email.md
+      - Currency Support: settings/currency.md
     - Export Data: settings/export.md
     - Import Data: settings/import.md
-    - Error Logs: settings/logs.md
-    - Email: settings/email.md
-    - Background Tasks: settings/tasks.md
-    - Currency Support: settings/currency.md
+    - Operations:
+      - Background Tasks: settings/tasks.md
+      - Error Logs: settings/logs.md
+      - Error Codes: settings/error_codes.md
   - App:
     - InvenTree App: app/app.md
     - Connect: app/connect.md

--- a/src/backend/InvenTree/web/templates/web/index.html
+++ b/src/backend/InvenTree/web/templates/web/index.html
@@ -1,5 +1,6 @@
 {% load spa_helper %}
 {% load inventree_extras %}
+{% spa_bundle as bundle %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -12,8 +13,17 @@
 
 <body>
   <div id="root"></div>
-  {% spa_settings %}
-  {% spa_bundle %}
+  <div id="spa_settings">{% spa_settings %}</div>
+  {% if bundle == "NOT_FOUND" %}
+  <div id="spa_bundle_error">
+    <div>
+      <h1>INVE-E1 - No frontend included</h1>
+      <p>The frontend bundle could not be found. Please check that your deployment method includes the bundle or check the <a href="https://docs.inventree.org/en/stable/faq/">FAQ</a>.<br/>
+        <span>Install method: <code>{% inventree_installer %}</code></span></p>
+  </div>
+  {% else %}
+  <div id="spa_bundle">{{ bundle }}</div>
+  {% endif %}
 </body>
 
 </html>

--- a/src/backend/InvenTree/web/templatetags/spa_helper.py
+++ b/src/backend/InvenTree/web/templatetags/spa_helper.py
@@ -37,13 +37,13 @@ def spa_bundle(manifest_path: Union[str, Path] = '', app: str = 'web'):
         # Final check - fail if manifest file not found
         if not manifest.exists():
             logger.error('Manifest file not found')
-            return
+            return 'NOT_FOUND'
 
     try:
         manifest_data = json.load(manifest.open())
     except (TypeError, json.decoder.JSONDecodeError):
         logger.exception('Failed to parse manifest file')
-        return
+        return ''
 
     return_string = ''
     # JS (based on index.html file as entrypoint)

--- a/src/backend/InvenTree/web/tests.py
+++ b/src/backend/InvenTree/web/tests.py
@@ -26,9 +26,8 @@ class TemplateTagTest(InvenTreeTestCase):
     def test_spa_bundle(self):
         """Test the 'spa_bundle' template tag."""
         resp = spa_helper.spa_bundle()
-        if not resp:
+        if resp == 'NOT_FOUND':
             # No Vite, no test
-            # TODO: Add a test for the non-Vite case (docker)
             return  # pragma: no cover
 
         shipped_js = resp.split('<script type="module" src="')[1:]
@@ -41,7 +40,7 @@ class TemplateTagTest(InvenTreeTestCase):
             manifest_file.with_suffix('.json.bak')
         )  # Rename
         resp = spa_helper.spa_bundle()
-        self.assertIsNone(resp)
+        self.assertEqual(resp, 'NOT_FOUND')
 
         # Try with differing name
         resp = spa_helper.spa_bundle(new_name)
@@ -50,7 +49,7 @@ class TemplateTagTest(InvenTreeTestCase):
         # Broken manifest file
         manifest_file.write_text('broken')
         resp = spa_helper.spa_bundle(manifest_file)
-        self.assertIsNone(resp)
+        self.assertEqual(resp, '')
 
         new_name.rename(manifest_file.with_suffix('.json'))  # Name back
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `0.17.x`:
 - [feat(backend): Improve error with missing manifest  (#8957)](https://github.com/inventree/InvenTree/pull/8957)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)