### PR TITLE
Add schema generation hints to resolve warning

### DIFF
--- a/src/backend/InvenTree/company/models.py
+++ b/src/backend/InvenTree/company/models.py
@@ -188,7 +188,7 @@ class Company(
     )
 
     @property
-    def address(self):
+    def address(self) -> str | None:
         """Return the string representation for the primary address.
 
         This property exists for backwards compatibility

--- a/src/backend/InvenTree/company/serializers.py
+++ b/src/backend/InvenTree/company/serializers.py
@@ -161,6 +161,8 @@ class CompanySerializer(
 
         return queryset
 
+    address = serializers.CharField(required=False, allow_null=True, read_only=True)
+
     primary_address = AddressSerializer(required=False, allow_null=True, read_only=True)
 
     url = serializers.CharField(source='get_absolute_url', read_only=True)


### PR DESCRIPTION
As a path to understanding the schema generator for #9045, I'm trying to address at least some of the warnings it currently produces.

`/git/inventree/InvenTree/src/backend/InvenTree/company/serializers.py:107: Warning [CompanyList > CompanySerializer]: unable to resolve type hint for function "address". Consider using a type hint or @extend_schema_field. Defaulting to string.`

String is actually the correct type in this case, but the field also needs to be nullable to be fully correct.

The two changes in this pull request accomplish the same goal: providing the nullable string type hint to the schema generator.

Adding a line to the serializer to explicitly define address produces:
```yaml
address:
  type: string
  readOnly: true
  nullable: true
```

while simply adding the return type hint to the model produces:
```yaml
address:
  type: string
  nullable: true
  description: |-
    Return the string representation for the primary address.

    This property exists for backwards compatibility
  readOnly: true
```

I would argue that the second option (adding type hints to the model) is the better way to go:
  1. It's less serializer-specific code that has to be maintained moving forward for simple fields like this one.
  2. The type definition is in the same place as the value that it matches for ease of maintenance.
  3. It displays the relevant documentation comment in the schema.

It's entirely possible that I'm missing something since I'm just focused on the schema, but the one (admittedly major) downside that I see to adding the hint to the model is that it doesn't match the way the existing serializers are set up.

Which route is preferable moving forward?