### PR TITLE
[UI] Settings to control editing of "completed" orders

### DIFF
--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1482,6 +1482,11 @@ class OrderLineItem(InvenTree.models.InvenTreeMetadataModel):
 
         Calls save method on the linked order
         """
+        if self.order and self.order.check_locked():
+            raise ValidationError({
+                'reference': _('The order is locked and cannot be modified')
+            })
+
         super().save(*args, **kwargs)
         self.order.save()
 
@@ -1490,6 +1495,11 @@ class OrderLineItem(InvenTree.models.InvenTreeMetadataModel):
 
         Calls save method on the linked order
         """
+        if self.order and self.order.check_locked():
+            raise ValidationError({
+                'reference': _('The order is locked and cannot be modified')
+            })
+
         super().delete(*args, **kwargs)
         self.order.save()
 

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -229,9 +229,13 @@ class Order(
 
         # Locking
         if update and self.check_locked(True):
-            raise ValidationError({
-                'reference': _('This order is locked and cannot be modified')
-            })
+            # Ensure that order status can be changed still
+            if self.get_db_instance().status != self.status:
+                pass
+            else:
+                raise ValidationError({
+                    'reference': _('This order is locked and cannot be modified')
+                })
 
         # Reference calculations
         self.reference_int = self.rebuild_reference_field(self.reference)

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -210,6 +210,7 @@ class Order(
     """
 
     REQUIRE_RESPONSIBLE_SETTING = None
+    LOCK_SETTING = None
 
     class Meta:
         """Metaclass options. Abstract ensures no database table is created."""
@@ -219,13 +220,46 @@ class Order(
     def save(self, *args, **kwargs):
         """Custom save method for the order models.
 
-        Ensures that the reference field is rebuilt whenever the instance is saved.
+        Enforces various business logics:
+        - Ensures the object is not locked
+        - Ensures that the reference field is rebuilt whenever the instance is saved.
         """
+        # check if we are updating the model, not adding it
+        update = self.pk is not None
+
+        # Locking
+        if update and self.check_locked(True):
+            raise ValidationError({
+                'reference': _('This order is locked and cannot be modified')
+            })
+
+        # Reference calculations
         self.reference_int = self.rebuild_reference_field(self.reference)
         if not self.creation_date:
             self.creation_date = InvenTree.helpers.current_date()
 
         super().save(*args, **kwargs)
+
+    def check_locked(self, db: bool = False) -> bool:
+        """Check if this order is 'locked'.
+
+        Args:
+            db: If True, check with the database. If False, check the instance (default False).
+        """
+        return (
+            self.LOCK_SETTING
+            and self.check_complete(db)
+            and get_global_setting(self.LOCK_SETTING)
+        )
+
+    def check_complete(self, db: bool = False) -> bool:
+        """Check if this order is 'complete'.
+
+        Args:
+            db: If True, check with the database. If False, check the instance (default False).
+        """
+        status = self.get_db_instance().status if db else self.status
+        return status in self.get_status_class().COMPLETE
 
     def clean(self):
         """Custom clean method for the generic order class."""
@@ -397,6 +431,7 @@ class PurchaseOrder(TotalPriceMixin, Order):
     REFERENCE_PATTERN_SETTING = 'PURCHASEORDER_REFERENCE_PATTERN'
     REQUIRE_RESPONSIBLE_SETTING = 'PURCHASEORDER_REQUIRE_RESPONSIBLE'
     STATUS_CLASS = PurchaseOrderStatus
+    LOCK_SETTING = 'PURCHASEORDER_EDIT_COMPLETED_ORDERS'
 
     class Meta:
         """Model meta options."""
@@ -967,6 +1002,7 @@ class SalesOrder(TotalPriceMixin, Order):
     REFERENCE_PATTERN_SETTING = 'SALESORDER_REFERENCE_PATTERN'
     REQUIRE_RESPONSIBLE_SETTING = 'SALESORDER_REQUIRE_RESPONSIBLE'
     STATUS_CLASS = SalesOrderStatus
+    LOCK_SETTING = 'SALESORDER_EDIT_COMPLETED_ORDERS'
 
     class Meta:
         """Model meta options."""
@@ -2212,6 +2248,7 @@ class ReturnOrder(TotalPriceMixin, Order):
     REFERENCE_PATTERN_SETTING = 'RETURNORDER_REFERENCE_PATTERN'
     REQUIRE_RESPONSIBLE_SETTING = 'RETURNORDER_REQUIRE_RESPONSIBLE'
     STATUS_CLASS = ReturnOrderStatus
+    LOCK_SETTING = 'RETURNORDER_EDIT_COMPLETED_ORDERS'
 
     class Meta:
         """Model meta options."""

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -248,8 +248,8 @@ class Order(
         """
         return (
             self.LOCK_SETTING
-            and self.check_complete(db)
             and get_global_setting(self.LOCK_SETTING)
+            and self.check_complete(db)
         )
 
     def check_complete(self, db: bool = False) -> bool:

--- a/src/backend/InvenTree/order/tests.py
+++ b/src/backend/InvenTree/order/tests.py
@@ -73,6 +73,10 @@ class OrderTest(TestCase, ExchangeRateMixin):
         order.save()
         self.assertFalse(order.check_locked())
 
+        order.add_line_item(SupplierPart.objects.get(pk=100), 100)
+        last_line = order.lines.last()
+        self.assertEqual(last_line.quantity, 100)
+
         # Reset
         order.status = PurchaseOrderStatus.PENDING
         order.save()
@@ -94,6 +98,12 @@ class OrderTest(TestCase, ExchangeRateMixin):
         # No editing allowed
         with self.assertRaises(django_exceptions.ValidationError):
             order.save()
+        # Also no adding of line items
+        with self.assertRaises(django_exceptions.ValidationError):
+            order.add_line_item(SupplierPart.objects.get(pk=100), 100)
+        # or deleting
+        with self.assertRaises(django_exceptions.ValidationError):
+            last_line.delete()
 
         # Still can create a completed item
         PurchaseOrder.objects.create(

--- a/src/backend/InvenTree/order/tests.py
+++ b/src/backend/InvenTree/order/tests.py
@@ -97,7 +97,11 @@ class OrderTest(TestCase, ExchangeRateMixin):
 
         # No editing allowed
         with self.assertRaises(django_exceptions.ValidationError):
+            order.description = 'test1'
             order.save()
+        order.refresh_from_db()
+        self.assertEqual(order.description, 'Ordering some screws')
+
         # Also no adding of line items
         with self.assertRaises(django_exceptions.ValidationError):
             order.add_line_item(SupplierPart.objects.get(pk=100), 100)
@@ -111,6 +115,17 @@ class OrderTest(TestCase, ExchangeRateMixin):
             reference='PO-99999',
             status=PurchaseOrderStatus.COMPLETE,
         )
+
+        # No editing (except status ;-) ) allowed
+        order.status = PurchaseOrderStatus.PENDING
+        order.save()
+
+        # Now it is a free for all again
+        order.description = 'test2'
+        order.save()
+
+        order.refresh_from_db()
+        self.assertEqual(order.description, 'test2')
 
     def test_overdue(self):
         """Test overdue status functionality."""


### PR DESCRIPTION
This re-implements the locking of completed orders - this time in the backend.

Todo:
- [x] also lock line items
- [x] exclude status itself from being locked

Fixes #8976