### PR TITLE
feat(backend): Add instance id for linked data plugins

### DIFF
--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -208,6 +208,7 @@ class InfoApiSerializer(serializers.Serializer):
         navbar_message = serializers
 
     server = serializers.CharField(read_only=True)
+    id = serializers.CharField(read_only=True)
     version = serializers.CharField(read_only=True)
     instance = serializers.CharField(read_only=True)
     apiVersion = serializers.IntegerField(read_only=True)  # noqa: N815

--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -260,6 +260,7 @@ class InfoView(APIView):
 
         data = {
             'server': 'InvenTree',
+            'id': InvenTree.version.inventree_identifier(),
             'version': InvenTree.version.inventreeVersion(),
             'instance': InvenTree.version.inventreeInstanceName(),
             'apiVersion': InvenTree.version.inventreeApiVersion(),

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,15 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 312
+INVENTREE_API_VERSION = 313
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+
+v313 - 2025-02-17 : https://github.com/inventree/InvenTree/pull/9087
+    - Adds instance id optionally to the info view endpoint
 
 v312 - 2025-02-15 : https://github.com/inventree/InvenTree/pull/9079
     - Remove old API endpoints associated with legacy BOM import functionality

--- a/src/backend/InvenTree/InvenTree/tests.py
+++ b/src/backend/InvenTree/InvenTree/tests.py
@@ -30,6 +30,7 @@ import InvenTree.helpers_model
 import InvenTree.tasks
 from common.currency import currency_codes
 from common.models import CustomUnit, InvenTreeSetting
+from common.settings import get_global_setting
 from InvenTree.helpers_mixin import ClassProviderMixin, ClassValidationMixin
 from InvenTree.sanitizer import sanitize_svg
 from InvenTree.unit_test import InvenTreeTestCase, in_env_context
@@ -1244,6 +1245,18 @@ class TestSettings(InvenTreeTestCase):
         # test typecasting to dict - invalid JSON string should be mapped to empty dict
         with in_env_context({TEST_ENV_NAME: "{'a': 1}"}):
             self.assertEqual(config.get_setting(TEST_ENV_NAME, None, typecast=dict), {})
+
+    def test_instance_id(self):
+        """Test get_instance_id."""
+        val = get_global_setting('INVENTREE_INSTANCE_ID')
+        self.assertGreater(len(val), 10)
+
+        # version helper
+        self.assertIsNone(version.inventree_identifier())
+
+        # with env set
+        with in_env_context({'INVENTREE_ANNOUNCE_ID': True}):
+            self.assertEqual(val, version.inventree_identifier())
 
 
 class TestInstanceName(InvenTreeTestCase):

--- a/src/backend/InvenTree/InvenTree/tests.py
+++ b/src/backend/InvenTree/InvenTree/tests.py
@@ -1255,7 +1255,7 @@ class TestSettings(InvenTreeTestCase):
         self.assertIsNone(version.inventree_identifier())
 
         # with env set
-        with in_env_context({'INVENTREE_ANNOUNCE_ID': True}):
+        with in_env_context({'INVENTREE_ANNOUNCE_ID': 'True'}):
             self.assertEqual(val, version.inventree_identifier())
 
 

--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -306,6 +306,8 @@ def inventree_identifier(override_announce: bool = False):
     """Return the InvenTree instance ID."""
     from common.settings import get_global_setting
 
-    if override_announce or get_global_setting('INVENTREE_ANNOUNCE_ID', default=False):
+    if override_announce or get_global_setting(
+        'INVENTREE_ANNOUNCE_ID', enviroment_key='INVENTREE_ANNOUNCE_ID', default=False
+    ):
         return get_global_setting('INVENTREE_INSTANCE_ID', default='')
     return None

--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -306,6 +306,6 @@ def inventree_identifier(override_announce: bool = False):
     """Return the InvenTree instance ID."""
     from common.settings import get_global_setting
 
-    if override_announce or get_global_setting('ANNOUNCE_ID', default=False):
+    if override_announce or get_global_setting('INVENTREE_ANNOUNCE_ID', default=False):
         return get_global_setting('INVENTREE_INSTANCE_ID', default='')
     return None

--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -300,3 +300,12 @@ def inventreeDatabase():
     """Return the InvenTree database backend e.g. 'postgresql'."""
     db = settings.DATABASES['default']
     return db.get('ENGINE', None).replace('django.db.backends.', '')
+
+
+def inventree_identifier(override_announce: bool = False):
+    """Return the InvenTree instance ID."""
+    from common.settings import get_global_setting
+
+    if override_announce or get_global_setting('ANNOUNCE_ID', default=False):
+        return get_global_setting('INVENTREE_INSTANCE_ID', default='')
+    return None

--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -307,7 +307,7 @@ def inventree_identifier(override_announce: bool = False):
     from common.settings import get_global_setting
 
     if override_announce or get_global_setting(
-        'INVENTREE_ANNOUNCE_ID', enviroment_key='INVENTREE_ANNOUNCE_ID', default=False
+        'INVENTREE_ANNOUNCE_ID', enviroment_key='INVENTREE_ANNOUNCE_ID'
     ):
         return get_global_setting('INVENTREE_INSTANCE_ID', default='')
     return None

--- a/src/backend/InvenTree/common/setting/system.py
+++ b/src/backend/InvenTree/common/setting/system.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+import uuid
 
 from django.conf import settings as django_settings
 from django.contrib.auth.models import Group
@@ -169,6 +170,20 @@ SYSTEM_SETTINGS: dict[str, InvenTreeSettingsKeyType] = {
         'description': _('Number of pending database migrations'),
         'default': 0,
         'validator': int,
+    },
+    'INVENTREE_INSTANCE_ID': {
+        'name': _('Instance ID'),
+        'description': _('Unique identifier for this InvenTree instance'),
+        'default': uuid.uuid4,
+        'hidden': True,
+    },
+    'INVENTREE_ANNOUNCE_ID': {
+        'name': _('Announce ID'),
+        'description': _(
+            'Announce the instance ID of the server in the server status info (unauthenticated)'
+        ),
+        'default': False,
+        'validator': bool,
     },
     'INVENTREE_INSTANCE': {
         'name': _('Server Instance Name'),

--- a/src/backend/InvenTree/common/setting/system.py
+++ b/src/backend/InvenTree/common/setting/system.py
@@ -121,6 +121,11 @@ def barcode_plugins() -> list:
     ]
 
 
+def default_uuid4() -> str:
+    """Return a default UUID4 value."""
+    return str(uuid.uuid4())
+
+
 class BaseURLValidator(URLValidator):
     """Validator for the InvenTree base URL.
 
@@ -174,7 +179,7 @@ SYSTEM_SETTINGS: dict[str, InvenTreeSettingsKeyType] = {
     'INVENTREE_INSTANCE_ID': {
         'name': _('Instance ID'),
         'description': _('Unique identifier for this InvenTree instance'),
-        'default': uuid.uuid4,
+        'default': default_uuid4,
         'hidden': True,
     },
     'INVENTREE_ANNOUNCE_ID': {

--- a/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
+++ b/src/frontend/src/pages/Index/Settings/SystemSettings.tsx
@@ -42,6 +42,8 @@ export default function SystemSettings() {
             keys={[
               'INVENTREE_BASE_URL',
               'INVENTREE_COMPANY_NAME',
+              'INVENTREE_INSTANCE_ID',
+              'INVENTREE_ANNOUNCE_ID',
               'INVENTREE_INSTANCE',
               'INVENTREE_INSTANCE_TITLE',
               'INVENTREE_RESTRICT_ABOUT',


### PR DESCRIPTION
Adds an instance id that plugins can use to ensure servers are referenced by the same string across plugins (by default uuid4). This ID can also be exposed (off by default) - this could be interesting for linked data/federation discovery.