### PR TITLE
[dev] Devcontainer tweak

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     expose:
       - 5432/tcp
     volumes:
-      - ../dev/psql/:/var/lib/postgresql/data:z
+      - ../dev-db/:/var/lib/postgresql/data:z
     environment:
       POSTGRES_DB: inventree
       POSTGRES_USER: inventree_user
@@ -25,12 +25,12 @@ services:
       - ../:/home/inventree:z
 
     environment:
-      INVENTREE_DEBUG: True
       INVENTREE_DB_ENGINE: postgresql
       INVENTREE_DB_NAME: inventree
       INVENTREE_DB_HOST: db
       INVENTREE_DB_USER: inventree_user
       INVENTREE_DB_PASSWORD: inventree_password
+      INVENTREE_DEBUG: True
       INVENTREE_CACHE_HOST: redis
       INVENTREE_CACHE_PORT: 6379
       INVENTREE_PLUGINS_ENABLED: True

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -34,6 +34,3 @@ invoke dev.setup-dev
 
 # Install required frontend packages
 invoke int.frontend-install
-
-# Install playwright dependencies
-cd src/frontend && sudo npx playwright install-deps

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+
+echo "Running postCreateCommand.sh ..."
 
 # Avoiding Dubious Ownership in Dev Containers for setup commands that use git
 git config --global --add safe.directory /home/inventree

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ js_tmp/
 
 # Development files
 dev/
+dev-db/
 data/
 env/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,9 +76,10 @@ repos:
         additional_dependencies: ["@biomejs/biome@1.9.4"]
         files: ^src/frontend/.*\.(js|ts|tsx)$
 -   repo: https://github.com/gitleaks/gitleaks
-    rev: v8.23.1
+    rev: v8.23.2
     hooks:
     -   id: gitleaks
+        language_version: 1.23.6
 #-   repo: https://github.com/jumanjihouse/pre-commit-hooks
 #    rev: 3.0.0
 #    hooks:

--- a/docs/docs/develop/devcontainer.md
+++ b/docs/docs/develop/devcontainer.md
@@ -111,7 +111,9 @@ Make sure you have `gnupg` and `pinentry-mac` installed and set up correctly. Re
 
 #### Where are the database, media files, ... stored?
 
-Database data, backups, media/static files, venv, plugin.txt, secret_key.txt, ... are stored in the `dev` folder. If you want to start with a clean setup, you can remove that folder, but be aware that this will delete everything you already setup in InvenTree.
+Backups, media/static files, venv, plugin.txt, secret_key.txt, ... are stored in the `dev` folder. If you want to start with a clean setup, you can remove that folder, but be aware that this will delete everything you already setup in InvenTree.
+
+Database data are stored in the `dev-db` directory. This is managed by the `postgres` docker container.
 
 ### Performance Improvements
 


### PR DESCRIPTION
Some tweaks to the devcontainer setup to fix issues. Follow up to https://github.com/inventree/InvenTree/pull/9041

## Postgres Database

Storing the database files locally uses the `root` user (because this is the user that the postgres container runs under). So, moved this to use the `dev-db` directory, so that the root user does not pollute the `dev` directory.

## postcreatecommand.sh

- Ensure that this script exits early if any of the steps fail
- remove the blocking step to install playwright deps

## pre-commit

Pin the pre-commit go version to prevent panic - https://github.com/gitleaks/gitleaks/issues/1751