### PR TITLE
[Docker] Alpine image fix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt update && apt install -y \
    postgresql-client \
    libldap2-dev libsasl2-dev \
    libpango1.0-0 libcairo2 \
-   weasyprint
+   poppler-utils weasyprint
 
 # Install packages required for frontend development
 RUN apt install -y \

--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -9,8 +9,7 @@
 # - Runs InvenTree web server under django development server
 # - Monitors source files for any changes, and live-reloads server
 
-FROM python:3.11-alpine3.21 AS inventree_base
-ARG base_image
+FROM python:3.11-alpine3.20 AS inventree_base
 
 # Build arguments for this image
 ARG commit_tag=""
@@ -68,8 +67,8 @@ RUN apk add --no-cache \
     libjpeg libwebp zlib \
     # Weasyprint requirements : https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#alpine-3-12
     py3-pip py3-pillow py3-cffi py3-brotli pango poppler-utils openldap \
-    # Postgres client (note: backwards compatible with postgres server <= 17)
-    postgresql17-client \
+    # Postgres client (note: backwards compatible with postgres server <= 16)
+    postgresql16-client \
     # MySQL / MariaDB client
     mariadb-client mariadb-connector-c \
     && \

--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -18,8 +18,8 @@ ARG commit_date=""
 
 ARG data_dir="data"
 
-ENV PYTHONUNBUFFERED 1
-ENV PIP_DISABLE_PIP_VERSION_CHECK 1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV INVOKE_RUN_SHELL="/bin/ash"
 
 ENV INVENTREE_DOCKER="true"
@@ -47,8 +47,7 @@ ENV INVENTREE_BACKGROUND_WORKERS="4"
 ENV INVENTREE_WEB_ADDR=0.0.0.0
 ENV INVENTREE_WEB_PORT=8000
 
-LABEL org.opencontainers.image.created=${DATE} \
-      org.opencontainers.image.vendor="inventree" \
+LABEL org.opencontainers.image.vendor="inventree" \
       org.opencontainers.image.title="InvenTree backend server" \
       org.opencontainers.image.description="InvenTree is the open-source inventory management system" \
       org.opencontainers.image.url="https://inventree.org" \
@@ -56,7 +55,6 @@ LABEL org.opencontainers.image.created=${DATE} \
       org.opencontainers.image.source="https://github.com/inventree/InvenTree" \
       org.opencontainers.image.revision=${commit_hash} \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.base.name="docker.io/library/${base_image}" \
       org.opencontainers.image.version=${commit_tag}
 
 

--- a/contrib/container/docker.dev.env
+++ b/contrib/container/docker.dev.env
@@ -1,6 +1,8 @@
 # InvenTree environment variables for a development setup
 # These variables will be used by the docker-compose.yml file
 
+INVENTREE_SITE_URL=http://localhost:8000
+
 # Set DEBUG to True for a development setup
 INVENTREE_DEBUG=True
 INVENTREE_LOG_LEVEL=INFO

--- a/contrib/container/docker.dev.env
+++ b/contrib/container/docker.dev.env
@@ -5,7 +5,7 @@ INVENTREE_SITE_URL=http://localhost:8000
 
 # Set DEBUG to True for a development setup
 INVENTREE_DEBUG=True
-INVENTREE_LOG_LEVEL=INFO
+INVENTREE_LOG_LEVEL=WARNING
 INVENTREE_DB_LOGGING=False
 
 # Database configuration options

--- a/contrib/container/install_build_packages.sh
+++ b/contrib/container/install_build_packages.sh
@@ -1,12 +1,11 @@
 #!/bin/ash
 
 # Install system packages required for building InvenTree python libraries
-# Note that for postgreslql, we use the version 13, which matches the version used in the InvenTree docker image
 
 apk add gcc g++ musl-dev openssl-dev libffi-dev cargo python3-dev openldap-dev \
     libstdc++ build-base linux-headers py3-grpcio \
     jpeg-dev openjpeg-dev libwebp-dev zlib-dev \
     sqlite sqlite-dev \
     mariadb-connector-c-dev mariadb-client mariadb-dev \
-    postgresql17-dev postgresql-libs \
+    postgresql16-dev postgresql-libs \
     $@

--- a/docs/docs/start/docker.md
+++ b/docs/docs/start/docker.md
@@ -123,7 +123,11 @@ Connecting to a different database container is entirely possible, but requires 
 The `inventree-server` and `inventree-worker` containers support connection to a postgres database up to (and including) version {{ config.extra.docker_postgres_version }}.
 
 !!! warning "Newer Postgres Versions"
-    The InvenTree docker image supports connection to a postgres database up to version {{ config.extra.docker_postgres_version }}. Connecting to a database using a newer version of postgres is not possible.
+    The InvenTree docker image supports connection to a postgres database up to version {{ config.extra.docker_postgres_version }}. Connecting to a database using a newer version of postgres is not guaranteed.
+
+#### Bypassing Backup Procedure
+
+If you are connecting the docker container to a postgresql database newer than version `{{ config.extra.docker_postgres_version }}`, the [backup and restore commands](../start/backup.md) will fail due to a version mismatch. To bypass this issue when performing the `invoke update` command, add the `--skip-backup` flag.
 
 ## Common Issues
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -285,7 +285,7 @@ extra:
   min_python_version: 3.9
   min_invoke_version: 2.0.0
   django_version: 4.2
-  docker_postgres_version: 17
+  docker_postgres_version: 16
 
   version:
     default: stable

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -47,15 +47,6 @@ if TESTING:
     TEST_RUNNER = 'django_slowtests.testrunner.DiscoverSlowestTestsRunner'
     NUM_SLOW_TESTS = 25
 
-    # Note: The following fix is "required" for docker build workflow
-    # Note: 2022-12-12 still unsure why...
-    if os.getenv('INVENTREE_DOCKER'):
-        # Ensure that sys.path includes global python libs
-        site_packages = '/usr/local/lib/python3.9/site-packages'
-
-        if site_packages not in sys.path:
-            print('Adding missing site-packages path:', site_packages)
-            sys.path.append(site_packages)
 
 # Are environment variables manipulated by tests? Needs to be set by testing code
 TESTING_ENV = False


### PR DESCRIPTION
Replaces https://github.com/inventree/InvenTree/pull/9114

It appears that the base docker image `python:3.11-alpine3.21` has some issues with segfaulting (see issues referenced below)

Thus, reverting back to `python:3.11-alpine3.20` which does not appear to have this issue.

The **caveat** is that this image only supports postgres:16 - the limitations around this are now referenced more clearly in the documentation.

Note: I have run the failing test (referenced in #9114) multiple times on this new setup, without issue.

### References

- https://github.com/docker-library/python/issues/993
- https://github.com/prowler-cloud/prowler/pull/6109