### PR TITLE
[Pricing] BOM pricing calculation fix

### DIFF
--- a/src/backend/InvenTree/part/models.py
+++ b/src/backend/InvenTree/part/models.py
@@ -2792,6 +2792,9 @@ class PartPricing(common.models.MetaMixin):
             for sub_part in bom_item.get_valid_parts_for_allocation():
                 # Check each part which *could* be used
 
+                if sub_part != bom_item.sub_part and not sub_part.active:
+                    continue
+
                 sub_part_pricing = sub_part.pricing
 
                 sub_part_min = self.convert(sub_part_pricing.overall_min)


### PR DESCRIPTION
Ignore inactive parts when calculating BOM price.

TBH this is another reason to offload pricing calculations to the plugin architecture. The logic here is getting very convoluted and obtuse.