### PR TITLE
Remove 'url' field from serializers

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,7 +1,7 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 314
+INVENTREE_API_VERSION = 315
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -8,6 +8,9 @@ INVENTREE_API_VERSION = 314
 
 INVENTREE_API_TEXT = """
 
+v315 - 2025-02-22 : https://github.com/inventree/InvenTree/pull/9150
+    - Remove outdated 'url' field from some API endpoints
+
 v314 - 2025-02-17 : https://github.com/inventree/InvenTree/pull/6293
     - Removes a considerable amount of old auth endpoints
     - Introduces allauth-provided auth endpoints
@@ -74,7 +77,7 @@ v297 - 2024-12-29 : https://github.com/inventree/InvenTree/pull/8438
     - Adjustments to the CustomUserState API endpoints and serializers
 
 v296 - 2024-12-25 : https://github.com/inventree/InvenTree/pull/8732
-    - Adjust default "part_detail" behaviour for StockItem API endpoints
+    - Adjust default "part_detail" behavior for StockItem API endpoints
 
 v295 - 2024-12-23 : https://github.com/inventree/InvenTree/pull/8746
     - Improve API documentation for build APIs
@@ -226,7 +229,7 @@ v252 - 2024-09-13 : https://github.com/inventree/InvenTree/pull/8040
     - Add endpoint for listing all known units
 
 v251 - 2024-09-06 : https://github.com/inventree/InvenTree/pull/8018
-    - Adds "attach_to_model" field to the ReporTemplate model
+    - Adds "attach_to_model" field to the ReportTemplate model
 
 v250 - 2024-09-04 : https://github.com/inventree/InvenTree/pull/8069
     - Fixes 'revision' field definition in Part serializer
@@ -367,7 +370,7 @@ v211 - 2024-06-26 : https://github.com/inventree/InvenTree/pull/6911
     - Adds API endpoints for managing data import and export
 
 v210 - 2024-06-26 : https://github.com/inventree/InvenTree/pull/7518
-    - Adds translateable text to User API fields
+    - Adds translatable text to User API fields
 
 v209 - 2024-06-26 : https://github.com/inventree/InvenTree/pull/7514
     - Add "top_level" filter to PartCategory API endpoint
@@ -489,7 +492,7 @@ v178 - 2024-02-29 : https://github.com/inventree/InvenTree/pull/6604
     - Stock quantities represented in the BuildLine API endpoint are now filtered by Build.source_location
 
 v177 - 2024-02-27 : https://github.com/inventree/InvenTree/pull/6581
-    - Adds "subcategoies" count to PartCategoryTree serializer
+    - Adds "subcategories" count to PartCategoryTree serializer
     - Adds "sublocations" count to StockLocationTree serializer
 
 v176 - 2024-02-26 : https://github.com/inventree/InvenTree/pull/6535
@@ -579,7 +582,7 @@ v153 -> 2023-11-21 : https://github.com/inventree/InvenTree/pull/5956
     - Adds override_min and override_max fields to part pricing API
 
 v152 -> 2023-11-20 : https://github.com/inventree/InvenTree/pull/5949
-    - Adds barcode support for manufacturerpart model
+    - Adds barcode support for ManufacturerPart model
     - Adds API endpoint for adding parts to purchase order using barcode scan
 
 v151 -> 2023-11-13 : https://github.com/inventree/InvenTree/pull/5906
@@ -1094,7 +1097,7 @@ v8  -> 2021-07-19
 
 v7  -> 2021-07-03
     - Introduced the concept of "API forms" in https://github.com/inventree/InvenTree/pull/1716
-    - API OPTIONS endpoints provide comprehensive field metedata
+    - API OPTIONS endpoints provide comprehensive field metadata
     - Multiple new API endpoints added for database models
 
 v6  -> 2021-06-23

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -62,7 +62,6 @@ class BuildSerializer(
         model = Build
         fields = [
             'pk',
-            'url',
             'title',
             'barcode_hash',
             'batch',
@@ -111,8 +110,6 @@ class BuildSerializer(
     reference = serializers.CharField(required=True)
 
     level = serializers.IntegerField(label=_('Build Level'), read_only=True)
-
-    url = serializers.CharField(source='get_absolute_url', read_only=True)
 
     status_text = serializers.CharField(source='get_status_display', read_only=True)
 
@@ -424,7 +421,7 @@ class BuildOutputCreateSerializer(serializers.Serializer):
             except DjangoValidationError as e:
                 raise ValidationError({'serial_numbers': e.messages})
 
-            # Check for conflicting serial numbesr
+            # Check for conflicting serial numbers
             existing = part.find_conflicting_serial_numbers(self.serials)
 
             if len(existing) > 0:

--- a/src/backend/InvenTree/company/serializers.py
+++ b/src/backend/InvenTree/company/serializers.py
@@ -113,7 +113,7 @@ class CompanySerializer(
 ):
     """Serializer for Company object (full detail)."""
 
-    export_exclude_fields = ['url', 'primary_address']
+    export_exclude_fields = ['primary_address']
 
     import_exclude_fields = ['image']
 
@@ -123,7 +123,6 @@ class CompanySerializer(
         model = Company
         fields = [
             'pk',
-            'url',
             'name',
             'description',
             'website',
@@ -162,8 +161,6 @@ class CompanySerializer(
         return queryset
 
     primary_address = AddressSerializer(required=False, allow_null=True, read_only=True)
-
-    url = serializers.CharField(source='get_absolute_url', read_only=True)
 
     image = InvenTreeImageSerializerField(required=False, allow_null=True)
 
@@ -353,7 +350,6 @@ class SupplierPartSerializer(
             'SKU',
             'supplier',
             'supplier_detail',
-            'url',
             'updated',
             'notes',
             'tags',
@@ -444,8 +440,6 @@ class SupplierPartSerializer(
     MPN = serializers.CharField(
         source='manufacturer_part.MPN', read_only=True, label=_('MPN')
     )
-
-    url = serializers.CharField(source='get_absolute_url', read_only=True)
 
     # Date fields
     updated = serializers.DateTimeField(allow_null=True, read_only=True)

--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -81,7 +81,6 @@ class CategorySerializer(
             'pathstring',
             'path',
             'starred',
-            'url',
             'structural',
             'icon',
             'parent_default_location',
@@ -123,8 +122,6 @@ class CategorySerializer(
         label=_('Parent Category'),
         help_text=_('Parent part category'),
     )
-
-    url = serializers.CharField(source='get_absolute_url', read_only=True)
 
     part_count = serializers.IntegerField(read_only=True, label=_('Parts'))
 
@@ -1134,11 +1131,11 @@ class PartSerializer(
             mpn = initial_supplier.get('mpn', '')
 
             if manufacturer and mpn:
-                manu_part = company.models.ManufacturerPart.objects.create(
+                manufacturer_part = company.models.ManufacturerPart.objects.create(
                     part=instance, manufacturer=manufacturer, MPN=mpn
                 )
             else:
-                manu_part = None
+                manufacturer_part = None
 
             supplier = initial_supplier.get('supplier', None)
             sku = initial_supplier.get('sku', '')
@@ -1148,7 +1145,7 @@ class PartSerializer(
                     part=instance,
                     supplier=supplier,
                     SKU=sku,
-                    manufacturer_part=manu_part,
+                    manufacturer_part=manufacturer_part,
                 )
 
         return instance

--- a/src/backend/InvenTree/part/test_api.py
+++ b/src/backend/InvenTree/part/test_api.py
@@ -178,7 +178,6 @@ class PartCategoryAPITest(InvenTreeAPITestCase):
             'parent',
             'part_count',
             'pathstring',
-            'url',
         ]
 
         response = self.get(url, expected_code=200)

--- a/src/backend/InvenTree/plugin/serializers.py
+++ b/src/backend/InvenTree/plugin/serializers.py
@@ -32,7 +32,7 @@ class MetadataSerializer(serializers.ModelSerializer):
         - Else, if it is a PUT update, overwrite any existing metadata
         """
         if self.partial:
-            # Default behaviour is to "merge" new data in
+            # Default behavior is to "merge" new data in
             metadata = instance.metadata.copy() if instance.metadata else {}
             metadata.update(data['metadata'])
             data['metadata'] = metadata

--- a/src/backend/InvenTree/stock/serializers.py
+++ b/src/backend/InvenTree/stock/serializers.py
@@ -1153,7 +1153,6 @@ class LocationSerializer(
         fields = [
             'pk',
             'barcode_hash',
-            'url',
             'name',
             'level',
             'description',
@@ -1205,8 +1204,6 @@ class LocationSerializer(
         label=_('Parent Location'),
         help_text=_('Parent stock location'),
     )
-
-    url = serializers.CharField(source='get_absolute_url', read_only=True)
 
     items = serializers.IntegerField(read_only=True, label=_('Stock Items'))
 

--- a/src/backend/InvenTree/stock/test_api.py
+++ b/src/backend/InvenTree/stock/test_api.py
@@ -114,7 +114,6 @@ class StockLocationTest(StockAPITestCase):
             'items',
             'pathstring',
             'owner',
-            'url',
             'icon',
             'location_type',
             'location_type_detail',


### PR DESCRIPTION
- Not used in any official client
- Inconsistent use across models

@matmair any thoughts on this one? *Some* models encode the "url" field into the API - but not all models do this. In fact, only a few. The clients (app / web) do not use this. 

If you are in agreement I think we should simply remove this field for a consistent approach.