### PR TITLE
Show location path in stock tables

### DIFF
--- a/src/frontend/src/tables/ColumnRenderers.tsx
+++ b/src/frontend/src/tables/ColumnRenderers.tsx
@@ -70,7 +70,7 @@ export function LocationColumn(props: TableColumnProps): TableColumn {
         );
       }
 
-      return <Text>{location.name}</Text>;
+      return <Text>{location.pathstring}</Text>;
     },
     ...props
   };


### PR DESCRIPTION
A first little PR from me to try out the process and learn a bit.

The full location path were visible in CUI in the stock tables. If the same sub location like "Box1" is used for multiple parents such as ShelfX  the full path is necessary to find the correct part.

I had the intention to also show the full path on the stock item details page. But i have not been able to figure out how to do that so I leave it as is for now.
