### PR TITLE
Don't fail QC when schema diff is too big for echo

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -175,6 +175,7 @@ jobs:
           revision: "src/backend/InvenTree/schema.yml"
           format: "html"
       - name: Echoing diff to step
+        continue-on-error: true
         env:
           DIFF: ${{ steps.breaking_changes.outputs.diff }}
         run: echo "${DIFF}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The large schema diff in #9143 caused the workflow to fail on master, which resulted in the new schema not getting published.

I'm not sure how to test this, but from the documentation I think it should prevent a too-large diff from breaking the job in the future.