### PR TITLE
Add pre and post processing scripts for schema generation

### DIFF
--- a/post_schema.sh
+++ b/post_schema.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+script_dir="$(realpath $(dirname "$0"))"
+schema_file="$script_dir/${1:-schema.yml}"
+
+# find fields that are conditionally removed
+field_list=$(find $script_dir/src/backend/ -name \*serializers.py -exec sed -n "s/^.*pass # self.fields.pop('\([^']\+\)'.*$/\1/p" {} \; | sort -u)
+# remove them from the lists of required fields
+for field in $field_list; do
+    sed -i "/- $field$/d" "$schema_file"
+done
+
+# restore original conditional removal of fields
+find $script_dir/src/backend/ -name \*serializers.py -exec sed -i "s/pass # self.fields.pop/self.fields.pop/g" {} \;

--- a/pre_schema.sh
+++ b/pre_schema.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+script_dir="$(realpath $(dirname "$0"))"
+
+# comment out conditional removal of fields as it causes the schema generator to exclude them unconditionally
+find $script_dir/src/backend/ -name \*serializers.py -exec sed -i "s/self.fields.pop/pass # self.fields.pop/g" {} \;


### PR DESCRIPTION
The biggest blocker I'm running into trying to address #9045 is that a number of fields are conditionally removed from the serializers depending on what view is calling it like this:

```python
if issubclass(view.__class__, ListModelMixin):
    self.fields.pop('notes', None)
```

The schema generator doesn't seem to handle this case at all, so any field that is conditionally removed is excluded from the schema entirely. That leaves me with a schema that doesn't define a `notes` field so when one is included in a details query the generated code reports it as an error (and certainly offers no way to view the data).

I haven't been able to figure out a programmatic way to detect when schema generation is happening to not remove the fields, nor have a found a configuration that affects this behavior.

The included scripts work, but they aren't integrated in any way. I'm opening this as a draft PR to ask if it's worth finding a way to integrate this into the `invoke dev.schema ...` command or if there's a better path I should be going down.

The scripts are intended to be used as follows:
```sh
./pre_schema.sh
invoke dev.schema --ignore-warnings --filename schema.yml --overwrite
./post_schema.sh schema.yml
```