### PR TITLE
Add missing namespace to devcontainer docs

### DIFF
--- a/docs/docs/develop/devcontainer.md
+++ b/docs/docs/develop/devcontainer.md
@@ -52,7 +52,7 @@ Tasks can help you executing scripts. You can run them by open the command panel
 
 #### Setup demo dataset
 
-If you need some demo test-data, run the `setup-test` task. This will import an `admin` user with the password `inventree`. For more info on what this dataset contains see [inventree/demo-dataset](../demo.md).
+If you need some demo test-data, run the `dev.setup-test` task. This will import an `admin` user with the password `inventree`. For more info on what this dataset contains see [inventree/demo-dataset](../demo.md).
 
 #### Setup a superuser
 


### PR DESCRIPTION
Stumbled on a missing namespace when I reinstalled the demo dataset