### PR TITLE
Static Asset Management

### DIFF
--- a/contrib/container/Caddyfile
+++ b/contrib/container/Caddyfile
@@ -41,6 +41,14 @@
 		max_size 100MB
 	}
 
+	# Redirect 'asset' requests to the static file server
+	handle_path /assets/* {
+		import cors-headers assets
+
+		root * /var/www/static/web/assets
+		file_server
+	}
+
 	# Handle static request files
 	handle_path /static/* {
 		import cors-headers static

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1181,7 +1181,7 @@ CORS_ALLOW_CREDENTIALS = get_boolean_setting(
 )
 
 # Only allow CORS access to the following URL endpoints
-CORS_URLS_REGEX = r'^/(api|auth|media|plugin|static)/.*$'
+CORS_URLS_REGEX = r'^/(api|auth|media|plugin|static|assets)/.*$'
 
 CORS_ALLOWED_ORIGINS = get_setting(
     'INVENTREE_CORS_ORIGIN_WHITELIST',

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       uploadToken: process.env.CODECOV_TOKEN
     })
   ],
+  base: '/static/web/',
   build: {
     manifest: true,
     outDir: '../../src/backend/InvenTree/web/static/web',


### PR DESCRIPTION
This PR ensures that the static frontend assets are served entirely by the proxy rather than requiring the python server to issue redirects back to the proxy.

This results in significant reduction in server load and reduces the number of backend requests a lot!

Tested out on the demo server, with much faster performance now.