### PR TITLE
Docker Compose Fix

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -103,6 +103,8 @@ jobs:
           docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run inventree-dev-server invoke install
           docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run inventree-dev-server invoke version
           docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run inventree-dev-server invoke update
+          docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run inventree-dev-server invoke backup
+          docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run inventree-dev-server invoke restore
           docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run inventree-dev-server invoke dev.setup-dev
           docker compose --project-directory . -f contrib/container/dev-docker-compose.yml up -d
           docker compose --project-directory . -f contrib/container/dev-docker-compose.yml run inventree-dev-server invoke wait

--- a/contrib/container/docker-compose.yml
+++ b/contrib/container/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     # Database service
     # Use PostgreSQL as the database backend
     inventree-db:
-        image: postgres:17
+        image: postgres:16
         container_name: inventree-db
         expose:
             - ${INVENTREE_DB_PORT:-5432}/tcp


### PR DESCRIPTION
Fixes mismatch between posgres versions in the docker compose file.

In the recent docker refactoring this was supposed to be pinned at `postgres:16` but somehow this has been missed.

Also adds some checks to the docker CI build to ensure that the backup and restore processes run.