### PR TITLE
Add docs for governance and security

### DIFF
--- a/docs/docs/concepts/thread_model.md
+++ b/docs/docs/concepts/thread_model.md
@@ -4,12 +4,15 @@ Deploying InvenTree to production requires to knowledge of the security assumpti
 ## Assumed trust
 
 1. The InvenTree server is only available to trusted networks and there are detection mechanisms in place to detect unauthorised access.
+
    1. When exposing to the internet, it is recommended to use a WAF and ensure only trusted IP ranges are allowed to access the server
    2. It is recommended to enforce usage of strong traffic encryption along the network path
    3. Authentication attempts are rate limited by InvenTree but should be monitored with appropriate monitoring and alerting solutions to detect long-running brute force attacks
+
 2. All users are trusted - therefore user uploaded files can be assumed to be safe. There are basic checks in place to ensure that the files are not using common attack vectors but those are not exhaustive.
 3. Superuser permissions are only given to trusted users and not used for daily operations. A superuser account can manipulate or extract all files on the server that the InvenTree server process have access to.
 4. All templates and plugins are trusted.
+
    1. It is recommended to only use plugins and templates from trusted sources.
    2. It is recommended to review the code of the plugins and templates before using them.
    3. Templates and plugins can access all files that the server and worker processes have access to

--- a/docs/docs/concepts/thread_model.md
+++ b/docs/docs/concepts/thread_model.md
@@ -1,12 +1,25 @@
 
-Placeholder for thread model documentation.
-
 Deploying InvenTree to production requires to knowledge of the security assumptions and thread model of the underlying system. This document outlines the security assumptions and thread model of InvenTree as a software. It is assumed that the system that InvenTree is deployed on top of is configured following best practices and is trusted.
 
-# Exposing InvenTree
+## Assumed trust
 
-# User Roles / Permissions
+1. The InvenTree server is only available to trusted networks and there are detection mechanisms in place to detect unauthorised access.
+   1. When exposing to the internet, it is recommended to use a WAF and ensure only trusted IP ranges are allowed to access the server
+   2. It is recommended to enforce usage of strong traffic encryption along the network path
+   3. Authentication attempts are rate limited by InvenTree but should be monitored with appropriate monitoring and alerting solutions to detect long-running brute force attacks
+2. All users are trusted - therefore user uploaded files can be assumed to be safe. There are basic checks in place to ensure that the files are not using common attack vectors but those are not exhaustive.
+3. Superuser permissions are only given to trusted users and not used for daily operations. A superuser account can manipulate or extract all files on the server that the InvenTree server process have access to.
+4. All templates and plugins are trusted.
+   1. It is recommended to only use plugins and templates from trusted sources.
+   2. It is recommended to review the code of the plugins and templates before using them.
+   3. Templates and plugins can access all files that the server and worker processes have access to
+   4. Plugins can access the inventree database and all data in the database
+   5. Plugins can access all environment variables that are accessible to the server and worker processes
 
-# Trust in user uploaded files
+## Possible attack vectors
 
-# Assumed trust in templating and plugins
+1. Malicious plugins or templates can overwrite or delete files on the server, bypass security checks, or leak sensitive information.
+2. Token phishing attacks can be used to impersonate users. Tokens are not scoped to specific IPs or devices. Limit their usage and use lowest possible user permissions.
+3. Malicious file uploads. Attachments are served (by default) under the same domain as the backend - this can lead to XSS attacks.
+
+There are various checks to gate against common attack vectors but above vectors are explicitly not addressed as they require organisational policies and procedures to mitigate.

--- a/docs/docs/concepts/thread_model.md
+++ b/docs/docs/concepts/thread_model.md
@@ -26,3 +26,7 @@ Deploying InvenTree to production requires to knowledge of the security assumpti
 3. Malicious file uploads. Attachments are served (by default) under the same domain as the backend - this can lead to XSS attacks.
 
 There are various checks to gate against common attack vectors but above vectors are explicitly not addressed as they require organisational policies and procedures to mitigate.
+
+## Secure Development Cycle
+
+The InvenTree project is developed following best practices. Read more in the [project security guide](../project/security.md).

--- a/docs/docs/concepts/thread_model.md
+++ b/docs/docs/concepts/thread_model.md
@@ -1,0 +1,12 @@
+
+Placeholder for thread model documentation.
+
+Deploying InvenTree to production requires to knowledge of the security assumptions and thread model of the underlying system. This document outlines the security assumptions and thread model of InvenTree as a software. It is assumed that the system that InvenTree is deployed on top of is configured following best practices and is trusted.
+
+# Exposing InvenTree
+
+# User Roles / Permissions
+
+# Trust in user uploaded files
+
+# Assumed trust in templating and plugins

--- a/docs/docs/concepts/threat_model.md
+++ b/docs/docs/concepts/threat_model.md
@@ -1,5 +1,5 @@
 
-Deploying InvenTree to production requires to knowledge of the security assumptions and thread model of the underlying system. This document outlines the security assumptions and thread model of InvenTree as a software. It is assumed that the system that InvenTree is deployed on top of is configured following best practices and is trusted.
+Deploying InvenTree to production requires to knowledge of the security assumptions and threat model of the underlying system. This document outlines the security assumptions and threat model of InvenTree as a software. It is assumed that the system that InvenTree is deployed on top of is configured following best practices and is trusted.
 
 ## Assumed trust
 

--- a/docs/docs/project/governance.md
+++ b/docs/docs/project/governance.md
@@ -1,0 +1,35 @@
+
+As a MIT licensed open-source project, there are not legal obligations for the InvenTree project team or any contributor to provide support or maintenance. The software is provided "as-is" - without warranty of any kind.
+However, the project team is committed to providing a reliable and [secure](security.md) code base with predictable upgrade paths.
+
+## Team organisation
+
+There is no legal entity that governs the InvenTree project at this time.
+The project is managed by a small team of volunteer developers, who are responsible for the ongoing development and maintenance of the software.
+
+### Maintainer
+
+InvenTree was started by and is run by SchrodingersGat, who is the maintainer of the project following the [BDFL model](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life).
+Releases are made by the maintainer, who is responsible for the overall direction of the project. Any directional decisions are at the sole discretion of the maintainer.
+
+### Core Team
+
+A number of developers are selected to join the `core team` to help with triage and review of issues and pull requests. Core team members are part of the @inventree/triage team on GitHub and might choose to make that association public. Team members might be listed on the website.
+
+The core team has moderation, triage and review permissions on most repositories of the organisation. There is no requirement (or assumption) of effort spend on the project.
+
+### Proofreaders
+
+The InvenTree project is translated into a number of languages using a web translation tool that requires approval of submitted strings. Members of the community can apply to be elevated to the role of `proofreader` for a specific language. Proofreaders are enabled to approve translations, at which point they are automatically proposed for inclusion in the code base.
+
+A list of proofreaders is being maintained on [GitHub](https://github.com/inventree/InvenTree/discussions/9073)
+
+## Write access to the code base
+
+Write access to the code base is granted to a very small number of developers. In daily operations only the [maintainer](#maintainer) is expected to make changes to the master or stable branches.
+
+To reduce the risk of losing access to the code base additional members are granted access.
+
+The following users have write access to the code base:
+- [SchrodingersGat](https://github.com/SchrodingersGat)
+- [matmair](https://github.com/matmair)

--- a/docs/docs/project/governance.md
+++ b/docs/docs/project/governance.md
@@ -20,7 +20,8 @@ The core team has moderation, triage and review permissions on most repositories
 
 ### Proofreaders
 
-The InvenTree project is translated into a number of languages using a web translation tool that requires approval of submitted strings. Members of the community can apply to be elevated to the role of `proofreader` for a specific language. Proofreaders are enabled to approve translations, at which point they are automatically proposed for inclusion in the code base.
+The InvenTree project is translated into a number of languages using a web translation tool that requires approval of submitted strings. Members of the community can apply to be elevated to the role of `proofreader` for a specific language.
+Proofreaders are enabled to approve translations, at which point they are automatically proposed for inclusion in the code base.
 
 A list of proofreaders is being maintained on [GitHub](https://github.com/inventree/InvenTree/discussions/9073)
 
@@ -28,8 +29,9 @@ A list of proofreaders is being maintained on [GitHub](https://github.com/invent
 
 Write access to the code base is granted to a very small number of developers. In daily operations only the [maintainer](#maintainer) is expected to make changes to the master or stable branches.
 
-To reduce the risk of losing access to the code base additional members are granted access.
+To reduce the risk of losing the possibility to address security issues in a timely manner additional members are granted access.
 
-The following users have write access to the code base:
+The following users have write access to the code base at this time:
+
 - [SchrodingersGat](https://github.com/SchrodingersGat)
 - [matmair](https://github.com/matmair)

--- a/docs/docs/project/security.md
+++ b/docs/docs/project/security.md
@@ -1,0 +1,53 @@
+
+The InvenTree project is committed to providing a secure and safe environment for all users. We know that many of our users rely on InvenTree to manage the inventory and manufacturing for their small and mid-size businesses, and we take that responsibility seriously.
+
+To that end, we have implemented a number of security measures over the years, which we will outline in this document.
+
+## Organisational measures
+
+The InvenTree project is managed by a small team of developers, who are responsible for the ongoing development and maintenance of the software. Two geographically distributed users have administrative access to the InvenTree codebase. Merges are only done by one of these two users, the maintainer Oliver. Read the Project [Governance](governance.md) document for more information.
+InvenTree is open-source, and we welcome contributions from the community. However, all contributions are reviewed and scrutinised before being merged into the codebase.
+
+We provide a written [Security Policy]({{ sourcefile("SECURITY.md") }}) in our main repo to ensure that all security issues are handled in a timely manner.
+
+If we become aware of a security issue, we will take immediate action to address the issue, and will provide a public disclosure of the issue once it has been resolved. We support assigning CVEs to security issues where appropriate.  Our [past security advisories can be found here](https://github.com/inventree/InvenTree/security/advisories).
+
+## Technical measures
+
+### Code hosting
+
+The InvenTree project is hosted on GitHub, and we rely on the security measures provided by GitHub to help protect the integrity of the codebase.
+
+Among those are:
+
+- Short-lived tokens where possible
+- Dependabot for automated dependency updates / alerts
+- Integrated security reporting
+- (Optional but encouraged) Two-factor authentication for user accounts
+- (Optional but encouraged) Signed commits / actions
+
+### Code style
+
+We enforce style and security checks in our CI/CD pipeline, and we have several automated tests to ensure that the codebase is secure and functional.
+Checks are run on every pull request, and we require that all checks pass before a pull request can be merged.
+
+### Current versions
+
+InvenTree is built using the Django framework, which has a strong focus on security. We follow best practices for Django development, and we are committed to keeping the codebase up-to-date with the latest security patches and within supported versions.
+
+### Test coverage
+
+We run coverage tests on our codebase to ensure that we have a high level of test coverage above 90%. This is public and can be found [here](https://app.codecov.io/gh/inventree/InvenTree).
+
+### Pinning dependencies
+
+We are pinning dependencies to specific versions - aiming for complete reproducibility of builds - wherever possible. Combined with continuous OSV checks, we are able to react quickly to security issues in our dependencies.
+
+## Best practices
+
+We follow most of GitHubs community best practices, check our compliance [here](https://github.com/inventree/InvenTree/community).
+
+We also follow OpenSSF recommendations where applicable and take part in multiple of their security efforts:
+
+- OSSF Best Practices, currently at a [level of passing](https://www.bestpractices.dev/de/projects/7179)
+- OSSF Scorecard, running with each merge [check current state](https://securityscorecards.dev/viewer/?uri=github.com/inventree/InvenTree)

--- a/docs/docs/project/security.md
+++ b/docs/docs/project/security.md
@@ -5,7 +5,9 @@ To that end, we have implemented a number of security measures over the years, w
 
 ## Organisational measures
 
-The InvenTree project is managed by a small team of developers, who are responsible for the ongoing development and maintenance of the software. Two geographically distributed users have administrative access to the InvenTree codebase. Merges are only done by one of these two users, the maintainer Oliver. Read the Project [Governance](governance.md) document for more information.
+The InvenTree project is managed by a small team of developers, who are responsible for the ongoing development and maintenance of the software. Two geographically distributed users have administrative access to the InvenTree codebase. Merges are only done by one of these two users, the maintainer Oliver.
+Read the Project [Governance](governance.md) document for more information.
+
 InvenTree is open-source, and we welcome contributions from the community. However, all contributions are reviewed and scrutinised before being merged into the codebase.
 
 We provide a written [Security Policy]({{ sourcefile("SECURITY.md") }}) in our main repo to ensure that all security issues are handled in a timely manner.

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -1,6 +1,6 @@
 
 There a 2 different documents regarding security:
 - [Project Security](project/security.md) addresses security measures taken by the InvenTree project around the code base and the project itself
-- [Threat Model](concepts/threat_model.md) describes the assumptions made regarding run an instance of InvenTree
+- [Threat Model](concepts/threat_model.md) describes the assumptions made regarding running an instance of InvenTree
 
 The official [Security Policy]({{ sourcefile("SECURITY.md") }}) is available in the code repository.

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -1,6 +1,6 @@
 
 There a 2 different documents regarding security:
 - [Project Security](project/security.md) addresses security measures taken by the InvenTree project around the code base and the project itself
-- [Thread Model](concepts/thread_model.md) describes the assumptions made regarding run an instance of InvenTree
+- [Threat Model](concepts/threat_model.md) describes the assumptions made regarding run an instance of InvenTree
 
 The official [Security Policy]({{ sourcefile("SECURITY.md") }}) is available in the code repository.

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -1,53 +1,6 @@
 
-The InvenTree project is committed to providing a secure and safe environment for all users. We know that many of our users rely on InvenTree to manage the inventory and manufacturing for their small and mid-size businesses, and we take that responsibility seriously.
+There a 2 different documents regarding security:
+- [Project Security](project/security.md) addresses security measures taken by the InvenTree project around the code base and the project itself
+- [Thread Model](concepts/thread_model.md) describes the assumptions made regarding run an instance of InvenTree
 
-To that end, we have implemented a number of security measures over the years, which we will outline in this document.
-
-## Organisational measures
-
-The InvenTree project is managed by a small team of developers, who are responsible for the ongoing development and maintenance of the software. Two geographically distributed users have administrative access to the InvenTree codebase. Merges are only done by one of these two users, the maintainer Oliver.
-InvenTree is open-source, and we welcome contributions from the community. However, all contributions are reviewed and scrutinised before being merged into the codebase.
-
-We provide a written [Security Policy]({{ sourcefile("SECURITY.md") }}) in our main repo to ensure that all security issues are handled in a timely manner.
-
-If we become aware of a security issue, we will take immediate action to address the issue, and will provide a public disclosure of the issue once it has been resolved. We support assigning CVEs to security issues where appropriate.  Our [past security advisories can be found here](https://github.com/inventree/InvenTree/security/advisories).
-
-## Technical measures
-
-### Code hosting
-
-The InvenTree project is hosted on GitHub, and we rely on the security measures provided by GitHub to help protect the integrity of the codebase.
-
-Among those are:
-
-- Short-lived tokens where possible
-- Dependabot for automated dependency updates / alerts
-- Integrated security reporting
-- (Optional but encouraged) Two-factor authentication for user accounts
-- (Optional but encouraged) Signed commits / actions
-
-### Code style
-
-We enforce style and security checks in our CI/CD pipeline, and we have several automated tests to ensure that the codebase is secure and functional.
-Checks are run on every pull request, and we require that all checks pass before a pull request can be merged.
-
-### Current versions
-
-InvenTree is built using the Django framework, which has a strong focus on security. We follow best practices for Django development, and we are committed to keeping the codebase up-to-date with the latest security patches and within supported versions.
-
-### Test coverage
-
-We run coverage tests on our codebase to ensure that we have a high level of test coverage above 90%. This is public and can be found [here](https://app.codecov.io/gh/inventree/InvenTree).
-
-### Pinning dependencies
-
-We are pinning dependencies to specific versions - aiming for complete reproducibility of builds - wherever possible. Combined with continuous OSV checks, we are able to react quickly to security issues in our dependencies.
-
-## Best practices
-
-We follow most of GitHubs community best practices, check our compliance [here](https://github.com/inventree/InvenTree/community).
-
-We also follow OpenSSF recommendations where applicable and take part in multiple of their security efforts:
-
-- OSSF Best Practices, currently at a [level of passing](https://www.bestpractices.dev/de/projects/7179)
-- OSSF Scorecard, running with each merge [check current state](https://securityscorecards.dev/viewer/?uri=github.com/inventree/InvenTree)
+The official [Security Policy]({{ sourcefile("SECURITY.md") }}) is available in the code repository.

--- a/docs/docs/start/bare_prod.md
+++ b/docs/docs/start/bare_prod.md
@@ -102,7 +102,7 @@ In addition to the InvenTree server, you will need a method of delivering static
 
 ### Check your security posture
 
-It is recommended to check the [thread modelling inputs](../concepts/thread_model.md) to ensure that your InvenTree installation is set up in the way that it is assumed in the software design.
+It is recommended to check the [threat modelling inputs](../concepts/threat_model.md) to ensure that your InvenTree installation is set up in the way that it is assumed in the software design.
 
 
 ### Next Steps

--- a/docs/docs/start/bare_prod.md
+++ b/docs/docs/start/bare_prod.md
@@ -100,6 +100,11 @@ In addition to the InvenTree server, you will need a method of delivering static
 !!! info "Read More"
     Refer to the [proxy server documentation](./processes.md#proxy-server) for more details
 
+### Check your security posture
+
+It is recommended to check the [thread modelling inputs](../concepts/thread_model.md) to ensure that your InvenTree installation is set up in the way that it is assumed in the software design.
+
+
 ### Next Steps
 
 You (or your system administrator) may wish to perform further steps such as placing the InvenTree server behind a [reverse proxy](./processes.md#proxy-server) such as [caddy](https://caddyserver.com/), or [nginx](https://www.nginx.com/).

--- a/docs/docs/start/docker_install.md
+++ b/docs/docs/start/docker_install.md
@@ -187,7 +187,7 @@ This will export database records to the file `data.json` in your mounted volume
 
 ### Check your security posture
 
-It is recommended to check the [thread modelling inputs](../concepts/thread_model.md) to ensure that your InvenTree installation is set up in the way that it is assumed in the software design.
+It is recommended to check the [threat modelling inputs](../concepts/threat_model.md) to ensure that your InvenTree installation is set up in the way that it is assumed in the software design.
 
 ### Custom Domain
 

--- a/docs/docs/start/docker_install.md
+++ b/docs/docs/start/docker_install.md
@@ -185,6 +185,10 @@ This will export database records to the file `data.json` in your mounted volume
 
 ## Further Configuration
 
+### Check your security posture
+
+It is recommended to check the [thread modelling inputs](../concepts/thread_model.md) to ensure that your InvenTree installation is set up in the way that it is assumed in the software design.
+
 ### Custom Domain
 
 By default, the InvenTree server is accessible at [http://inventree.localhost](http://inventree.localhost). If you wish to use a custom domain, you can edit the `.env` environment file to specify the domain name.

--- a/docs/docs/start/intro.md
+++ b/docs/docs/start/intro.md
@@ -21,7 +21,7 @@ To quickly jump to a specific installation method, refer to the following links:
     The recommended method of installing InvenTree is to follow our [docker setup guide](./docker.md). InvenTree provides out-of-the-box support for docker and docker compose, which provides a simple, reliable and repeatable pipeline for integration into your production environment.
 
 !!! warning "Important Security Considerations"
-    We provide documentation around the security posture that is assumed by the InvenTree project in the software design. Assessing this is a *critical* part of the setup process, and should be read carefully before deploying InvenTree in a production environment. You can read more about the [threat moddeling inputs here](../concepts/threat_model.md).
+    We provide documentation around the security posture that is assumed by the InvenTree project in the software design. Assessing this is a *critical* part of the setup process, and should be read carefully before deploying InvenTree in a production environment. You can read more about the [threat modelling inputs here](../concepts/threat_model.md).
 
 !!! info "Further Reading"
     For more information on the InvenTree tech stack, continue reading below!

--- a/docs/docs/start/intro.md
+++ b/docs/docs/start/intro.md
@@ -20,6 +20,9 @@ To quickly jump to a specific installation method, refer to the following links:
 !!! success "Docker Recommended"
     The recommended method of installing InvenTree is to follow our [docker setup guide](./docker.md). InvenTree provides out-of-the-box support for docker and docker compose, which provides a simple, reliable and repeatable pipeline for integration into your production environment.
 
+!!! warning "Important Security Considerations"
+    We provide documentation around the security posture that is assumed by the InvenTree project in the software design. Assessing this is a *critical* part of the setup process, and should be read carefully before deploying InvenTree in a production environment. You can read more about the [thread moddeling inputs here](../concepts/thread_model.md).
+
 !!! info "Further Reading"
     For more information on the InvenTree tech stack, continue reading below!
 

--- a/docs/docs/start/intro.md
+++ b/docs/docs/start/intro.md
@@ -21,7 +21,7 @@ To quickly jump to a specific installation method, refer to the following links:
     The recommended method of installing InvenTree is to follow our [docker setup guide](./docker.md). InvenTree provides out-of-the-box support for docker and docker compose, which provides a simple, reliable and repeatable pipeline for integration into your production environment.
 
 !!! warning "Important Security Considerations"
-    We provide documentation around the security posture that is assumed by the InvenTree project in the software design. Assessing this is a *critical* part of the setup process, and should be read carefully before deploying InvenTree in a production environment. You can read more about the [thread moddeling inputs here](../concepts/thread_model.md).
+    We provide documentation around the security posture that is assumed by the InvenTree project in the software design. Assessing this is a *critical* part of the setup process, and should be read carefully before deploying InvenTree in a production environment. You can read more about the [threat moddeling inputs here](../concepts/threat_model.md).
 
 !!! info "Further Reading"
     For more information on the InvenTree tech stack, continue reading below!

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,7 +79,7 @@ nav:
       - Physical Units: concepts/units.md
       - Custom States: concepts/custom_states.md
       - Pricing: concepts/pricing.md
-      - Thread Model: concepts/thread_model.md
+      - Threat Model: concepts/threat_model.md
     - Development:
       - Contributing: develop/contributing.md
       - Devcontainer: develop/devcontainer.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -88,7 +88,7 @@ nav:
     - Release Notes: releases/release_notes.md
     - Project:
       - Governance: project/governance.md
-      - Security: project/security.md
+      - Project Security: project/security.md
     - Security: security.md
   - Install:
     - Introduction: start/intro.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,12 +79,16 @@ nav:
       - Physical Units: concepts/units.md
       - Custom States: concepts/custom_states.md
       - Pricing: concepts/pricing.md
+      - Thread Model: concepts/thread_model.md
     - Development:
       - Contributing: develop/contributing.md
       - Devcontainer: develop/devcontainer.md
       - React Frontend: develop/react-frontend.md
     - Privacy: privacy.md
     - Release Notes: releases/release_notes.md
+    - Project:
+      - Governance: project/governance.md
+      - Security: project/security.md
     - Security: security.md
   - Install:
     - Introduction: start/intro.md


### PR DESCRIPTION
This PR:
- creates a clear distinction between project and instance security (added)
- adds a governance overview