### PR TITLE
Use dayjs in DateField

### DIFF
--- a/src/frontend/src/components/forms/fields/DateField.tsx
+++ b/src/frontend/src/components/forms/fields/DateField.tsx
@@ -48,7 +48,7 @@ export default function DateField({
     let dv: Date | null = null;
 
     if (field.value) {
-      dv = new Date(field.value);
+      dv = dayjs(field.value).toDate();
     }
 
     // Ensure that the date is valid


### PR DESCRIPTION
In my browser's timezone (`America/Denver`), using the native `Date` constructor on `field.value` results in a day that is one behind the day I'm attempting to select. This resulted in the day being misrepresented in the form field but correctly represented in the resulting `PATCH` request on form submit

Tested with

```typescript
const dateValue: Date | null = useMemo(() => {
    let dv: Date | null = null;
    
    if (field.value) {
      console.log(`field.value was ${field.value}`)
      dv = new Date(field.value);
      console.log(`dv is ${dv}`)
    }
    ...
}
```

and got 

![image](https://github.com/user-attachments/assets/fb55e4b3-70fb-4d11-8e43-7c3c4ebb9361)

Switching to use `dayjs` as the "constructor" fixed this issue for me. It would be a good idea to confirm this works for your timezones as well to ensure this is globally correct.....

Aren't timezones fun? <https://xkcd.com/1883/>

![date_bug](https://github.com/user-attachments/assets/d470be26-5710-442d-b065-b6f2746569c4)
