### PR TITLE
Supply `url_fetcher` to `weasyprint` to support `/media` and `/static` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ exclude: |
     )$
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -18,7 +18,7 @@ repos:
         exclude: mkdocs.yml
     -   id: mixed-line-ending
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.14.0
     hooks:
     - id: ruff-format
       args: [--preview]
@@ -29,7 +29,7 @@ repos:
         --preview
       ]
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.7.12
+    rev: 0.9.3
     hooks:
       - id: pip-compile
         name: pip-compile requirements-dev.in
@@ -71,16 +71,16 @@ repos:
           src/frontend/vite.config.ts |
       )$
 -   repo: https://github.com/biomejs/pre-commit
-    rev: v2.0.0-beta.5
+    rev: v2.2.6
     hooks:
     -   id: biome-check
         additional_dependencies: ["@biomejs/biome@1.9.4"]
         files: ^src/frontend/.*\.(js|ts|tsx)$
 -   repo: https://github.com/gitleaks/gitleaks
-    rev: v8.27.2
+    rev: v8.28.0
     hooks:
     -   id: gitleaks
-        language_version: 1.23.6
+        language_version: 1.23.8
 #-   repo: https://github.com/jumanjihouse/pre-commit-hooks
 #    rev: 3.0.0
 #    hooks:

--- a/src/backend/InvenTree/report/api.py
+++ b/src/backend/InvenTree/report/api.py
@@ -293,7 +293,13 @@ class ReportPrint(GenericAPIView):
         item_ids = [item.pk for item in items_to_print]
 
         # Offload the task to the background worker
-        offload_task(report.tasks.print_reports, template.pk, item_ids, output.pk)
+        offload_task(
+            report.tasks.print_reports,
+            template.pk,
+            item_ids,
+            output.pk,
+            request=request,
+        )
 
         output.refresh_from_db()
 

--- a/src/backend/InvenTree/report/tasks.py
+++ b/src/backend/InvenTree/report/tasks.py
@@ -38,7 +38,7 @@ def print_reports(template_id: int, item_ids: list[int], output_id: int, **kwarg
     # Ensure they are sorted by the order of the provided item IDs
     items = sorted(items, key=lambda item: item_ids.index(item.pk))
 
-    template.print(items, output=output)
+    template.print(items, output=output, request=kwargs.get('request'))
 
 
 @tracer.start_as_current_span('print_labels')


### PR DESCRIPTION
Pull request with changes from a [comment](https://github.com/inventree/InvenTree/discussions/9351#discussioncomment-12632521) made on #9351.

This allows `weasyprint` to grab files from `/media` and `/static` locations by redirecting them to `open()` calls with respect to `MEDIA_ROOT` and `STATIC_ROOT` settings.

Probably could be made better. But at least ensures that the resulting path is always still a child of the parent folder.