### PR TITLE
Add request body to schema for bulk delete operations, deconflict list

### DIFF
--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -383,9 +383,7 @@ class BulkRequestSerializer(serializers.Serializer):
     )
 
     filters = serializers.DictField(
-        label='A dictionary of filter values',
-        child=serializers.CharField(),
-        required=False,
+        label='A dictionary of filter values', required=False
     )
 
 

--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -553,7 +553,7 @@ class BulkDeleteMixin(BulkOperationMixin):
             for item in queryset:
                 item.delete()
 
-        return Response({'success': f'Deleted {n_deleted} items'}, status=204)
+        return Response({'success': f'Deleted {n_deleted} items'}, status=200)
 
 
 class ListCreateDestroyAPIView(BulkDeleteMixin, ListCreateAPI):

--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -373,6 +373,22 @@ class NotFoundView(APIView):
         return self.not_found(request)
 
 
+class BulkRequestSerializer(serializers.Serializer):
+    """Parameters for selecting items for bulk operations."""
+
+    items = serializers.ListField(
+        label='A list of primary key values',
+        child=serializers.IntegerField(),
+        required=False,
+    )
+
+    filters = serializers.DictField(
+        label='A dictionary of filter values',
+        child=serializers.CharField(),
+        required=False,
+    )
+
+
 class BulkOperationMixin:
     """Mixin class for handling bulk data operations.
 
@@ -532,6 +548,7 @@ class BulkDeleteMixin(BulkOperationMixin):
         """
         return queryset
 
+    @extend_schema(request=BulkRequestSerializer)
     def delete(self, request, *args, **kwargs):
         """Perform a DELETE operation against this list endpoint.
 

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,16 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 329
+INVENTREE_API_VERSION = 330
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+
+v330 - 2025-03-31 : https://github.com/inventree/InvenTree/pull/9420
+    - Deconflict operation id between single and bulk destroy operations
+    - Add request body definition for bulk destroy operations
 
 v329 - 2025-03-30 : https://github.com/inventree/InvenTree/pull/9399
     - Convert url path regex-specified PKs to int

--- a/src/backend/InvenTree/InvenTree/schema.py
+++ b/src/backend/InvenTree/InvenTree/schema.py
@@ -7,12 +7,12 @@ def postprocess_bulk_delete(result, generator, request, public):
     drf-spectacular doesn't support a body on DELETE endpoints because the semantics are not well-defined and OpenAPI
     recommends against it. This allows us to generate a schema that follows existing behavior.
     """
-    request = {'schema': {'$ref': '#/components/schemas/BulkDeleteRequest'}}
+    request_schema = {'schema': {'$ref': '#/components/schemas/BulkDeleteRequest'}}
     request_body = {
         'content': {
-            'application/json': request,
-            'application/x-www-form-urlencoded': request,
-            'multipart/form-data': request,
+            'application/json': request_schema,
+            'application/x-www-form-urlencoded': request_schema,
+            'multipart/form-data': request_schema,
         },
         'required': True,
     }

--- a/src/backend/InvenTree/InvenTree/schema.py
+++ b/src/backend/InvenTree/InvenTree/schema.py
@@ -1,10 +1,68 @@
 """Schema processing functions for cleaning up generated schema."""
 
 
+def postprocess_bulk_delete(result, generator, request, public):
+    """Add a request body to bulk DELETE endpoints.
+
+    drf-spectacular doesn't support a body on DELETE endpoints because the semantics are not well-defined and OpenAPI
+    recommends against it. This allows us to generate a schema that follows existing behavior.
+    """
+    request = {'schema': {'$ref': '#/components/schemas/BulkDeleteRequest'}}
+    request_body = {
+        'content': {
+            'application/json': request,
+            'application/x-www-form-urlencoded': request,
+            'multipart/form-data': request,
+        },
+        'required': True,
+    }
+
+    # Update relevant operations to reference the bulk delete schema
+    target_operation_suffix = '_destroy'
+    paths = result.get('paths', {})
+    for path, operations in paths.items():
+        # Anything ending in a path parameter is not a bulk operation
+        if path.endswith('/{id}/'):
+            continue
+
+        delete_operation = operations.get('delete', {})
+        operation_id = delete_operation.get('operationId', '')
+        if operation_id.endswith(target_operation_suffix):
+            # change id to deconflict with single destroy operations
+            delete_operation['operationId'] = operation_id.replace(
+                target_operation_suffix, '_bulk_destroy'
+            )
+            delete_operation['requestBody'] = request_body
+
+    # Add BulkDeleteRequest to schemas: because drf-spectacular strips requests from delete operations there's no way
+    # to attach a serializer to generate this automatically
+    schema_def = {
+        'type': 'object',
+        'description': 'Parameters for selecting items to bulk delete.',
+        'properties': {
+            'items': {
+                'type': 'array',
+                'items': {'type': 'integer'},
+                'description': 'A list of primary key values',
+            },
+            'filters': {
+                'type': 'object',
+                'additionalProperties': {'type': 'string'},
+                'description': 'A dictionary of filter values.',
+            },
+        },
+    }
+    result.get('components').get('schemas')['BulkDeleteRequest'] = schema_def
+
+    return result
+
+
 def postprocess_required_nullable(result, generator, request, public):
     """Un-require nullable fields.
 
-    Read-only values are all marked as required by spectacular, but InvenTree doesn't always include them in the response. This removes them from the required list to allow responses lacking read-only nullable fields to validate against the schema.
+    Read-only values are all marked as required by spectacular, but InvenTree doesn't always include them in the
+    response. This removes them from the required list to allow responses lacking read-only nullable fields to validate
+    against the schema.
     """
     # Process schema section
     schemas = result.get('components', {}).get('schemas', {})

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -1427,6 +1427,7 @@ SPECTACULAR_SETTINGS = {
     'SCHEMA_PATH_PREFIX': '/api/',
     'POSTPROCESSING_HOOKS': [
         'drf_spectacular.hooks.postprocess_schema_enums',
+        'InvenTree.schema.postprocess_bulk_delete',
         'InvenTree.schema.postprocess_required_nullable',
     ],
 }

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -536,7 +536,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissions',
         'InvenTree.permissions.RolePermission',
     ],
-    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_SCHEMA_CLASS': 'InvenTree.schema.ExtendedAutoSchema',
     'DEFAULT_METADATA_CLASS': 'InvenTree.metadata.InvenTreeMetadata',
     'DEFAULT_RENDERER_CLASSES': ['rest_framework.renderers.JSONRenderer'],
     'TOKEN_MODEL': 'users.models.ApiToken',
@@ -1427,7 +1427,6 @@ SPECTACULAR_SETTINGS = {
     'SCHEMA_PATH_PREFIX': '/api/',
     'POSTPROCESSING_HOOKS': [
         'drf_spectacular.hooks.postprocess_schema_enums',
-        'InvenTree.schema.postprocess_bulk_delete',
         'InvenTree.schema.postprocess_required_nullable',
     ],
 }

--- a/src/backend/InvenTree/common/tests.py
+++ b/src/backend/InvenTree/common/tests.py
@@ -1112,7 +1112,7 @@ class NotificationTest(InvenTreeAPITestCase):
 
         # Now, let's bulk delete all 'unread' notifications via the API,
         # but only associated with the logged in user
-        response = self.delete(url, {'filters': {'read': False}}, expected_code=204)
+        response = self.delete(url, {'filters': {'read': False}}, expected_code=200)
 
         # Only 7 notifications should have been deleted,
         # as the notifications associated with other users must remain untouched

--- a/src/backend/InvenTree/order/test_api.py
+++ b/src/backend/InvenTree/order/test_api.py
@@ -756,7 +756,7 @@ class PurchaseOrderLineItemTest(OrderTest):
         url = reverse('api-po-line-list')
 
         # Try to delete a set of line items via their IDs
-        self.delete(url, {'items': [1, 2]}, expected_code=204)
+        self.delete(url, {'items': [1, 2]}, expected_code=200)
 
         # We should have 2 less PurchaseOrderLineItems after deletign them
         self.assertEqual(models.PurchaseOrderLineItem.objects.count(), n - 2)

--- a/src/backend/InvenTree/stock/test_api.py
+++ b/src/backend/InvenTree/stock/test_api.py
@@ -2015,7 +2015,7 @@ class StockTestResultTest(StockAPITestCase):
 
         # Try again, but with the correct filters this time
         response = self.delete(
-            url, {'items': tests, 'filters': {'stock_item': 1}}, expected_code=204
+            url, {'items': tests, 'filters': {'stock_item': 1}}, expected_code=200
         )
 
         self.assertEqual(StockItemTestResult.objects.count(), n)


### PR DESCRIPTION
Changes:
 - Fix bulk delete response code (204 is NO_CONTENT but content was provided, 200 seemed more appropriate).
 - Add a schema post processing hook to:
   - Deconflict the operation id of bulk deletes from normal deletes: previously they both mapped to `..._destroy` (caused warnings on schema generation as well as ambiguous naming when generating code from the schema), now they're `..._destroy` and `..._bulk_destroy`)
   - Define a request body for the bulk delete operation, as well as a schema definition for it to use.

The drf-spectacular project does not populate requestBody on DELETE operations (see https://github.com/tfranzel/drf-spectacular/issues/809). Apparently this is a discouraged pattern, but it's what InvenTree uses and I'm of the opinion that the schema should reflect the actual API. Even annotating an `@extend_schema` on a DELETE operation is ignored on schema generation, so to work around that I added a post-processing hook to do it manually.

The added bonus of the post-processing hook is that the paths for bulk and individual deletes are distinct, so I could change the operation id mapping to make the schema operations reflect their intent.

If there's another way to do this mapping I'm open to suggestions. The only other way I found was to override the bulk delete function in each api class that extended it just so I could annotate a custom operation id to it, and that felt like too much bloat just to feed the schema generator.

Related to #9045