### PR TITLE
Notify subscribed users

### DIFF
--- a/src/backend/InvenTree/InvenTree/helpers_model.py
+++ b/src/backend/InvenTree/InvenTree/helpers_model.py
@@ -265,6 +265,7 @@ def notify_responsible(
     sender,
     content: NotificationBody = InvenTreeNotificationBodies.NewOrder,
     exclude=None,
+    extra_users: Optional[list] = None,
 ):
     """Notify all responsible parties of a change in an instance.
 
@@ -276,15 +277,19 @@ def notify_responsible(
         sender: Sender model reference
         content (NotificationBody, optional): _description_. Defaults to InvenTreeNotificationBodies.NewOrder.
         exclude (User, optional): User instance that should be excluded. Defaults to None.
+        extra_users (list, optional): List of extra users to notify. Defaults to None.
     """
     import InvenTree.ready
 
     if InvenTree.ready.isImportingData() or InvenTree.ready.isRunningMigrations():
         return
 
-    notify_users(
-        [instance.responsible], instance, sender, content=content, exclude=exclude
-    )
+    users = [instance.responsible]
+
+    if extra_users:
+        users.extend(extra_users)
+
+    notify_users(users, instance, sender, content=content, exclude=exclude)
 
 
 def notify_users(

--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -817,6 +817,7 @@ class Build(
             Build,
             exclude=self.issued_by,
             content=InvenTreeNotificationBodies.OrderCanceled,
+            extra_users=self.part.get_subscribers(),
         )
 
         trigger_event(BuildEvents.CANCELLED, id=self.pk)
@@ -1470,7 +1471,10 @@ def after_save_build(sender, instance: Build, created: bool, **kwargs):
 
             # Notify the responsible users that the build order has been created
             InvenTree.helpers_model.notify_responsible(
-                instance, sender, exclude=instance.issued_by
+                instance,
+                sender,
+                exclude=instance.issued_by,
+                extra_users=instance.part.get_subscribers(),
             )
 
         else:

--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -628,8 +628,13 @@ class Build(
         self.allocated_stock.delete()
 
     @transaction.atomic
-    def complete_build(self, user, trim_allocated_stock=False):
-        """Mark this build as complete."""
+    def complete_build(self, user: User, trim_allocated_stock: bool = False):
+        """Mark this build as complete.
+
+        Arguments:
+            user: The user who is completing the build
+            trim_allocated_stock: If True, trim any allocated stock
+        """
         return self.handle_transition(
             self.status,
             BuildStatus.COMPLETE.value,
@@ -680,6 +685,9 @@ class Build(
 
         # Notify users that this build has been completed
         targets = [self.issued_by, self.responsible]
+
+        # Also inform anyone subscribed to the assembly part
+        targets.extend(self.part.get_subscribers())
 
         # Notify those users interested in the parent build
         if self.parent:

--- a/src/backend/InvenTree/build/tasks.py
+++ b/src/backend/InvenTree/build/tasks.py
@@ -262,6 +262,8 @@ def notify_overdue_build_order(bo: build_models.Build):
     if bo.responsible:
         targets.append(bo.responsible)
 
+    targets.extend(bo.part.get_subscribers())
+
     name = _('Overdue Build Order')
 
     context = {

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -2640,7 +2640,7 @@ class ReturnOrder(TotalPriceMixin, Order):
             ReturnOrder,
             exclude=user,
             content=InvenTreeNotificationBodies.ReturnOrderItemsReceived,
-            extra_users=line.part.get_subscribers(),
+            extra_users=line.item.part.get_subscribers(),
         )
 
 

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -580,15 +580,15 @@ class PurchaseOrder(TotalPriceMixin, Order):
 
         By this, we mean users to are interested in any of the parts associated with this order.
         """
-        subsribed_users = set()
+        subscribed_users = set()
 
         for line in self.lines.all():
             if line.part and line.part.part:
                 # Add the part to the list of subscribed users
                 for user in line.part.part.get_subscribers():
-                    subsribed_users.add(user)
+                    subscribed_users.add(user)
 
-        return list(subsribed_users)
+        return list(subscribed_users)
 
     def __str__(self):
         """Render a string representation of this PurchaseOrder."""
@@ -2385,7 +2385,7 @@ class ReturnOrder(TotalPriceMixin, Order):
         subscribed_users = set()
 
         for line in self.lines.all():
-            if line.part:
+            if line.item and line.item.part:
                 # Add the part to the list of subscribed users
                 for user in line.item.part.get_subscribers():
                     subscribed_users.add(user)

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -575,6 +575,21 @@ class PurchaseOrder(TotalPriceMixin, Order):
         """Return the associated barcode model type code for this model."""
         return 'PO'
 
+    def subscribed_users(self) -> list[User]:
+        """Return a list of users subscribed to this PurchaseOrder.
+
+        By this, we mean users to are interested in any of the parts associated with this order.
+        """
+        subsribed_users = set()
+
+        for line in self.lines.all():
+            if line.part and line.part.part:
+                # Add the part to the list of subscribed users
+                for user in line.part.part.get_subscribers():
+                    subsribed_users.add(user)
+
+        return list(subsribed_users)
+
     def __str__(self):
         """Render a string representation of this PurchaseOrder."""
         return f'{self.reference} - {self.supplier.name if self.supplier else _("deleted")}'
@@ -747,6 +762,7 @@ class PurchaseOrder(TotalPriceMixin, Order):
                 PurchaseOrder,
                 exclude=self.created_by,
                 content=InvenTreeNotificationBodies.NewOrder,
+                extra_users=self.subscribed_users(),
             )
 
     def _action_complete(self, *args, **kwargs):
@@ -841,6 +857,7 @@ class PurchaseOrder(TotalPriceMixin, Order):
                 PurchaseOrder,
                 exclude=self.created_by,
                 content=InvenTreeNotificationBodies.OrderCanceled,
+                extra_users=self.subscribed_users(),
             )
 
     @property
@@ -1045,6 +1062,7 @@ class PurchaseOrder(TotalPriceMixin, Order):
             PurchaseOrder,
             exclude=user,
             content=InvenTreeNotificationBodies.ItemsReceived,
+            extra_users=line.part.part.get_subscribers(),
         )
 
 
@@ -1095,6 +1113,21 @@ class SalesOrder(TotalPriceMixin, Order):
     def barcode_model_type_code(cls):
         """Return the associated barcode model type code for this model."""
         return 'SO'
+
+    def subscribed_users(self) -> list[User]:
+        """Return a list of users subscribed to this SalesOrder.
+
+        By this, we mean users to are interested in any of the parts associated with this order.
+        """
+        subscribed_users = set()
+
+        for line in self.lines.all():
+            if line.part:
+                # Add the part to the list of subscribed users
+                for user in line.part.part.get_subscribers():
+                    subscribed_users.add(user)
+
+        return list(subscribed_users)
 
     def __str__(self):
         """Render a string representation of this SalesOrder."""
@@ -1248,6 +1281,15 @@ class SalesOrder(TotalPriceMixin, Order):
 
             trigger_event(SalesOrderEvents.ISSUED, id=self.pk)
 
+            # Notify users that the order has been placed
+            notify_responsible(
+                self,
+                SalesOrder,
+                exclude=self.created_by,
+                content=InvenTreeNotificationBodies.NewOrder,
+                extra_users=self.subscribed_users(),
+            )
+
     @property
     def can_hold(self):
         """Return True if this order can be placed on hold."""
@@ -1325,6 +1367,7 @@ class SalesOrder(TotalPriceMixin, Order):
             SalesOrder,
             exclude=self.created_by,
             content=InvenTreeNotificationBodies.OrderCanceled,
+            extra_users=self.subscribed_users(),
         )
 
         return True
@@ -1465,9 +1508,6 @@ def after_save_sales_order(sender, instance: SalesOrder, created: bool, **kwargs
         if get_global_setting('SALESORDER_DEFAULT_SHIPMENT'):
             # Create default shipment
             SalesOrderShipment.objects.create(order=instance, reference='1')
-
-        # Notify the responsible users that the sales order has been created
-        notify_responsible(instance, sender, exclude=instance.created_by)
 
 
 class OrderLineItem(InvenTree.models.InvenTreeMetadataModel):
@@ -2337,6 +2377,21 @@ class ReturnOrder(TotalPriceMixin, Order):
         """Return the associated barcode model type code for this model."""
         return 'RO'
 
+    def subscribed_users(self) -> list[User]:
+        """Return a list of users subscribed to this ReturnOrder.
+
+        By this, we mean users to are interested in any of the parts associated with this order.
+        """
+        subscribed_users = set()
+
+        for line in self.lines.all():
+            if line.part:
+                # Add the part to the list of subscribed users
+                for user in line.part.part.get_subscribers():
+                    subscribed_users.add(user)
+
+        return list(subscribed_users)
+
     def __str__(self):
         """Render a string representation of this ReturnOrder."""
         return f'{self.reference} - {self.customer.name if self.customer else _("no customer")}'
@@ -2439,6 +2494,7 @@ class ReturnOrder(TotalPriceMixin, Order):
                 ReturnOrder,
                 exclude=self.created_by,
                 content=InvenTreeNotificationBodies.OrderCanceled,
+                extra_users=self.subscribed_users(),
             )
 
     def _action_complete(self, *args, **kwargs):
@@ -2470,6 +2526,15 @@ class ReturnOrder(TotalPriceMixin, Order):
             self.save()
 
             trigger_event(ReturnOrderEvents.ISSUED, id=self.pk)
+
+            # Notify users that the order has been placed
+            notify_responsible(
+                self,
+                ReturnOrder,
+                exclude=self.created_by,
+                content=InvenTreeNotificationBodies.NewOrder,
+                extra_users=self.subscribed_users(),
+            )
 
     @transaction.atomic
     def hold_order(self):
@@ -2575,6 +2640,7 @@ class ReturnOrder(TotalPriceMixin, Order):
             ReturnOrder,
             exclude=user,
             content=InvenTreeNotificationBodies.ReturnOrderItemsReceived,
+            extra_users=line.part.get_subscribers(),
         )
 
 

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1124,7 +1124,7 @@ class SalesOrder(TotalPriceMixin, Order):
         for line in self.lines.all():
             if line.part:
                 # Add the part to the list of subscribed users
-                for user in line.part.part.get_subscribers():
+                for user in line.part.get_subscribers():
                     subscribed_users.add(user)
 
         return list(subscribed_users)
@@ -2387,7 +2387,7 @@ class ReturnOrder(TotalPriceMixin, Order):
         for line in self.lines.all():
             if line.part:
                 # Add the part to the list of subscribed users
-                for user in line.part.part.get_subscribers():
+                for user in line.item.part.get_subscribers():
                     subscribed_users.add(user)
 
         return list(subscribed_users)

--- a/src/backend/InvenTree/order/test_sales_order.py
+++ b/src/backend/InvenTree/order/test_sales_order.py
@@ -333,17 +333,19 @@ class SalesOrderTest(TestCase):
         self.assertEqual(len(messages), 1)
 
     def test_new_so_notification(self):
-        """Test that a notification is sent when a new SalesOrder is created.
+        """Test that a notification is sent when a new SalesOrder is issued.
 
         - The responsible user should receive a notification
         - The creating user should *not* receive a notification
         """
-        SalesOrder.objects.create(
+        so = SalesOrder.objects.create(
             customer=self.customer,
             reference='1234567',
             created_by=get_user_model().objects.get(pk=3),
             responsible=Owner.create(obj=Group.objects.get(pk=3)),
         )
+
+        so.issue_order()
 
         messages = NotificationMessage.objects.filter(category='order.new_salesorder')
 

--- a/src/backend/InvenTree/part/models.py
+++ b/src/backend/InvenTree/part/models.py
@@ -286,11 +286,14 @@ class PartCategory(InvenTree.models.InvenTreeTree):
 
         return prefetch.filter(category=self.id)
 
-    def get_subscribers(self, include_parents: bool = True):
+    def get_subscribers(self, include_parents: bool = True) -> list[User]:
         """Return a list of users who subscribe to this PartCategory.
 
         Arguments:
             include_parents (bool): If True, include users who subscribe to parent categories.
+
+        Returns:
+            list[User]: List of users who subscribe to this category.
         """
         subscribers = set()
 
@@ -1435,12 +1438,15 @@ class Part(
 
     def get_subscribers(
         self, include_variants: bool = True, include_categories: bool = True
-    ):
+    ) -> list[User]:
         """Return a list of users who are 'subscribed' to this part.
 
         Arguments:
             include_variants: If True, include users who are subscribed to a variant part
             include_categories: If True, include users who are subscribed to the category
+
+        Returns:
+            list[User]: A list of users who are subscribed to this part
 
         A user may 'subscribe' to this part in the following ways:
 

--- a/src/backend/InvenTree/part/models.py
+++ b/src/backend/InvenTree/part/models.py
@@ -286,8 +286,12 @@ class PartCategory(InvenTree.models.InvenTreeTree):
 
         return prefetch.filter(category=self.id)
 
-    def get_subscribers(self, include_parents=True):
-        """Return a list of users who subscribe to this PartCategory."""
+    def get_subscribers(self, include_parents: bool = True):
+        """Return a list of users who subscribe to this PartCategory.
+
+        Arguments:
+            include_parents (bool): If True, include users who subscribe to parent categories.
+        """
         subscribers = set()
 
         if include_parents:
@@ -1429,8 +1433,14 @@ class Part(
         """
         return self.total_stock - self.allocation_count() + self.on_order
 
-    def get_subscribers(self, include_variants=True, include_categories=True):
+    def get_subscribers(
+        self, include_variants: bool = True, include_categories: bool = True
+    ):
         """Return a list of users who are 'subscribed' to this part.
+
+        Arguments:
+            include_variants: If True, include users who are subscribed to a variant part
+            include_categories: If True, include users who are subscribed to the category
 
         A user may 'subscribe' to this part in the following ways:
 

--- a/src/backend/InvenTree/templates/email/overdue_return_order.html
+++ b/src/backend/InvenTree/templates/email/overdue_return_order.html
@@ -1,0 +1,24 @@
+{% extends "email/email.html" %}
+
+{% load i18n %}
+{% load inventree_extras %}
+
+{% block title %}
+{{ message }}
+{% if link %}
+<p>{% trans "Click on the following link to view this order" %}: <a href="{{ link }}">{{ link }}</a></p>
+{% endif %}
+{% endblock title %}
+
+{% block body %}
+<tr style="height: 3rem; border-bottom: 1px solid">
+    <th>{% trans "Return Order" %}</th>
+    <th>{% trans "Customer" %}</th>
+</tr>
+
+<tr style="height: 3rem">
+    <td style="text-align: center;">{{ order }}</td>
+    <td style="text-align: center;">{{ order.customer }}</td>
+</tr>
+
+{% endblock body %}


### PR DESCRIPTION
Extend the existing notifications system to include any users who are "subscribed" to a particular part.

Ensures that users who have elected to receive notifications for a given part (or category) will receive those notifications for internal and external order updates.