### PR TITLE
Report cache fix

### DIFF
--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -21,6 +21,7 @@ from django.core.validators import URLValidator
 from django.http import Http404, HttpResponseGone
 
 import structlog
+from corsheaders.defaults import default_headers as default_cors_headers
 from dotenv import load_dotenv
 
 from InvenTree.cache import get_cache_config, is_global_cache_enabled
@@ -1202,6 +1203,11 @@ CORS_ALLOWED_ORIGIN_REGEXES = get_setting(
     default_value=[],
     typecast=list,
 )
+
+# Allow extra CORS headers in DEBUG mode
+# Required for serving /static/ and /media/ files
+if DEBUG:
+    CORS_ALLOW_HEADERS = (*default_cors_headers, 'cache-control', 'pragma', 'expires')
 
 # In debug mode allow CORS requests from localhost
 # This allows connection from the frontend development server

--- a/src/frontend/src/components/editors/TemplateEditor/TemplateEditor.tsx
+++ b/src/frontend/src/components/editors/TemplateEditor/TemplateEditor.tsx
@@ -131,8 +131,17 @@ export function TemplateEditor(props: Readonly<TemplateEditorProps>) {
 
     api.get(templateUrl).then((response: any) => {
       if (response.data?.template) {
+        // Fetch the raw template file from the server
+        // Request that it is provided without any caching,
+        // to ensure that we always get the latest version
         api
-          .get(response.data.template)
+          .get(response.data.template, {
+            headers: {
+              'Cache-Control': 'no-cache',
+              Pragma: 'no-cache',
+              Expires: '0'
+            }
+          })
           .then((res) => {
             codeRef.current = res.data;
             loadCodeToEditor(res.data);


### PR DESCRIPTION
### References

- Closes https://github.com/inventree/InvenTree/issues/8259
- Closes https://github.com/inventree/InvenTree/issues/9398

Fixes issue where template files are "cached" (either by the browser, or the backend proxy) resulting in an out-of-date version being supplied to the editor.