### PR TITLE
Fix icons API endpoint

### DIFF
--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -807,7 +807,7 @@ class IconList(ListAPI):
 
     def get_queryset(self):
         """Return a list of all available icon packages."""
-        return get_icon_packs().values()
+        return list(get_icon_packs().values())
 
 
 class SelectionListList(ListCreateAPI):


### PR DESCRIPTION
Calling the /api/icons endpoint was throwing a server error:
`TypeError("'dict_values' object is not subscriptable")`

Quick 1-line fix to get the data in the format the serializer expects. No modification to the schema needed.