### PR TITLE
Schema: Batch of small fixes

### DIFF
--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -79,8 +79,8 @@ def read_license_file(path: Path) -> list:
 class LicenseViewSerializer(serializers.Serializer):
     """Serializer for license information."""
 
-    backend = serializers.CharField(help_text='Backend licenses texts', read_only=True)
-    frontend = serializers.CharField(
+    backend = serializers.ListField(help_text='Backend licenses texts', read_only=True)
+    frontend = serializers.ListField(
         help_text='Frontend licenses texts', read_only=True
     )
 

--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -122,7 +122,6 @@ class VersionViewSerializer(serializers.Serializer):
 
         doc = serializers.URLField()
         code = serializers.URLField()
-        credit = serializers.URLField()
         app = serializers.URLField()
         bug = serializers.URLField()
 
@@ -155,7 +154,6 @@ class VersionView(APIView):
             'links': {
                 'doc': InvenTree.version.inventreeDocUrl(),
                 'code': InvenTree.version.inventreeGithubUrl(),
-                'credit': InvenTree.version.inventreeCreditsUrl(),
                 'app': InvenTree.version.inventreeAppUrl(),
                 'bug': f'{InvenTree.version.inventreeGithubUrl()}issues',
             },

--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -113,7 +113,7 @@ class VersionViewSerializer(serializers.Serializer):
         api = serializers.IntegerField()
         commit_hash = serializers.CharField()
         commit_date = serializers.CharField()
-        commit_branch = serializers.CharField()
+        commit_branch = serializers.CharField(allow_null=True)
         python = serializers.CharField()
         django = serializers.CharField()
 

--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext_lazy as _
 
 import structlog
 from django_q.models import OrmQ
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import permissions, serializers
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
@@ -164,9 +164,9 @@ class VersionInformationSerializer(serializers.Serializer):
     """Serializer for a single version."""
 
     version = serializers.CharField()
-    date = serializers.CharField()
-    gh = serializers.CharField()
-    text = serializers.CharField()
+    date = serializers.DateField()
+    gh = serializers.CharField(allow_null=True)
+    text = serializers.ListField(child=serializers.CharField())
     latest = serializers.BooleanField()
 
     class Meta:
@@ -175,12 +175,21 @@ class VersionInformationSerializer(serializers.Serializer):
         fields = '__all__'
 
 
-class VersionApiSerializer(serializers.Serializer):
-    """Serializer for the version api endpoint."""
-
-    VersionInformationSerializer(many=True)
-
-
+@extend_schema(
+    parameters=[
+        OpenApiParameter(
+            name='versions',
+            type=int,
+            description='Number of versions to return.',
+            default=10,
+        ),
+        OpenApiParameter(
+            name='start_version',
+            type=int,
+            description='First version to report. Defaults to return the latest {versions} versions.',
+        ),
+    ]
+)
 class VersionTextView(ListAPI):
     """Simple JSON endpoint for InvenTree version text."""
 
@@ -188,10 +197,22 @@ class VersionTextView(ListAPI):
 
     permission_classes = [permissions.IsAdminUser]
 
-    @extend_schema(responses={200: OpenApiResponse(response=VersionApiSerializer)})
+    # Specifically disable pagination for this view
+    pagination_class = None
+
     def list(self, request, *args, **kwargs):
         """Return information about the InvenTree server."""
-        return JsonResponse(inventreeApiText())
+        versions = request.query_params.get('versions')
+        start_version = request.query_params.get('start_version')
+
+        api_kwargs = {}
+        if versions is not None:
+            api_kwargs['versions'] = int(versions)
+        if start_version is not None:
+            api_kwargs['start_version'] = int(start_version)
+
+        version_data = inventreeApiText(**api_kwargs)
+        return JsonResponse(list(version_data.values()), safe=False)
 
 
 class InfoApiSerializer(serializers.Serializer):

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -38,7 +38,7 @@ v330 -> 2025-03-31 : https://github.com/inventree/InvenTree/pull/9420
 v329 -> 2025-03-30 : https://github.com/inventree/InvenTree/pull/9399
     - Convert url path regex-specified PKs to int
 
-v228 -> 2025-03-29 : https://github.com/inventree/InvenTree/pull/9407
+v328 -> 2025-03-29 : https://github.com/inventree/InvenTree/pull/9407
     - Updates schema to include paging arguments
 
 v327 -> 2025-03-20 : https://github.com/inventree/InvenTree/pull/9339
@@ -256,29 +256,29 @@ v269 -> 2024-10-16 : https://github.com/inventree/InvenTree/pull/8295
     - Adds "include_variants" filter to the PurchaseOrderLineItem API endpoint
     - Adds "include_variants" filter to the ReturnOrder API endpoint
 
-268 - 2024-10-11 : https://github.com/inventree/InvenTree/pull/8274
+v268 -> 2024-10-11 : https://github.com/inventree/InvenTree/pull/8274
     - Adds "in_stock" attribute to the StockItem serializer
 
-267 - 2024-10-8 : https://github.com/inventree/InvenTree/pull/8250
+v267 -> 2024-10-8 : https://github.com/inventree/InvenTree/pull/8250
     - Remove "allocations" field from the SalesOrderShipment API endpoint(s)
     - Add "allocated_items" field to the SalesOrderShipment API endpoint(s)
 
-266 - 2024-10-07 : https://github.com/inventree/InvenTree/pull/8249
+v266 -> 2024-10-07 : https://github.com/inventree/InvenTree/pull/8249
     - Tweak SalesOrderShipment API for more efficient data retrieval
 
-265 - 2024-10-07 : https://github.com/inventree/InvenTree/pull/8228
+v265 -> 2024-10-07 : https://github.com/inventree/InvenTree/pull/8228
     - Adds API endpoint for providing custom admin integration details for plugins
 
-264 - 2024-10-03 : https://github.com/inventree/InvenTree/pull/8231
+v264 -> 2024-10-03 : https://github.com/inventree/InvenTree/pull/8231
     - Adds Sales Order Shipment attachment model type
 
-263 - 2024-09-30 : https://github.com/inventree/InvenTree/pull/8194
+v263 -> 2024-09-30 : https://github.com/inventree/InvenTree/pull/8194
     - Adds Sales Order Shipment report
 
-262 - 2024-09-30 : https://github.com/inventree/InvenTree/pull/8220
+v262 -> 2024-09-30 : https://github.com/inventree/InvenTree/pull/8220
     - Tweak permission requirements for uninstalling plugins via API
 
-261 - 2024-09-26 : https://github.com/inventree/InvenTree/pull/8184
+v261 -> 2024-09-26 : https://github.com/inventree/InvenTree/pull/8184
     - Fixes for BuildOrder API serializers
 
 v260 -> 2024-09-26 : https://github.com/inventree/InvenTree/pull/8190

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -8,245 +8,245 @@ INVENTREE_API_VERSION = 335
 
 INVENTREE_API_TEXT = """
 
-v335 - 2025-04-09 : https://github.com/inventree/InvenTree/pull/9476
+v335 -> 2025-04-09 : https://github.com/inventree/InvenTree/pull/9476
     - Adds "roles" detail to the Group API endpoint
     - Adds "users" detail to the Group API endpoint
     - Adds "groups" detail to the User API endpoint
 
-v334 - 2025-04-08 : https://github.com/inventree/InvenTree/pull/9453
+v334 -> 2025-04-08 : https://github.com/inventree/InvenTree/pull/9453
     - Fixes various operationId and enum collisions and help texts
 
-v333 - 2025-04-03 : https://github.com/inventree/InvenTree/pull/9452
+v333 -> 2025-04-03 : https://github.com/inventree/InvenTree/pull/9452
     - Currency string is no longer restricted to a hardcoded enum
     - Customizable status keys are no longer hardcoded enum values
 
-v332 - 2025-04-02 : https://github.com/inventree/InvenTree/pull/9393
+v332 -> 2025-04-02 : https://github.com/inventree/InvenTree/pull/9393
     - Adds 'search_notes' parameter to all searchable API endpoints
 
-v331 - 2025-04-01 : https://github.com/inventree/InvenTree/pull/9437
+v331 -> 2025-04-01 : https://github.com/inventree/InvenTree/pull/9437
     - Set correct types on various formerly-string PK fields as well permissions
     - Include metadata request and response types
 
-v330 - 2025-03-31 : https://github.com/inventree/InvenTree/pull/9420
+v330 -> 2025-03-31 : https://github.com/inventree/InvenTree/pull/9420
     - Deconflict operation id between single and bulk destroy operations
     - Add request body definition for bulk destroy operations
 
-v329 - 2025-03-30 : https://github.com/inventree/InvenTree/pull/9399
+v329 -> 2025-03-30 : https://github.com/inventree/InvenTree/pull/9399
     - Convert url path regex-specified PKs to int
 
-v228 - 2025-03-29 : https://github.com/inventree/InvenTree/pull/9407
+v228 -> 2025-03-29 : https://github.com/inventree/InvenTree/pull/9407
     - Updates schema to include paging arguments
 
-v327 - 2025-03-20 : https://github.com/inventree/InvenTree/pull/9339
+v327 -> 2025-03-20 : https://github.com/inventree/InvenTree/pull/9339
     - Adds "is_mandatory" field to the Plugin API
     - Adds ability to filter by "mandatory" status in the Plugin API
 
-v326 - 2025-03-18 : https://github.com/inventree/InvenTree/pull/9096
+v326 -> 2025-03-18 : https://github.com/inventree/InvenTree/pull/9096
     - Overhaul the data-export API functionality
     - Allow customization of data exporting via plugins
     - Consolidate LabelOutput and ReportOutput API endpoints into single DataOutput endpoint
 
-v325 - 2024-03-17 : https://github.com/inventree/InvenTree/pull/9244
+v325 -> 2024-03-17 : https://github.com/inventree/InvenTree/pull/9244
     - Adds the option for superusers to list all user tokens
     - Make list endpoints sortable, filterable and searchable
 
-v324 - 2025-03-17 : https://github.com/inventree/InvenTree/pull/9320
+v324 -> 2025-03-17 : https://github.com/inventree/InvenTree/pull/9320
     - Adds BulkUpdate support for the SalesOrderAllocation model
     - Adds BulkUpdate support for the PartCategory model
     - Adds BulkUpdate support for the StockLocation model
 
-v323 - 2025-03-17 : https://github.com/inventree/InvenTree/pull/9313
+v323 -> 2025-03-17 : https://github.com/inventree/InvenTree/pull/9313
     - Adds BulkUpdate support to the Part API endpoint
     - Remove legacy API endpoint to set part category for multiple parts
 
-v322 - 2025-03-16 : https://github.com/inventree/InvenTree/pull/8933
+v322 -> 2025-03-16 : https://github.com/inventree/InvenTree/pull/8933
     - Add min_date and max_date query filters for orders, for use in calendar views
 
-v321 - 2025-03-06 : https://github.com/inventree/InvenTree/pull/9236
+v321 -> 2025-03-06 : https://github.com/inventree/InvenTree/pull/9236
     - Adds conditionally-returned fields to the schema to match API behavior
     - Removes required flag for nullable read-only fields to match API behavior
 
-v320 - 2025-03-05 : https://github.com/inventree/InvenTree/pull/9243
+v320 -> 2025-03-05 : https://github.com/inventree/InvenTree/pull/9243
     - Link fields are now up to 2000 chars long
 
-v319 - 2025-03-04 : https://github.com/inventree/InvenTree/pull/9199
+v319 -> 2025-03-04 : https://github.com/inventree/InvenTree/pull/9199
     - Add detail API endpoint for the LabelOutput model
     - Add detail API endpoint for the ReportOutput model
 
-v318 - 2025-02-25 : https://github.com/inventree/InvenTree/pull/9116
+v318 -> 2025-02-25 : https://github.com/inventree/InvenTree/pull/9116
     - Adds user profile API endpoints
 
-v317 - 2025-02-26 : https://github.com/inventree/InvenTree/pull/9143
+v317 -> 2025-02-26 : https://github.com/inventree/InvenTree/pull/9143
     - Default 'overdue' field to False in Build serializer
     - Add allow_null to various fields in Build, Settings, Order, Part, and Stock serializers
     - Add type hints to Users model to properly type fields
 
-v316 - 2025-02-26 : https://github.com/inventree/InvenTree/pull/9185
+v316 -> 2025-02-26 : https://github.com/inventree/InvenTree/pull/9185
     - Allow 'icon' field to be nullified in the PartCategory API
     - Allow 'custom_icon' field to be nullified in the StockLocation API
 
-v315 - 2025-02-22 : https://github.com/inventree/InvenTree/pull/9150
+v315 -> 2025-02-22 : https://github.com/inventree/InvenTree/pull/9150
     - Remove outdated 'url' field from some API endpoints
 
-v314 - 2025-02-17 : https://github.com/inventree/InvenTree/pull/6293
+v314 -> 2025-02-17 : https://github.com/inventree/InvenTree/pull/6293
     - Removes a considerable amount of old auth endpoints
     - Introduces allauth-provided auth endpoints
 
-v313 - 2025-02-17 : https://github.com/inventree/InvenTree/pull/9087
+v313 -> 2025-02-17 : https://github.com/inventree/InvenTree/pull/9087
     - Adds instance id optionally to the info view endpoint
 
-v312 - 2025-02-15 : https://github.com/inventree/InvenTree/pull/9079
+v312 -> 2025-02-15 : https://github.com/inventree/InvenTree/pull/9079
     - Remove old API endpoints associated with legacy BOM import functionality
 
-v311 - 2025-02-14 : https://github.com/inventree/InvenTree/pull/9076
+v311 -> 2025-02-14 : https://github.com/inventree/InvenTree/pull/9076
     - Adds "model_filters" attribute to settings API
 
-v310 - 2025-02-14 : https://github.com/inventree/InvenTree/pull/9077
+v310 -> 2025-02-14 : https://github.com/inventree/InvenTree/pull/9077
     - Adds 'is_variant' filter to the Part list API
 
-v309 - 2025-02-02 : https://github.com/inventree/InvenTree/pull/9008
+v309 -> 2025-02-02 : https://github.com/inventree/InvenTree/pull/9008
     - Bug fixes for the "Part" serializer
     - Fixes for data import API endpoints
 
-v308 - 2025-02-01 : https://github.com/inventree/InvenTree/pull/9003
+v308 -> 2025-02-01 : https://github.com/inventree/InvenTree/pull/9003
     - Adds extra detail to the ReportOutput and LabelOutput API endpoints
     - Allows ordering of output list endpoints
 
-v307 - 2025-01-29 : https://github.com/inventree/InvenTree/pull/8969
+v307 -> 2025-01-29 : https://github.com/inventree/InvenTree/pull/8969
     - Extend Info Endpoint to include customizations
 
-v306 - 2025-01-28 : https://github.com/inventree/InvenTree/pull/8966
+v306 -> 2025-01-28 : https://github.com/inventree/InvenTree/pull/8966
     - Adds "start_date" to PurchasesOrder API
     - Adds "start_date" to SalesOrder API
     - Adds "start_date" to ReturnOrder API
     - Updated API filters
 
-v305 - 2025-01-26 : https://github.com/inventree/InvenTree/pull/8950
+v305 -> 2025-01-26 : https://github.com/inventree/InvenTree/pull/8950
     - Bug fixes for the SupplierPart API
     - Refactoring for data export via API
 
-v304 - 2025-01-22 : https://github.com/inventree/InvenTree/pull/8940
+v304 -> 2025-01-22 : https://github.com/inventree/InvenTree/pull/8940
     - Adds "category" filter to build list API
 
-v303 - 2025-01-20 : https://github.com/inventree/InvenTree/pull/8915
+v303 -> 2025-01-20 : https://github.com/inventree/InvenTree/pull/8915
     - Adds "start_date" field to Build model and API endpoints
     - Adds additional API filtering and sorting options for Build list
 
-v302 - 2025-01-18 : https://github.com/inventree/InvenTree/pull/8905
+v302 -> 2025-01-18 : https://github.com/inventree/InvenTree/pull/8905
     - Fix schema definition on the /label/print endpoint
 
-v301 - 2025-01-14 : https://github.com/inventree/InvenTree/pull/8894
+v301 -> 2025-01-14 : https://github.com/inventree/InvenTree/pull/8894
     - Remove ui preferences from the API
 
-v300 - 2025-01-13 : https://github.com/inventree/InvenTree/pull/8886
+v300 -> 2025-01-13 : https://github.com/inventree/InvenTree/pull/8886
     - Allow null value for 'expiry_date' field introduced in #8867
 
-v299 - 2025-01-10 : https://github.com/inventree/InvenTree/pull/8867
+v299 -> 2025-01-10 : https://github.com/inventree/InvenTree/pull/8867
     - Adds 'expiry_date' field to the PurchaseOrderReceive API endpoint
     - Adds 'default_expiry` field to the PartBriefSerializer, affecting API endpoints which use it
 
-v298 - 2025-01-07 : https://github.com/inventree/InvenTree/pull/8848
+v298 -> 2025-01-07 : https://github.com/inventree/InvenTree/pull/8848
     - Adds 'created_by' field to PurchaseOrder API endpoints
     - Adds 'created_by' field to SalesOrder API endpoints
     - Adds 'created_by' field to ReturnOrder API endpoints
 
-v297 - 2024-12-29 : https://github.com/inventree/InvenTree/pull/8438
+v297 -> 2024-12-29 : https://github.com/inventree/InvenTree/pull/8438
     - Adjustments to the CustomUserState API endpoints and serializers
 
-v296 - 2024-12-25 : https://github.com/inventree/InvenTree/pull/8732
+v296 -> 2024-12-25 : https://github.com/inventree/InvenTree/pull/8732
     - Adjust default "part_detail" behavior for StockItem API endpoints
 
-v295 - 2024-12-23 : https://github.com/inventree/InvenTree/pull/8746
+v295 -> 2024-12-23 : https://github.com/inventree/InvenTree/pull/8746
     - Improve API documentation for build APIs
 
-v294 - 2024-12-23 : https://github.com/inventree/InvenTree/pull/8738
+v294 -> 2024-12-23 : https://github.com/inventree/InvenTree/pull/8738
     - Extends registration API documentation
 
-v293 - 2024-12-14 : https://github.com/inventree/InvenTree/pull/8658
+v293 -> 2024-12-14 : https://github.com/inventree/InvenTree/pull/8658
     - Adds new fields to the supplier barcode API endpoints
 
-v292 - 2024-12-03 : https://github.com/inventree/InvenTree/pull/8625
+v292 -> 2024-12-03 : https://github.com/inventree/InvenTree/pull/8625
     - Add "on_order" and "in_stock" annotations to SupplierPart API
     - Enhanced filtering for the SupplierPart API
 
-v291 - 2024-11-30 : https://github.com/inventree/InvenTree/pull/8596
+v291 -> 2024-11-30 : https://github.com/inventree/InvenTree/pull/8596
     - Allow null / empty values for plugin settings
 
-v290 - 2024-11-29 : https://github.com/inventree/InvenTree/pull/8590
+v290 -> 2024-11-29 : https://github.com/inventree/InvenTree/pull/8590
     - Adds "quantity" field to ReturnOrderLineItem model and API
 
-v289 - 2024-11-27 : https://github.com/inventree/InvenTree/pull/8570
+v289 -> 2024-11-27 : https://github.com/inventree/InvenTree/pull/8570
     - Enable status change when transferring stock items
 
-v288 - 2024-11-27 : https://github.com/inventree/InvenTree/pull/8574
+v288 -> 2024-11-27 : https://github.com/inventree/InvenTree/pull/8574
     - Adds "consumed" filter to StockItem API
 
-v287 - 2024-11-27 : https://github.com/inventree/InvenTree/pull/8571
+v287 -> 2024-11-27 : https://github.com/inventree/InvenTree/pull/8571
     - Adds ability to set stock status when returning items from a customer
 
-v286 - 2024-11-26 : https://github.com/inventree/InvenTree/pull/8054
+v286 -> 2024-11-26 : https://github.com/inventree/InvenTree/pull/8054
     - Adds "SelectionList" and "SelectionListEntry" API endpoints
 
-v285 - 2024-11-25 : https://github.com/inventree/InvenTree/pull/8559
+v285 -> 2024-11-25 : https://github.com/inventree/InvenTree/pull/8559
     - Adds better description for registration endpoints
 
-v284 - 2024-11-25 : https://github.com/inventree/InvenTree/pull/8544
+v284 -> 2024-11-25 : https://github.com/inventree/InvenTree/pull/8544
     - Adds new date filters to the StockItem API
     - Adds new date filters to the BuildOrder API
     - Adds new date filters to the SalesOrder API
     - Adds new date filters to the PurchaseOrder API
     - Adds new date filters to the ReturnOrder API
 
-v283 - 2024-11-20 : https://github.com/inventree/InvenTree/pull/8524
+v283 -> 2024-11-20 : https://github.com/inventree/InvenTree/pull/8524
     - Adds "note" field to the PartRelated API endpoint
 
-v282 - 2024-11-19 : https://github.com/inventree/InvenTree/pull/8487
+v282 -> 2024-11-19 : https://github.com/inventree/InvenTree/pull/8487
     - Remove the "test statistics" API endpoints
     - This is now provided via a custom plugin
 
-v281 - 2024-11-15 : https://github.com/inventree/InvenTree/pull/8480
+v281 -> 2024-11-15 : https://github.com/inventree/InvenTree/pull/8480
     - Fixes StockHistory API data serialization
 
-v280 - 2024-11-10 : https://github.com/inventree/InvenTree/pull/8461
+v280 -> 2024-11-10 : https://github.com/inventree/InvenTree/pull/8461
     - Makes schema for API information endpoint more informing
     - Removes general not found endpoint
 
-v279 - 2024-11-09 : https://github.com/inventree/InvenTree/pull/8458
+v279 -> 2024-11-09 : https://github.com/inventree/InvenTree/pull/8458
     - Adds "order_outstanding" and "part" filters to the BuildLine API endpoint
     - Adds "order_outstanding" filter to the SalesOrderLineItem API endpoint
 
-v278 - 2024-11-07 : https://github.com/inventree/InvenTree/pull/8445
+v278 -> 2024-11-07 : https://github.com/inventree/InvenTree/pull/8445
     - Updates to the SalesOrder API endpoints
     - Add "shipment count" information to the SalesOrder API endpoints
     - Allow null value for SalesOrderAllocation.shipment field
     - Additional filtering options for allocation endpoints
 
-v277 - 2024-11-01 : https://github.com/inventree/InvenTree/pull/8278
+v277 -> 2024-11-01 : https://github.com/inventree/InvenTree/pull/8278
     - Allow build order list to be filtered by "outstanding" (alias for "active")
 
-v276 - 2024-10-31 : https://github.com/inventree/InvenTree/pull/8403
+v276 -> 2024-10-31 : https://github.com/inventree/InvenTree/pull/8403
     - Adds 'destination' field to the PurchaseOrder model and API endpoints
 
-v275 - 2024-10-31 : https://github.com/inventree/InvenTree/pull/8396
+v275 -> 2024-10-31 : https://github.com/inventree/InvenTree/pull/8396
     - Adds SKU and MPN fields to the StockItem serializer
     - Additional export options for the StockItem serializer
 
-v274 - 2024-10-29 : https://github.com/inventree/InvenTree/pull/8392
+v274 -> 2024-10-29 : https://github.com/inventree/InvenTree/pull/8392
     - Add more detailed information to NotificationEntry API serializer
 
-v273 - 2024-10-28 : https://github.com/inventree/InvenTree/pull/8376
+v273 -> 2024-10-28 : https://github.com/inventree/InvenTree/pull/8376
     - Fixes for the BuildLine API endpoint
 
-v272 - 2024-10-25 : https://github.com/inventree/InvenTree/pull/8343
+v272 -> 2024-10-25 : https://github.com/inventree/InvenTree/pull/8343
     - Adjustments to BuildLine API serializers
 
-v271 - 2024-10-22 : https://github.com/inventree/InvenTree/pull/8331
+v271 -> 2024-10-22 : https://github.com/inventree/InvenTree/pull/8331
     - Fixes for SalesOrderLineItem endpoints
 
-v270 - 2024-10-19 : https://github.com/inventree/InvenTree/pull/8307
+v270 -> 2024-10-19 : https://github.com/inventree/InvenTree/pull/8307
     - Adds missing date fields from order API endpoint(s)
 
-v269 - 2024-10-16 : https://github.com/inventree/InvenTree/pull/8295
+v269 -> 2024-10-16 : https://github.com/inventree/InvenTree/pull/8295
     - Adds "include_variants" filter to the BuildOrder API endpoint
     - Adds "include_variants" filter to the SalesOrder API endpoint
     - Adds "include_variants" filter to the PurchaseOrderLineItem API endpoint
@@ -277,321 +277,321 @@ v269 - 2024-10-16 : https://github.com/inventree/InvenTree/pull/8295
 261 - 2024-09-26 : https://github.com/inventree/InvenTree/pull/8184
     - Fixes for BuildOrder API serializers
 
-v260 - 2024-09-26 : https://github.com/inventree/InvenTree/pull/8190
+v260 -> 2024-09-26 : https://github.com/inventree/InvenTree/pull/8190
     - Adds facility for server-side context data to be passed to client-side plugins
 
-v259 - 2024-09-20 : https://github.com/inventree/InvenTree/pull/8137
+v259 -> 2024-09-20 : https://github.com/inventree/InvenTree/pull/8137
     - Implements new API endpoint for enabling custom UI features via plugins
 
-v258 - 2024-09-24 : https://github.com/inventree/InvenTree/pull/8163
+v258 -> 2024-09-24 : https://github.com/inventree/InvenTree/pull/8163
     - Enhances the existing PartScheduling API endpoint
     - Adds a formal DRF serializer to the endpoint
 
-v257 - 2024-09-22 : https://github.com/inventree/InvenTree/pull/8150
+v257 -> 2024-09-22 : https://github.com/inventree/InvenTree/pull/8150
     - Adds API endpoint for reporting barcode scan history
 
-v256 - 2024-09-19 : https://github.com/inventree/InvenTree/pull/7704
+v256 -> 2024-09-19 : https://github.com/inventree/InvenTree/pull/7704
     - Adjustments for "stocktake" (stock history) API endpoints
 
-v255 - 2024-09-19 : https://github.com/inventree/InvenTree/pull/8145
+v255 -> 2024-09-19 : https://github.com/inventree/InvenTree/pull/8145
     - Enables copying line items when duplicating an order
 
-v254 - 2024-09-14 : https://github.com/inventree/InvenTree/pull/7470
+v254 -> 2024-09-14 : https://github.com/inventree/InvenTree/pull/7470
     - Implements new API endpoints for enabling custom UI functionality via plugins
 
-v253 - 2024-09-14 : https://github.com/inventree/InvenTree/pull/7944
+v253 -> 2024-09-14 : https://github.com/inventree/InvenTree/pull/7944
     - Adjustments for user API endpoints
 
-v252 - 2024-09-13 : https://github.com/inventree/InvenTree/pull/8040
+v252 -> 2024-09-13 : https://github.com/inventree/InvenTree/pull/8040
     - Add endpoint for listing all known units
 
-v251 - 2024-09-06 : https://github.com/inventree/InvenTree/pull/8018
+v251 -> 2024-09-06 : https://github.com/inventree/InvenTree/pull/8018
     - Adds "attach_to_model" field to the ReportTemplate model
 
-v250 - 2024-09-04 : https://github.com/inventree/InvenTree/pull/8069
+v250 -> 2024-09-04 : https://github.com/inventree/InvenTree/pull/8069
     - Fixes 'revision' field definition in Part serializer
 
-v249 - 2024-08-23 : https://github.com/inventree/InvenTree/pull/7978
+v249 -> 2024-08-23 : https://github.com/inventree/InvenTree/pull/7978
     - Sort status enums
 
-v248 - 2024-08-23 : https://github.com/inventree/InvenTree/pull/7965
+v248 -> 2024-08-23 : https://github.com/inventree/InvenTree/pull/7965
     - Small adjustments to labels for new custom status fields
 
-v247 - 2024-08-22 : https://github.com/inventree/InvenTree/pull/7956
+v247 -> 2024-08-22 : https://github.com/inventree/InvenTree/pull/7956
     - Adjust "attachment" field on StockItemTestResult serializer
     - Allow null values for attachment
 
-v246 - 2024-08-21 : https://github.com/inventree/InvenTree/pull/7862
+v246 -> 2024-08-21 : https://github.com/inventree/InvenTree/pull/7862
     - Adds custom status fields to various serializers
     - Adds endpoints to admin custom status fields
 
-v245 - 2024-08-21 : https://github.com/inventree/InvenTree/pull/7520
+v245 -> 2024-08-21 : https://github.com/inventree/InvenTree/pull/7520
     - Documented pagination fields (no functional changes)
 
-v244 - 2024-08-21 : https://github.com/inventree/InvenTree/pull/7941
+v244 -> 2024-08-21 : https://github.com/inventree/InvenTree/pull/7941
     - Adds "create_child_builds" field to the Build API
     - Write-only field to create child builds from the API
     - Only available when creating a new build order
 
-v243 - 2024-08-21 : https://github.com/inventree/InvenTree/pull/7940
+v243 -> 2024-08-21 : https://github.com/inventree/InvenTree/pull/7940
     - Expose "ancestor" filter to the BuildOrder API
 
-v242 - 2024-08-20 : https://github.com/inventree/InvenTree/pull/7932
+v242 -> 2024-08-20 : https://github.com/inventree/InvenTree/pull/7932
     - Adds "level" attribute to BuildOrder serializer
     - Allow ordering of BuildOrder API by "level" attribute
     - Allow "parent" filter for BuildOrder API to have "cascade=True" option
 
-v241 - 2024-08-18 : https://github.com/inventree/InvenTree/pull/7906
+v241 -> 2024-08-18 : https://github.com/inventree/InvenTree/pull/7906
     - Adjusts required fields for the MeUserDetail endpoint
 
-v240 - 2024-08-16 : https://github.com/inventree/InvenTree/pull/7900
+v240 -> 2024-08-16 : https://github.com/inventree/InvenTree/pull/7900
     - Adjust "issued_by" filter for the BuildOrder list endpoint
     - Adjust "assigned_to" filter for the BuildOrder list endpoint
 
-v239 - 2024-08-15 : https://github.com/inventree/InvenTree/pull/7888
+v239 -> 2024-08-15 : https://github.com/inventree/InvenTree/pull/7888
     - Adds "testable" field to the Part model
     - Adds associated filters to various API endpoints
 
-v238 - 2024-08-14 : https://github.com/inventree/InvenTree/pull/7874
+v238 -> 2024-08-14 : https://github.com/inventree/InvenTree/pull/7874
     - Add "assembly" filter to BuildLine API endpoint
 
-v237 - 2024-08-13 : https://github.com/inventree/InvenTree/pull/7863
+v237 -> 2024-08-13 : https://github.com/inventree/InvenTree/pull/7863
     - Reimplement "bulk delete" operation for Attachment model
     - Fix permission checks for Attachment API endpoints
 
-v236 - 2024-08-10 : https://github.com/inventree/InvenTree/pull/7844
+v236 -> 2024-08-10 : https://github.com/inventree/InvenTree/pull/7844
     - Adds "supplier_name" to the PurchaseOrder API serializer
 
-v235 - 2024-08-08 : https://github.com/inventree/InvenTree/pull/7837
+v235 -> 2024-08-08 : https://github.com/inventree/InvenTree/pull/7837
     - Adds "on_order" quantity to SalesOrderLineItem serializer
     - Adds "building" quantity to SalesOrderLineItem serializer
 
-v234 - 2024-08-08 : https://github.com/inventree/InvenTree/pull/7829
+v234 -> 2024-08-08 : https://github.com/inventree/InvenTree/pull/7829
     - Fixes bug in the plugin metadata endpoint
 
-v233 - 2024-08-04 : https://github.com/inventree/InvenTree/pull/7807
+v233 -> 2024-08-04 : https://github.com/inventree/InvenTree/pull/7807
     - Adds new endpoints for managing state of build orders
     - Adds new endpoints for managing state of purchase orders
     - Adds new endpoints for managing state of sales orders
     - Adds new endpoints for managing state of return orders
 
-v232 - 2024-08-03 : https://github.com/inventree/InvenTree/pull/7793
+v232 -> 2024-08-03 : https://github.com/inventree/InvenTree/pull/7793
     - Allow ordering of SalesOrderShipment API by 'shipment_date' and 'delivery_date'
 
-v231 - 2024-08-03 : https://github.com/inventree/InvenTree/pull/7794
+v231 -> 2024-08-03 : https://github.com/inventree/InvenTree/pull/7794
     - Optimize BuildItem and BuildLine serializers to improve API efficiency
 
-v230 - 2024-05-05 : https://github.com/inventree/InvenTree/pull/7164
+v230 -> 2024-05-05 : https://github.com/inventree/InvenTree/pull/7164
     - Adds test statistics endpoint
 
-v229 - 2024-07-31 : https://github.com/inventree/InvenTree/pull/7775
+v229 -> 2024-07-31 : https://github.com/inventree/InvenTree/pull/7775
     - Add extra exportable fields to the BomItem serializer
 
-v228 - 2024-07-18 : https://github.com/inventree/InvenTree/pull/7684
+v228 -> 2024-07-18 : https://github.com/inventree/InvenTree/pull/7684
     - Adds "icon" field to the PartCategory.path and StockLocation.path API
     - Adds icon packages API endpoint
 
-v227 - 2024-07-19 : https://github.com/inventree/InvenTree/pull/7693/
+v227 -> 2024-07-19 : https://github.com/inventree/InvenTree/pull/7693/
     - Adds endpoints to list and revoke the tokens issued to the current user
 
-v226 - 2024-07-15 : https://github.com/inventree/InvenTree/pull/7648
+v226 -> 2024-07-15 : https://github.com/inventree/InvenTree/pull/7648
     - Adds barcode generation API endpoint
 
-v225 - 2024-07-17 : https://github.com/inventree/InvenTree/pull/7671
+v225 -> 2024-07-17 : https://github.com/inventree/InvenTree/pull/7671
     - Adds "filters" field to DataImportSession API
 
-v224 - 2024-07-14 : https://github.com/inventree/InvenTree/pull/7667
+v224 -> 2024-07-14 : https://github.com/inventree/InvenTree/pull/7667
     - Add notes field to ManufacturerPart and SupplierPart API endpoints
 
-v223 - 2024-07-14 : https://github.com/inventree/InvenTree/pull/7649
+v223 -> 2024-07-14 : https://github.com/inventree/InvenTree/pull/7649
     - Allow adjustment of "packaging" field when receiving items against a purchase order
 
-v222 - 2024-07-14 : https://github.com/inventree/InvenTree/pull/7635
+v222 -> 2024-07-14 : https://github.com/inventree/InvenTree/pull/7635
     - Adjust the BomItem API endpoint to improve data import process
 
-v221 - 2024-07-13 : https://github.com/inventree/InvenTree/pull/7636
+v221 -> 2024-07-13 : https://github.com/inventree/InvenTree/pull/7636
     - Adds missing fields from StockItemBriefSerializer
     - Adds missing fields from PartBriefSerializer
     - Adds extra exportable fields to BuildItemSerializer
 
-v220 - 2024-07-11 : https://github.com/inventree/InvenTree/pull/7585
+v220 -> 2024-07-11 : https://github.com/inventree/InvenTree/pull/7585
     - Adds "revision_of" field to Part serializer
     - Adds new API filters for "revision" status
 
-v219 - 2024-07-11 : https://github.com/inventree/InvenTree/pull/7611
+v219 -> 2024-07-11 : https://github.com/inventree/InvenTree/pull/7611
     - Adds new fields to the BuildItem API endpoints
     - Adds new ordering / filtering options to the BuildItem API endpoints
 
-v218 - 2024-07-11 : https://github.com/inventree/InvenTree/pull/7619
+v218 -> 2024-07-11 : https://github.com/inventree/InvenTree/pull/7619
     - Adds "can_build" field to the BomItem API
 
-v217 - 2024-07-09 : https://github.com/inventree/InvenTree/pull/7599
+v217 -> 2024-07-09 : https://github.com/inventree/InvenTree/pull/7599
     - Fixes bug in "project_code" field for order API endpoints
 
-v216 - 2024-07-08 : https://github.com/inventree/InvenTree/pull/7595
+v216 -> 2024-07-08 : https://github.com/inventree/InvenTree/pull/7595
     - Moves API endpoint for contenttype lookup by model name
 
-v215 - 2024-07-09 : https://github.com/inventree/InvenTree/pull/7591
+v215 -> 2024-07-09 : https://github.com/inventree/InvenTree/pull/7591
     - Adds additional fields to the BuildLine serializer
 
-v214 - 2024-07-08 : https://github.com/inventree/InvenTree/pull/7587
+v214 -> 2024-07-08 : https://github.com/inventree/InvenTree/pull/7587
     - Adds "default_location_detail" field to the Part API
 
-v213 - 2024-07-06 : https://github.com/inventree/InvenTree/pull/7527
+v213 -> 2024-07-06 : https://github.com/inventree/InvenTree/pull/7527
     - Adds 'locked' field to Part API
 
-v212 - 2024-07-06 : https://github.com/inventree/InvenTree/pull/7562
+v212 -> 2024-07-06 : https://github.com/inventree/InvenTree/pull/7562
     - Makes API generation more robust (no functional changes)
 
-v211 - 2024-06-26 : https://github.com/inventree/InvenTree/pull/6911
+v211 -> 2024-06-26 : https://github.com/inventree/InvenTree/pull/6911
     - Adds API endpoints for managing data import and export
 
-v210 - 2024-06-26 : https://github.com/inventree/InvenTree/pull/7518
+v210 -> 2024-06-26 : https://github.com/inventree/InvenTree/pull/7518
     - Adds translatable text to User API fields
 
-v209 - 2024-06-26 : https://github.com/inventree/InvenTree/pull/7514
+v209 -> 2024-06-26 : https://github.com/inventree/InvenTree/pull/7514
     - Add "top_level" filter to PartCategory API endpoint
     - Add "top_level" filter to StockLocation API endpoint
 
-v208 - 2024-06-19 : https://github.com/inventree/InvenTree/pull/7479
+v208 -> 2024-06-19 : https://github.com/inventree/InvenTree/pull/7479
     - Adds documentation for the user roles API endpoint (no functional changes)
 
-v207 - 2024-06-09 : https://github.com/inventree/InvenTree/pull/7420
+v207 -> 2024-06-09 : https://github.com/inventree/InvenTree/pull/7420
     - Moves all "Attachment" models into a single table
     - All "Attachment" operations are now performed at /api/attachment/
     - Add permissions information to /api/user/roles/ endpoint
 
-v206 - 2024-06-08 : https://github.com/inventree/InvenTree/pull/7417
+v206 -> 2024-06-08 : https://github.com/inventree/InvenTree/pull/7417
     - Adds "choices" field to the PartTestTemplate model
 
-v205 - 2024-06-03 : https://github.com/inventree/InvenTree/pull/7284
+v205 -> 2024-06-03 : https://github.com/inventree/InvenTree/pull/7284
     - Added model_type and model_id fields to the "NotesImage" serializer
 
-v204 - 2024-06-03 : https://github.com/inventree/InvenTree/pull/7393
+v204 -> 2024-06-03 : https://github.com/inventree/InvenTree/pull/7393
     - Fixes previous API update which resulted in inconsistent ordering of currency codes
 
-v203 - 2024-06-03 : https://github.com/inventree/InvenTree/pull/7390
+v203 -> 2024-06-03 : https://github.com/inventree/InvenTree/pull/7390
     - Currency codes are now configurable as a run-time setting
 
-v202 - 2024-05-27 : https://github.com/inventree/InvenTree/pull/7343
+v202 -> 2024-05-27 : https://github.com/inventree/InvenTree/pull/7343
     - Adjust "required" attribute of Part.category field to be optional
 
-v201 - 2024-05-21 : https://github.com/inventree/InvenTree/pull/7074
+v201 -> 2024-05-21 : https://github.com/inventree/InvenTree/pull/7074
     - Major refactor of the report template / report printing interface
     - This is a *breaking change* to the report template API
 
-v200 - 2024-05-20 : https://github.com/inventree/InvenTree/pull/7000
+v200 -> 2024-05-20 : https://github.com/inventree/InvenTree/pull/7000
     - Adds API endpoint for generating custom batch codes
     - Adds API endpoint for generating custom serial numbers
 
-v199 - 2024-05-20 : https://github.com/inventree/InvenTree/pull/7264
+v199 -> 2024-05-20 : https://github.com/inventree/InvenTree/pull/7264
     - Expose "bom_valid" filter for the Part API
     - Expose "starred" filter for the Part API
 
-v198 - 2024-05-19 : https://github.com/inventree/InvenTree/pull/7258
+v198 -> 2024-05-19 : https://github.com/inventree/InvenTree/pull/7258
     - Fixed lookup field conflicts in the plugins API
 
-v197 - 2024-05-14 : https://github.com/inventree/InvenTree/pull/7224
+v197 -> 2024-05-14 : https://github.com/inventree/InvenTree/pull/7224
     - Refactor the plugin API endpoints to use the plugin "key" for lookup, rather than the PK value
 
-v196 - 2024-05-05 : https://github.com/inventree/InvenTree/pull/7160
+v196 -> 2024-05-05 : https://github.com/inventree/InvenTree/pull/7160
     - Adds "location" field to BuildOutputComplete API endpoint
 
-v195 - 2024-05-03 : https://github.com/inventree/InvenTree/pull/7153
+v195 -> 2024-05-03 : https://github.com/inventree/InvenTree/pull/7153
     - Fixes bug in BuildOrderCancel API endpoint
 
-v194 - 2024-05-01 : https://github.com/inventree/InvenTree/pull/7147
+v194 -> 2024-05-01 : https://github.com/inventree/InvenTree/pull/7147
     -  Adds field description to the currency_exchange_retrieve API call
 
-v193 - 2024-04-30 : https://github.com/inventree/InvenTree/pull/7144
+v193 -> 2024-04-30 : https://github.com/inventree/InvenTree/pull/7144
     - Adds "assigned_to" filter to PurchaseOrder / SalesOrder / ReturnOrder API endpoints
 
-v192 - 2024-04-23 : https://github.com/inventree/InvenTree/pull/7106
+v192 -> 2024-04-23 : https://github.com/inventree/InvenTree/pull/7106
     - Adds 'trackable' ordering option to BuildLineLabel API endpoint
 
-v191 - 2024-04-22 : https://github.com/inventree/InvenTree/pull/7079
+v191 -> 2024-04-22 : https://github.com/inventree/InvenTree/pull/7079
     - Adds API endpoints for Contenttype model
 
-v190 - 2024-04-19 : https://github.com/inventree/InvenTree/pull/7024
+v190 -> 2024-04-19 : https://github.com/inventree/InvenTree/pull/7024
     - Adds "active" field to the Company API endpoints
     - Allow company list to be filtered by "active" status
 
-v189 - 2024-04-19 : https://github.com/inventree/InvenTree/pull/7066
+v189 -> 2024-04-19 : https://github.com/inventree/InvenTree/pull/7066
     - Adds "currency" field to CompanyBriefSerializer class
 
-v188 - 2024-04-16 : https://github.com/inventree/InvenTree/pull/6970
+v188 -> 2024-04-16 : https://github.com/inventree/InvenTree/pull/6970
     - Adds session authentication support for the API
     - Improvements for login / logout endpoints for better support of React web interface
 
-v187 - 2024-04-10 : https://github.com/inventree/InvenTree/pull/6985
+v187 -> 2024-04-10 : https://github.com/inventree/InvenTree/pull/6985
     - Allow Part list endpoint to be sorted by pricing_min and pricing_max values
     - Allow BomItem list endpoint to be sorted by pricing_min and pricing_max values
     - Allow InternalPrice and SalePrice endpoints to be sorted by quantity
     - Adds total pricing values to BomItem serializer
 
-v186 - 2024-03-26 : https://github.com/inventree/InvenTree/pull/6855
+v186 -> 2024-03-26 : https://github.com/inventree/InvenTree/pull/6855
     - Adds license information to the API
 
-v185 - 2024-03-24 : https://github.com/inventree/InvenTree/pull/6836
+v185 -> 2024-03-24 : https://github.com/inventree/InvenTree/pull/6836
     - Remove /plugin/activate endpoint
     - Update docstrings and typing for various API endpoints (no functional changes)
 
-v184 - 2024-03-17 : https://github.com/inventree/InvenTree/pull/10464
+v184 -> 2024-03-17 : https://github.com/inventree/InvenTree/pull/10464
     - Add additional fields for tests (start/end datetime, test station)
 
-v183 - 2024-03-14 : https://github.com/inventree/InvenTree/pull/5972
+v183 -> 2024-03-14 : https://github.com/inventree/InvenTree/pull/5972
     - Adds "category_default_location" annotated field to part serializer
     - Adds "part_detail.category_default_location" annotated field to stock item serializer
     - Adds "part_detail.category_default_location" annotated field to purchase order line serializer
     - Adds "parent_default_location" annotated field to category serializer
 
-v182 - 2024-03-13 : https://github.com/inventree/InvenTree/pull/6714
+v182 -> 2024-03-13 : https://github.com/inventree/InvenTree/pull/6714
     - Expose ReportSnippet model to the /report/snippet/ API endpoint
     - Expose ReportAsset model to the /report/asset/ API endpoint
 
-v181 - 2024-02-21 : https://github.com/inventree/InvenTree/pull/6541
+v181 -> 2024-02-21 : https://github.com/inventree/InvenTree/pull/6541
     - Adds "width" and "height" fields to the LabelTemplate API endpoint
     - Adds "page_size" and "landscape" fields to the ReportTemplate API endpoint
 
-v180 - 2024-3-02 : https://github.com/inventree/InvenTree/pull/6463
+v180 -> 2024-3-02 : https://github.com/inventree/InvenTree/pull/6463
     - Tweaks to API documentation to allow automatic documentation generation
 
-v179 - 2024-03-01 : https://github.com/inventree/InvenTree/pull/6605
+v179 -> 2024-03-01 : https://github.com/inventree/InvenTree/pull/6605
     - Adds "subcategories" count to PartCategory serializer
     - Adds "sublocations" count to StockLocation serializer
     - Adds "image" field to PartBrief serializer
     - Adds "image" field to CompanyBrief serializer
 
-v178 - 2024-02-29 : https://github.com/inventree/InvenTree/pull/6604
+v178 -> 2024-02-29 : https://github.com/inventree/InvenTree/pull/6604
     - Adds "external_stock" field to the Part API endpoint
     - Adds "external_stock" field to the BomItem API endpoint
     - Adds "external_stock" field to the BuildLine API endpoint
     - Stock quantities represented in the BuildLine API endpoint are now filtered by Build.source_location
 
-v177 - 2024-02-27 : https://github.com/inventree/InvenTree/pull/6581
+v177 -> 2024-02-27 : https://github.com/inventree/InvenTree/pull/6581
     - Adds "subcategories" count to PartCategoryTree serializer
     - Adds "sublocations" count to StockLocationTree serializer
 
-v176 - 2024-02-26 : https://github.com/inventree/InvenTree/pull/6535
+v176 -> 2024-02-26 : https://github.com/inventree/InvenTree/pull/6535
     - Adds the field "plugins_install_disabled" to the Server info API endpoint
 
-v175 - 2024-02-21 : https://github.com/inventree/InvenTree/pull/6538
+v175 -> 2024-02-21 : https://github.com/inventree/InvenTree/pull/6538
     - Adds "parts" count to PartParameterTemplate serializer
 
-v174 - 2024-02-21 : https://github.com/inventree/InvenTree/pull/6536
+v174 -> 2024-02-21 : https://github.com/inventree/InvenTree/pull/6536
     - Expose PartCategory filters to the API documentation
     - Expose StockLocation filters to the API documentation
 
-v173 - 2024-02-20 : https://github.com/inventree/InvenTree/pull/6483
+v173 -> 2024-02-20 : https://github.com/inventree/InvenTree/pull/6483
     - Adds "merge_items" to the PurchaseOrderLine create API endpoint
     - Adds "auto_pricing" to the PurchaseOrderLine create/update API endpoint
 
-v172 - 2024-02-20 : https://github.com/inventree/InvenTree/pull/6526
+v172 -> 2024-02-20 : https://github.com/inventree/InvenTree/pull/6526
     - Adds "enabled" field to the PartTestTemplate API endpoint
     - Adds "enabled" filter to the PartTestTemplate list
     - Adds "enabled" filter to the StockItemTestResult list
 
-v171 - 2024-02-19 : https://github.com/inventree/InvenTree/pull/6516
+v171 -> 2024-02-19 : https://github.com/inventree/InvenTree/pull/6516
     - Adds "key" as a filterable parameter to PartTestTemplate list endpoint
 
 v170 -> 2024-02-19 : https://github.com/inventree/InvenTree/pull/6514

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,12 +1,16 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 335
+INVENTREE_API_VERSION = 336
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
+
+v336 -> 2025-04-10 : https://github.com/inventree/InvenTree/pull/9492
+    - Fixed query and response serialization for units_all and version_text
+    - Fixed LicenseView and VersionInformation serialization
 
 v335 -> 2025-04-09 : https://github.com/inventree/InvenTree/pull/9476
     - Adds "roles" detail to the Group API endpoint

--- a/src/backend/InvenTree/InvenTree/test_api.py
+++ b/src/backend/InvenTree/InvenTree/test_api.py
@@ -515,24 +515,43 @@ class GeneralApiTests(InvenTreeAPITestCase):
 
     def test_inventree_api_text_fnc(self):
         """Test that the inventreeApiText function works expected."""
+        latest_version = f'v{INVENTREE_API_VERSION}'
+
         # Normal run
         resp = inventreeApiText()
         self.assertEqual(len(resp), 10)
+        self.assertIn(latest_version, resp)
 
         # More responses
         resp = inventreeApiText(20)
         self.assertEqual(len(resp), 20)
+        self.assertIn(latest_version, resp)
 
         # Specific version
         resp = inventreeApiText(start_version=5)
         self.assertEqual(list(resp)[0], 'v5')
+        self.assertEqual(list(resp)[-1], 'v14')
 
     def test_parse_version_text_fnc(self):
         """Test that api version text is correctly parsed."""
         resp = parse_version_text()
 
-        # Check that all texts are parsed
-        self.assertEqual(len(resp), INVENTREE_API_VERSION - 1)
+        latest_version = INVENTREE_API_VERSION
+        self.assertTrue(resp[f'v{latest_version}']['latest'])
+
+        # All fields except github link should exist for every version
+        latest_count = 0
+        for k, v in resp.items():
+            self.assertEqual('v', k[0], f'Version should start with v: {k}')
+            self.assertEqual(k, v['version'])
+            self.assertGreater(len(v['date']), 0, f'Date is missing from {v}')
+            self.assertGreater(len(v['text']), 0, f'Text is missing from {v}')
+            self.assertIsNotNone(v['latest'])
+            latest_count = latest_count + (1 if v['latest'] else 0)
+        self.assertEqual(1, latest_count, 'Should have a single version marked latest')
+
+        # Check that all texts are parsed: v1 and v2 are missing
+        self.assertEqual(len(resp), INVENTREE_API_VERSION - 2)
 
     def test_api_license(self):
         """Test that the license endpoint is working."""

--- a/src/backend/InvenTree/InvenTree/tests.py
+++ b/src/backend/InvenTree/InvenTree/tests.py
@@ -1049,49 +1049,6 @@ class TestVersionNumber(TestCase):
         self.assertEqual(d, version.inventreeCommitDate())
 
 
-class VersionTextTest(TestCase):
-    """Unit tests for API version text functions."""
-
-    def test_parse_text(self):
-        """Test that the version text parsing produces the expected fields."""
-        parsed_text = version.parse_version_text()
-
-        latest_version = version.inventreeApiVersion()
-        self.assertTrue(parsed_text[f'v{latest_version}']['latest'])
-
-        # All fields except github link should exist for every version
-        latest_count = 0
-        for k, v in parsed_text.items():
-            self.assertEqual(k, v['version'])
-            self.assertIsNotNone(v['date'])
-            self.assertIsNotNone(v['text'])
-            self.assertGreater(len(v['text']), 0, v)
-            self.assertIsNotNone(v['latest'])
-            latest_count = latest_count + (1 if v['latest'] else 0)
-        self.assertEqual(1, latest_count, 'Should have a single version marked latest')
-
-    def test_inventreeApiText(self):
-        """Test that the api text helper method picks the right versions."""
-        latest_version_number = version.inventreeApiVersion()
-        latest_version = f'v{latest_version_number}'
-
-        # default: 10 latest versions in increasing order
-        actual = version.inventreeApiText()
-        self.assertEqual(10, len(actual))
-        self.assertIn(latest_version, actual)
-
-        # latest 1 version
-        actual = version.inventreeApiText(versions=1)
-        self.assertEqual(1, len(actual))
-        self.assertIn(latest_version, actual)
-
-        # first 10 versions in changelog
-        actual = version.inventreeApiText(start_version=3)
-        self.assertEqual(10, len(actual))
-        self.assertIn('v3', actual)
-        self.assertIn('v12', actual)
-
-
 class CurrencyTests(TestCase):
     """Unit tests for currency / exchange rate functionality."""
 

--- a/src/backend/InvenTree/InvenTree/tests.py
+++ b/src/backend/InvenTree/InvenTree/tests.py
@@ -1049,6 +1049,28 @@ class TestVersionNumber(TestCase):
         self.assertEqual(d, version.inventreeCommitDate())
 
 
+class VersionTextTest(TestCase):
+    """Unit tests for API version text functions."""
+
+    def test_parse_text(self):
+        """Test that the version text parsing produces the expected fields."""
+        parsed_text = version.parse_version_text()
+
+        latest_version = version.inventreeApiVersion()
+        self.assertTrue(parsed_text[f'v{latest_version}']['latest'])
+
+        # All fields except github link should exist for every version
+        latest_count = 0
+        for k, v in parsed_text.items():
+            self.assertEqual(k, v['version'])
+            self.assertIsNotNone(v['date'])
+            self.assertIsNotNone(v['text'])
+            self.assertGreater(len(v['text']), 0, v)
+            self.assertIsNotNone(v['latest'])
+            latest_count = latest_count + (1 if v['latest'] else 0)
+        self.assertEqual(1, latest_count, 'Should have a single version marked latest')
+
+
 class CurrencyTests(TestCase):
     """Unit tests for currency / exchange rate functionality."""
 

--- a/src/backend/InvenTree/InvenTree/tests.py
+++ b/src/backend/InvenTree/InvenTree/tests.py
@@ -1070,6 +1070,27 @@ class VersionTextTest(TestCase):
             latest_count = latest_count + (1 if v['latest'] else 0)
         self.assertEqual(1, latest_count, 'Should have a single version marked latest')
 
+    def test_inventreeApiText(self):
+        """Test that the api text helper method picks the right versions."""
+        latest_version_number = version.inventreeApiVersion()
+        latest_version = f'v{latest_version_number}'
+
+        # default: 10 latest versions in increasing order
+        actual = version.inventreeApiText()
+        self.assertEqual(10, len(actual))
+        self.assertIn(latest_version, actual)
+
+        # latest 1 version
+        actual = version.inventreeApiText(versions=1)
+        self.assertEqual(1, len(actual))
+        self.assertIn(latest_version, actual)
+
+        # first 10 versions in changelog
+        actual = version.inventreeApiText(start_version=3)
+        self.assertEqual(10, len(actual))
+        self.assertIn('v3', actual)
+        self.assertIn('v12', actual)
+
 
 class CurrencyTests(TestCase):
     """Unit tests for currency / exchange rate functionality."""

--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -205,7 +205,7 @@ def inventreeApiText(versions: int = 10, start_version: int = 0):
 
     # Define the range of versions to return
     if start_version == 0:
-        start_version = INVENTREE_API_VERSION - versions
+        start_version = INVENTREE_API_VERSION - versions + 1
 
     return {
         f'v{a}': version_data.get(f'v{a}', None)

--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -167,6 +167,7 @@ def parse_version_text():
     # Remove first newline on latest version
     patched_data[0] = patched_data[0].replace('\n', '', 1)
 
+    latest_version = f'v{INVENTREE_API_VERSION}'
     version_data = {}
     for version in patched_data:
         data = version.split('\n')
@@ -184,7 +185,7 @@ def parse_version_text():
             'date': version_detail[0].strip(),
             'gh': version_detail[1].strip() if len(version_detail) > 1 else None,
             'text': data[1:],
-            'latest': f'v{INVENTREE_API_VERSION}' == version_string,
+            'latest': latest_version == version_string,
         }
         version_data[version_string] = new_data
     return version_data

--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -172,17 +172,21 @@ def parse_version_text():
         data = version.split('\n')
 
         version_split = data[0].split(' -> ')
+        version_string = version_split[0].strip()
+        if version_string == '':
+            continue
+
         version_detail = (
             version_split[1].split(':', 1) if len(version_split) > 1 else ['']
         )
         new_data = {
-            'version': version_split[0].strip(),
+            'version': version_string,
             'date': version_detail[0].strip(),
             'gh': version_detail[1].strip() if len(version_detail) > 1 else None,
             'text': data[1:],
-            'latest': False,
+            'latest': f'v{INVENTREE_API_VERSION}' == version_string,
         }
-        version_data[new_data['version']] = new_data
+        version_data[version_string] = new_data
     return version_data
 
 

--- a/src/backend/InvenTree/InvenTree/version.py
+++ b/src/backend/InvenTree/InvenTree/version.py
@@ -129,11 +129,6 @@ def inventreeAppUrl():
     return 'https://docs.inventree.org/app/'
 
 
-def inventreeCreditsUrl():
-    """Return URL for InvenTree credits site."""
-    return 'https://docs.inventree.org/en/latest/credits/'
-
-
 def inventreeGithubUrl():
     """Return URL for InvenTree github site."""
     return 'https://github.com/InvenTree/InvenTree/'

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -541,7 +541,7 @@ class CustomUnitDetail(RetrieveUpdateDestroyAPI):
     permission_classes = [permissions.IsAuthenticated, IsStaffOrReadOnly]
 
 
-class AllUnitList(ListAPI):
+class AllUnitList(RetrieveAPI):
     """List of all defined units."""
 
     serializer_class = common.serializers.AllUnitListResponseSerializer

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -428,7 +428,7 @@ class AllUnitListResponseSerializer(serializers.Serializer):
 
     default_system = serializers.CharField()
     available_systems = serializers.ListField(child=serializers.CharField())
-    available_units = Unit(many=True)
+    available_units = serializers.DictField(child=Unit())
 
 
 class ErrorMessageSerializer(InvenTreeModelSerializer):

--- a/src/frontend/src/components/modals/AboutInvenTreeModal.tsx
+++ b/src/frontend/src/components/modals/AboutInvenTreeModal.tsx
@@ -162,7 +162,6 @@ export function AboutInvenTreeModal({
             [
               { ref: 'doc', title: <Trans>Documentation</Trans> },
               { ref: 'code', title: <Trans>Source Code</Trans> },
-              { ref: 'credit', title: <Trans>Credits</Trans> },
               { ref: 'app', title: <Trans>Mobile App</Trans> },
               { ref: 'bug', title: <Trans>Submit Bug Report</Trans> }
             ],


### PR DESCRIPTION
This branch started as a handful of small serialization changes to various endpoints, then got a lot more involved when I hit `VersionTextView`

**API Changes:**
- `AllUnitList` returns an object, not a list. Changed type to `RetrieveAPI` and fixed the serializer to match the data structure
- `LicenseViewSerializer`: licenses are lists of objects, not raw strings: fixed serializer to match data structure
- `VersionView`:
  - removed dead credits link (it was removed in #8811) and references to it
  - allowed `commit_branch` to be null to support detatched HEAD state (checking out a commit instead of branch)
- `VersionTextView`:
  - added missing query parameters
  - removed default pagination
  - fixed response to be a list instead of dict

In the course of testing `VersionTextView` I discovered a number of problems with the version text parsing, first of which was that the format used in `api_version.py` no longer is following the format that the parser expects. I converted a bunch of '-' to the expected '->' rather than changing the parser to handle both cases for simplicity.

I added tests to cover the changes to `version.py` to ensure that moving forward the schema change log file parses correctly.

I tested the Units, License, and Version changes in the UI, but I did not find anywhere that displays the VersionText information (which is probably how we managed to not have the log properly parsing for the last year).

Progress on #9045