### PR TITLE
refactor(backend): Remove custom role admin

### DIFF
--- a/src/backend/InvenTree/users/admin.py
+++ b/src/backend/InvenTree/users/admin.py
@@ -1,7 +1,7 @@
 """Admin classes for the 'users' app."""
 
 from django import forms
-from django.contrib import admin, messages
+from django.contrib import admin
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
@@ -115,157 +115,6 @@ class InvenTreeGroupAdminForm(forms.ModelForm):
         return instance
 
 
-class RoleGroupAdmin(admin.ModelAdmin):  # pragma: no cover
-    """Custom admin interface for the Group model."""
-
-    form = InvenTreeGroupAdminForm
-
-    inlines = [RuleSetInline]
-
-    list_display = (
-        'name',
-        'admin',
-        'part_category',
-        'part',
-        'stocktake',
-        'stock_location',
-        'stock_item',
-        'build',
-        'purchase_order',
-        'sales_order',
-        'return_order',
-    )
-
-    def get_rule_set(self, obj, rule_set_type):
-        """Return list of permissions for the given ruleset."""
-        # Get all rulesets associated to object
-        rule_sets = RuleSet.objects.filter(group=obj.pk)
-
-        # Select ruleset based on type
-        for rule_set in rule_sets:
-            if rule_set.name == rule_set_type:
-                break
-
-        def append_permission_level(permission_level, next_level):
-            """Append permission level."""
-            if not permission_level:
-                return next_level
-
-            if permission_level[:-1].endswith('|'):
-                permission_level += next_level
-            else:
-                permission_level += ' | ' + next_level
-
-            return permission_level
-
-        permission_level = ''
-
-        if rule_set.can_view:
-            permission_level = append_permission_level(permission_level, 'V')
-
-        if rule_set.can_add:
-            permission_level = append_permission_level(permission_level, 'A')
-
-        if rule_set.can_change:
-            permission_level = append_permission_level(permission_level, 'C')
-
-        if rule_set.can_delete:
-            permission_level = append_permission_level(permission_level, 'D')
-
-        return permission_level
-
-    def admin(self, obj):
-        """Return the ruleset for the admin role."""
-        return self.get_rule_set(obj, 'admin')
-
-    def part_category(self, obj):
-        """Return the ruleset for the PartCategory role."""
-        return self.get_rule_set(obj, 'part_category')
-
-    def part(self, obj):
-        """Return the ruleset for the Part role."""
-        return self.get_rule_set(obj, 'part')
-
-    def stocktake(self, obj):
-        """Return the ruleset for the Stocktake role."""
-        return self.get_rule_set(obj, 'stocktake')
-
-    def stock_location(self, obj):
-        """Return the ruleset for the StockLocation role."""
-        return self.get_rule_set(obj, 'stock_location')
-
-    def stock_item(self, obj):
-        """Return the ruleset for the StockItem role."""
-        return self.get_rule_set(obj, 'stock')
-
-    def build(self, obj):
-        """Return the ruleset for the BuildOrder role."""
-        return self.get_rule_set(obj, 'build')
-
-    def purchase_order(self, obj):
-        """Return the ruleset for the PurchaseOrder role."""
-        return self.get_rule_set(obj, 'purchase_order')
-
-    def sales_order(self, obj):
-        """Return the ruleset for the SalesOrder role."""
-        return self.get_rule_set(obj, 'sales_order')
-
-    def return_order(self, obj):
-        """Return the ruleset ofr the ReturnOrder role."""
-        return self.get_rule_set(obj, 'return_order')
-
-    def get_formsets_with_inlines(self, request, obj=None):
-        """Retrieve all inline formsets for the given request and object.
-
-        Args:
-            request (HttpRequest): The HTTP request object.
-            obj (Model, optional): The model instance for which the formsets are being retrieved. Defaults to None.
-
-        Yields:
-            tuple: A tuple containing the formset and the corresponding inline instance.
-        """
-        for inline in self.get_inline_instances(request, obj):
-            # Hide RuleSetInline in the 'Add role' view
-            if not isinstance(inline, RuleSetInline) or obj is not None:
-                yield inline.get_formset(request, obj), inline
-
-    filter_horizontal = ['permissions']
-
-    def save_model(self, request, obj, form, change):
-        """Save overwrite.
-
-        This method serves two purposes:
-            - show warning message whenever the group users belong to multiple groups
-            - skip saving of the group instance model as inlines needs to be saved before.
-        """
-        # Get form cleaned data
-        users = form.cleaned_data['users']
-
-        # Check for users who are members of multiple groups
-        multiple_group_users = []
-
-        for user in users:
-            if user.groups.all().count() > 1:
-                multiple_group_users.append(user.username)
-
-        # If any, display warning message when group is saved
-        if len(multiple_group_users) > 0:
-            msg = (
-                _('The following users are members of multiple groups')
-                + ': '
-                + ', '.join(multiple_group_users)
-            )
-
-            messages.add_message(request, messages.WARNING, msg)
-
-    def save_formset(self, request, form, formset, change):
-        """Save the inline formset."""
-        # Save inline Rulesets
-        formset.save()
-        # Save Group instance and update permissions
-        form.instance.save(update_fields=['name'])
-
-
 class InvenTreeUserAdmin(UserAdmin):
     """Custom admin page for the User model.
 
@@ -300,9 +149,6 @@ class OwnerAdmin(admin.ModelAdmin):
 
     search_fields = ['name']
 
-
-admin.site.unregister(Group)
-admin.site.register(Group, RoleGroupAdmin)
 
 admin.site.unregister(User)
 admin.site.register(User, InvenTreeUserAdmin)


### PR DESCRIPTION
See https://github.com/inventree/InvenTree/pull/9476#issuecomment-2791584989

Removes the custom role admin in favour of the new PUI admin interface. We have no good way of collecting e2e coverage for Django admin so removing it is the best course.