### PR TITLE
fix(backend): re-ignore standard uv venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .Python
 env/
 inventree-env/
+.venv/
 ./build/
 .cache/
 develop-eggs/


### PR DESCRIPTION
Small fix as standard uv venv is not ignored anymore
follow up to #9439