### PR TITLE
refactor: fix task helper names

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -30,6 +30,7 @@ def is_rtd_environment():
     return is_true(os.environ.get('READTHEDOCS', 'False'))
 
 
+# region execution logging helpers
 def task_exception_handler(t, v, tb):
     """Handle exceptions raised by tasks.
 
@@ -82,7 +83,11 @@ def info(*args):
     print(wrap_color(msg, '94'))
 
 
-def checkInvokeVersion():
+# endregion
+
+
+# region environment checks
+def check_invoke_version():
     """Check that the installed invoke version meets minimum requirements."""
     MIN_INVOKE_VERSION = '2.0.0'
 
@@ -95,7 +100,7 @@ def checkInvokeVersion():
         sys.exit(1)
 
 
-def chceckInvokePath():
+def check_invoke_path():
     """Check that the path of the used invoke is correct."""
     if is_docker_environment() or is_rtd_environment():
         return
@@ -113,7 +118,7 @@ def chceckInvokePath():
         sys.exit(1)
 
 
-def checkPythonVersion():
+def check_python_version():
     """Check that the installed python version meets minimum requirements.
 
     If the python version is not sufficient, exits with a non-zero exit code.
@@ -137,9 +142,10 @@ def checkPythonVersion():
 
 
 if __name__ in ['__main__', 'tasks']:
-    checkInvokeVersion()
-    chceckInvokePath()
-    checkPythonVersion()
+    check_invoke_version()
+    check_invoke_path()
+    check_python_version()
+# endregion
 
 
 def apps():
@@ -217,7 +223,8 @@ def content_excludes(
     return ' '.join([f'--exclude {e}' for e in excludes])
 
 
-def localDir() -> Path:
+# region file helpers
+def local_dir() -> Path:
     """Returns the directory of *THIS* file.
 
     Used to ensure that the various scripts always run
@@ -226,14 +233,17 @@ def localDir() -> Path:
     return Path(__file__).parent.resolve()
 
 
-def managePyDir():
+def manage_py_dir():
     """Returns the directory of the manage.py file."""
-    return localDir().joinpath('src', 'backend', 'InvenTree')
+    return local_dir().joinpath('src', 'backend', 'InvenTree')
 
 
-def managePyPath():
+def manage_py_path():
     """Return the path of the manage.py file."""
-    return managePyDir().joinpath('manage.py')
+    return manage_py_dir().joinpath('manage.py')
+
+
+# endregion
 
 
 def run(c, cmd, path: Optional[Path] = None, pty=False, env=None):
@@ -247,7 +257,7 @@ def run(c, cmd, path: Optional[Path] = None, pty=False, env=None):
         env (dict, optional): Environment variables to pass to the command. Defaults to None.
     """
     env = env or {}
-    path = path or localDir()
+    path = path or local_dir()
 
     try:
         c.run(f'cd "{path}" && {cmd}', pty=pty, env=env)
@@ -266,7 +276,7 @@ def manage(c, cmd, pty: bool = False, env=None):
         pty (bool, optional): Run an interactive session. Defaults to False.
         env (dict, optional): Environment variables to pass to the command. Defaults to None.
     """
-    run(c, f'python3 manage.py {cmd}', managePyDir(), pty, env)
+    run(c, f'python3 manage.py {cmd}', manage_py_dir(), pty, env)
 
 
 def yarn(c, cmd):
@@ -276,7 +286,7 @@ def yarn(c, cmd):
         c: Command line context.
         cmd: Yarn command to run.
     """
-    path = localDir().joinpath('src', 'frontend')
+    path = local_dir().joinpath('src', 'frontend')
     run(c, cmd, path, False)
 
 
@@ -334,6 +344,7 @@ def check_file_existence(filename: Path, overwrite: bool = False):
 
 
 # Install tasks
+# region tasks
 @task(help={'uv': 'Use UV (experimental package manager)'})
 def plugins(c, uv=False):
     """Installs all plugins as specified in 'plugins.txt'."""
@@ -363,7 +374,7 @@ def plugins(c, uv=False):
 def install(c, uv=False, skip_plugins=False):
     """Installs required python packages."""
     # Ensure path is relative to *this* directory
-    INSTALL_FILE = localDir().joinpath('src/backend/requirements.txt')
+    INSTALL_FILE = local_dir().joinpath('src/backend/requirements.txt')
 
     info(f"Installing required python packages from '{INSTALL_FILE}'")
 
@@ -392,7 +403,7 @@ def install(c, uv=False, skip_plugins=False):
         plugins(c, uv=uv)
 
     # Compile license information
-    lic_path = managePyDir().joinpath('InvenTree', 'licenses.txt')
+    lic_path = manage_py_dir().joinpath('InvenTree', 'licenses.txt')
     run(
         c,
         f'pip-licenses --format=json --with-license-file --no-license-path > {lic_path}',
@@ -531,7 +542,7 @@ def backup(c, clean=False, path=None):
         # Resolve the provided path
         path = Path(path)
         if not os.path.isabs(path):
-            path = localDir().joinpath(path).resolve()
+            path = local_dir().joinpath(path).resolve()
 
         cmd += f' -O {path}'
 
@@ -569,7 +580,7 @@ def restore(
         # Resolve the provided path
         path = Path(path)
         if not os.path.isabs(path):
-            path = localDir().joinpath(path).resolve()
+            path = local_dir().joinpath(path).resolve()
 
         base_cmd += f' -I {path}'
 
@@ -732,7 +743,7 @@ def export_records(
     # Get an absolute path to the file
     target = Path(filename)
     if not target.is_absolute():
-        target = localDir().joinpath(filename).resolve()
+        target = local_dir().joinpath(filename).resolve()
 
     info(f"Exporting database records to file '{target}'")
 
@@ -802,7 +813,7 @@ def import_records(
     # Get an absolute path to the supplied filename
     target = Path(filename)
     if not target.is_absolute():
-        target = localDir().joinpath(filename)
+        target = local_dir().joinpath(filename)
 
     if not target.exists():
         error(f"ERROR: File '{target}' does not exist")
@@ -953,10 +964,8 @@ def gunicorn(c, address='0.0.0.0:8000', workers=None):
 
     Note: This server will not auto-reload in response to code changes.
     """
-    config_file = localDir().joinpath('contrib', 'container', 'gunicorn.conf.py')
-    cmd = (
-        f'gunicorn -c {config_file} InvenTree.wsgi -b {address} --chdir {managePyDir()}'
-    )
+    config_file = local_dir().joinpath('contrib', 'container', 'gunicorn.conf.py')
+    cmd = f'gunicorn -c {config_file} InvenTree.wsgi -b {address} --chdir {manage_py_dir()}'
 
     if workers:
         cmd += f' --workers={workers}'
@@ -1132,7 +1141,7 @@ def test(
 
     if coverage:
         # Run tests within coverage environment, and generate report
-        run(c, f'coverage run {managePyPath()} {cmd}')
+        run(c, f'coverage run {manage_py_path()} {cmd}')
         run(c, 'coverage xml -i')
     else:
         # Run simple test runner, without coverage
@@ -1158,7 +1167,7 @@ def setup_test(
     if not ignore_update:
         update(c)
 
-    template_dir = localDir().joinpath(path)
+    template_dir = local_dir().joinpath(path)
 
     # Remove old data directory
     if template_dir.exists():
@@ -1327,7 +1336,7 @@ Environment {sys.prefix}
 Invoke Tool {invoke_path}
 
 Installation paths:
-Base        {localDir()}
+Base        {local_dir()}
 Config      {get_config_file()}
 Plugin File {get_plugin_file() or NOT_SPECIFIED}
 Media       {get_media_dir(error=False) or NOT_SPECIFIED}
@@ -1483,7 +1492,7 @@ def frontend_download(
         if not extract:
             return
 
-        dest_path = managePyDir().joinpath('web', 'static', 'web')
+        dest_path = manage_py_dir().joinpath('web', 'static', 'web')
 
         # if clean, delete static/web directory
         if clean:
@@ -1522,9 +1531,13 @@ def frontend_download(
         ref = 'tag' if tag else 'commit'
 
         if tag:
-            current = managePyDir().joinpath('web', 'static', 'web', '.vite', 'tag.txt')
+            current = manage_py_dir().joinpath(
+                'web', 'static', 'web', '.vite', 'tag.txt'
+            )
         elif sha:
-            current = managePyDir().joinpath('web', 'static', 'web', '.vite', 'sha.txt')
+            current = manage_py_dir().joinpath(
+                'web', 'static', 'web', '.vite', 'sha.txt'
+            )
         else:
             raise ValueError('Either tag or sha needs to be set')
 
@@ -1562,7 +1575,7 @@ def frontend_download(
             ).strip()
         except Exception:
             # .deb Packages contain extra information in the VERSION file
-            version_file = localDir().joinpath('VERSION')
+            version_file = local_dir().joinpath('VERSION')
             if not version_file.exists():
                 return
             from dotenv import dotenv_values
@@ -1678,6 +1691,8 @@ def clear_generated(c):
     run(c, 'find src -name "django.mo" -exec rm -f {} +')
     run(c, 'find src -name "messages.mo" -exec rm -f {} +')
 
+
+# endregion tasks
 
 # Collection sorting
 development = Collection(


### PR DESCRIPTION
Various names in the tasks.py do not fit standard python naming patterns.