### PR TITLE
[UI] Add CUI compatibility URLs

### DIFF
--- a/src/backend/InvenTree/InvenTree/config.py
+++ b/src/backend/InvenTree/InvenTree/config.py
@@ -484,4 +484,13 @@ def get_frontend_settings(debug=True):
         # If no servers are specified, show server selector
         frontend_settings['show_server_selector'] = True
 
+    # Support compatibility with "legacy" URLs?
+    try:
+        frontend_settings['url_compatibility'] = bool(
+            frontend_settings.get('url_compatibility', True)
+        )
+    except Exception:
+        # If the value is not a boolean, set it to True
+        frontend_settings['url_compatibility'] = True
+
     return frontend_settings

--- a/src/backend/InvenTree/InvenTree/tests.py
+++ b/src/backend/InvenTree/InvenTree/tests.py
@@ -1723,14 +1723,3 @@ class URLCompatibilityTest(InvenTreeTestCase):
             response = self.client.get(old_url)
             self.assertEqual(response.status_code, 302)
             self.assertEqual(response['Location'], new_url)
-
-    @override_settings(
-        FRONTEND_SETTINGS={'base_url': 'web', 'url_compatibility': False}
-    )
-    def test_legacy_urls_disabled(self):
-        """Test that legacy URLs are disabled when configured."""
-        # If legacy URLs are disabled, they should return a 302 redirect to the home page
-        for old_url, _new_url in self.URL_MAPPINGS:
-            response = self.client.get(old_url)
-            self.assertEqual(response.status_code, 302)
-            self.assertEqual(response['Location'], 'web')

--- a/src/backend/InvenTree/InvenTree/urls.py
+++ b/src/backend/InvenTree/InvenTree/urls.py
@@ -28,6 +28,7 @@ import report.api
 import stock.api
 import users.api
 from plugin.urls import get_plugin_urls
+from web.urls import cui_compatibility_urls
 from web.urls import urlpatterns as platform_urls
 
 from .api import (
@@ -171,6 +172,9 @@ urlpatterns.append(
         RedirectView.as_view(url=f'{settings.STATIC_URL}img/favicon/favicon.ico'),
     )
 )
+
+# Compatibility layer for old (CUI) URLs
+urlpatterns += cui_compatibility_urls(settings.FRONTEND_URL_BASE)
 
 # Send any unknown URLs to the index page
 urlpatterns += [

--- a/src/backend/InvenTree/InvenTree/urls.py
+++ b/src/backend/InvenTree/InvenTree/urls.py
@@ -174,7 +174,7 @@ urlpatterns.append(
 )
 
 # Compatibility layer for old (CUI) URLs
-if settings.FRONTEND_SETTINGS.get('url_compatibility', True):
+if settings.FRONTEND_SETTINGS.get('url_compatibility'):
     urlpatterns += cui_compatibility_urls(settings.FRONTEND_URL_BASE)
 
 # Send any unknown URLs to the index page

--- a/src/backend/InvenTree/InvenTree/urls.py
+++ b/src/backend/InvenTree/InvenTree/urls.py
@@ -174,7 +174,8 @@ urlpatterns.append(
 )
 
 # Compatibility layer for old (CUI) URLs
-urlpatterns += cui_compatibility_urls(settings.FRONTEND_URL_BASE)
+if settings.FRONTEND_SETTINGS.get('url_compatibility', True):
+    urlpatterns += cui_compatibility_urls(settings.FRONTEND_URL_BASE)
 
 # Send any unknown URLs to the index page
 urlpatterns += [

--- a/src/backend/InvenTree/web/urls.py
+++ b/src/backend/InvenTree/web/urls.py
@@ -3,9 +3,130 @@
 from django.conf import settings
 from django.urls import include, path, re_path
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django.views.generic import TemplateView
+from django.views.generic import RedirectView, TemplateView
 
 spa_view = ensure_csrf_cookie(TemplateView.as_view(template_name='web/index.html'))
+
+
+def cui_compatibility_urls(base: str) -> list:
+    """Generate a list of URL patterns for compatibility with old (CUI) URLs.
+
+    These URLs are provided for backwards compatibility with older versions of InvenTree,
+    before we moved to a SPA (Single Page Application) architecture in the 1.0.0 release.
+
+    At some future point these may be removed?
+
+    Args:
+        base (str): The base URL to use for generating the patterns.
+
+    Returns:
+        list: A list of URL patterns.
+    """
+    return [
+        # Old 'index' view - reroute to the dashboard
+        path('index/', RedirectView.as_view(url=f'/{base}')),
+        path('settings/', RedirectView.as_view(url=f'/{base}/settings')),
+        # Company patterns
+        path(
+            'company/',
+            include([
+                path(
+                    'customers/',
+                    RedirectView.as_view(url=f'/{base}/sales/index/customers'),
+                ),
+                path(
+                    'manufacturers/',
+                    RedirectView.as_view(url=f'/{base}/purchasing/index/manufacturers'),
+                ),
+                path(
+                    'suppliers/',
+                    RedirectView.as_view(url=f'/{base}/purchasing/index/suppliers'),
+                ),
+                re_path(
+                    r'(?P<pk>\d+)/', RedirectView.as_view(url=f'/{base}/company/%(pk)s')
+                ),
+            ]),
+        ),
+        # "Part" app views
+        re_path(
+            r'^part/(?P<path>.*)$', RedirectView.as_view(url=f'/{base}/part/%(path)s')
+        ),
+        # "Stock" app views
+        re_path(
+            r'^stock/(?P<path>.*)$', RedirectView.as_view(url=f'/{base}/stock/%(path)s')
+        ),
+        # "Build" app views (requires some custom handling)
+        path(
+            'build/',
+            include([
+                re_path(
+                    r'^(?P<pk>\d+)/',
+                    RedirectView.as_view(
+                        url=f'/{base}/manufacturing/build-order/%(pk)s'
+                    ),
+                ),
+                re_path('.*', RedirectView.as_view(url=f'/{base}/manufacturing/')),
+            ]),
+        ),
+        # "Order" app views
+        path(
+            'order/',
+            include([
+                path(
+                    'purchase-order/',
+                    include([
+                        re_path(
+                            r'^(?P<pk>\d+)/',
+                            RedirectView.as_view(
+                                url=f'/{base}/purchasing/purchase-order/%(pk)s'
+                            ),
+                        ),
+                        re_path(
+                            '.*',
+                            RedirectView.as_view(
+                                url=f'/{base}/purchasing/index/purchaseorders/'
+                            ),
+                        ),
+                    ]),
+                ),
+                path(
+                    'sales-order/',
+                    include([
+                        re_path(
+                            r'^(?P<pk>\d+)/',
+                            RedirectView.as_view(
+                                url=f'/{base}/sales/sales-order/%(pk)s'
+                            ),
+                        ),
+                        re_path(
+                            '.*',
+                            RedirectView.as_view(
+                                url=f'/{base}/sales/index/salesorders/'
+                            ),
+                        ),
+                    ]),
+                ),
+                path(
+                    'return-order/',
+                    include([
+                        re_path(
+                            r'^(?P<pk>\d+)/',
+                            RedirectView.as_view(
+                                url=f'/{base}/sales/return-order/%(pk)s'
+                            ),
+                        ),
+                        re_path(
+                            '.*',
+                            RedirectView.as_view(
+                                url=f'/{base}/sales/index/returnorders/'
+                            ),
+                        ),
+                    ]),
+                ),
+            ]),
+        ),
+    ]
+
 
 urlpatterns = [
     path(


### PR DESCRIPTION
Rerouting for "CUI" (legacy) URLs to new UI patterns.

Allows external links to InvenTree to still work now that we have removed the old UI entirely