### PR TITLE
Schema: Require pagination limit parameter

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,7 +1,7 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 339
+INVENTREE_API_VERSION = 340
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,13 +1,13 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 340
+INVENTREE_API_VERSION = 341
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
-v340 -> 2025-04-21 : https://github.com/inventree/InvenTree/pull/9547
+v341 -> 2025-04-21 : https://github.com/inventree/InvenTree/pull/9547
     - Require pagination limit on list queries
 
 v340 -> 2025-04-15 : https://github.com/inventree/InvenTree/pull/9546

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -7,6 +7,8 @@ INVENTREE_API_VERSION = 339
 
 
 INVENTREE_API_TEXT = """
+v340 -> 2025-04-21 : https://github.com/inventree/InvenTree/pull/9547
+    - Require pagination limit on list queries
 
 v339 -> 2025-04-15 : https://github.com/inventree/InvenTree/pull/9283
     - Remove need for source in /plugins/ui/features


### PR DESCRIPTION
I'm offering this as a possible solution to the linked issue, I don't know if it's something we want.

**Problem:** If a pagination limit is not provided in a list query, the response comes back as a list of all relevant objects, not a paginated wrapper object as the schema defines.

**Solution:** Require `limit` to be set on list queries. That way if you're following the schema specification when you make the call the response you get also follows the schema specification.

This completely ignores/hides the shape changing nature of the current API for list endpoints.

Fixes #9195