### PR TITLE
Add revision column to BO table

### DIFF
--- a/src/frontend/src/tables/build/BuildOrderTable.tsx
+++ b/src/frontend/src/tables/build/BuildOrderTable.tsx
@@ -77,6 +77,11 @@ export function BuildOrderTable({
         title: t`IPN`
       },
       {
+        accessor: 'part_detail.revision',
+        title: t`Revision`,
+        sortable: true
+      },
+      {
         accessor: 'title',
         sortable: false
       },


### PR DESCRIPTION
When revisions of parts are used it would be good to see that field also in the BO table

![image](https://github.com/user-attachments/assets/fc720414-b588-4172-a2e3-883dbdf4d8b8)
