### PR TITLE
Refactor/ubiquitous language

### DIFF
--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1695,7 +1695,7 @@ class PurchaseOrderLineItem(OrderLineItem):
             return None
         return self.part.part
 
-    part = models.ForeignKey(
+    supplier_part = models.ForeignKey(
         SupplierPart,
         on_delete=models.SET_NULL,
         blank=False,

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1765,8 +1765,8 @@ class PurchaseOrderLineItem(OrderLineItem):
 
     def update_pricing(self):
         """Update pricing information based on the supplier part data."""
-        if self.part:
-            price = self.part.get_price(
+        if self.supplier_part:
+            price = self.supplier_part.get_price(
                 self.quantity, currency=self.purchase_price_currency
             )
 


### PR DESCRIPTION
## Refactor: Ubiquitous Language

Hello maintainers,

As part of our assignment, we were tasked with applying Domain-Driven Design (DDD) principles to InvenTree. One aspect of DDD includes ubiquitous language, which refers to shared vocabulary between developers and domain experts. As we read through the codebase, we noticed a frequent usage of the `part` variable.

In the case when a `part` is supplied by a company, it is called a `SupplierPart`. This can be confusing to new contributors because,`part`, as a term is used frequently throughout the entire codebase, but in some instances when the term `part`, is used, it is referring to a `SupplierPart` instead.

This Pull Request refactors instances of `part` in the PurchaseOrder context to `supplier_part` to better reflect the entity's role and improve code readability.  We recognize that adopting this change consistently across the codebase would require significant effort, especially given our limited familiarity with all parts of the project.

As such, this is proposed as a suggestion to improve clarity. We’re happy to explore it further if it aligns with the maintainers’ vision for the codebase.

