### PR TITLE
fix(ci): Make translation step more robust

### DIFF
--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -49,9 +49,12 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add src/backend/InvenTree/locale/en/LC_MESSAGES/django.po src/frontend/src/locales/en/messages.po
+          echo "Adding commit (or ignoring if no changes)"
           git commit -m "add translations" || true
+          echo "Removing all other changes"
           git reset --hard
-          git reset HEAD~
+          echo "Resetting to HEAD~"
+          git reset HEAD~ || true
       - name: crowdin action
         uses: crowdin/github-action@b8012bd5491b8aa8578b73ab5b5f5e7c94aaa6e2 # pin@v2
         with:


### PR DESCRIPTION
The translation push step fails from time to time - this adds more step logging and makes it more robust https://github.com/inventree/InvenTree/actions/runs/14653723469/job/41124911037