### PR TITLE
feat(frontend): add grouping in the admin center

### DIFF
--- a/src/frontend/src/components/panels/Panel.tsx
+++ b/src/frontend/src/components/panels/Panel.tsx
@@ -13,3 +13,10 @@ export type PanelType = {
   disabled?: boolean;
   showHeadline?: boolean;
 };
+
+export type PanelGroupType = {
+  id: string;
+  label: string;
+  panelIDs?: string[];
+  panels?: PanelType[];
+};

--- a/src/frontend/src/components/panels/PanelGroup.tsx
+++ b/src/frontend/src/components/panels/PanelGroup.tsx
@@ -6,6 +6,7 @@ import {
   Paper,
   Stack,
   Tabs,
+  Text,
   Tooltip
 } from '@mantine/core';
 import {
@@ -36,6 +37,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { identifierString } from '../../functions/conversion';
 import { usePluginPanels } from '../../hooks/UsePluginPanels';
 import { useLocalState } from '../../states/LocalState';
+import { vars } from '../../theme';
 import { Boundary } from '../Boundary';
 import { StylishText } from '../items/StylishText';
 import type { PanelGroupType, PanelType } from '../panels/Panel';
@@ -99,7 +101,7 @@ function BasePanelGroup({
 
   // Rebuild the list of panels
   const [allPanels, groupedPanels] = useMemo(() => {
-    const _grouped_pannels: PanelGroupType[] = [];
+    const _grouped_panels: PanelGroupType[] = [];
     const _panels = [...panels];
     const _allpanels: PanelType[] = [...panels];
 
@@ -113,12 +115,12 @@ function BasePanelGroup({
           _panels.splice(index, 1);
         }
       });
-      _grouped_pannels.push(newVal);
+      _grouped_panels.push(newVal);
     });
 
     // Add remaining panels to group
     if (_panels.length > 0) {
-      _grouped_pannels.push({
+      _grouped_panels.push({
         id: 'ungrouped',
         label: '',
         panels: _panels
@@ -145,14 +147,14 @@ function BasePanelGroup({
     });
 
     if (pluginPanels.length > 0) {
-      _grouped_pannels.push({
+      _grouped_panels.push({
         id: 'plugins',
         label: markCustomPanels ? t`Plugin Provided` : '',
         panels: pluginPanels
       });
     }
 
-    return [_allpanels, _grouped_pannels];
+    return [_allpanels, _grouped_panels];
   }, [groups, panels, pluginPanelSet]);
 
   const activePanels = useMemo(
@@ -238,7 +240,13 @@ function BasePanelGroup({
 
               return (
                 <>
-                  <strong>{group.label}</strong>
+                  <Text
+                    fs={'italic'}
+                    ml={'1rem'}
+                    c={vars.colors.primaryColors[7]}
+                  >
+                    {group.label}
+                  </Text>
                   {groupTabls}
                 </>
               );

--- a/src/frontend/src/components/panels/PanelGroup.tsx
+++ b/src/frontend/src/components/panels/PanelGroup.tsx
@@ -144,6 +144,10 @@ function BasePanelGroup({
         ...panel,
         name: panelKey
       });
+      _allpanels.push({
+        ...panel,
+        name: panelKey
+      });
     });
 
     if (pluginPanels.length > 0) {

--- a/src/frontend/src/components/panels/PanelGroup.tsx
+++ b/src/frontend/src/components/panels/PanelGroup.tsx
@@ -31,13 +31,14 @@ import {
 import type { ModelType } from '@lib/enums/ModelType';
 import { cancelEvent } from '@lib/functions/Events';
 import { navigateToLink } from '@lib/functions/Navigation';
+import { t } from '@lingui/core/macro';
 import { useShallow } from 'zustand/react/shallow';
 import { identifierString } from '../../functions/conversion';
 import { usePluginPanels } from '../../hooks/UsePluginPanels';
 import { useLocalState } from '../../states/LocalState';
 import { Boundary } from '../Boundary';
 import { StylishText } from '../items/StylishText';
-import type { PanelType } from '../panels/Panel';
+import type { PanelGroupType, PanelType } from '../panels/Panel';
 import * as classes from './PanelGroup.css';
 
 /**
@@ -56,6 +57,7 @@ import * as classes from './PanelGroup.css';
 export type PanelProps = {
   pageKey: string;
   panels: PanelType[];
+  groups?: PanelGroupType[];
   instance?: any;
   reloadInstance?: () => void;
   model?: ModelType | string;
@@ -63,18 +65,21 @@ export type PanelProps = {
   selectedPanel?: string;
   onPanelChange?: (panel: string) => void;
   collapsible?: boolean;
+  markCustomPanels?: boolean;
 };
 
 function BasePanelGroup({
   pageKey,
   panels,
+  groups,
   onPanelChange,
   selectedPanel,
   reloadInstance,
   instance,
   model,
   id,
-  collapsible = true
+  collapsible = true,
+  markCustomPanels = false
 }: Readonly<PanelProps>): ReactNode {
   const localState = useLocalState();
   const location = useLocation();
@@ -93,29 +98,62 @@ function BasePanelGroup({
   });
 
   // Rebuild the list of panels
-  const allPanels = useMemo(() => {
+  const [allPanels, groupedPanels] = useMemo(() => {
+    const _grouped_pannels: PanelGroupType[] = [];
     const _panels = [...panels];
+    const _allpanels: PanelType[] = [...panels];
+
+    groups?.forEach((group) => {
+      const newVal: any = { ...group, panels: [] };
+      // Add panel to group and remove from main list
+      group.panelIDs?.forEach((panelID) => {
+        const index = _panels.findIndex((p) => p.name === panelID);
+        if (index !== -1) {
+          newVal.panels.push(_panels[index]);
+          _panels.splice(index, 1);
+        }
+      });
+      _grouped_pannels.push(newVal);
+    });
+
+    // Add remaining panels to group
+    if (_panels.length > 0) {
+      _grouped_pannels.push({
+        id: 'ungrouped',
+        label: '',
+        panels: _panels
+      });
+    }
 
     // Add plugin panels
+    const pluginPanels: any = [];
     pluginPanelSet.panels?.forEach((panel) => {
       let panelKey = panel.name;
 
       // Check if panel with this name already exists
-      const existingPanel = _panels.find((p) => p.name === panelKey);
+      const existingPanel = panels.find((p) => p.name === panelKey);
 
       if (existingPanel) {
         // Create a unique key for the panel which includes the plugin slug
         panelKey = identifierString(`${panel.pluginName}-${panel.name}`);
       }
 
-      _panels.push({
+      pluginPanels.push({
         ...panel,
         name: panelKey
       });
     });
 
-    return _panels;
-  }, [panels, pluginPanelSet]);
+    if (pluginPanels.length > 0) {
+      _grouped_pannels.push({
+        id: 'plugins',
+        label: markCustomPanels ? t`Plugins` : '',
+        panels: pluginPanels
+      });
+    }
+
+    return [_allpanels, _grouped_pannels];
+  }, [groups, panels, pluginPanelSet]);
 
   const activePanels = useMemo(
     () => allPanels.filter((panel) => !panel.hidden && !panel.disabled),
@@ -170,32 +208,41 @@ function BasePanelGroup({
           classNames={{ tab: classes.selectedPanelTab }}
         >
           <Tabs.List justify='left' aria-label={`panel-tabs-${pageKey}`}>
-            {allPanels.map(
-              (panel) =>
-                !panel.hidden && (
-                  <Tooltip
-                    label={panel.label ?? panel.name}
-                    key={panel.name}
-                    disabled={expanded}
-                    position='right'
-                  >
-                    <Tabs.Tab
-                      p='xs'
-                      key={`panel-label-${panel.name}`}
-                      value={panel.name}
-                      leftSection={panel.icon}
-                      hidden={panel.hidden}
-                      disabled={panel.disabled}
-                      style={{ cursor: panel.disabled ? 'unset' : 'pointer' }}
-                      onClick={(event: any) =>
-                        handlePanelChange(panel.name, event)
-                      }
+            {groupedPanels.map((group) => {
+              const groupTabls = group.panels?.map(
+                (panel) =>
+                  !panel.hidden && (
+                    <Tooltip
+                      label={panel.label ?? panel.name}
+                      key={panel.name}
+                      disabled={expanded}
+                      position='right'
                     >
-                      {expanded && panel.label}
-                    </Tabs.Tab>
-                  </Tooltip>
-                )
-            )}
+                      <Tabs.Tab
+                        p='xs'
+                        key={`panel-label-${panel.name}`}
+                        value={panel.name}
+                        leftSection={panel.icon}
+                        hidden={panel.hidden}
+                        disabled={panel.disabled}
+                        style={{ cursor: panel.disabled ? 'unset' : 'pointer' }}
+                        onClick={(event: any) =>
+                          handlePanelChange(panel.name, event)
+                        }
+                      >
+                        {expanded && panel.label}
+                      </Tabs.Tab>
+                    </Tooltip>
+                  )
+              );
+
+              return (
+                <>
+                  <strong>{group.label}</strong>
+                  {groupTabls}
+                </>
+              );
+            })}
             {collapsible && (
               <Group wrap='nowrap' gap='xs'>
                 <ActionIcon

--- a/src/frontend/src/components/panels/PanelGroup.tsx
+++ b/src/frontend/src/components/panels/PanelGroup.tsx
@@ -147,7 +147,7 @@ function BasePanelGroup({
     if (pluginPanels.length > 0) {
       _grouped_pannels.push({
         id: 'plugins',
-        label: markCustomPanels ? t`Plugins` : '',
+        label: markCustomPanels ? t`Plugin Provided` : '',
         panels: pluginPanels
       });
     }

--- a/src/frontend/src/pages/Index/Settings/AdminCenter/Index.tsx
+++ b/src/frontend/src/pages/Index/Settings/AdminCenter/Index.tsx
@@ -242,7 +242,7 @@ export default function AdminCenter() {
       },
       {
         id: 'data',
-        label: t`Data`,
+        label: t`Data Management`,
         panelIDs: [
           'import',
           'export',
@@ -254,16 +254,22 @@ export default function AdminCenter() {
       {
         id: 'reporting',
         label: t`Reporting`,
-        panelIDs: ['labels', 'reports', 'stocktake']
+        panelIDs: ['labels', 'reports']
       },
       {
         id: 'extend',
-        label: t`Extend`,
+        label: t`Extend / Integrate`,
         panelIDs: ['plugin', 'machine']
       },
       {
-        id: 'other',
-        label: t`Other`
+        id: 'plm',
+        label: t`PLM`,
+        panelIDs: [
+          'part-parameters',
+          'category-parameters',
+          'location-types',
+          'stocktake'
+        ]
       }
     ];
   }, []);

--- a/src/frontend/src/pages/Index/Settings/AdminCenter/Index.tsx
+++ b/src/frontend/src/pages/Index/Settings/AdminCenter/Index.tsx
@@ -25,7 +25,10 @@ import { UserRoles } from '@lib/enums/Roles';
 import PermissionDenied from '../../../../components/errors/PermissionDenied';
 import PageTitle from '../../../../components/nav/PageTitle';
 import { SettingsHeader } from '../../../../components/nav/SettingsHeader';
-import type { PanelType } from '../../../../components/panels/Panel';
+import type {
+  PanelGroupType,
+  PanelType
+} from '../../../../components/panels/Panel';
 import { PanelGroup } from '../../../../components/panels/PanelGroup';
 import { GlobalSettingList } from '../../../../components/settings/SettingList';
 import { Loadable } from '../../../../functions/loading';
@@ -104,7 +107,7 @@ export default function AdminCenter() {
     return [
       {
         name: 'user',
-        label: t`User Management`,
+        label: t`Users / Access`,
         icon: <IconUsersGroup />,
         content: <UserManagementPanel />,
         hidden: !user.hasViewRole(UserRoles.admin)
@@ -224,6 +227,46 @@ export default function AdminCenter() {
       }
     ];
   }, [user]);
+  const grouping: PanelGroupType[] = useMemo(() => {
+    return [
+      {
+        id: 'ops',
+        label: t`Operations`,
+        panelIDs: [
+          'user',
+          'barcode-history',
+          'background',
+          'errors',
+          'currencies'
+        ]
+      },
+      {
+        id: 'data',
+        label: t`Data`,
+        panelIDs: [
+          'import',
+          'export',
+          'project-codes',
+          'custom-states',
+          'custom-units'
+        ]
+      },
+      {
+        id: 'reporting',
+        label: t`Reporting`,
+        panelIDs: ['labels', 'reports', 'stocktake']
+      },
+      {
+        id: 'extend',
+        label: t`Extend`,
+        panelIDs: ['plugin', 'machine']
+      },
+      {
+        id: 'other',
+        label: t`Other`
+      }
+    ];
+  }, []);
 
   return (
     <>
@@ -238,7 +281,9 @@ export default function AdminCenter() {
           <PanelGroup
             pageKey='admin-center'
             panels={adminCenterPanels}
+            groups={grouping}
             collapsible={true}
+            markCustomPanels={true}
             model='admincenter'
             id={null}
           />


### PR DESCRIPTION
This PR adds the option to configure groupings for panels, providing a better overview regarding impacted areas of the panels.
![grafik](https://github.com/user-attachments/assets/ddb600c8-7300-4f53-bc6f-e6c23ce71265)
