### PR TITLE
feat(docs): add stable links for external sites

### DIFF
--- a/docs/main.py
+++ b/docs/main.py
@@ -93,7 +93,8 @@ def check_link(url) -> bool:
 
     while attempts > 0:
         response = requests.head(url, timeout=5000)
-        if response.status_code == 200:
+        # Ensure GH is not causing issues
+        if response.status_code in (200, 429):
             # Update the cache file
             with open(CACHE_FILE, 'a', encoding='utf-8') as f:
                 f.write(f'{url}\n')

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -263,9 +263,9 @@ plugins:
             show_root_toc_entry: false
   - redirects:
       redirect_maps:
-        'sref/contrib.md': 'docs/develop/contributing.md'  #  https://github.com/inventree/InvenTree/blob/master/CONTRIBUTING.md.
-        'sref/docs.md': 'docs/index.md' #   https://docs.inventree.org/en/latest/
-        'sref/api.md': 'docs/api/index.md' #  https://demo.inventree.org/api-doc/
+        'sref/contrib.md': 'develop/contributing.md'  #  https://github.com/inventree/InvenTree/blob/master/CONTRIBUTING.md.
+        'sref/docs.md': 'index.md' #   https://docs.inventree.org/en/latest/
+        'sref/api.md': 'api/index.md' #  https://demo.inventree.org/api-doc/
         'sref/code.md': 'https://github.com/inventree/InvenTree/tree/master' #  https://github.com/inventree/InvenTree/tree/master
         'sref/oci-image.md': 'https://hub.docker.com/r/inventree/inventree/tags' #  https://hub.docker.com/r/inventree/inventree/tags
         'sref/releases.md': 'https://github.com/inventree/InvenTree/releases' # https://github.com/inventree/InvenTree/releases

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -261,6 +261,22 @@ plugins:
             show_symbol_type_toc: true
             show_root_heading: false
             show_root_toc_entry: false
+  - redirects:
+      redirect_maps:
+        'sref/contrib.md': 'docs/develop/contributing.md'  #  https://github.com/inventree/InvenTree/blob/master/CONTRIBUTING.md.
+        'sref/docs.md': 'docs/index.md' #   https://docs.inventree.org/en/latest/
+        'sref/api.md': 'docs/api/index.md' #  https://demo.inventree.org/api-doc/
+        'sref/code.md': 'https://github.com/inventree/InvenTree/tree/master' #  https://github.com/inventree/InvenTree/tree/master
+        'sref/oci-image.md': 'https://hub.docker.com/r/inventree/inventree/tags' #  https://hub.docker.com/r/inventree/inventree/tags
+        'sref/releases.md': 'https://github.com/inventree/InvenTree/releases' # https://github.com/inventree/InvenTree/releases
+        'sref/issues.md': 'https://github.com/inventree/InvenTree/issues' # https://github.com/inventree/InvenTree/issues
+        'sref/security-policy.md': 'https://github.com/inventree/InvenTree/security/policy' # https://github.com/inventree/InvenTree/security/policy
+        'sref/security-history.md': 'https://huntr.dev/repos/inventree/inventree/' # https://huntr.dev/repos/inventree/inventree/
+        'sref/ci.md': 'https://github.com/inventree/InvenTree/actions' # https://github.com/inventree/InvenTree/actions
+        'sref/ci-sample.md': 'https://github.com/inventree/InvenTree/blob/master/.github/workflows/qc_checks.yaml' # https://github.com/inventree/InvenTree/blob/master/.github/workflows/qc_checks.yaml
+        'sref/ci-pre.md': 'https://github.com/inventree/InvenTree/blob/master/.pre-commit-config.yaml' # https://github.com/inventree/InvenTree/blob/master/.pre-commit-config.yaml
+        'sref/test-sample.md': 'https://github.com/inventree/InvenTree/blob/master/src/backend/InvenTree/InvenTree/tests.py' # https://github.com/inventree/InvenTree/blob/master/src/backend/InvenTree/InvenTree/tests.py
+        'sref/coverage.md': 'https://coveralls.io/github/inventree/InvenTree' # https://coveralls.io/github/inventree/InvenTree
 
 # Extensions
 markdown_extensions:

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -2,6 +2,7 @@ mkdocs==1.6.1
 mkdocs-macros-plugin>=0.7,<2.0
 mkdocs-material>=9.0,<10.0
 mkdocs-git-revision-date-localized-plugin>=1.1,<2.0
+mkdocs-redirects
 mkdocs-simple-hooks>=0.1,<1.0
 mkdocs-include-markdown-plugin
 neoteroi-mkdocs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -306,6 +306,7 @@ mkdocs==1.6.1 \
     #   mkdocs-include-markdown-plugin
     #   mkdocs-macros-plugin
     #   mkdocs-material
+    #   mkdocs-redirects
     #   mkdocs-simple-hooks
     #   mkdocstrings
     #   neoteroi-mkdocs
@@ -339,6 +340,10 @@ mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \
     --hash=sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31
     # via mkdocs-material
+mkdocs-redirects==1.2.2 \
+    --hash=sha256:3094981b42ffab29313c2c1b8ac3969861109f58b2dd58c45fc81cd44bfa0095 \
+    --hash=sha256:7dbfa5647b79a3589da4401403d69494bd1f4ad03b9c15136720367e1f340ed5
+    # via -r docs/requirements.in
 mkdocs-simple-hooks==0.1.5 \
     --hash=sha256:dddbdf151a18723c9302a133e5cf79538be8eb9d274e8e07d2ac3ac34890837c \
     --hash=sha256:efeabdbb98b0850a909adee285f3404535117159d5cb3a34f541d6eaa644d50a


### PR DESCRIPTION
This is useful for the CII best practices badge and other sites where we might need stable links; assuming we maintain control of docs.inventree.org seems like a good bet with current project structures.