### PR TITLE
refactor(docs): better security linking and references for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Want to see what we are working on? Check out the [roadmap tag](https://github.c
 
 InvenTree is designed to be **extensible**, and provides multiple options for **integration** with external applications or addition of custom plugins:
 
-* [InvenTree API](https://docs.inventree.org/en/latest/api/api/)
-* [Python module](https://docs.inventree.org/en/latest/api/python/python/)
-* [Plugin interface](https://docs.inventree.org/en/latest/extend/plugins)
-* [Third party tools](https://docs.inventree.org/en/latest/extend/integrate)
+* [InvenTree API](https://docs.inventree.org/en/latest/api/)
+* [Python module](https://docs.inventree.org/en/latest/api/python/)
+* [Plugin interface](https://docs.inventree.org/en/latest/plugins/)
+* [Third party tools](https://docs.inventree.org/en/latest/plugins/integrate/)
 
 <!-- TechStack -->
 ### :space_invader: Tech Stack

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ InvenTree is following industry best practices for security. Our security policy
 <!-- Contributing -->
 ## :wave: Contributing
 
-Contributions are welcomed and encouraged. Please help to make this project even better! Refer to the [contribution page](CONTRIBUTING.md).
+Contributions are welcomed and encouraged. Please help to make this project even better! Refer to the [contribution page](https://docs.inventree.org/en/latest/develop/contributing/).
 
 <!-- Translation -->
 ## :scroll: Translation

--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ InvenTree is supported by a [companion mobile app](https://docs.inventree.org/ap
     <a href="https://apps.apple.com/au/app/inventree/id1581731101#?platform=iphone">Apple App Store</a>
 </h4></div>
 
+<!-- Security -->
+## :lock: Code of Conduct & Security Policy
+
+The InvenTree project team is committed to providing a safe and welcoming environment for all users. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) for more information.
+
+InvenTree is following industry best practices for security. Our security policy is included [in this repo](SECURITY.md). We provide dedicated security pages on [our documentation site](https://docs.inventree.org/en/latest/security/).
+
 <!-- Contributing -->
 ## :wave: Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,3 +17,9 @@ Someone from the InvenTree development team will acknowledge your email as soon 
 
 
 The team will endeavour to keep you informed of the progress towards a fix for the issue, and subsequent release to the stable and development code branches. Where possible, the issue will be resolved within 90 days of reporting.
+
+### Public Disclosure
+
+Using GitHub's security advisory system, we will publish a public disclosure of the issue once it has been acknowledged, reproduced and resolved.
+We support assigning CVEs to security issues where appropriate.
+The project can be identified by the CPE code ``cpe:2.3:a:inventree_project:inventree:``.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,9 @@
 # Security Policy
 
 The InvenTree team take all security vulnerabilities seriously. Thank you for improving the security of our open source software.
+
 We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
+The general project security policies and processes are documented in [our documentation](https://docs.inventree.org/en/stable/security/).
 
 ## Reporting a Vulnerability
 
@@ -11,7 +13,7 @@ Please report security vulnerabilities by emailing the InvenTree team at:
 security@inventree.org
 ```
 
-Someone from the InvenTree development team will acknowledge your email as soon as possible, and indicate the next steps in handling your security report.
+Someone from the InvenTree development team will acknowledge your email as soon as possible (normally within a week), and indicate the next steps in handling your security report.
 
 
 The team will endeavour to keep you informed of the progress towards a fix for the issue, and subsequent release to the stable and development code branches. Where possible, the issue will be resolved within 90 days of reporting.

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -10,8 +10,12 @@ Read the Project [Governance](./project/governance.md) document for more informa
 
 InvenTree is open-source, and we welcome contributions from the community. However, all contributions are reviewed and scrutinised before being merged into the codebase.
 
-We provide a written [Security Policy]({{ sourcefile("SECURITY.md") }}) in our main repo to ensure that all security issues are handled in a timely manner.
+### Security Policy
 
+The official [Security Policy]({{ sourcefile("SECURITY.md") }}) is available in the code repository.
+We provide this document in our main repo to increase discoverabiltity to ensure that all security issues are handled in a timely manner.
+
+### Past Reports
 If we become aware of a security issue, we will take immediate action to address the issue, and will provide a public disclosure of the issue once it has been resolved. We support assigning CVEs to security issues where appropriate.  Our [past security advisories can be found here](https://github.com/inventree/InvenTree/security/advisories).
 
 ## Technical measures
@@ -54,6 +58,6 @@ We also follow OpenSSF recommendations where applicable and take part in multipl
 - OSSF Best Practices, currently at a [level of passing](https://www.bestpractices.dev/de/projects/7179)
 - OSSF Scorecard, running with each merge [check current state](https://securityscorecards.dev/viewer/?uri=github.com/inventree/InvenTree)
 
-## Security Policy
+## Hall of Fame
 
-The official [Security Policy]({{ sourcefile("SECURITY.md") }}) is available in the code repository.
+We are grateful for all reports. Confirmed reports can be rewarded with a mention in the Hall of Fame below if the reporter requests it. We are also happy to provide a CVE if applicable.

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -1,6 +1,9 @@
 
 The InvenTree project is committed to providing a secure and safe environment for all users. We know that many of our users rely on InvenTree to manage the inventory and manufacturing for their small and mid-size businesses, and we take that responsibility seriously.
 
+!!! tip "This page covers the InvenTree project"
+    This page covers the InvenTree project as a whole. Specific security measures for deploying your own instance of InvenTree can be found on the [Threat Model](./concepts/threat_model.md) page.
+
 To that end, we have implemented a number of security measures over the years, which we will outline in this document.
 
 ## Organisational measures


### PR DESCRIPTION
- Adds a link to the general docs on security to the security.md
- Adds a link to security and code of conduct to the readme
- Adds a bit more structure to the project security docs