### PR TITLE
Fix Generate API schema name mismatch

### DIFF
--- a/src/backend/InvenTree/stock/serializers.py
+++ b/src/backend/InvenTree/stock/serializers.py
@@ -143,20 +143,24 @@ class GenerateSerialNumberSerializer(serializers.Serializer):
     Any of the provided write-only fields can be used for additional context.
 
     Note that in the case where multiple serial numbers are required,
-    the "serial" field will return a string with multiple serial numbers separated by a comma.
+    the "serial_number" field will return a string with multiple serial numbers
+    separated by a comma.
     """
 
     class Meta:
         """Metaclass options."""
 
-        fields = ['serial', 'part', 'quantity']
+        fields = ['serial_number', 'part', 'quantity']
 
-        read_only_fields = ['serial']
+        read_only_fields = ['serial_number']
 
         write_only_fields = ['part', 'quantity']
 
-    serial = serializers.CharField(
-        read_only=True, help_text=_('Generated serial number'), label=_('Serial Number')
+    serial_number = serializers.CharField(
+        read_only=True,
+        allow_null=True,
+        help_text=_('Generated serial number'),
+        label=_('Serial Number'),
     )
 
     part = serializers.PrimaryKeyRelatedField(


### PR DESCRIPTION
`GenerateSerialNumber` returns data directly. A serializer class is specified (and used for schema generation) but didn't match the name used in the data return.

See `src/backend/InvenTree/stock/api.py#GenerateSerialNumber` for where the returned json is created.