### PR TITLE
Match YesNoButton green to DetailsBadge green

### DIFF
--- a/src/frontend/src/components/buttons/YesNoButton.tsx
+++ b/src/frontend/src/components/buttons/YesNoButton.tsx
@@ -18,7 +18,7 @@ export function PassFailButton({
 
   return (
     <Badge
-      color={v ? 'lime.5' : 'red.6'}
+      color={v ? 'green' : 'red'}
       variant='filled'
       radius='lg'
       size='sm'


### PR DESCRIPTION
I've gotten complaints from my users about this mismatch in green color between the `DetailsBadge` and `YesNoButton`, particularly apparent when in dark mode. I propose we match these colors by just using the standard `green` and `red` in the `YesNoButton`. 

It's subtle, but I tend to agree it improves readability and contrast, particularly in dark mode. I've already patched my local version with this, but curious if you agree with the change. I'll add some screenshots in the comments
