### PR TITLE
Change color of SO status SHIPPED

### DIFF
--- a/src/backend/InvenTree/order/status_codes.py
+++ b/src/backend/InvenTree/order/status_codes.py
@@ -47,7 +47,7 @@ class SalesOrderStatus(StatusCode):
         _('In Progress'),
         ColorEnum.primary,
     )  # Order has been issued, and is in progress
-    SHIPPED = 20, _('Shipped'), ColorEnum.success  # Order has been shipped to customer
+    SHIPPED = 20, _('Shipped'), ColorEnum.primary  # Order has been shipped to customer
     ON_HOLD = 25, _('On Hold'), ColorEnum.warning  # Order is on hold
     COMPLETE = 30, _('Complete'), ColorEnum.success  # Order is complete
     CANCELLED = 40, _('Cancelled'), ColorEnum.danger  # Order has been cancelled


### PR DESCRIPTION
Ref: #9665

Reserving a unique color for orders that are `COMPLETE` makes it easier to spot orders that still needs to act upon.

Before:

![Screenshot 2025-05-16 224447](https://github.com/user-attachments/assets/0daf9edf-8723-4ebe-b825-2539348315d2)

After:

![Screenshot 2025-05-16 225132](https://github.com/user-attachments/assets/36b7a126-97de-4c62-a611-f0aeae756df0)
