### PR TITLE
[Docs] Updated  path to supervisor config file

### DIFF
--- a/docs/docs/start/bare_prod.md
+++ b/docs/docs/start/bare_prod.md
@@ -67,12 +67,12 @@ sudo apt-get install supervisor
 
 !!! warning "Configuration Override"
     If you already have supervisor installed on your system, you will not want to override your existing configuration file.
-    In this case, edit the existing configuration file at `/etc/supervisord.conf` to integrate the InvenTree processes
+    In this case, edit the existing configuration file at `/etc/supervisor/supervisord.conf` to integrate the InvenTree processes
 
 Copy the supervisor configuration file:
 
 ```
-sudo cp /home/inventree/src/contrib/deploy/supervisord.conf /etc/supervisord.conf
+sudo cp /home/inventree/src/contrib/deploy/supervisord.conf /etc/supervisor/supervisord.conf
 ```
 
 ### Start Supervisor Daemon


### PR DESCRIPTION
I just installed a new bare metal InvenTree system on a clean Ubuntu 22.04 VM.

The current supervisor version in the Ubuntu 22.04 repo is 4.2.1 and since version 3.3.0 [the config file has been moved](https://supervisord.org/configuration.html) to `/etc/supervisor/supervisord.conf`. Although the old location still works I suggest to update the InvenTree documentation to reflect the latest implementaiton.
