### PR TITLE
Expose devcontainer ports

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,10 +38,16 @@
   },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [5173, 8000, 8080],
+  "forwardPorts": [5173, 5432, 6379, 8000, 8080],
   "portsAttributes": {
     "5173": {
       "label": "Vite Server"
+    },
+    "5432": {
+      "label": "PostgreSQL Database"
+    },
+    "6379": {
+      "label": "Redis Server"
     },
     "8000": {
       "label": "InvenTree Server"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   db:
     image: postgres:15
     restart: unless-stopped
-    expose:
+    ports:
       - 5432/tcp
     volumes:
       - ../dev-db/:/var/lib/postgresql/data:z
@@ -14,7 +14,7 @@ services:
   redis:
     image: redis:7.0
     restart: always
-    expose:
+    ports:
       - 6379
 
   inventree:


### PR DESCRIPTION
- Allow external connection to DB (in devcontainer)
- Allows developers to use an external GUI to view internal database data