### PR TITLE
Cleanup panel groups

### DIFF
--- a/src/frontend/src/components/panels/PanelGroup.tsx
+++ b/src/frontend/src/components/panels/PanelGroup.tsx
@@ -218,13 +218,16 @@ function BasePanelGroup({
             {groupedPanels.map((group) => (
               <Box key={`group-${group.id}`} w={'100%'}>
                 <Text
-                  fs={'italic'}
-                  ml={'1rem'}
+                  hidden={!group.label || !expanded}
                   c={vars.colors.primaryColors[7]}
                   key={`group-label-${group.id}`}
+                  style={{
+                    paddingLeft: '10px'
+                  }}
                 >
                   {group.label}
                 </Text>
+                {group.label && <Divider c={vars.colors.primaryColors[7]} />}
                 {group.panels?.map(
                   (panel) =>
                     !panel.hidden && (

--- a/src/frontend/src/pages/Index/Settings/AdminCenter/Index.tsx
+++ b/src/frontend/src/pages/Index/Settings/AdminCenter/Index.tsx
@@ -257,11 +257,6 @@ export default function AdminCenter() {
         panelIDs: ['labels', 'reports']
       },
       {
-        id: 'extend',
-        label: t`Extend / Integrate`,
-        panelIDs: ['plugin', 'machine']
-      },
-      {
         id: 'plm',
         label: t`PLM`,
         panelIDs: [
@@ -270,6 +265,11 @@ export default function AdminCenter() {
           'location-types',
           'stocktake'
         ]
+      },
+      {
+        id: 'extend',
+        label: t`Extend / Integrate`,
+        panelIDs: ['plugin', 'machine']
       }
     ];
   }, []);


### PR DESCRIPTION
- Hide label if panel is not expanded
- Add a visual divider

### Screenshots

| Expanded | Collapsed |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/997177f9-ae1c-4d02-b63b-d8b577ce953e) | ![image](https://github.com/user-attachments/assets/23f4d7df-d556-4127-8bca-60cc98de7f31) |

