### PR TITLE
Schema: Add possible order fields to 'ordering' field description

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,11 +1,15 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 350
+INVENTREE_API_VERSION = 351
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+v351 -> 2025-06-18 : https://github.com/inventree/InvenTree/pull/9803
+    - Make PurchaseOrderLineItem link to BuildOrder reference nullable
+    - Add valid fields to ordering field descriptions
+
 v350 -> 2025-06-17 : https://github.com/inventree/InvenTree/pull/9798
     - Adds "can_build" field to the part requirements API endpoint
     - Remove "allocated" and "required" fields from the part requirements API endpoint

--- a/src/backend/InvenTree/InvenTree/schema.py
+++ b/src/backend/InvenTree/InvenTree/schema.py
@@ -91,6 +91,16 @@ class ExtendedAutoSchema(AutoSchema):
                 if parameter['name'] == 'limit':
                     parameter['required'] = True
 
+        # Add valid order selections to the ordering field description.
+        ordering_fields = getattr(self.view, 'ordering_fields', None)
+        if ordering_fields is not None:
+            parameters = operation.get('parameters', [])
+            for parameter in parameters:
+                if parameter['name'] == 'ordering':
+                    parameter['description'] = (
+                        f'{parameter["description"]} Possible fields: {", ".join(ordering_fields)}.'
+                    )
+
         return operation
 
 

--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -649,7 +649,7 @@ class PurchaseOrderLineItemSerializer(
     )
 
     build_order_detail = build.serializers.BuildSerializer(
-        source='build_order', read_only=True, many=False
+        source='build_order', read_only=True, allow_null=True, many=False
     )
 
     merge_items = serializers.BooleanField(


### PR DESCRIPTION
This PR adds documentation of the valid fields for ordering to the schema description of the various `ordering` fields. Sample change:

```diff
diff --git a/original_schema.yml b/schema.yml
--- a/original_schema.yml
+++ b/schema.yml
@@ -131,7 +131,8 @@ paths:
       - name: ordering
         required: false
         in: query
-        description: Which field to use when ordering the results.
+        description: 'Which field to use when ordering the results. Possible values:
+          model_id, model_type, upload_date, file_size.'
         schema:
           type: string
```

And because I just caught up to recent changes, I added a fix for the schema not allowing `PurchaseOrderLineItem`s to have null `BuildOrder` references.