### PR TITLE
[0.17.x] feat: add cluster monitor task (#9812)

### DIFF
--- a/src/backend/requirements.in
+++ b/src/backend/requirements.in
@@ -1,5 +1,6 @@
 # Please keep this list sorted - if you pin a version provide a reason
 Django<5.0                              # Django package
+blessed                                 # CLI for Q Monitor
 coreapi                                 # API documentation for djangorestframework
 cryptography>=40.0.0,!=40.0.2           # Core cryptographic functionality
 django-allauth[openid,saml]               # SSO for external providers via OpenID

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -26,6 +26,10 @@ bleach[css]==6.2.0 \
     --hash=sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e \
     --hash=sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f
     # via django-markdownify
+blessed==1.21.0 \
+    --hash=sha256:ece8bbc4758ab9176452f4e3a719d70088eb5739798cd5582c9e05f2a28337ec \
+    --hash=sha256:f831e847396f5a2eac6c106f4dfadedf46c4f804733574b15fe86d2ed45a9588
+    # via -r src/backend/requirements.in
 brotli==1.1.0 \
     --hash=sha256:03d20af184290887bdea3f0f78c4f737d126c74dc2f3ccadf07e54ceca3bf208 \
     --hash=sha256:0541e747cce78e24ea12d69176f6a7ddb690e62c425e01d31cc065e69ce55b48 \

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -1643,7 +1643,9 @@ urllib3==2.2.3 \
 wcwidth==0.2.13 \
     --hash=sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859 \
     --hash=sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5
-    # via prettytable
+    # via
+    #   blessed
+    #   prettytable
 weasyprint==62.3 \
     --hash=sha256:8d8680d732f7fa0fcbc587692a5a5cb095c3525627066918d6e203cbf42b7fcd \
     --hash=sha256:d31048646ce15084e135b33e334a61f526aa68d2f679fcc109ed0e0f5edaed21

--- a/tasks.py
+++ b/tasks.py
@@ -1549,6 +1549,11 @@ def clear_generated(c):
     run(c, 'find src -name "messages.mo" -exec rm -f {} +')
 
 
+@task(pre=[wait])
+def monitor(c):
+    """Monitor the worker performance."""
+    manage(c, 'qmonitor', pty=True)
+
 # Collection sorting
 development = Collection(
     delete_data,
@@ -1597,6 +1602,7 @@ ns = Collection(
     version,
     wait,
     worker,
+    monitor,
 )
 
 ns.add_collection(development, 'dev')

--- a/tasks.py
+++ b/tasks.py
@@ -1554,6 +1554,7 @@ def monitor(c):
     """Monitor the worker performance."""
     manage(c, 'qmonitor', pty=True)
 
+
 # Collection sorting
 development = Collection(
     delete_data,


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `0.17.x`:
 - [feat: add cluster monitor task (#9812)](https://github.com/inventree/InvenTree/pull/9812)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)