### PR TITLE
Plugin url fix

### DIFF
--- a/src/backend/InvenTree/plugin/base/integration/UrlsMixin.py
+++ b/src/backend/InvenTree/plugin/base/integration/UrlsMixin.py
@@ -1,7 +1,6 @@
 """Plugin mixin class for UrlsMixin."""
 
 from django.conf import settings
-from django.urls import include, re_path
 
 import structlog
 
@@ -72,12 +71,11 @@ class UrlsMixin:
 
     @property
     def urlpatterns(self):
-        """Urlpatterns for this plugin."""
+        """URL patterns for this plugin."""
         if self.has_urls:
-            return re_path(
-                f'^{self.slug}/', include((self.urls, self.slug)), name=self.slug
-            )
-        return None
+            return self.urls or None
+        else:
+            return None
 
     @property
     def has_urls(self):

--- a/src/backend/InvenTree/plugin/base/integration/UrlsMixin.py
+++ b/src/backend/InvenTree/plugin/base/integration/UrlsMixin.py
@@ -72,10 +72,7 @@ class UrlsMixin:
     @property
     def urlpatterns(self):
         """URL patterns for this plugin."""
-        if self.has_urls:
-            return self.urls or None
-        else:
-            return None
+        return self.urls or None
 
     @property
     def has_urls(self):

--- a/src/backend/InvenTree/plugin/base/integration/test_mixins.py
+++ b/src/backend/InvenTree/plugin/base/integration/test_mixins.py
@@ -113,13 +113,10 @@ class UrlsMixinTest(BaseMixinDefinition, TestCase):
         target_pattern = re_path(
             f'^{plg_name}/', include((self.mixin.urls, plg_name)), name=plg_name
         )
-        self.assertEqual(
-            self.mixin.urlpatterns.reverse_dict, target_pattern.reverse_dict
-        )
 
         # resolve the view
-        self.assertEqual(self.mixin.urlpatterns.resolve('/testpath').func(), 'ccc')
-        self.assertEqual(self.mixin.urlpatterns.reverse('test'), 'testpath')
+        self.assertEqual(target_pattern.resolve('/testpath').func(), 'ccc')
+        self.assertEqual(target_pattern.reverse('test'), 'testpath')
 
         # no url
         self.assertIsNone(self.mixin_nothing.urls)

--- a/src/backend/InvenTree/plugin/urls.py
+++ b/src/backend/InvenTree/plugin/urls.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.urls import include, re_path
+from django.urls.exceptions import Resolver404
 from django.views.generic.base import RedirectView
 
 from common.validators import get_global_setting
@@ -24,7 +25,10 @@ def get_plugin_urls():
                     # Check if the plugin has a custom URL pattern
                     for url in plugin_urls:
                         # Attempt to resolve against the URL pattern as a validation check
-                        url.resolve('')
+                        try:
+                            url.resolve('')
+                        except Resolver404:
+                            pass
 
                     urls.append(
                         re_path(

--- a/src/backend/InvenTree/plugin/urls.py
+++ b/src/backend/InvenTree/plugin/urls.py
@@ -21,6 +21,11 @@ def get_plugin_urls():
         for plugin in registry.with_mixin(PluginMixinEnum.URLS):
             try:
                 if plugin_urls := plugin.urlpatterns:
+                    # Check if the plugin has a custom URL pattern
+                    for url in plugin_urls:
+                        # Attempt to resolve against the URL pattern as a validation check
+                        url.resolve('')
+
                     urls.append(
                         re_path(
                             f'^{plugin.slug}/',
@@ -30,6 +35,7 @@ def get_plugin_urls():
                     )
             except Exception:
                 log_error('get_plugin_urls', plugin=plugin.slug)
+                continue
 
     # Redirect anything else to the root index
     urls.append(


### PR DESCRIPTION
Adds error separation between plugins which register URLs. If a single plugin provides a broken URL path, it no longer will result in all the plugin URLs from breaking