### PR TITLE
Adjust "child_items" annotation for stockitem

### DIFF
--- a/src/backend/InvenTree/stock/filters.py
+++ b/src/backend/InvenTree/stock/filters.py
@@ -37,28 +37,6 @@ def annotate_location_items(filter: Q = None):
     )
 
 
-def annotate_child_items():
-    """Construct a queryset annotation which returns the number of children below a certain StockItem node in a StockItem tree."""
-    child_stock_query = stock.models.StockItem.objects.filter(
-        tree_id=OuterRef('tree_id'),
-        lft__gt=OuterRef('lft'),
-        rght__lt=OuterRef('rght'),
-        level__gte=OuterRef('level'),
-    )
-
-    return Coalesce(
-        Subquery(
-            child_stock_query.annotate(
-                count=Func(F('pk'), function='COUNT', output_field=IntegerField())
-            )
-            .values('count')
-            .order_by()
-        ),
-        0,
-        output_field=IntegerField(),
-    )
-
-
 def annotate_sub_locations():
     """Construct a queryset annotation which returns the number of sub-locations below a certain StockLocation node in a StockLocation tree."""
     subquery = stock.models.StockLocation.objects.filter(

--- a/src/backend/InvenTree/stock/serializers.py
+++ b/src/backend/InvenTree/stock/serializers.py
@@ -604,7 +604,7 @@ class StockItemSerializer(
         queryset = queryset.annotate(installed_items=SubqueryCount('installed_parts'))
 
         # Annotate with the total number of "child items" (split stock items)
-        queryset = queryset.annotate(child_items=stock.filters.annotate_child_items())
+        queryset = queryset.annotate(child_items=SubqueryCount('children'))
 
         return queryset
 


### PR DESCRIPTION
- Show the direct children only
- Makes more a much more efficient DB query
- In a mysql setup, reduced from  >20 seconds to < 200ms

This is a subtle change in the returned data - the  "child_items" field now shows the *direct* children of a stock item, rather than all the top-to-bottom children.

This makes no change to the user interface or behaviour. The "child items" table in the stock item view will still show all the children underneath a given item, no matter the "level".

However it makes a significant difference if running on a mysql DB which cannot run OuterRef queries as efficiently.