### PR TITLE
Change logger in labelTemplate.print, corrects order of arguments

### DIFF
--- a/src/backend/InvenTree/report/models.py
+++ b/src/backend/InvenTree/report/models.py
@@ -711,10 +711,7 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
             ValidationError: If there is an error during label printing
         """
         logger.info(
-            "Printing %s labels against template '%s' using plugin '%s'",
-            len(items),
-            plugin.slug,
-            self.name,
+            f"Printing {len(items)} labels against template '{self.name}' using plugin '{plugin.slug}'"
         )
 
         if not output:


### PR DESCRIPTION
Change logger.info in labelTemplate.print to use f-string, correct the order of arguments.

Before, output was something like:
```
Printing 1 labels against template 'inventreelabelmachine' using plugin 'InvenTree Stock Item Label (QR)'
```

since plugin and template name were in the wrong place. f-strings makes this clearer and easier to maintain.