### PR TITLE
Enable 'units' field for plugin settings

### DIFF
--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -213,6 +213,7 @@ class GenericReferencedSettingSerializer(SettingsSerializer):
                 'model_filters',
                 'api_url',
                 'typ',
+                'units',
                 'required',
             ]
 

--- a/src/backend/InvenTree/plugin/samples/integration/sample.py
+++ b/src/backend/InvenTree/plugin/samples/integration/sample.py
@@ -64,6 +64,7 @@ class SampleIntegrationPlugin(
             'description': _('A numerical setting'),
             'validator': int,
             'default': 123,
+            'units': 'metres',
         },
         'CHOICE_SETTING': {
             'name': _('Choice Setting'),


### PR DESCRIPTION
- Adds missing "units" field for settings associated with a plugin
- Already defined, just missing from the serializer
- Allows display of "units" in UI