### PR TITLE
[bug] Fix for tracing init

### DIFF
--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -878,7 +878,7 @@ if TRACING_ENABLED:  # pragma: no cover
 
         # Run tracing/logging instrumentation
         setup_tracing(**TRACING_DETAILS)
-        setup_instruments()
+        setup_instruments(DB_ENGINE)
     else:
         logger.warning('OpenTelemetry tracing not enabled because endpoint is not set')
 


### PR DESCRIPTION
- Circular include means that settings.DB_ENGINE may not be available
- Fixes bug introduced in https://github.com/inventree/InvenTree/pull/9808
- Currently killed the demo server

![image](https://github.com/user-attachments/assets/66bae400-2790-4c7e-be0c-ae0673316685)
