### PR TITLE
[UI Improve Table cache

### DIFF
--- a/src/frontend/src/hooks/UseFilterSet.tsx
+++ b/src/frontend/src/hooks/UseFilterSet.tsx
@@ -7,6 +7,7 @@ export function useFilterSet(filterKey: string): FilterSetState {
   const [activeFilters, setActiveFilters] = useLocalStorage<TableFilter[]>({
     key: `inventree-filterset-${filterKey}`,
     defaultValue: [],
+    sync: false,
     getInitialValueInEffect: false
   });
 

--- a/src/frontend/src/hooks/UseTable.tsx
+++ b/src/frontend/src/hooks/UseTable.tsx
@@ -72,6 +72,7 @@ export function useTable(tableName: string, idAccessor = 'pk'): TableState {
   const [pageSize, setPageSize] = useLocalStorage<number>({
     key: 'inventree-table-page-size',
     defaultValue: 25,
+    sync: false,
     deserialize: (value: string | undefined) => {
       setPageSizeLoaded(true);
       return value === undefined ? 25 : JSON.parse(value);
@@ -85,6 +86,7 @@ export function useTable(tableName: string, idAccessor = 'pk'): TableState {
   const [hiddenColumns, setHiddenColumns] = useLocalStorage<string[] | null>({
     key: `inventree-hidden-table-columns-${tableName}`,
     defaultValue: null,
+    sync: false,
     deserialize: (value) => {
       setHiddenColumnsLoaded(true);
       return value === undefined ? null : JSON.parse(value);


### PR DESCRIPTION
Currently the "table state" values are stored and retrieved directly using the `useLocalStorage` hook. As this is shared across tabs and browser sessions, this can lead to undesirable behavior with multiple tabs open on the same table view.

If multiple duplicate tables are open, and you change the visible columns or active filters on one browser, the table in the other browser will update / reload too:


This PR changes the cache behavior - the table settings are loaded from localStorage only on initial table render. Any changes to the table state are *written* to localStorage, but not loaded again until the next time the table is reloaded entirely.

### Before

https://github.com/user-attachments/assets/788e6b61-0b80-414c-b18b-97261fe41e94

### After


https://github.com/user-attachments/assets/3d9706e2-3265-40f9-a798-ae7912871c44

