### PR TITLE
fix(frontend): Incorrect redirect to MFA set up

### DIFF
--- a/src/frontend/src/states/states.tsx
+++ b/src/frontend/src/states/states.tsx
@@ -55,18 +55,9 @@ export async function fetchGlobalStates(
   }
 
   setApiDefaults();
-
-  await useServerApiState.getState().fetchServerApiState();
-  const result = await useUserSettingsState.getState().fetchSettings();
-
-  if (!result && navigate) {
-    console.log('MFA is required - setting up');
-    // call mfa setup
-    navigate('/mfa-setup');
-    return;
-  }
-
   await Promise.all([
+    useServerApiState.getState().fetchServerApiState(),
+    useUserSettingsState.getState().fetchSettings(),
     useGlobalSettingsState.getState().fetchSettings(),
     useGlobalStatusState.getState().fetchStatus(),
     useIconState.getState().fetchIcons()


### PR DESCRIPTION
Removes unneeded fallback for MFA login and makes all state requests parallel
Fixes #9880