### PR TITLE
Fix for invoke dev.translate task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -640,7 +640,7 @@ def translate(c, ignore_static=False, no_frontend=False):
     manage(c, 'compilemessages')
 
     if not no_frontend and node_available():
-        frontend_compile(c)
+        frontend_compile(c, extract=True)
 
     # Update static files
     if not ignore_static:
@@ -1525,17 +1525,18 @@ def frontend_check(c):
     print(node_available())
 
 
-@task
+@task(help={'extract': 'Extract translation strings. Default: False'})
 @state_logger('TASK06')
-def frontend_compile(c):
+def frontend_compile(c, extract: bool = False):
     """Generate react frontend.
 
-    Args:
+    Arguments:
         c: Context variable
+        extract (bool): Whether to extract translations from source code. Defaults to False.
     """
     info('Compiling frontend code...')
     frontend_install(c)
-    frontend_trans(c, extract=False)
+    frontend_trans(c, extract=extract)
     frontend_build(c)
     success('Frontend compilation complete')
 


### PR DESCRIPTION
- This task is used for syncing translations with crowdin
- However, it has been broken for some time, and does not *extract* translations
- Thus, no *new* translations have been uploaded to crowdin recently

@matmair this is a pretty crucial one, not sure how we missed this for so long.

As we have been adding new strings to the frontend UI, they have not actually been uploaded to crowdin for translation, as the sync task (in `.github/translations.yaml`) ran the following code:

```yaml
- name: Make Translations
  run: invoke dev.translate
```

and `dev.translate`:

```python
@task
def translate(c, ignore_static=False, no_frontend=False):
    """Rebuild translation source files. Advanced use only!

    Note: This command should not be used on a local install,
    it is performed as part of the InvenTree translation toolchain.
    """
    info('Building translation files')

    # Translate applicable .py / .html / .js files
    manage(c, 'makemessages --all -e py,html,js --no-wrap')
    manage(c, 'compilemessages')

    if not no_frontend and node_available():
        frontend_compile(c)

    # Update static files
    if not ignore_static:
        static(c)

    success('Translation files built successfully')
```

And `frontend_compile(c)` explicitly *does not extract translations*

```python
@task
@state_logger('TASK06')
def frontend_compile(c):
    """Generate react frontend.

    Args:
        c: Context variable
    """
    info('Compiling frontend code...')
    frontend_install(c)
    frontend_trans(c, extract=False)
    frontend_build(c)
    success('Frontend compilation complete')
```