### PR TITLE
Negative annotations

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,11 +1,14 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 358
+INVENTREE_API_VERSION = 359
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v359 -> 2025-07-01 : https://github.com/inventree/InvenTree/pull/9909
+    - Fixes annotated types for various part fields
 
 v358 -> 2025-06-25 : https://github.com/inventree/InvenTree/pull/9857
     - Provide list of generated stock items against "StockItemSerialize" API endpoint

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -1566,13 +1566,14 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
 
         # Calculate 'available_stock' based on previously annotated fields
         queryset = queryset.annotate(
-            available_stock=ExpressionWrapper(
-                Greatest(
+            available_stock=Greatest(
+                ExpressionWrapper(
                     F('total_stock')
                     - F('allocated_to_sales_orders')
                     - F('allocated_to_build_orders'),
-                    0,
+                    output_field=models.DecimalField(),
                 ),
+                0,
                 output_field=models.DecimalField(),
             )
         )
@@ -1606,13 +1607,14 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
 
         # Calculate 'available_substitute_stock' field
         queryset = queryset.annotate(
-            available_substitute_stock=ExpressionWrapper(
-                Greatest(
+            available_substitute_stock=Greatest(
+                ExpressionWrapper(
                     F('substitute_stock')
                     - F('substitute_build_allocations')
                     - F('substitute_sales_allocations'),
-                    0,
+                    output_field=models.DecimalField(),
                 ),
+                0,
                 output_field=models.DecimalField(),
             )
         )
@@ -1635,13 +1637,14 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
         )
 
         queryset = queryset.annotate(
-            available_variant_stock=ExpressionWrapper(
-                Greatest(
+            available_variant_stock=Greatest(
+                ExpressionWrapper(
                     F('variant_stock_total')
                     - F('variant_bo_allocations')
                     - F('variant_so_allocations'),
-                    0,
+                    output_field=FloatField(),
                 ),
+                0,
                 output_field=FloatField(),
             )
         )

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -15,7 +15,7 @@ from django.db.models import (
     Value,
     When,
 )
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, Greatest
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -1567,9 +1567,12 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
         # Calculate 'available_stock' based on previously annotated fields
         queryset = queryset.annotate(
             available_stock=ExpressionWrapper(
-                F('total_stock')
-                - F('allocated_to_sales_orders')
-                - F('allocated_to_build_orders'),
+                Greatest(
+                    F('total_stock')
+                    - F('allocated_to_sales_orders')
+                    - F('allocated_to_build_orders'),
+                    0,
+                ),
                 output_field=models.DecimalField(),
             )
         )
@@ -1604,9 +1607,12 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
         # Calculate 'available_substitute_stock' field
         queryset = queryset.annotate(
             available_substitute_stock=ExpressionWrapper(
-                F('substitute_stock')
-                - F('substitute_build_allocations')
-                - F('substitute_sales_allocations'),
+                Greatest(
+                    F('substitute_stock')
+                    - F('substitute_build_allocations')
+                    - F('substitute_sales_allocations'),
+                    0,
+                ),
                 output_field=models.DecimalField(),
             )
         )
@@ -1630,9 +1636,12 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
 
         queryset = queryset.annotate(
             available_variant_stock=ExpressionWrapper(
-                F('variant_stock_total')
-                - F('variant_bo_allocations')
-                - F('variant_so_allocations'),
+                Greatest(
+                    F('variant_stock_total')
+                    - F('variant_bo_allocations')
+                    - F('variant_so_allocations'),
+                    0,
+                ),
                 output_field=FloatField(),
             )
         )

--- a/src/backend/InvenTree/company/filters.py
+++ b/src/backend/InvenTree/company/filters.py
@@ -3,7 +3,7 @@
 from decimal import Decimal
 
 from django.db.models import DecimalField, ExpressionWrapper, F, Q
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, Greatest
 
 from sql_util.utils import SubquerySum
 
@@ -25,8 +25,11 @@ def annotate_on_order_quantity():
     return Coalesce(
         SubquerySum(
             ExpressionWrapper(
-                F('purchase_order_line_items__quantity')
-                - F('purchase_order_line_items__received'),
+                Greatest(
+                    F('purchase_order_line_items__quantity')
+                    - F('purchase_order_line_items__received'),
+                    0,
+                ),
                 output_field=DecimalField(),
             ),
             filter=order_filter,

--- a/src/backend/InvenTree/company/filters.py
+++ b/src/backend/InvenTree/company/filters.py
@@ -24,12 +24,13 @@ def annotate_on_order_quantity():
 
     return Coalesce(
         SubquerySum(
-            ExpressionWrapper(
-                Greatest(
+            Greatest(
+                ExpressionWrapper(
                     F('purchase_order_line_items__quantity')
                     - F('purchase_order_line_items__received'),
-                    0,
+                    output_field=DecimalField(),
                 ),
+                0,
                 output_field=DecimalField(),
             ),
             filter=order_filter,

--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -14,7 +14,7 @@ from django.db.models import (
     Value,
     When,
 )
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, Greatest
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -1206,9 +1206,12 @@ class SalesOrderLineItemSerializer(
 
         queryset = queryset.annotate(
             available_stock=ExpressionWrapper(
-                F('total_stock')
-                - F('allocated_to_sales_orders')
-                - F('allocated_to_build_orders'),
+                Greatest(
+                    F('total_stock')
+                    - F('allocated_to_sales_orders')
+                    - F('allocated_to_build_orders'),
+                    0,
+                ),
                 output_field=models.DecimalField(),
             )
         )
@@ -1233,9 +1236,12 @@ class SalesOrderLineItemSerializer(
 
         queryset = queryset.annotate(
             available_variant_stock=ExpressionWrapper(
-                F('variant_stock_total')
-                - F('variant_bo_allocations')
-                - F('variant_so_allocations'),
+                Greatest(
+                    F('variant_stock_total')
+                    - F('variant_bo_allocations')
+                    - F('variant_so_allocations'),
+                    0,
+                ),
                 output_field=models.DecimalField(),
             )
         )

--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -1205,13 +1205,14 @@ class SalesOrderLineItemSerializer(
         )
 
         queryset = queryset.annotate(
-            available_stock=ExpressionWrapper(
-                Greatest(
+            available_stock=Greatest(
+                ExpressionWrapper(
                     F('total_stock')
                     - F('allocated_to_sales_orders')
                     - F('allocated_to_build_orders'),
-                    0,
+                    output_field=models.DecimalField(),
                 ),
+                0,
                 output_field=models.DecimalField(),
             )
         )
@@ -1235,13 +1236,14 @@ class SalesOrderLineItemSerializer(
         )
 
         queryset = queryset.annotate(
-            available_variant_stock=ExpressionWrapper(
-                Greatest(
+            available_variant_stock=Greatest(
+                ExpressionWrapper(
                     F('variant_stock_total')
                     - F('variant_bo_allocations')
                     - F('variant_so_allocations'),
-                    0,
+                    output_field=models.DecimalField(),
                 ),
+                0,
                 output_field=models.DecimalField(),
             )
         )

--- a/src/backend/InvenTree/part/filters.py
+++ b/src/backend/InvenTree/part/filters.py
@@ -29,7 +29,7 @@ from django.db.models import (
     Value,
     When,
 )
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, Greatest
 
 from sql_util.utils import SubquerySum
 
@@ -74,7 +74,11 @@ def annotate_scheduled_to_build_quantity(reference: str = ''):
     return Coalesce(
         SubquerySum(
             ExpressionWrapper(
-                F(f'{reference}builds__quantity') - F(f'{reference}builds__completed'),
+                Greatest(
+                    F(f'{reference}builds__quantity')
+                    - F(f'{reference}builds__completed'),
+                    0,
+                ),
                 output_field=DecimalField(),
             ),
             filter=building_filter,

--- a/src/backend/InvenTree/part/filters.py
+++ b/src/backend/InvenTree/part/filters.py
@@ -106,25 +106,30 @@ def annotate_on_order_quantity(reference: str = ''):
         order__status__in=PurchaseOrderStatusGroups.OPEN, quantity__gt=F('received')
     )
 
-    return Coalesce(
-        SubquerySum(
-            ExpressionWrapper(
-                F(f'{reference}supplier_parts__purchase_order_line_items__quantity')
-                * F(f'{reference}supplier_parts__pack_quantity_native'),
-                output_field=DecimalField(),
+    return Greatest(
+        Coalesce(
+            SubquerySum(
+                ExpressionWrapper(
+                    F(f'{reference}supplier_parts__purchase_order_line_items__quantity')
+                    * F(f'{reference}supplier_parts__pack_quantity_native'),
+                    output_field=DecimalField(),
+                ),
+                filter=order_filter,
             ),
-            filter=order_filter,
-        ),
-        Decimal(0),
-        output_field=DecimalField(),
-    ) - Coalesce(
-        SubquerySum(
-            ExpressionWrapper(
-                F(f'{reference}supplier_parts__purchase_order_line_items__received')
-                * F(f'{reference}supplier_parts__pack_quantity_native'),
-                output_field=DecimalField(),
+            Decimal(0),
+            output_field=DecimalField(),
+        )
+        - Coalesce(
+            SubquerySum(
+                ExpressionWrapper(
+                    F(f'{reference}supplier_parts__purchase_order_line_items__received')
+                    * F(f'{reference}supplier_parts__pack_quantity_native'),
+                    output_field=DecimalField(),
+                ),
+                filter=order_filter,
             ),
-            filter=order_filter,
+            Decimal(0),
+            output_field=DecimalField(),
         ),
         Decimal(0),
         output_field=DecimalField(),

--- a/src/backend/InvenTree/part/filters.py
+++ b/src/backend/InvenTree/part/filters.py
@@ -75,18 +75,18 @@ def annotate_scheduled_to_build_quantity(reference: str = ''):
         SubquerySum(
             Greatest(
                 ExpressionWrapper(
-                    Cast(F(f'{reference}builds__quantity'), output_field=DecimalField())
+                    Cast(F(f'{reference}builds__quantity'), output_field=IntegerField())
                     - Cast(
-                        F(f'{reference}builds__completed'), output_field=DecimalField()
+                        F(f'{reference}builds__completed'), output_field=IntegerField()
                     ),
-                    output_field=DecimalField(),
+                    output_field=IntegerField(),
                 ),
-                Decimal(0),
+                0,
             ),
             filter=building_filter,
         ),
-        Decimal(0),
-        output_field=DecimalField(),
+        0,
+        output_field=IntegerField(),
     )
 
 

--- a/src/backend/InvenTree/part/filters.py
+++ b/src/backend/InvenTree/part/filters.py
@@ -29,7 +29,7 @@ from django.db.models import (
     Value,
     When,
 )
-from django.db.models.functions import Coalesce, Greatest
+from django.db.models.functions import Cast, Coalesce, Greatest
 
 from sql_util.utils import SubquerySum
 
@@ -73,13 +73,15 @@ def annotate_scheduled_to_build_quantity(reference: str = ''):
 
     return Coalesce(
         SubquerySum(
-            ExpressionWrapper(
-                Greatest(
-                    F(f'{reference}builds__quantity')
-                    - F(f'{reference}builds__completed'),
-                    0,
+            Greatest(
+                ExpressionWrapper(
+                    Cast(F(f'{reference}builds__quantity'), output_field=DecimalField())
+                    - Cast(
+                        F(f'{reference}builds__completed'), output_field=DecimalField()
+                    ),
+                    output_field=DecimalField(),
                 ),
-                output_field=DecimalField(),
+                Decimal(0),
             ),
             filter=building_filter,
         ),

--- a/src/backend/InvenTree/part/models.py
+++ b/src/backend/InvenTree/part/models.py
@@ -1530,10 +1530,12 @@ class Part(
 
         # Calculate the 'available stock' based on previous annotations
         queryset = queryset.annotate(
-            available_stock=ExpressionWrapper(
-                Greatest(
-                    F('total_stock') - F('so_allocations') - F('bo_allocations'), 0
+            available_stock=Greatest(
+                ExpressionWrapper(
+                    F('total_stock') - F('so_allocations') - F('bo_allocations'),
+                    output_field=models.DecimalField(),
                 ),
+                0,
                 output_field=models.DecimalField(),
             )
         )
@@ -1551,13 +1553,14 @@ class Part(
         )
 
         queryset = queryset.annotate(
-            substitute_stock=ExpressionWrapper(
-                Greatest(
+            substitute_stock=Greatest(
+                ExpressionWrapper(
                     F('sub_total_stock')
                     - F('sub_so_allocations')
                     - F('sub_bo_allocations'),
-                    0,
+                    output_field=models.DecimalField(),
                 ),
+                0,
                 output_field=models.DecimalField(),
             )
         )
@@ -1578,13 +1581,14 @@ class Part(
         )
 
         queryset = queryset.annotate(
-            variant_stock=ExpressionWrapper(
-                Greatest(
+            variant_stock=Greatest(
+                ExpressionWrapper(
                     F('var_total_stock')
                     - F('var_bo_allocations')
                     - F('var_so_allocations'),
-                    0,
+                    output_field=models.DecimalField(),
                 ),
+                0,
                 output_field=models.DecimalField(),
             )
         )

--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -1229,7 +1229,7 @@ class PartRequirementsSerializer(InvenTree.serializers.InvenTreeModelSerializer)
         read_only=True, label=_('In Production'), source='quantity_in_production'
     )
 
-    scheduled_to_build = serializers.FloatField(
+    scheduled_to_build = serializers.IntegerField(
         read_only=True, label=_('Scheduled to Build'), source='quantity_being_built'
     )
 

--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -843,13 +843,14 @@ class PartSerializer(
         # Annotate with the total 'available stock' quantity
         # This is the current stock, minus any allocations
         queryset = queryset.annotate(
-            unallocated_stock=ExpressionWrapper(
-                Greatest(
+            unallocated_stock=Greatest(
+                ExpressionWrapper(
                     F('total_in_stock')
                     - F('allocated_to_sales_orders')
                     - F('allocated_to_build_orders'),
-                    0,
+                    output_field=models.DecimalField(),
                 ),
+                Decimal(0),
                 output_field=models.DecimalField(),
             )
         )
@@ -1869,13 +1870,14 @@ class BomItemSerializer(
 
         # Calculate 'available_stock' based on previously annotated fields
         queryset = queryset.annotate(
-            available_stock=ExpressionWrapper(
-                Greatest(
+            available_stock=Greatest(
+                ExpressionWrapper(
                     F('total_stock')
                     - F('allocated_to_sales_orders')
                     - F('allocated_to_build_orders'),
-                    0,
+                    output_field=models.DecimalField(),
                 ),
+                Decimal(0),
                 output_field=models.DecimalField(),
             )
         )
@@ -1902,13 +1904,14 @@ class BomItemSerializer(
 
         # Calculate 'available_substitute_stock' field
         queryset = queryset.annotate(
-            available_substitute_stock=ExpressionWrapper(
-                Greatest(
+            available_substitute_stock=Greatest(
+                ExpressionWrapper(
                     F('substitute_stock')
                     - F('substitute_build_allocations')
                     - F('substitute_sales_allocations'),
-                    0,
+                    output_field=models.DecimalField(),
                 ),
+                Decimal(0),
                 output_field=models.DecimalField(),
             )
         )
@@ -1929,13 +1932,14 @@ class BomItemSerializer(
         )
 
         queryset = queryset.annotate(
-            available_variant_stock=ExpressionWrapper(
-                Greatest(
+            available_variant_stock=Greatest(
+                ExpressionWrapper(
                     F('variant_stock_total')
                     - F('variant_bo_allocations')
                     - F('variant_so_allocations'),
-                    0,
+                    output_field=FloatField(),
                 ),
+                0,
                 output_field=FloatField(),
             )
         )

--- a/src/backend/InvenTree/part/test_api.py
+++ b/src/backend/InvenTree/part/test_api.py
@@ -2357,13 +2357,15 @@ class PartAPIAggregationTest(InvenTreeAPITestCase):
             )
 
         # Let's also update the "completeed" count
+        builds[1].completed = 5
+        builds[1].save()
         builds[2].completed = 13
         builds[2].save()
 
         data = self.get(url).data
 
         self.assertEqual(data['building'], 55)
-        self.assertEqual(data['scheduled_to_build'], 37)
+        self.assertEqual(data['scheduled_to_build'], 32)
 
 
 class BomItemTest(InvenTreeAPITestCase):

--- a/src/backend/InvenTree/part/test_api.py
+++ b/src/backend/InvenTree/part/test_api.py
@@ -1999,7 +1999,7 @@ class PartPricingDetailTests(InvenTreeAPITestCase):
 
 
 class PartAPIAggregationTest(InvenTreeAPITestCase):
-    """Tests to ensure that the various aggregation annotations are working correctly..."""
+    """Tests to ensure that the various aggregation annotations are working correctly."""
 
     fixtures = [
         'category',
@@ -2302,6 +2302,68 @@ class PartAPIAggregationTest(InvenTreeAPITestCase):
 
             # The annotated quantity must also match the part.on_order quantity
             self.assertEqual(on_order, p.on_order)
+
+    def test_building(self):
+        """Test the 'building' quantity annotations."""
+        # Create a new "buildable" part
+        part = Part.objects.create(
+            name='Buildable Part',
+            description='A part which can be built',
+            category=PartCategory.objects.get(pk=1),
+            assembly=True,
+        )
+
+        url = reverse('api-part-detail', kwargs={'pk': part.pk})
+
+        # Initially, no quantity in production
+        data = self.get(url).data
+
+        self.assertEqual(data['building'], 0)
+        self.assertEqual(data['scheduled_to_build'], 0)
+
+        # Create some builds for this part
+        builds = []
+        for idx in range(3):
+            builds.append(
+                build.models.Build.objects.create(
+                    part=part,
+                    quantity=10 * (idx + 1),
+                    title=f'Build {idx + 1}',
+                    reference=f'BO-{idx + 999}',
+                )
+            )
+
+        data = self.get(url).data
+
+        # There should now be 60 "scheduled", but nothing currently "building"
+        self.assertEqual(data['building'], 0)
+        self.assertEqual(data['scheduled_to_build'], 60)
+
+        # Update the "completed" count for the first build
+        # Even though this build will be "negative" it should not affect the other builds
+        # The "scheduled_to_build" count should reduce by 10, not 9999
+        builds[0].completed = 9999
+        builds[0].save()
+
+        data = self.get(url).data
+
+        self.assertEqual(data['building'], 0)
+        self.assertEqual(data['scheduled_to_build'], 50)
+
+        # Create some "in production" items against the third build
+        for idx in range(10):
+            StockItem.objects.create(
+                part=part, build=builds[2], quantity=(1 + idx), is_building=True
+            )
+
+        # Let's also update the "completeed" count
+        builds[2].completed = 13
+        builds[2].save()
+
+        data = self.get(url).data
+
+        self.assertEqual(data['building'], 55)
+        self.assertEqual(data['scheduled_to_build'], 37)
 
 
 class BomItemTest(InvenTreeAPITestCase):

--- a/src/frontend/src/components/panels/PanelGroup.tsx
+++ b/src/frontend/src/components/panels/PanelGroup.tsx
@@ -269,22 +269,28 @@ function BasePanelGroup({
                 )}
               </Box>
             ))}
+            {collapsible && <Divider />}
             {collapsible && (
               <Group wrap='nowrap' gap='xs'>
-                <ActionIcon
-                  style={{
-                    paddingLeft: '10px'
-                  }}
-                  onClick={() => setExpanded(!expanded)}
-                  variant='transparent'
-                  size='md'
+                <Tooltip
+                  position='right'
+                  label={expanded ? t`Collapse panels` : t`Expand panels`}
                 >
-                  {expanded ? (
-                    <IconLayoutSidebarLeftCollapse opacity={0.5} />
-                  ) : (
-                    <IconLayoutSidebarRightCollapse opacity={0.5} />
-                  )}
-                </ActionIcon>
+                  <ActionIcon
+                    style={{
+                      paddingLeft: '10px'
+                    }}
+                    onClick={() => setExpanded(!expanded)}
+                    variant='transparent'
+                    size='lg'
+                  >
+                    {expanded ? (
+                      <IconLayoutSidebarLeftCollapse opacity={0.75} />
+                    ) : (
+                      <IconLayoutSidebarRightCollapse opacity={0.75} />
+                    )}
+                  </ActionIcon>
+                </Tooltip>
                 {pluginPanelSet.isLoading && <Loader size='xs' />}
               </Group>
             )}


### PR DESCRIPTION
Fixes an issue with queryset annotations which involve negative numbers. Logically, having the "available stock" for a part being negative does not make sense, however the existing annotations could produce negative numbers.

Additionally, the "quantity in production" could be negative if the "completed" count for a build was more than the "quantity" (let's say the build order was over-produced). In such a case we want the "outstanding" value to be zero, *NOT* negative.

Further, in MYSQL the annotated value returning as negative throws a database error as the source fields for the annotation are UNSIGNED.

This PR solves this issue in multiple locations by wrapping the annotation in a `Greatest` call.  Also adds a unit test to ensure that the annotations return expected values.