### PR TITLE
Add setting to show location path as plain text in tables

### DIFF
--- a/docs/docs/settings/user.md
+++ b/docs/docs/settings/user.md
@@ -25,6 +25,7 @@ The *Display Settings* screen shows general display configuration options:
 {{ usersetting("PART_SHOW_QUANTITY_IN_FORMS") }}
 {{ usersetting("DISPLAY_STOCKTAKE_TAB") }}
 {{ usersetting("ENABLE_LAST_BREADCRUMB") }}
+{{ usersetting("SHOW_FULL_LOCATION_PATH_IN_TABLES") }}
 
 ### Search Settings
 

--- a/src/backend/InvenTree/common/setting/user.py
+++ b/src/backend/InvenTree/common/setting/user.py
@@ -225,6 +225,14 @@ USER_SETTINGS: dict[str, InvenTreeSettingsKeyType] = {
         'default': False,
         'validator': bool,
     },
+    'SHOW_FULL_LOCATION_PATH_IN_TABLES': {
+        'name': _('Show Stock Item Location Path in Tables as text'),
+        'description': _(
+            'Disabled: The full location path is displayed as a hover tooltip. Enabled: The full location path is displayed as plain text.'
+        ),
+        'default': False,
+        'validator': bool,
+    },
     'NOTIFICATION_ERROR_REPORT': {
         'name': _('Receive error reports'),
         'description': _('Receive notifications for system errors'),

--- a/src/frontend/src/pages/Index/Settings/UserSettings.tsx
+++ b/src/frontend/src/pages/Index/Settings/UserSettings.tsx
@@ -55,7 +55,8 @@ export default function UserSettings() {
               'FORMS_CLOSE_USING_ESCAPE',
               'PART_SHOW_QUANTITY_IN_FORMS',
               'DISPLAY_STOCKTAKE_TAB',
-              'ENABLE_LAST_BREADCRUMB'
+              'ENABLE_LAST_BREADCRUMB',
+              'SHOW_FULL_LOCATION_PATH_IN_TABLES'
             ]}
           />
         )

--- a/src/frontend/src/tables/ColumnRenderers.tsx
+++ b/src/frontend/src/tables/ColumnRenderers.tsx
@@ -19,7 +19,10 @@ import { TableStatusRenderer } from '../components/render/StatusRenderer';
 import { RenderOwner, RenderUser } from '../components/render/User';
 import { formatCurrency, formatDate } from '../defaults/formatters';
 import { resolveItem } from '../functions/conversion';
-import { useGlobalSettingsState } from '../states/SettingsStates';
+import {
+  useGlobalSettingsState,
+  useUserSettingsState
+} from '../states/SettingsStates';
 import type { TableColumn, TableColumnProps } from './Column';
 import { ProjectCodeHoverCard, TableHoverCard } from './TableHoverCard';
 
@@ -114,14 +117,49 @@ export function PathColumn(props: TableColumnProps): TableColumn {
   };
 }
 
-export function LocationColumn(props: TableColumnProps): TableColumn {
-  return PathColumn({
+export function PathColumnPlainText(props: TableColumnProps): TableColumn {
+  return {
     accessor: 'location',
     title: t`Location`,
     sortable: true,
     ordering: 'location',
+    render: (record: any) => {
+      const location = resolveItem(record, props.accessor ?? '');
+      if (!location) {
+        return (
+          <Text style={{ fontStyle: 'italic' }}>{t`No location set`}</Text>
+        );
+      }
+
+      return <Text>{location.pathstring}</Text>;
+    },
     ...props
-  });
+  };
+}
+
+export function LocationColumn(props: TableColumnProps): TableColumn {
+  const userSettings = useUserSettingsState.getState();
+  const enabled = userSettings.isSet(
+    'SHOW_FULL_LOCATION_PATH_IN_TABLES',
+    false
+  );
+  if (enabled) {
+    return PathColumnPlainText({
+      accessor: 'location',
+      title: t`Location`,
+      sortable: true,
+      ordering: 'location',
+      ...props
+    });
+  } else {
+    return PathColumn({
+      accessor: 'location',
+      title: t`Location`,
+      sortable: true,
+      ordering: 'location',
+      ...props
+    });
+  }
 }
 
 export function CategoryColumn(props: TableColumnProps): TableColumn {

--- a/src/frontend/src/tables/stock/StockItemTable.tsx
+++ b/src/frontend/src/tables/stock/StockItemTable.tsx
@@ -25,8 +25,8 @@ import type { TableColumn } from '../Column';
 import {
   DateColumn,
   DescriptionColumn,
+  LocationColumn,
   PartColumn,
-  PathColumn,
   StatusColumn
 } from '../ColumnRenderers';
 import {
@@ -223,10 +223,9 @@ function stockItemTableColumns({
       accessor: 'batch',
       sortable: true
     },
-    PathColumn({
-      accessor: 'location_detail',
-      title: t`Location`,
-      hidden: !showLocation
+    LocationColumn({
+      hidden: !showLocation,
+      accessor: 'location_detail'
     }),
     {
       accessor: 'purchase_order',


### PR DESCRIPTION
Follow up to #9918 

I think I figured out how to add a user setting to control the visibility of the location path.

@SchrodingersGat I'm not sure why you decided to use different entry points for the column rederer for the different tables. I changed back to using the same entry point (LocationColumn) for all tables. Let me know if this was the wrong decision.

