### PR TITLE
[bug] Tree fix

### DIFF
--- a/src/backend/InvenTree/InvenTree/helpers.py
+++ b/src/backend/InvenTree/InvenTree/helpers.py
@@ -154,7 +154,7 @@ def generateTestKey(test_name: str) -> str:
     return key
 
 
-def constructPathString(path, max_chars=250):
+def constructPathString(path: list[str], max_chars: int = 250) -> str:
     """Construct a 'path string' for the given path.
 
     Arguments:

--- a/src/backend/InvenTree/InvenTree/models.py
+++ b/src/backend/InvenTree/InvenTree/models.py
@@ -554,12 +554,17 @@ class InvenTreeTree(MetadataMixin, PluginValidationMixin, MPTTModel):
 
         order_insertion_by = ['name']
 
-    def delete(self, delete_children=False, delete_items=False):
+    def delete(self, delete_children: bool = False, delete_items: bool = False):
         """Handle the deletion of a tree node.
 
-        1. Update nodes and items under the current node
-        2. Delete this node
-        3. Rebuild the model tree
+        Arguments:
+            delete_children: If True, delete all child nodes (otherwise, point to the parent of this node)
+            delete_items: If True, delete all items associated with this node (otherwise, point to the parent of this node)
+
+        Order of operations:
+            1. Update nodes and items under the current node
+            2. Delete this node
+            3. Rebuild the model tree
         """
         tree_id = self.tree_id if self.parent else None
 

--- a/src/backend/InvenTree/InvenTree/models.py
+++ b/src/backend/InvenTree/InvenTree/models.py
@@ -541,6 +541,9 @@ class InvenTreeTree(MetadataMixin, PluginValidationMixin, MPTTModel):
     # e.g. for StockLocation, this value is 'location'
     ITEM_PARENT_KEY = None
 
+    # Field to use for constructing a "pathstring" for the tree
+    PATH_FIELD = 'name'
+
     # Extra fields to include in the get_path result. E.g. icon
     EXTRA_PATH_FIELDS = []
 
@@ -708,7 +711,9 @@ class InvenTreeTree(MetadataMixin, PluginValidationMixin, MPTTModel):
 
     def construct_pathstring(self):
         """Construct the pathstring for this tree node."""
-        return InvenTree.helpers.constructPathString([item.name for item in self.path])
+        return InvenTree.helpers.constructPathString([
+            getattr(item, self.PATH_FIELD, item.pk) for item in self.path
+        ])
 
     def save(self, *args, **kwargs):
         """Custom save method for InvenTreeTree abstract model."""
@@ -855,7 +860,7 @@ class InvenTreeTree(MetadataMixin, PluginValidationMixin, MPTTModel):
         return [
             {
                 'pk': item.pk,
-                'name': item.name,
+                'name': getattr(item, self.PATH_FIELD, item.pk),
                 **{k: getattr(item, k, None) for k in self.EXTRA_PATH_FIELDS},
             }
             for item in self.path

--- a/src/backend/InvenTree/InvenTree/models.py
+++ b/src/backend/InvenTree/InvenTree/models.py
@@ -526,16 +526,7 @@ class InvenTreeAttachmentMixin:
 
 
 class InvenTreeTree(MetadataMixin, PluginValidationMixin, MPTTModel):
-    """Provides an abstracted self-referencing tree model for data categories.
-
-    - Each Category has one parent Category, which can be blank (for a top-level Category).
-    - Each Category can have zero-or-more child Category(y/ies)
-
-    Attributes:
-        name: brief name
-        description: longer form description
-        parent: The item immediately above this one. An item with a null parent is a top-level item
-    """
+    """Provides an abstracted self-referencing tree model for data categories."""
 
     # How each node reference its parent object
     NODE_PARENT_KEY = 'parent'
@@ -550,7 +541,7 @@ class InvenTreeTree(MetadataMixin, PluginValidationMixin, MPTTModel):
         abstract = True
 
     class MPTTMeta:
-        """Set insert order."""
+        """MPTT metaclass options."""
 
         order_insertion_by = ['name']
 
@@ -589,14 +580,15 @@ class InvenTreeTree(MetadataMixin, PluginValidationMixin, MPTTModel):
         if tree_id:
             try:
                 self.__class__.objects.partial_rebuild(tree_id)
-            except Exception:
+            except Exception as e:
                 InvenTree.exceptions.log_error(
                     f'{self.__class__.__name__}.partial_rebuild'
                 )
-                logger.warning(
-                    'Failed to rebuild tree for %s <%s>',
+                logger.exception(
+                    'Failed to rebuild tree for %s <%s>: %s',
                     self.__class__.__name__,
                     self.pk,
+                    e,
                 )
                 # If the partial rebuild fails, rebuild the entire tree
                 self.__class__.objects.rebuild()

--- a/src/backend/InvenTree/InvenTree/models.py
+++ b/src/backend/InvenTree/InvenTree/models.py
@@ -785,14 +785,14 @@ class PathStringMixin(models.Model):
 
     def save(self, *args, **kwargs):
         """Update the pathstring field when saving the model instance."""
-        pathstring = self.construct_pathstring()
-
-        rebuild = pathstring != self.pathstring
+        old_pathstring = self.pathstring
 
         # Rebuild upper first, to ensure the lower nodes are updated correctly
         super().save(*args, **kwargs)
 
-        if rebuild:
+        pathstring = self.construct_pathstring()
+
+        if pathstring != old_pathstring:
             kwargs.pop('force_insert', None)
             kwargs['force_update'] = True
 

--- a/src/backend/InvenTree/InvenTree/models.py
+++ b/src/backend/InvenTree/InvenTree/models.py
@@ -661,7 +661,7 @@ class InvenTreeTree(MetadataMixin, PluginValidationMixin, MPTTModel):
         Arguments:
             nodes: A queryset of nodes to delete
         """
-        nodes.update(**{self.ITEM_PARENT_KEY: None})
+        nodes.update(**{self.NODE_PARENT_KEY: None})
         nodes.delete()
 
     def api_instance_filters(self):

--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -15,7 +15,7 @@ from django.utils.translation import gettext_lazy as _
 
 import structlog
 from mptt.exceptions import InvalidMove
-from mptt.models import MPTTModel, TreeForeignKey
+from mptt.models import TreeForeignKey
 from rest_framework import serializers
 
 import generic.states
@@ -78,12 +78,10 @@ class Build(
     InvenTree.models.InvenTreeAttachmentMixin,
     InvenTree.models.InvenTreeBarcodeMixin,
     InvenTree.models.InvenTreeNotesMixin,
-    InvenTree.models.MetadataMixin,
-    InvenTree.models.PluginValidationMixin,
     InvenTree.models.ReferenceIndexingMixin,
     StateTransitionMixin,
     StatusCodeMixin,
-    MPTTModel,
+    InvenTree.models.InvenTreeTree,
 ):
     """A Build object organises the creation of new StockItem objects from other existing StockItem objects.
 
@@ -116,6 +114,11 @@ class Build(
 
         verbose_name = _('Build Order')
         verbose_name_plural = _('Build Orders')
+
+    class MPTTMeta:
+        """MPTT options for the BuildOrder model."""
+
+        order_insertion_by = ['reference']
 
     OVERDUE_FILTER = (
         Q(status__in=BuildStatusGroups.ACTIVE_CODES)

--- a/src/backend/InvenTree/build/tests.py
+++ b/src/backend/InvenTree/build/tests.py
@@ -144,3 +144,168 @@ class BuildTestSimple(InvenTreeTestCase):
 
         # Check that expected quantity of new builds is created
         self.assertEqual(Build.objects.count(), n + 4)
+
+
+class BuildTreeTest(InvenTreeTestCase):
+    """Unit tests for the Build tree structure."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Initialize test data for the Build tree tests."""
+        from build.models import Build
+        from part.models import Part
+
+        # Create a test assembly part
+        cls.assembly = Part.objects.create(
+            name='Test Assembly',
+            description='A test assembly part',
+            assembly=True,
+            active=True,
+            locked=False,
+        )
+
+        # Generate a top-level build
+        cls.build = Build.objects.create(
+            part=cls.assembly, quantity=5, reference='BO-1234', target_date=None
+        )
+
+        Build.objects.rebuild()
+
+    def test_basic_tree(self):
+        """Test basic tree structure functionality.
+
+        - In this test we test a simple non-branching tree structure.
+        - Check that the tree structure is correctly created.
+        - Verify parent-child relationships and tree properties.
+        - Ensure that the number of children and descendants is as expected.
+        - Validate that the tree properties (tree_id, level, lft, rght) are correct
+        - Check that node deletion works correctly.
+        """
+        from build.models import Build
+
+        # Create a cascading tree structure of builds
+        child = self.build
+
+        builds = [self.build]
+
+        self.assertEqual(Build.objects.count(), 1)
+
+        for i in range(10):
+            child = Build.objects.create(
+                part=self.assembly, quantity=2, reference=f'BO-{1235 + i}', parent=child
+            )
+
+            builds.append(child)
+
+        self.assertEqual(Build.objects.count(), 11)
+
+        # Test the tree structure for each node
+        for idx, child in enumerate(builds):
+            # Check parent-child relationships
+            expected_parent = builds[idx - 1] if idx > 0 else None
+            self.assertEqual(child.parent, expected_parent)
+
+            # Check number of children
+            expected_children = 0 if idx == 10 else 1
+            self.assertEqual(child.get_children().count(), expected_children)
+
+            # Check number of descendants
+            expected_descendants = max(10 - idx, 0)
+            self.assertEqual(
+                child.get_descendants(include_self=False).count(), expected_descendants
+            )
+
+            # Test tree structure
+            self.assertEqual(child.tree_id, self.build.tree_id)
+            self.assertEqual(child.level, idx)
+            self.assertEqual(child.lft, idx + 1)
+            self.assertEqual(child.rght, 22 - idx)
+
+        # Test deletion of a node - delete BO-1238
+        Build.objects.get(reference='BO-1238').delete()
+
+        # We expect that only a SINGLE node is deleted
+        self.assertEqual(Build.objects.count(), 10)
+        self.assertEqual(self.build.get_descendants(include_self=False).count(), 9)
+
+        # Check that the item parents have been correctly remapped
+        build_reference_map = {
+            'BO-1235': 'BO-1234',
+            'BO-1236': 'BO-1235',
+            'BO-1237': 'BO-1236',
+            'BO-1239': 'BO-1237',  # BO-1238 was deleted, so BO-1239's parent is now BO-1237
+            'BO-1240': 'BO-1239',
+            'BO-1241': 'BO-1240',
+            'BO-1242': 'BO-1241',
+            'BO-1243': 'BO-1242',
+            'BO-1244': 'BO-1243',
+        }
+
+        # Check that the tree structure is still valid
+        for child_ref, parent_ref in build_reference_map.items():
+            build = Build.objects.get(reference=child_ref)
+            parent = Build.objects.get(reference=parent_ref)
+            self.assertEqual(parent_ref, parent.reference)
+            self.assertEqual(build.tree_id, self.build.tree_id)
+            self.assertEqual(build.level, parent.level + 1)
+            self.assertEqual(build.lft, parent.lft + 1)
+            self.assertEqual(build.rght, parent.rght - 1)
+
+    def test_complex_tree(self):
+        """Test a more complex tree structure with multiple branches.
+
+        - Ensure that grafting nodes works correctly.
+        """
+        ref = 1235
+
+        for ii in range(3):
+            # Create child builds
+            child = Build.objects.create(
+                part=self.assembly,
+                quantity=2,
+                reference=f'BO-{ref + (ii * 4)}',
+                parent=self.build,
+            )
+
+            for jj in range(3):
+                # Create grandchild builds
+                grandchild = Build.objects.create(
+                    part=self.assembly,
+                    quantity=2,
+                    reference=f'BO-{ref + (ii * 4) + jj + 1}',
+                    parent=child,
+                )
+
+                self.assertEqual(grandchild.parent, child)
+                self.assertEqual(grandchild.tree_id, self.build.tree_id)
+                self.assertEqual(grandchild.level, 2)
+
+            self.assertEqual(child.get_children().count(), 3)
+            self.assertEqual(child.get_descendants(include_self=False).count(), 3)
+
+            self.assertEqual(child.level, 1)
+            self.assertEqual(child.tree_id, self.build.tree_id)
+
+        # Basic tests
+        self.assertEqual(Build.objects.count(), 13)
+        self.assertEqual(self.build.get_children().count(), 3)
+        self.assertEqual(self.build.get_descendants(include_self=False).count(), 12)
+
+        # Move one of the child builds
+        build = Build.objects.get(reference='BO-1239')
+        self.assertEqual(build.parent.reference, 'BO-1234')
+        self.assertEqual(build.level, 1)
+        self.assertEqual(build.get_children().count(), 3)
+        for bo in build.get_children():
+            self.assertEqual(bo.level, 2)
+
+        parent = Build.objects.get(reference='BO-1235')
+        build.parent = parent
+        build.save()
+
+        build = Build.objects.get(reference='BO-1239')
+        self.assertEqual(build.parent.reference, 'BO-1235')
+        self.assertEqual(build.level, 2)
+        self.assertEqual(build.get_children().count(), 3)
+        for bo in build.get_children():
+            self.assertEqual(bo.level, 3)

--- a/src/backend/InvenTree/part/models.py
+++ b/src/backend/InvenTree/part/models.py
@@ -70,7 +70,7 @@ from stock import models as StockModels
 logger = structlog.get_logger('inventree')
 
 
-class PartCategory(InvenTree.models.InvenTreeTree):
+class PartCategory(InvenTree.models.PathStringMixin, InvenTree.models.InvenTreeTree):
     """PartCategory provides hierarchical organization of Part objects.
 
     Attributes:

--- a/src/backend/InvenTree/stock/models.py
+++ b/src/backend/InvenTree/stock/models.py
@@ -137,6 +137,7 @@ class StockLocationReportContext(report.mixins.BaseReportContext):
 class StockLocation(
     InvenTree.models.InvenTreeBarcodeMixin,
     report.mixins.InvenTreeReportMixin,
+    InvenTree.models.PathStringMixin,
     InvenTree.models.InvenTreeTree,
 ):
     """Organization tree for StockItem objects.

--- a/src/backend/InvenTree/stock/serializers.py
+++ b/src/backend/InvenTree/stock/serializers.py
@@ -788,7 +788,7 @@ class SerializeStockItemSerializer(serializers.Serializer):
             item.serializeStock(
                 data['quantity'],
                 serials,
-                user,
+                user=user,
                 notes=data.get('notes', ''),
                 location=data['destination'],
             )

--- a/src/backend/InvenTree/stock/tasks.py
+++ b/src/backend/InvenTree/stock/tasks.py
@@ -16,6 +16,8 @@ def rebuild_stock_item_tree(tree_id=None):
     from InvenTree.exceptions import log_error
     from stock.models import StockItem
 
+    raise NotImplementedError('THIS FUNCTION WILL BE REMOVED!!!')
+
     if tree_id:
         try:
             StockItem.objects.partial_rebuild(tree_id)

--- a/src/backend/InvenTree/stock/tasks.py
+++ b/src/backend/InvenTree/stock/tasks.py
@@ -7,25 +7,53 @@ tracer = trace.get_tracer(__name__)
 logger = structlog.get_logger('inventree')
 
 
-@tracer.start_as_current_span('rebuild_stock_item_tree')
-def rebuild_stock_item_tree(tree_id=None):
-    """Rebuild the stock tree structure.
+@tracer.start_as_current_span('rebuild_stock_items')
+def rebuild_stock_items():
+    """Rebuild the entire StockItem tree structure.
 
-    The StockItem tree uses the MPTT library to manage the tree structure.
+    This may be necessary if the tree structure has become corrupted or inconsistent.
     """
     from InvenTree.exceptions import log_error
     from stock.models import StockItem
 
-    raise NotImplementedError('THIS FUNCTION WILL BE REMOVED!!!')
+    logger.info('Rebuilding StockItem tree structure')
+
+    try:
+        StockItem.objects.rebuild()
+    except Exception as e:
+        log_error('rebuild_stock_items')
+        logger.exception('Failed to rebuild StockItem tree: %s', e)
+
+
+def rebuild_stock_item_tree(tree_id: int, rebuild_on_fail: bool = True) -> bool:
+    """Rebuild the stock tree structure.
+
+    Arguments:
+        tree_id (int): The ID of the StockItem tree to rebuild.
+        rebuild_on_fail (bool): If True, will attempt to rebuild the entire StockItem tree if the partial rebuild fails.
+
+    Returns:
+        bool: True if the partial tree rebuild was successful, False otherwise.
+
+    - If the rebuild fails, schedule a rebuild of the entire StockItem tree.
+    """
+    from InvenTree.exceptions import log_error
+    from InvenTree.tasks import offload_task
+    from stock.models import StockItem
 
     if tree_id:
         try:
             StockItem.objects.partial_rebuild(tree_id)
+            logger.info('Rebuilt StockItem tree for tree_id: %s', tree_id)
+            return True
         except Exception:
             log_error('rebuild_stock_item_tree')
-            logger.warning('Failed to rebuild StockItem tree')
+            logger.warning('Failed to rebuild StockItem tree for tree_id: %s', tree_id)
             # If the partial rebuild fails, rebuild the entire tree
-            StockItem.objects.rebuild()
+            if rebuild_on_fail:
+                offload_task(rebuild_stock_items, group='stock')
+            return False
     else:
         # No tree_id provided, so rebuild the entire tree
         StockItem.objects.rebuild()
+        return True

--- a/src/backend/InvenTree/stock/tests.py
+++ b/src/backend/InvenTree/stock/tests.py
@@ -58,81 +58,6 @@ class StockTestBase(InvenTreeTestCase):
 class StockTest(StockTestBase):
     """Tests to ensure that the stock location tree functions correctly."""
 
-    def test_pathstring(self):
-        """Check that pathstring updates occur as expected."""
-        a = StockLocation.objects.create(name='A')
-        b = StockLocation.objects.create(name='B', parent=a)
-        c = StockLocation.objects.create(name='C', parent=b)
-        d = StockLocation.objects.create(name='D', parent=c)
-
-        def refresh():
-            a.refresh_from_db()
-            b.refresh_from_db()
-            c.refresh_from_db()
-            d.refresh_from_db()
-
-        # Initial checks
-        self.assertEqual(a.pathstring, 'A')
-        self.assertEqual(b.pathstring, 'A/B')
-        self.assertEqual(c.pathstring, 'A/B/C')
-        self.assertEqual(d.pathstring, 'A/B/C/D')
-
-        c.name = 'Cc'
-        c.save()
-
-        refresh()
-        self.assertEqual(a.pathstring, 'A')
-        self.assertEqual(b.pathstring, 'A/B')
-        self.assertEqual(c.pathstring, 'A/B/Cc')
-        self.assertEqual(d.pathstring, 'A/B/Cc/D')
-
-        b.name = 'Bb'
-        b.save()
-
-        refresh()
-        self.assertEqual(a.pathstring, 'A')
-        self.assertEqual(b.pathstring, 'A/Bb')
-        self.assertEqual(c.pathstring, 'A/Bb/Cc')
-        self.assertEqual(d.pathstring, 'A/Bb/Cc/D')
-
-        a.name = 'Aa'
-        a.save()
-
-        refresh()
-        self.assertEqual(a.pathstring, 'Aa')
-        self.assertEqual(b.pathstring, 'Aa/Bb')
-        self.assertEqual(c.pathstring, 'Aa/Bb/Cc')
-        self.assertEqual(d.pathstring, 'Aa/Bb/Cc/D')
-
-        d.name = 'Dd'
-        d.save()
-
-        refresh()
-        self.assertEqual(a.pathstring, 'Aa')
-        self.assertEqual(b.pathstring, 'Aa/Bb')
-        self.assertEqual(c.pathstring, 'Aa/Bb/Cc')
-        self.assertEqual(d.pathstring, 'Aa/Bb/Cc/Dd')
-
-        # Test a really long name
-        # (it will be clipped to < 250 characters)
-        a.name = 'A' * 100
-        a.save()
-        b.name = 'B' * 100
-        b.save()
-        c.name = 'C' * 100
-        c.save()
-        d.name = 'D' * 100
-        d.save()
-
-        refresh()
-        self.assertEqual(len(a.pathstring), 100)
-        self.assertEqual(len(b.pathstring), 201)
-        self.assertEqual(len(c.pathstring), 249)
-        self.assertEqual(len(d.pathstring), 249)
-
-        self.assertTrue(d.pathstring.startswith('AAAAAAAA'))
-        self.assertTrue(d.pathstring.endswith('DDDDDDDD'))
-
     def test_link(self):
         """Test the link URL field validation."""
         item = StockItem.objects.get(pk=1)
@@ -768,132 +693,6 @@ class StockTest(StockTestBase):
         # Serialize the remainder of the stock
         item.serializeStock(2, [99, 100], self.user)
 
-    def test_location_tree(self):
-        """Unit tests for stock location tree structure (MPTT).
-
-        Ensure that the MPTT structure is rebuilt correctly,
-        and the current ancestor tree is observed.
-
-        Ref: https://github.com/inventree/InvenTree/issues/2636
-        Ref: https://github.com/inventree/InvenTree/issues/2733
-        """
-        # First, we will create a stock location structure
-
-        A = StockLocation.objects.create(name='A', description='Top level location')
-        B1 = StockLocation.objects.create(name='B1', parent=A)
-        B2 = StockLocation.objects.create(name='B2', parent=A)
-        B3 = StockLocation.objects.create(name='B3', parent=A)
-        C11 = StockLocation.objects.create(name='C11', parent=B1)
-        C12 = StockLocation.objects.create(name='C12', parent=B1)
-        C21 = StockLocation.objects.create(name='C21', parent=B2)
-        C22 = StockLocation.objects.create(name='C22', parent=B2)
-        C31 = StockLocation.objects.create(name='C31', parent=B3)
-        C32 = StockLocation.objects.create(name='C32', parent=B3)
-
-        # Check that the tree_id is correct for each sublocation
-        for loc in [B1, B2, B3, C11, C12, C21, C22, C31, C32]:
-            self.assertEqual(loc.tree_id, A.tree_id)
-
-        # Check that the tree levels are correct for each node in the tree
-
-        self.assertEqual(A.level, 0)
-        self.assertEqual(A.get_ancestors().count(), 0)
-
-        for loc in [B1, B2, B3]:
-            self.assertEqual(loc.parent, A)
-            self.assertEqual(loc.level, 1)
-            self.assertEqual(loc.get_ancestors().count(), 1)
-
-        for loc in [C11, C12]:
-            self.assertEqual(loc.parent, B1)
-            self.assertEqual(loc.level, 2)
-            self.assertEqual(loc.get_ancestors().count(), 2)
-
-        for loc in [C21, C22]:
-            self.assertEqual(loc.parent, B2)
-            self.assertEqual(loc.level, 2)
-            self.assertEqual(loc.get_ancestors().count(), 2)
-
-        for loc in [C31, C32]:
-            self.assertEqual(loc.parent, B3)
-            self.assertEqual(loc.level, 2)
-            self.assertEqual(loc.get_ancestors().count(), 2)
-
-        # Spot-check for C32
-        ancestors = C32.get_ancestors(include_self=True)
-
-        self.assertEqual(ancestors[0], A)
-        self.assertEqual(ancestors[1], B3)
-        self.assertEqual(ancestors[2], C32)
-
-        # At this point, we are confident that the tree is correctly structured.
-
-        # Let's delete node B3 from the tree. We expect that:
-        # - C31 should move directly under A
-        # - C32 should move directly under A
-
-        # Add some stock items to B3
-        for _ in range(10):
-            StockItem.objects.create(
-                part=Part.objects.get(pk=1), quantity=10, location=B3
-            )
-
-        self.assertEqual(StockItem.objects.filter(location=B3).count(), 10)
-        self.assertEqual(StockItem.objects.filter(location=A).count(), 0)
-
-        B3.delete()
-
-        A.refresh_from_db()
-        C31.refresh_from_db()
-        C32.refresh_from_db()
-
-        # Stock items have been moved to A
-        self.assertEqual(StockItem.objects.filter(location=A).count(), 10)
-
-        # Parent should be A
-        self.assertEqual(C31.parent, A)
-        self.assertEqual(C32.parent, A)
-
-        self.assertEqual(C31.tree_id, A.tree_id)
-        self.assertEqual(C31.level, 1)
-
-        self.assertEqual(C32.tree_id, A.tree_id)
-        self.assertEqual(C32.level, 1)
-
-        # Ancestor tree should be just A
-        ancestors = C31.get_ancestors()
-        self.assertEqual(ancestors.count(), 1)
-        self.assertEqual(ancestors[0], A)
-
-        ancestors = C32.get_ancestors()
-        self.assertEqual(ancestors.count(), 1)
-        self.assertEqual(ancestors[0], A)
-
-        # Delete A
-        A.delete()
-
-        # Stock items have been moved to top-level location
-        self.assertEqual(StockItem.objects.filter(location=None).count(), 10)
-
-        for loc in [B1, B2, C11, C12, C21, C22]:
-            loc.refresh_from_db()
-
-        self.assertEqual(B1.parent, None)
-        self.assertEqual(B2.parent, None)
-
-        self.assertEqual(C11.parent, B1)
-        self.assertEqual(C12.parent, B1)
-        self.assertEqual(C11.get_ancestors().count(), 1)
-        self.assertEqual(C12.get_ancestors().count(), 1)
-
-        self.assertEqual(C21.parent, B2)
-        self.assertEqual(C22.parent, B2)
-
-        ancestors = C21.get_ancestors()
-
-        self.assertEqual(C21.get_ancestors().count(), 1)
-        self.assertEqual(C22.get_ancestors().count(), 1)
-
     def test_metadata(self):
         """Unit tests for the metadata field."""
         for model in [StockItem, StockLocation]:
@@ -1100,6 +899,211 @@ class VariantTest(StockTestBase):
 
         item.serial = int(n) + 2
         item.save()
+
+
+class StockLocationTreeTest(StockTestBase):
+    """Unit test for the StockLocation tree structure."""
+
+    def test_pathstring(self):
+        """Check that pathstring updates occur as expected."""
+        a = StockLocation.objects.create(name='A')
+        b = StockLocation.objects.create(name='B', parent=a)
+        c = StockLocation.objects.create(name='C', parent=b)
+        d = StockLocation.objects.create(name='D', parent=c)
+
+        def refresh():
+            a.refresh_from_db()
+            b.refresh_from_db()
+            c.refresh_from_db()
+            d.refresh_from_db()
+
+        # Initial checks
+        self.assertEqual(a.pathstring, 'A')
+        self.assertEqual(b.pathstring, 'A/B')
+        self.assertEqual(c.pathstring, 'A/B/C')
+        self.assertEqual(d.pathstring, 'A/B/C/D')
+
+        c.name = 'Cc'
+        c.save()
+
+        refresh()
+        self.assertEqual(a.pathstring, 'A')
+        self.assertEqual(b.pathstring, 'A/B')
+        self.assertEqual(c.pathstring, 'A/B/Cc')
+        self.assertEqual(d.pathstring, 'A/B/Cc/D')
+
+        b.name = 'Bb'
+        b.save()
+
+        refresh()
+        self.assertEqual(a.pathstring, 'A')
+        self.assertEqual(b.pathstring, 'A/Bb')
+        self.assertEqual(c.pathstring, 'A/Bb/Cc')
+        self.assertEqual(d.pathstring, 'A/Bb/Cc/D')
+
+        a.name = 'Aa'
+        a.save()
+
+        refresh()
+        self.assertEqual(a.pathstring, 'Aa')
+        self.assertEqual(b.pathstring, 'Aa/Bb')
+        self.assertEqual(c.pathstring, 'Aa/Bb/Cc')
+        self.assertEqual(d.pathstring, 'Aa/Bb/Cc/D')
+
+        d.name = 'Dd'
+        d.save()
+
+        refresh()
+        self.assertEqual(a.pathstring, 'Aa')
+        self.assertEqual(b.pathstring, 'Aa/Bb')
+        self.assertEqual(c.pathstring, 'Aa/Bb/Cc')
+        self.assertEqual(d.pathstring, 'Aa/Bb/Cc/Dd')
+
+        # Test a really long name
+        # (it will be clipped to < 250 characters)
+        a.name = 'A' * 100
+        a.save()
+        b.name = 'B' * 100
+        b.save()
+        c.name = 'C' * 100
+        c.save()
+        d.name = 'D' * 100
+        d.save()
+
+        refresh()
+        self.assertEqual(len(a.pathstring), 100)
+        self.assertEqual(len(b.pathstring), 201)
+        self.assertEqual(len(c.pathstring), 249)
+        self.assertEqual(len(d.pathstring), 249)
+
+        self.assertTrue(d.pathstring.startswith('AAAAAAAA'))
+        self.assertTrue(d.pathstring.endswith('DDDDDDDD'))
+
+    def test_location_tree(self):
+        """Unit tests for stock location tree structure (MPTT).
+
+        Ensure that the MPTT structure is rebuilt correctly,
+        and the current ancestor tree is observed.
+
+        Ref: https://github.com/inventree/InvenTree/issues/2636
+        Ref: https://github.com/inventree/InvenTree/issues/2733
+        """
+        # First, we will create a stock location structure
+
+        A = StockLocation.objects.create(name='A', description='Top level location')
+        B1 = StockLocation.objects.create(name='B1', parent=A)
+        B2 = StockLocation.objects.create(name='B2', parent=A)
+        B3 = StockLocation.objects.create(name='B3', parent=A)
+        C11 = StockLocation.objects.create(name='C11', parent=B1)
+        C12 = StockLocation.objects.create(name='C12', parent=B1)
+        C21 = StockLocation.objects.create(name='C21', parent=B2)
+        C22 = StockLocation.objects.create(name='C22', parent=B2)
+        C31 = StockLocation.objects.create(name='C31', parent=B3)
+        C32 = StockLocation.objects.create(name='C32', parent=B3)
+
+        # Check that the tree_id is correct for each sublocation
+        for loc in [B1, B2, B3, C11, C12, C21, C22, C31, C32]:
+            self.assertEqual(loc.tree_id, A.tree_id)
+
+        # Check that the tree levels are correct for each node in the tree
+
+        self.assertEqual(A.level, 0)
+        self.assertEqual(A.get_ancestors().count(), 0)
+
+        for loc in [B1, B2, B3]:
+            self.assertEqual(loc.parent, A)
+            self.assertEqual(loc.level, 1)
+            self.assertEqual(loc.get_ancestors().count(), 1)
+
+        for loc in [C11, C12]:
+            self.assertEqual(loc.parent, B1)
+            self.assertEqual(loc.level, 2)
+            self.assertEqual(loc.get_ancestors().count(), 2)
+
+        for loc in [C21, C22]:
+            self.assertEqual(loc.parent, B2)
+            self.assertEqual(loc.level, 2)
+            self.assertEqual(loc.get_ancestors().count(), 2)
+
+        for loc in [C31, C32]:
+            self.assertEqual(loc.parent, B3)
+            self.assertEqual(loc.level, 2)
+            self.assertEqual(loc.get_ancestors().count(), 2)
+
+        # Spot-check for C32
+        ancestors = C32.get_ancestors(include_self=True)
+
+        self.assertEqual(ancestors[0], A)
+        self.assertEqual(ancestors[1], B3)
+        self.assertEqual(ancestors[2], C32)
+
+        # At this point, we are confident that the tree is correctly structured.
+
+        # Let's delete node B3 from the tree. We expect that:
+        # - C31 should move directly under A
+        # - C32 should move directly under A
+
+        # Add some stock items to B3
+        for _ in range(10):
+            StockItem.objects.create(
+                part=Part.objects.get(pk=1), quantity=10, location=B3
+            )
+
+        self.assertEqual(StockItem.objects.filter(location=B3).count(), 10)
+        self.assertEqual(StockItem.objects.filter(location=A).count(), 0)
+
+        B3.delete()
+
+        A.refresh_from_db()
+        C31.refresh_from_db()
+        C32.refresh_from_db()
+
+        # Stock items have been moved to A
+        self.assertEqual(StockItem.objects.filter(location=A).count(), 10)
+
+        # Parent should be A
+        self.assertEqual(C31.parent, A)
+        self.assertEqual(C32.parent, A)
+
+        self.assertEqual(C31.tree_id, A.tree_id)
+        self.assertEqual(C31.level, 1)
+
+        self.assertEqual(C32.tree_id, A.tree_id)
+        self.assertEqual(C32.level, 1)
+
+        # Ancestor tree should be just A
+        ancestors = C31.get_ancestors()
+        self.assertEqual(ancestors.count(), 1)
+        self.assertEqual(ancestors[0], A)
+
+        ancestors = C32.get_ancestors()
+        self.assertEqual(ancestors.count(), 1)
+        self.assertEqual(ancestors[0], A)
+
+        # Delete A
+        A.delete()
+
+        # Stock items have been moved to top-level location
+        self.assertEqual(StockItem.objects.filter(location=None).count(), 10)
+
+        for loc in [B1, B2, C11, C12, C21, C22]:
+            loc.refresh_from_db()
+
+        self.assertEqual(B1.parent, None)
+        self.assertEqual(B2.parent, None)
+
+        self.assertEqual(C11.parent, B1)
+        self.assertEqual(C12.parent, B1)
+        self.assertEqual(C11.get_ancestors().count(), 1)
+        self.assertEqual(C12.get_ancestors().count(), 1)
+
+        self.assertEqual(C21.parent, B2)
+        self.assertEqual(C22.parent, B2)
+
+        ancestors = C21.get_ancestors()
+
+        self.assertEqual(C21.get_ancestors().count(), 1)
+        self.assertEqual(C22.get_ancestors().count(), 1)
 
 
 class StockTreeTest(StockTestBase):


### PR DESCRIPTION
This is a significant bug which was discovered as part of general hardening of tests for the upcoming 1.0.0 release

### Background

We make use of the [django-mptt](https://django-mptt.readthedocs.io/en/latest/) library throughout the code, to realize a database-efficient "tree" structure for the following models:

- PartCategory
- Part
- StockLocation
- StockItem
- Build

Of these, the `PartCategory` and `StockLocation` models have special consideration (via the `InvenTreeTree` model) which handles node deletion and re-parenting of child nodes.

The other models (`Part`, `StockItem` and `Build`) inherit directly from the `MPTTModel` class, without this mixin shim.

**However** - it turns out that by default, `django-mptt` does not handle tree rebuilds correctly when a node is deleted from the tree (*at least, not in the way that we need it to*).

So, as per the current code base, if a `StockItem` (or `Part` or `Build`) is deleted, and it has child nodes attached, those nodes are effectively orphaned, as they are not correctly re-parented to the upstream node. As these child nodes retain the same `tree_id` value, this creates a corrupted tree, which requires a full rebuild of the model structure (which can be extremely expensive for a large dataset).

### Changes

This PR removes the direct inheritance from the `MPTTModel` class - instead ensuring that all our "tree" structures inherit from the `InvenTreeTree` class - which correctly handles node deletion, re-parenting, etc.

Additionally it adds a significant amount of unit test code to ensure that tree operations are sufficiently covered for all model types, to ensure we do not get a regression here.

To achieve this, the `InvenTreeTree` model had to be refactored somewhat, and some of the functionality has been split out into another mixin which is relevant only for the `StockLocation` and `PartCategory` models.

There are no migrations or changes to the API.

### Backporting

If it can be backported cleanly...

### TODO

- [x] Update `Build` model
- [x] Update `StockItem` model
- [x] Update `Part` model
- [ ] Ensure all unit tests run