### PR TITLE
[plugin] Add option for pointing plugin content to a vite host

### DIFF
--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -209,6 +209,14 @@ PLUGIN_TESTING_EVENTS = False  # Flag if events are tested right now
 PLUGIN_TESTING_EVENTS_ASYNC = False  # Flag if events are tested asynchronously
 PLUGIN_TESTING_RELOAD = False  # Flag if plugin reloading is in testing (check_reload)
 
+PLUGIN_DEV_SLUG = (
+    get_setting('INVENTREE_PLUGIN_DEV_SLUG', 'plugin_dev.slug') if DEBUG else None
+)
+
+PLUGIN_DEV_HOST = get_setting(
+    'INVENTREE_PLUGIN_DEV_HOST', 'plugin_dev.host', 'http://localhost:5174'
+)  # Host for the plugin development server
+
 PLUGIN_RETRY = get_setting(
     'INVENTREE_PLUGIN_RETRY', 'PLUGIN_RETRY', 3, typecast=int
 )  # How often should plugin loading be tried?

--- a/src/backend/InvenTree/plugin/plugin.py
+++ b/src/backend/InvenTree/plugin/plugin.py
@@ -473,16 +473,34 @@ class InvenTreePlugin(VersionMixin, MixinBase, MetaBase):
 
     # endregion
 
-    def plugin_static_file(self, *args):
-        """Construct a path to a static file within the plugin directory."""
+    def plugin_static_file(self, *args) -> str:
+        """Construct a path to a static file within the plugin directory.
+
+        - This will return a URL can be used to access the static file
+        - The path is constructed using the STATIC_URL setting and the plugin slug
+        - Note: If the plugin is selected for "development" mode, the path will point to a vite server URL
+
+        """
         import os
 
         from django.conf import settings
 
-        url = os.path.join(settings.STATIC_URL, 'plugins', self.SLUG, *args)
+        if (
+            settings.DEBUG
+            and settings.PLUGIN_DEV_HOST
+            and settings.PLUGIN_DEV_SLUG
+            and self.SLUG == settings.PLUGIN_DEV_SLUG
+        ):
+            # If the plugin is selected for development mode, use the development host
+            pathname = '/'.join(list(args))
+            url = f'{settings.PLUGIN_DEV_HOST}/src/{pathname}'
+            url = url.replace('.js', '.tsx')
+        else:
+            # Otherwise, construct the URL using the STATIC_URL setting
+            url = os.path.join(settings.STATIC_URL, 'plugins', self.SLUG, *args)
 
-        if not url.startswith('/'):
-            url = '/' + url
+            if not url.startswith('/'):
+                url = '/' + url
 
         return url
 


### PR DESCRIPTION
When developing a plugin with UI features it's currently *very frustrating* to make an update:

- Update the plugin code
- Recompile with `npm run build`
- Reinstall the plugin 
- Reload the plugin registry
- Deactivate and reactivate the plugin (to copy the compiled files into the "static" dir)

This PR adds a mechanism to allow a single plugin to be installed in "dev" mode. In this mode, calls for static files (via the `plugin_static_file` helper) will redirect to a local vite server, where the plugin UI code is running in dev mode.

The sequence is then:

- Update the plugin code
- Reload the InvenTree page

And, voila, the UI plugin is reloaded on the page.

### Implementation

A runtime setting, either via env var or config file, to identify the "slug" of a plugin which should be redirected to vite. Only works if the server is running in debug mode. Can also optionally specify the vite host.

### Future Development

In the future I would like to add support for HMR for instant reload of plugins - however I spent ages playing around with this and can't get it to work cleanly yet..

- Ref: https://github.com/inventree/InvenTree/pull/9323

### References

- Followup to https://github.com/inventree/InvenTree/pull/10000

### Plugin Config

To get the plugin code to run in "dev" mode and use the react global object provided by InvenTree UI, some changes are needed to vite dev config.

The plugin creator now handles this natively - https://github.com/inventree/plugin-creator/pull/58

### Example

From a [plugin I am working on](https://github.com/SchrodingersGat/inventree-manufacturing-costs)

<img width="1532" height="886" alt="image" src="https://github.com/user-attachments/assets/eb102397-3d2a-4307-ae70-f2e2f03ed8fa" />
