### PR TITLE
[UI] Sales order fixes

### DIFF
--- a/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
@@ -480,7 +480,7 @@ export default function SalesOrderLineItemTable({
             orderId={orderId}
             lineItemId={record.pk}
             partId={record.part}
-            allowEdit={false}
+            allowEdit={true}
             modelTarget={ModelType.stockitem}
             modelField={'item'}
             isSubTable

--- a/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
@@ -482,6 +482,7 @@ export default function SalesOrderLineItemTable({
             partId={record.part}
             allowEdit={false}
             modelTarget={ModelType.stockitem}
+            modelField={'item'}
             isSubTable
           />
         );


### PR DESCRIPTION
Fixes two small issues for the sales-order-line-item table:

- Selecting allocated item navigates to the correct page
- Allow edit of allocated items from sub-table