### PR TITLE
[UI] Part requirements

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,11 +1,16 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 369
+INVENTREE_API_VERSION = 370
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v370 -> 2025-07-17 : https://github.com/inventree/InvenTree/pull/10036
+    - Adds optional "assembly_detail" information to BuildLine API endpoint
+    - Adds "include_variants" filter to SalesOrderLineItem API endpoint
+    - Improves the "PartRequirements" API endpoint to include variant aggregations
 
 v369 -> 2025-07-15 : https://github.com/inventree/InvenTree/pull/10023
     - Adds "note", "updated", "updated_by" fields to the PartParameter API endpoints

--- a/src/backend/InvenTree/InvenTree/ready.py
+++ b/src/backend/InvenTree/InvenTree/ready.py
@@ -50,12 +50,19 @@ def isGeneratingSchema():
     if isInServerThread() or isInWorkerThread():
         return False
 
+    if isRunningMigrations() or isRunningBackup() or isRebuildingData():
+        return False
+
+    if isImportingData():
+        return False
+
     if isInTestMode():
         return False
 
     if 'schema' in sys.argv:
         return True
 
+    # This is a very inefficient call - so we only use it as a last resort
     return any('drf_spectacular' in frame.filename for frame in inspect.stack())
 
 

--- a/src/backend/InvenTree/build/api.py
+++ b/src/backend/InvenTree/build/api.py
@@ -533,6 +533,7 @@ class BuildLineEndpoint:
             params = self.request.query_params
 
             kwargs['bom_item_detail'] = str2bool(params.get('bom_item_detail', True))
+            kwargs['assembly_detail'] = str2bool(params.get('assembly_detail', True))
             kwargs['part_detail'] = str2bool(params.get('part_detail', True))
             kwargs['build_detail'] = str2bool(params.get('build_detail', False))
             kwargs['allocations'] = str2bool(params.get('allocations', True))

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -1319,6 +1319,7 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
             'part_category_name',
             # Extra detail (related field) serializers
             'bom_item_detail',
+            'assembly_detail',
             'part_detail',
             'build_detail',
         ]
@@ -1328,6 +1329,7 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
     def __init__(self, *args, **kwargs):
         """Determine which extra details fields should be included."""
         part_detail = kwargs.pop('part_detail', True)
+        assembly_detail = kwargs.pop('assembly_detail', True)
         bom_item_detail = kwargs.pop('bom_item_detail', True)
         build_detail = kwargs.pop('build_detail', True)
         allocations = kwargs.pop('allocations', True)
@@ -1348,6 +1350,9 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
 
         if not allocations:
             self.fields.pop('allocations', None)
+
+        if not assembly_detail:
+            self.fields.pop('assembly_detail', None)
 
     # Build info fields
     build_reference = serializers.CharField(
@@ -1404,6 +1409,14 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
         substitutes=False,
         sub_part_detail=False,
         part_detail=False,
+    )
+
+    assembly_detail = part_serializers.PartBriefSerializer(
+        label=_('Assembly'),
+        source='bom_item.part',
+        many=False,
+        read_only=True,
+        pricing=False,
     )
 
     part_detail = part_serializers.PartBriefSerializer(

--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -1277,7 +1277,7 @@ class PartRequirementsSerializer(InvenTree.serializers.InvenTreeModelSerializer)
 
     def get_allocated_to_sales_orders(self, part) -> float:
         """Return the allocated sales order quantity."""
-        return part.sales_order_allocation_count(pending=True)
+        return part.sales_order_allocation_count(include_variants=True, pending=True)
 
 
 class PartStocktakeSerializer(InvenTree.serializers.InvenTreeModelSerializer):

--- a/src/backend/InvenTree/templates/email/build_order_required_stock.html
+++ b/src/backend/InvenTree/templates/email/build_order_required_stock.html
@@ -25,9 +25,9 @@
         <a href='{{ line.link }}'>{{ line.part.full_name }}</a>{% if line.part.description %} - <em>{{ line.part.description }}</em>{% endif %}
     </td>
     <td style="text-align: center;">
-        {% decimal line.required %} {% include "part/part_units.html" with part=line.part %}
+        {% decimal line.required %}
     </td>
-    <td style="text-align: center;">{% decimal line.available %}  {% include "part/part_units.html" with part=line.part %}</td>
+    <td style="text-align: center;">{% decimal line.available %}</td>
 </tr>
 
 {% endfor %}

--- a/src/frontend/src/components/buttons/StarredToggleButton.tsx
+++ b/src/frontend/src/components/buttons/StarredToggleButton.tsx
@@ -3,7 +3,7 @@ import { ApiEndpoints } from '@lib/enums/ApiEndpoints';
 import { ModelType } from '@lib/enums/ModelType';
 import { apiUrl } from '@lib/functions/Api';
 import { t } from '@lingui/core/macro';
-import { showNotification } from '@mantine/notifications';
+import { hideNotification, showNotification } from '@mantine/notifications';
 import { IconBell } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useApi } from '../../contexts/ApiContext';
@@ -31,8 +31,10 @@ export default function StarredToggleButton({
         { starred: !starred }
       )
       .then(() => {
+        hideNotification('subscription-update');
         showNotification({
-          title: 'Subscription updated',
+          title: t`Subscription Updated`,
+          id: 'subscription-update',
           message: `Subscription ${starred ? 'removed' : 'added'}`,
           autoClose: 5000,
           color: 'blue'

--- a/src/frontend/src/pages/part/PartDetail.tsx
+++ b/src/frontend/src/pages/part/PartDetail.tsx
@@ -153,6 +153,9 @@ export default function PartDetail() {
 
     const data = { ...part };
 
+    const fetching =
+      partRequirementsQuery.isFetching || instanceQuery.isFetching;
+
     // Copy part requirements data into the main part data
     data.total_in_stock =
       partRequirements?.total_stock ?? part?.total_in_stock ?? 0;
@@ -280,11 +283,12 @@ export default function PartDetail() {
         label: t`In Stock`
       },
       {
-        type: 'number',
+        type: 'progressbar',
         name: 'unallocated_stock',
-        unit: part.units,
+        total: data.total_in_stock,
+        progress: data.unallocated,
         label: t`Available Stock`,
-        hidden: part.total_in_stock == part.unallocated_stock
+        hidden: data.total_in_stock == data.unallocated
       },
       {
         type: 'number',
@@ -324,8 +328,9 @@ export default function PartDetail() {
         progress: partRequirements.allocated_to_build_orders,
         label: t`Allocated to Build Orders`,
         hidden:
-          partRequirements.required_for_build_orders <= 0 &&
-          partRequirements.allocated_to_build_orders <= 0
+          fetching ||
+          (partRequirements.required_for_build_orders <= 0 &&
+            partRequirements.allocated_to_build_orders <= 0)
       },
       {
         type: 'progressbar',
@@ -335,8 +340,9 @@ export default function PartDetail() {
         progress: partRequirements.allocated_to_sales_orders,
         label: t`Allocated to Sales Orders`,
         hidden:
-          partRequirements.required_for_sales_orders <= 0 &&
-          partRequirements.allocated_to_sales_orders <= 0
+          fetching ||
+          (partRequirements.required_for_sales_orders <= 0 &&
+            partRequirements.allocated_to_sales_orders <= 0)
       },
       {
         type: 'progressbar',
@@ -345,14 +351,15 @@ export default function PartDetail() {
         progress: partRequirements.building,
         total: partRequirements.scheduled_to_build,
         hidden:
-          !partRequirements.building && !partRequirements.scheduled_to_build
+          fetching ||
+          (!partRequirements.building && !partRequirements.scheduled_to_build)
       },
       {
         type: 'number',
         name: 'can_build',
         unit: part.units,
         label: t`Can Build`,
-        hidden: !part.assembly || partRequirementsQuery.isFetching
+        hidden: !part.assembly || fetching
       }
     ];
 

--- a/src/frontend/src/pages/part/PartDetail.tsx
+++ b/src/frontend/src/pages/part/PartDetail.tsx
@@ -292,21 +292,6 @@ export default function PartDetail() {
       },
       {
         type: 'number',
-        name: 'variant_stock',
-        unit: part.units,
-        label: t`Variant Stock`,
-        hidden: !part.variant_stock,
-        icon: 'stock'
-      },
-      {
-        type: 'number',
-        name: 'minimum_stock',
-        unit: part.units,
-        label: t`Minimum Stock`,
-        hidden: part.minimum_stock <= 0
-      },
-      {
-        type: 'number',
         name: 'ordering',
         label: t`On order`,
         unit: part.units,
@@ -360,6 +345,13 @@ export default function PartDetail() {
         unit: part.units,
         label: t`Can Build`,
         hidden: !part.assembly || fetching
+      },
+      {
+        type: 'number',
+        name: 'minimum_stock',
+        unit: part.units,
+        label: t`Minimum Stock`,
+        hidden: part.minimum_stock <= 0
       }
     ];
 

--- a/src/frontend/src/tables/Filter.tsx
+++ b/src/frontend/src/tables/Filter.tsx
@@ -249,6 +249,15 @@ export function HasProjectCodeFilter(): TableFilter {
   };
 }
 
+export function IncludeVariantsFilter(): TableFilter {
+  return {
+    name: 'include_variants',
+    type: 'boolean',
+    label: t`Include Variants`,
+    description: t`Include results for part variants`
+  };
+}
+
 export function OrderStatusFilter({
   model
 }: { model: ModelType }): TableFilter {

--- a/src/frontend/src/tables/build/BuildAllocatedStockTable.tsx
+++ b/src/frontend/src/tables/build/BuildAllocatedStockTable.tsx
@@ -26,7 +26,7 @@ import {
   ReferenceColumn,
   StatusColumn
 } from '../ColumnRenderers';
-import { StockLocationFilter } from '../Filter';
+import { IncludeVariantsFilter, StockLocationFilter } from '../Filter';
 import { InvenTreeTable } from '../InvenTreeTable';
 
 /**
@@ -66,12 +66,7 @@ export default function BuildAllocatedStockTable({
     ];
 
     if (!!partId) {
-      filters.push({
-        name: 'include_variants',
-        type: 'boolean',
-        label: t`Include Variants`,
-        description: t`Include orders for part variants`
-      });
+      filters.push(IncludeVariantsFilter());
     }
 
     filters.push(StockLocationFilter());

--- a/src/frontend/src/tables/build/BuildOrderTable.tsx
+++ b/src/frontend/src/tables/build/BuildOrderTable.tsx
@@ -33,6 +33,7 @@ import {
   CreatedAfterFilter,
   CreatedBeforeFilter,
   HasProjectCodeFilter,
+  IncludeVariantsFilter,
   IssuedByFilter,
   MaxDateFilter,
   MinDateFilter,
@@ -190,12 +191,7 @@ export function BuildOrderTable({
 
     // If we are filtering on a specific part, we can include the "include variants" filter
     if (!!partId) {
-      filters.push({
-        name: 'include_variants',
-        type: 'boolean',
-        label: t`Include Variants`,
-        description: t`Include orders for part variants`
-      });
+      filters.push(IncludeVariantsFilter());
     }
 
     return filters;

--- a/src/frontend/src/tables/build/BuildOutputTable.tsx
+++ b/src/frontend/src/tables/build/BuildOutputTable.tsx
@@ -285,6 +285,7 @@ export default function BuildOutputTable({
     title: t`Add Build Output`,
     modalId: 'add-build-output',
     fields: buildOutputFields,
+    successMessage: t`Build output created`,
     timeout: 10000,
     initialData: {
       batch_code: build.batch,

--- a/src/frontend/src/tables/part/PartBuildAllocationsTable.tsx
+++ b/src/frontend/src/tables/part/PartBuildAllocationsTable.tsx
@@ -10,6 +10,7 @@ import { ApiEndpoints } from '@lib/enums/ApiEndpoints';
 import { ModelType } from '@lib/enums/ModelType';
 import { UserRoles } from '@lib/enums/Roles';
 import { apiUrl } from '@lib/functions/Api';
+import type { TableFilter } from '@lib/types/Filters';
 import type { TableColumn } from '@lib/types/Tables';
 import { useTable } from '../../hooks/UseTable';
 import { useUserState } from '../../states/UserState';
@@ -19,6 +20,7 @@ import {
   ProjectCodeColumn,
   StatusColumn
 } from '../ColumnRenderers';
+import { IncludeVariantsFilter } from '../Filter';
 import { InvenTreeTable } from '../InvenTreeTable';
 import RowExpansionIcon from '../RowExpansionIcon';
 import { BuildLineSubTable } from '../build/BuildLineTable';
@@ -53,9 +55,25 @@ export default function PartBuildAllocationsTable({
         )
       },
       {
-        accessor: 'part',
+        accessor: 'assembly_detail',
         title: t`Assembly`,
+        switchable: false,
+        render: (record: any) => <PartColumn part={record.assembly_detail} />
+      },
+      {
+        accessor: 'assembly_detail.IPN',
+        title: t`Assembly IPN`
+      },
+      {
+        accessor: 'part_detail',
+        title: t`Part`,
+        defaultVisible: false,
         render: (record: any) => <PartColumn part={record.part_detail} />
+      },
+      {
+        accessor: 'part_detail.IPN',
+        defaultVisible: false,
+        title: t`Part IPN`
       },
       DescriptionColumn({
         accessor: 'build_detail.title'
@@ -114,6 +132,10 @@ export default function PartBuildAllocationsTable({
     };
   }, [table.isRowExpanded]);
 
+  const tableFilters: TableFilter[] = useMemo(() => {
+    return [IncludeVariantsFilter()];
+  }, []);
+
   return (
     <InvenTreeTable
       url={apiUrl(ApiEndpoints.build_line_list)}
@@ -124,13 +146,16 @@ export default function PartBuildAllocationsTable({
         params: {
           part: partId,
           consumable: false,
+          part_detail: true,
+          assembly_detail: true,
           build_detail: true,
           order_outstanding: true
         },
         enableColumnSwitching: true,
         enableSearch: false,
         rowActions: rowActions,
-        rowExpansion: rowExpansion
+        rowExpansion: rowExpansion,
+        tableFilters: tableFilters
       }}
     />
   );

--- a/src/frontend/src/tables/part/PartParameterTable.tsx
+++ b/src/frontend/src/tables/part/PartParameterTable.tsx
@@ -32,7 +32,7 @@ import {
   NoteColumn,
   PartColumn
 } from '../ColumnRenderers';
-import { UserFilter } from '../Filter';
+import { IncludeVariantsFilter, UserFilter } from '../Filter';
 import { InvenTreeTable } from '../InvenTreeTable';
 import { TableHoverCard } from '../TableHoverCard';
 
@@ -142,11 +142,7 @@ export function PartParameterTable({
 
   const tableFilters: TableFilter[] = useMemo(() => {
     return [
-      {
-        name: 'include_variants',
-        label: t`Include Variants`,
-        type: 'boolean'
-      },
+      IncludeVariantsFilter(),
       UserFilter({
         name: 'updated_by',
         label: t`Updated By`,

--- a/src/frontend/src/tables/part/PartPurchaseOrdersTable.tsx
+++ b/src/frontend/src/tables/part/PartPurchaseOrdersTable.tsx
@@ -11,7 +11,7 @@ import type { TableColumn } from '@lib/types/Tables';
 import { formatCurrency } from '../../defaults/formatters';
 import { useTable } from '../../hooks/UseTable';
 import { DateColumn, ReferenceColumn, StatusColumn } from '../ColumnRenderers';
-import { StatusFilterOptions } from '../Filter';
+import { IncludeVariantsFilter, StatusFilterOptions } from '../Filter';
 import { InvenTreeTable } from '../InvenTreeTable';
 import { TableHoverCard } from '../TableHoverCard';
 
@@ -133,12 +133,7 @@ export default function PartPurchaseOrdersTable({
         description: t`Filter by order status`,
         choiceFunction: StatusFilterOptions(ModelType.purchaseorder)
       },
-      {
-        name: 'include_variants',
-        type: 'boolean',
-        label: t`Include Variants`,
-        description: t`Include orders for part variants`
-      }
+      IncludeVariantsFilter()
     ];
   }, []);
 

--- a/src/frontend/src/tables/part/PartSalesAllocationsTable.tsx
+++ b/src/frontend/src/tables/part/PartSalesAllocationsTable.tsx
@@ -135,6 +135,7 @@ export default function PartSalesAllocationsTable({
         minHeight: 200,
         params: {
           part: partId,
+          part_detail: true,
           order_detail: true,
           order_outstanding: true
         },

--- a/src/frontend/src/tables/part/PartSalesAllocationsTable.tsx
+++ b/src/frontend/src/tables/part/PartSalesAllocationsTable.tsx
@@ -10,6 +10,7 @@ import { ApiEndpoints } from '@lib/enums/ApiEndpoints';
 import { ModelType } from '@lib/enums/ModelType';
 import { UserRoles } from '@lib/enums/Roles';
 import { apiUrl } from '@lib/functions/Api';
+import type { TableFilter } from '@lib/types/Filters';
 import type { TableColumn } from '@lib/types/Tables';
 import { useTable } from '../../hooks/UseTable';
 import { useUserState } from '../../states/UserState';
@@ -19,6 +20,7 @@ import {
   ProjectCodeColumn,
   StatusColumn
 } from '../ColumnRenderers';
+import { IncludeVariantsFilter } from '../Filter';
 import { InvenTreeTable } from '../InvenTreeTable';
 import RowExpansionIcon from '../RowExpansionIcon';
 import SalesOrderAllocationTable from '../sales/SalesOrderAllocationTable';
@@ -98,6 +100,10 @@ export default function PartSalesAllocationsTable({
     [user]
   );
 
+  const tableFilters: TableFilter[] = useMemo(() => {
+    return [IncludeVariantsFilter()];
+  }, []);
+
   // Control row expansion
   const rowExpansion: DataTableRowExpansionProps<any> = useMemo(() => {
     return {
@@ -132,6 +138,7 @@ export default function PartSalesAllocationsTable({
           order_detail: true,
           order_outstanding: true
         },
+        tableFilters: tableFilters,
         enableSearch: false,
         enableColumnSwitching: true,
         rowExpansion: rowExpansion,

--- a/src/frontend/src/tables/part/PartSalesAllocationsTable.tsx
+++ b/src/frontend/src/tables/part/PartSalesAllocationsTable.tsx
@@ -72,7 +72,7 @@ export default function PartSalesAllocationsTable({
       }),
       {
         accessor: 'allocated',
-        title: t`Required Stock`,
+        title: t`Allocated Stock`,
         switchable: false,
         render: (record: any) => (
           <ProgressBar

--- a/src/frontend/src/tables/part/PartSalesAllocationsTable.tsx
+++ b/src/frontend/src/tables/part/PartSalesAllocationsTable.tsx
@@ -15,6 +15,7 @@ import { useTable } from '../../hooks/UseTable';
 import { useUserState } from '../../states/UserState';
 import {
   DescriptionColumn,
+  PartColumn,
   ProjectCodeColumn,
   StatusColumn
 } from '../ColumnRenderers';
@@ -36,6 +37,7 @@ export default function PartSalesAllocationsTable({
       {
         accessor: 'order',
         title: t`Sales Order`,
+        switchable: false,
         render: (record: any) => (
           <Group wrap='nowrap' gap='xs'>
             <RowExpansionIcon
@@ -49,6 +51,15 @@ export default function PartSalesAllocationsTable({
       DescriptionColumn({
         accessor: 'order_detail.description'
       }),
+      {
+        accessor: 'part_detail',
+        title: t`Part`,
+        render: (record: any) => <PartColumn part={record.part_detail} />
+      },
+      {
+        accessor: 'part_detail.IPN',
+        title: t`IPN`
+      },
       ProjectCodeColumn({
         accessor: 'order_detail.project_code_detail'
       }),
@@ -60,6 +71,7 @@ export default function PartSalesAllocationsTable({
       {
         accessor: 'allocated',
         title: t`Required Stock`,
+        switchable: false,
         render: (record: any) => (
           <ProgressBar
             progressLabel
@@ -121,7 +133,7 @@ export default function PartSalesAllocationsTable({
           order_outstanding: true
         },
         enableSearch: false,
-        enableColumnSwitching: false,
+        enableColumnSwitching: true,
         rowExpansion: rowExpansion,
         rowActions: rowActions
       }}

--- a/src/frontend/src/tables/sales/ReturnOrderTable.tsx
+++ b/src/frontend/src/tables/sales/ReturnOrderTable.tsx
@@ -34,6 +34,7 @@ import {
   CreatedBeforeFilter,
   CreatedByFilter,
   HasProjectCodeFilter,
+  IncludeVariantsFilter,
   MaxDateFilter,
   MinDateFilter,
   OrderStatusFilter,
@@ -93,12 +94,7 @@ export function ReturnOrderTable({
     ];
 
     if (!!partId) {
-      filters.push({
-        name: 'include_variants',
-        type: 'boolean',
-        label: t`Include Variants`,
-        description: t`Include orders for part variants`
-      });
+      filters.push(IncludeVariantsFilter());
     }
 
     return filters;

--- a/src/frontend/src/tables/sales/SalesOrderAllocationTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderAllocationTable.tsx
@@ -32,7 +32,7 @@ import {
   ReferenceColumn,
   StatusColumn
 } from '../ColumnRenderers';
-import { StockLocationFilter } from '../Filter';
+import { IncludeVariantsFilter, StockLocationFilter } from '../Filter';
 import { InvenTreeTable } from '../InvenTreeTable';
 
 export default function SalesOrderAllocationTable({
@@ -94,12 +94,7 @@ export default function SalesOrderAllocationTable({
     ];
 
     if (!!partId) {
-      filters.push({
-        name: 'include_variants',
-        type: 'boolean',
-        label: t`Include Variants`,
-        description: t`Include orders for part variants`
-      });
+      filters.push(IncludeVariantsFilter());
     }
 
     return filters;

--- a/src/frontend/src/tables/sales/SalesOrderTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderTable.tsx
@@ -35,6 +35,7 @@ import {
   CreatedBeforeFilter,
   CreatedByFilter,
   HasProjectCodeFilter,
+  IncludeVariantsFilter,
   MaxDateFilter,
   MinDateFilter,
   OrderStatusFilter,
@@ -94,12 +95,7 @@ export function SalesOrderTable({
     ];
 
     if (!!partId) {
-      filters.push({
-        name: 'include_variants',
-        type: 'boolean',
-        label: t`Include Variants`,
-        description: t`Include orders for part variants`
-      });
+      filters.push(IncludeVariantsFilter());
     }
 
     return filters;

--- a/src/frontend/src/tables/stock/StockItemTable.tsx
+++ b/src/frontend/src/tables/stock/StockItemTable.tsx
@@ -32,6 +32,7 @@ import {
 import {
   BatchFilter,
   HasBatchCodeFilter,
+  IncludeVariantsFilter,
   IsSerializedFilter,
   SerialFilter,
   SerialGTEFilter,
@@ -356,11 +357,7 @@ function stockItemTableFilters({
       label: t`In Production`,
       description: t`Show items which are in production`
     },
-    {
-      name: 'include_variants',
-      label: t`Include Variants`,
-      description: t`Include stock items for variant parts`
-    },
+    IncludeVariantsFilter(),
     {
       name: 'consumed',
       label: t`Consumed`,

--- a/src/frontend/tests/pages/pui_part.spec.ts
+++ b/src/frontend/tests/pages/pui_part.spec.ts
@@ -187,6 +187,45 @@ test('Parts - Details', async ({ browser }) => {
   await page.getByText('2022-04-29').waitFor();
 });
 
+test('Parts - Requirements', async ({ browser }) => {
+  // Navigate to the "Widget Assembly" part detail page
+  // This part has multiple "variants"
+  // We expect that the template page includes variant requirements
+  const page = await doCachedLogin(browser, { url: 'part/77/details' });
+
+  // Check top-level badges
+  await page.getByText('In Stock: 209').waitFor();
+  await page.getByText('Available: 204').waitFor();
+  await page.getByText('Required: 275').waitFor();
+  await page.getByText('In Production: 24').waitFor();
+
+  // Check requirements details
+  await page.getByText('204 / 209').waitFor(); // Available stock
+  await page.getByText('0 / 100').waitFor(); // Allocated to build orders
+  await page.getByText('5 / 175').waitFor(); // Allocated to sales orders
+  await page.getByText('24 / 214').waitFor(); // In production
+
+  // Let's check out the "variants" for this part, too
+  await navigate(page, 'part/81/details'); // WID-REV-A
+  await page.getByText('WID-REV-A', { exact: true }).first().waitFor();
+  await page.getByText('In Stock: 165').waitFor();
+  await page.getByText('Required: 75').waitFor();
+
+  await navigate(page, 'part/903/details'); // WID-REV-B
+  await page.getByText('WID-REV-B', { exact: true }).first().waitFor();
+
+  await page.getByText('In Stock: 44').waitFor();
+  await page.getByText('Available: 39').waitFor();
+  await page.getByText('Required: 100').waitFor();
+  await page.getByText('In Production: 10').waitFor();
+
+  await page.getByText('39 / 44').waitFor(); // Available stock
+  await page.getByText('5 / 100').waitFor(); // Allocated to sales orders
+  await page.getByText('10 / 125').waitFor(); // In production
+
+  await page.waitForTimeout(2500);
+});
+
 test('Parts - Allocations', async ({ browser }) => {
   // Let's look at the allocations for a single stock item
   const page = await doCachedLogin(browser, { url: 'stock/item/324/' });

--- a/tasks.py
+++ b/tasks.py
@@ -296,6 +296,7 @@ def content_excludes(
         'exchange.rate',
         'exchange.exchangebackend',
         'common.dataoutput',
+        'common.newsfeedentry',
         'common.notificationentry',
         'common.notificationmessage',
         'importer.dataimportsession',


### PR DESCRIPTION
Enhance the "requirements" on the part detail page, to include variant requirements for template parts.

This provides a much improved production overview when looking at a template part which has multiple active variants.

- Order and requirement overviews now aggregate variant requirements when displayed on the part detail page
- Part allocation tables can now display variants also