### PR TITLE
Plugin sequence fix

### DIFF
--- a/src/backend/InvenTree/InvenTree/apps.py
+++ b/src/backend/InvenTree/InvenTree/apps.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import AppRegistryNotReady
 from django.db import transaction
-from django.db.utils import IntegrityError, OperationalError
+from django.db.utils import IntegrityError
 
 import structlog
 from allauth.socialaccount.signals import social_account_updated
@@ -65,7 +65,8 @@ class InvenTreeConfig(AppConfig):
             self.start_background_tasks()
 
             if not InvenTree.ready.isInTestMode():  # pragma: no cover
-                self.update_exchange_rates()
+                # Update exchange rates
+                InvenTree.tasks.offload_task(InvenTree.tasks.update_exchange_rates)
                 # Let the background worker check for migrations
                 InvenTree.tasks.offload_task(InvenTree.tasks.check_for_migrations)
 
@@ -179,6 +180,8 @@ class InvenTreeConfig(AppConfig):
                 InvenTree.tasks.offload_task(
                     InvenTree.tasks.heartbeat, force_async=True, group='heartbeat'
                 )
+        except AppRegistryNotReady:  # pragma: no cover
+            pass
         except Exception:
             pass
 
@@ -193,63 +196,6 @@ class InvenTreeConfig(AppConfig):
                     import_module(f'{app.module.__package__}.tasks')
                 except Exception as e:  # pragma: no cover
                     logger.exception('Error loading tasks for %s: %s', app_name, e)
-
-    def update_exchange_rates(self):  # pragma: no cover
-        """Update exchange rates each time the server is started.
-
-        Only runs *if*:
-        a) Have not been updated recently (one day or less)
-        b) The base exchange rate has been altered
-        """
-        try:
-            from djmoney.contrib.exchange.models import ExchangeBackend
-
-            from common.currency import currency_code_default
-            from InvenTree.tasks import update_exchange_rates
-        except AppRegistryNotReady:  # pragma: no cover
-            pass
-
-        base_currency = currency_code_default()
-
-        update = False
-
-        try:
-            backend = ExchangeBackend.objects.filter(name='InvenTreeExchange')
-
-            if backend.exists():
-                backend = backend.first()
-
-                last_update = backend.last_update
-
-                if last_update is None:
-                    # Never been updated
-                    logger.info('Exchange backend has never been updated')
-                    update = True
-
-                # Backend currency has changed?
-                if base_currency != backend.base_currency:
-                    logger.info(
-                        'Base currency changed from %s to %s',
-                        backend.base_currency,
-                        base_currency,
-                    )
-                    update = True
-
-        except ExchangeBackend.DoesNotExist:
-            logger.info('Exchange backend not found - updating')
-            update = True
-
-        except Exception:
-            # Some other error - potentially the tables are not ready yet
-            return
-
-        if update:
-            try:
-                update_exchange_rates()
-            except OperationalError:
-                logger.warning('Could not update exchange rates - database not ready')
-            except Exception as e:
-                logger.exception('Error updating exchange rates: %s (%s)', e, type(e))
 
     def update_site_url(self):
         """Update the site URL setting.

--- a/src/backend/InvenTree/common/currency.py
+++ b/src/backend/InvenTree/common/currency.py
@@ -15,12 +15,14 @@ import InvenTree.helpers
 logger = structlog.get_logger('inventree')
 
 
-def currency_code_default():
+def currency_code_default(create: bool = True):
     """Returns the default currency code (or USD if not specified)."""
     from common.settings import get_global_setting
 
     try:
-        code = get_global_setting('INVENTREE_DEFAULT_CURRENCY', create=True, cache=True)
+        code = get_global_setting(
+            'INVENTREE_DEFAULT_CURRENCY', create=create, cache=True
+        )
     except Exception:  # pragma: no cover
         # Database may not yet be ready, no need to throw an error here
         code = ''

--- a/src/backend/InvenTree/plugin/apps.py
+++ b/src/backend/InvenTree/plugin/apps.py
@@ -32,19 +32,7 @@ class PluginAppConfig(AppConfig):
         else:
             logger.info('Loading InvenTree plugins')
 
-            if not registry.is_loading:
-                # this is the first startup
-                try:
-                    from common.models import InvenTreeSetting
-
-                    if InvenTreeSetting.get_setting(
-                        'PLUGIN_ON_STARTUP', create=False, cache=False
-                    ):
-                        # make sure all plugins are installed
-                        registry.install_plugin_file()
-                except Exception:  # pragma: no cover
-                    pass
-
+            if not registry.is_ready:
                 # Mark the registry as ready
                 # This ensures that other apps cannot access the registry before it is fully initialized
                 logger.info('Plugin registry is ready - performing initial load')

--- a/src/backend/InvenTree/plugin/apps.py
+++ b/src/backend/InvenTree/plugin/apps.py
@@ -45,6 +45,11 @@ class PluginAppConfig(AppConfig):
                 except Exception:  # pragma: no cover
                     pass
 
+                # Mark the registry as ready
+                # This ensures that other apps cannot access the registry before it is fully initialized
+                registry.ready = True
+                logger.info('Plugin registry is ready')
+
                 # Perform a full reload of the plugin registry
                 registry.reload_plugins(
                     full_reload=True, force_reload=True, collect=True

--- a/src/backend/InvenTree/plugin/apps.py
+++ b/src/backend/InvenTree/plugin/apps.py
@@ -47,13 +47,8 @@ class PluginAppConfig(AppConfig):
 
                 # Mark the registry as ready
                 # This ensures that other apps cannot access the registry before it is fully initialized
-                registry.ready = True
-                logger.info('Plugin registry is ready')
-
-                # Perform a full reload of the plugin registry
-                registry.reload_plugins(
-                    full_reload=True, force_reload=True, collect=True
-                )
+                logger.info('Plugin registry is ready - performing initial load')
+                registry.set_ready()
 
                 # drop out of maintenance
                 # makes sure we did not have an error in reloading and maintenance is still active

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -105,6 +105,11 @@ class PluginsRegistry:
         self.installed_apps = []  # Holds all added plugin_paths
 
     @property
+    def is_ready(self) -> bool:
+        """Return True if the plugin registry is ready to be used."""
+        return self.ready
+
+    @property
     def is_loading(self) -> bool:
         """Return True if the plugin registry is currently loading."""
         return self.loading_lock.locked()

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -369,7 +369,7 @@ class PluginsRegistry:
             logger.info('Plugin Registry: Loaded %s plugins', len(self.plugins))
 
         except Exception as e:
-            logger.exception('Expected error during plugin reload: %s', e)
+            logger.exception('Unexpected error during plugin reload: %s', e)
             log_error('reload_plugins', scope='plugins')
 
         finally:

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -68,6 +68,8 @@ class PluginsRegistry:
         'parameter-exporter',
     ]
 
+    ready: bool = False  # Marks if the registry is ready to be used
+
     def __init__(self) -> None:
         """Initialize registry.
 
@@ -81,6 +83,8 @@ class PluginsRegistry:
         self.plugins_full: dict[
             str, InvenTreePlugin
         ] = {}  # List of all plugin instances
+
+        self.ready = False  # Marks if the registry is ready to be used
 
         # Keep an internal hash of the plugin registry state
         self.registry_hash = None
@@ -323,6 +327,10 @@ class PluginsRegistry:
             clear_errors (bool, optional): Clear any previous loading errors. Defaults to False.
             _internal (list, optional): Internal apps to reload (used for testing). Defaults to None
         """
+        if not self.is_ready:
+            logger.warning('Plugin registry is not ready - cannot reload plugins')
+            return
+
         # Do not reload when currently loading
         if self.is_loading:
             logger.debug('Skipping reload - plugin registry is currently loading')

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -155,6 +155,11 @@ class PluginsRegistry:
         self.reload_plugins(full_reload=True, force_reload=True, collect=True)
 
     @property
+    def is_ready(self) -> bool:
+        """Return True if the plugin registry is ready to be used."""
+        return self.ready
+
+    @property
     def is_loading(self) -> bool:
         """Return True if the plugin registry is currently loading."""
         return self.loading_lock.locked()

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -104,6 +104,17 @@ class PluginsRegistry:
 
         self.installed_apps = []  # Holds all added plugin_paths
 
+    def set_ready(self):
+        """Set the registry as ready to be used.
+
+        This method should only be called once per application start,
+        after all apps have been loaded and the registry is fully initialized.
+        """
+        self.ready = True
+
+        # Perform initial plugin discovery
+        self.reload_plugins(full_reload=True, force_reload=True, collect=True)
+
     @property
     def is_ready(self) -> bool:
         """Return True if the plugin registry is ready to be used."""

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -44,7 +44,7 @@ from .plugin import InvenTreePlugin
 logger = structlog.get_logger('inventree')
 
 
-def registry_entrypoint(check_reload: bool = True, default_value=None) -> Any:
+def registry_entrypoint(check_reload: bool = True, default_value: Any = None) -> Any:
     """Function decorator for registry entrypoints methods.
 
     - Ensure that the registry is ready before calling the method.

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -141,7 +141,14 @@ class PluginsRegistry:
         This method should only be called once per application start,
         after all apps have been loaded and the registry is fully initialized.
         """
+        from common.models import InvenTreeSetting
+
         self.ready = True
+
+        # Install plugins from file (if required)
+        if InvenTreeSetting.get_setting('PLUGIN_ON_STARTUP', create=False, cache=False):
+            # make sure all plugins are installed
+            registry.install_plugin_file()
 
         # Perform initial plugin discovery
         self.reload_plugins(full_reload=True, force_reload=True, collect=True)

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -237,7 +237,7 @@ class PluginsRegistry:
         # Update the registry hash value
         self.update_plugin_hash()
 
-    @registry_entrypoint(default_value=None)
+    @registry_entrypoint()
     def call_plugin_function(self, slug: str, func: str, *args, **kwargs):
         """Call a member function (named by 'func') of the plugin named by 'slug'.
 
@@ -266,7 +266,7 @@ class PluginsRegistry:
 
     # region registry functions
 
-    @registry_entrypoint()
+    @registry_entrypoint(default_value=[])
     def with_mixin(
         self, mixin: str, active: bool = True, builtin: Optional[bool] = None
     ) -> list[InvenTreePlugin]:

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -138,6 +138,10 @@ class PluginsRegistry:
         Returns:
             InvenTreePlugin or None: The plugin instance if found, otherwise None.
         """
+        if not self.is_ready:
+            logger.warning('registry.get_plugin: Plugin registry is not ready')
+            return None
+
         # Check if the registry needs to be reloaded
         self.check_reload()
 
@@ -196,6 +200,10 @@ class PluginsRegistry:
             slug (str): Plugin slug
             state (bool): Plugin state - true = active, false = inactive
         """
+        if not self.is_ready:
+            logger.warning('registry.set_plugin_state: Plugin registry is not ready')
+            return
+
         # Check if the registry needs to be reloaded
         self.check_reload()
 
@@ -218,6 +226,12 @@ class PluginsRegistry:
 
         Instead, any error messages are returned to the worker.
         """
+        if not self.is_ready:
+            logger.warning(
+                'registry.call_plugin_function: Plugin registry is not ready'
+            )
+            return None
+
         # Check if the registry needs to be reloaded
         self.check_reload()
 
@@ -250,6 +264,10 @@ class PluginsRegistry:
             active (bool, optional): Filter by 'active' status of plugin. Defaults to True.
             builtin (bool, optional): Filter by 'builtin' status of plugin. Defaults to None.
         """
+        if not self.is_ready:
+            logger.warning('registry.with_mixin: Plugin registry is not ready')
+            return []
+
         # Check if the registry needs to be loaded
         self.check_reload()
 
@@ -929,6 +947,10 @@ class PluginsRegistry:
 
         Returns True if the registry has changed and was reloaded.
         """
+        if not self.is_ready:
+            logger.warning('registry.check_reload: Plugin registry is not ready')
+            return False
+
         if settings.TESTING and not settings.PLUGIN_TESTING_RELOAD:
             # Skip if running during unit testing
             return False

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -100,7 +100,7 @@ class PluginsRegistry:
         'parameter-exporter',
     ]
 
-    ready: bool = False  # Marks if the registry is ready to be used
+    ready: bool
 
     def __init__(self) -> None:
         """Initialize registry.

--- a/src/backend/InvenTree/plugin/urls.py
+++ b/src/backend/InvenTree/plugin/urls.py
@@ -18,28 +18,32 @@ def get_plugin_urls():
 
     urls = []
 
-    if get_global_setting('ENABLE_PLUGINS_URL', False) or settings.PLUGIN_TESTING_SETUP:
-        for plugin in registry.with_mixin(PluginMixinEnum.URLS):
-            try:
-                if plugin_urls := plugin.urlpatterns:
-                    # Check if the plugin has a custom URL pattern
-                    for url in plugin_urls:
-                        # Attempt to resolve against the URL pattern as a validation check
-                        try:
-                            url.resolve('')
-                        except Resolver404:
-                            pass
+    if registry.is_ready:
+        if (
+            get_global_setting('ENABLE_PLUGINS_URL', False)
+            or settings.PLUGIN_TESTING_SETUP
+        ):
+            for plugin in registry.with_mixin(PluginMixinEnum.URLS):
+                try:
+                    if plugin_urls := plugin.urlpatterns:
+                        # Check if the plugin has a custom URL pattern
+                        for url in plugin_urls:
+                            # Attempt to resolve against the URL pattern as a validation check
+                            try:
+                                url.resolve('')
+                            except Resolver404:
+                                pass
 
-                    urls.append(
-                        re_path(
-                            f'^{plugin.slug}/',
-                            include((plugin_urls, plugin.slug)),
-                            name=plugin.slug,
+                        urls.append(
+                            re_path(
+                                f'^{plugin.slug}/',
+                                include((plugin_urls, plugin.slug)),
+                                name=plugin.slug,
+                            )
                         )
-                    )
-            except Exception:
-                log_error('get_plugin_urls', plugin=plugin.slug)
-                continue
+                except Exception:
+                    log_error('get_plugin_urls', plugin=plugin.slug)
+                    continue
 
     # Redirect anything else to the root index
     urls.append(


### PR DESCRIPTION
Fixes a significant logic bug which was discovered as part of https://github.com/inventree/InvenTree/pull/10056

### Problem Description

When launching the InvenTree project, the various `apps.py` models contain a `ready` method - this is code which is run when all apps are loaded.

In `plugin/apps.py` we explicitly load the plugin apps - until this point in the code, the plugin registry is initialized but none of the plugins have been discovered yet.

However, *other* apps can trigger code which can (directly or indirectly) call a function which requires plugin functionality. 

In the existing code (prior to this patch) this can result in the plugin registry being "reloaded" (by the other app) before it has actually been fully loaded yet (depending on which app "ready" function is called first).

This can lead to very complex and hard to debug circular imports, or other issues where apps are only partially initialized.

### Solution

This PR introduces a single "ready" flag for the plugin registry. Until that flag is set, plugins cannot be accessed and the registry cannot be loaded.

The ready flag is only set once - in `apps.py` 'ready' method.

### References

- Likely cause of https://github.com/inventree/InvenTree/pull/9899