### PR TITLE
Custom event when bulk-creating items

### DIFF
--- a/src/backend/InvenTree/stock/events.py
+++ b/src/backend/InvenTree/stock/events.py
@@ -14,3 +14,5 @@ class StockEvents(BaseEventEnum):
     ITEM_COUNTED = 'stockitem.counted'
     ITEM_QUANTITY_UPDATED = 'stockitem.quantityupdated'
     ITEM_INSTALLED_INTO_ASSEMBLY = 'stockitem.installed'
+
+    ITEMS_CREATED = 'stockitem.created_items'

--- a/src/backend/InvenTree/stock/models.py
+++ b/src/backend/InvenTree/stock/models.py
@@ -650,8 +650,17 @@ class StockItem(
             )
             stock.tasks.rebuild_stock_item_tree(parent.tree_id)
 
+        # Fetch the new StockItem objects from the database
+        items = StockItem.objects.filter(part=part, serial__in=serials)
+
+        # Trigger a 'created' event for the new items
+        # Note that instead of a single event for each item,
+        # we trigger a single event for all items created
+        stock_ids = list(items.values_list('id', flat=True).distinct())
+        trigger_event(StockEvents.ITEMS_CREATED, ids=stock_ids)
+
         # Return the newly created StockItem objects
-        return StockItem.objects.filter(part=part, serial__in=serials)
+        return items
 
     @staticmethod
     def convert_serial_to_int(serial: str) -> int:


### PR DESCRIPTION
- Closes https://github.com/inventree/InvenTree/issues/10002
- Adds custom event which triggers when a group of stock items is bulk created
- Difficult (and expensive) to trigger a single event for each created item