### PR TITLE
Prevent 'modelRenderer' passing through

### DIFF
--- a/src/frontend/src/components/forms/fields/RelatedModelField.tsx
+++ b/src/frontend/src/components/forms/fields/RelatedModelField.tsx
@@ -282,6 +282,7 @@ export function RelatedModelField({
     return {
       ...definition,
       autoFill: undefined,
+      modelRenderer: undefined,
       onValueChange: undefined,
       adjustFilters: undefined,
       exclude: undefined,


### PR DESCRIPTION
- Not recognized by underlying component