### PR TITLE
Add missing nullable annotations, search_field schema documentation

### DIFF
--- a/src/backend/InvenTree/InvenTree/schema.py
+++ b/src/backend/InvenTree/InvenTree/schema.py
@@ -103,6 +103,16 @@ class ExtendedAutoSchema(AutoSchema):
                         f'{parameter["description"]} Possible fields: {", ".join(ordering_fields)}.'
                     )
 
+        # Add valid search fields to the search description.
+        search_fields = getattr(self.view, 'search_fields', None)
+        if search_fields is not None:
+            parameters = operation.get('parameters', [])
+            for parameter in parameters:
+                if parameter['name'] == 'search':
+                    parameter['description'] = (
+                        f'{parameter["description"]} Searched fields: {", ".join(search_fields)}.'
+                    )
+
         return operation
 
 

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -1417,6 +1417,7 @@ class BuildLineSerializer(DataImportExportSerializerMixin, InvenTreeModelSeriali
         source='bom_item.part',
         many=False,
         read_only=True,
+        allow_null=True,
         pricing=False,
     )
 

--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -1447,7 +1447,11 @@ class SalesOrderAllocationSerializer(InvenTreeModelSerializer):
     )
 
     shipment_detail = SalesOrderShipmentSerializer(
-        source='shipment', order_detail=False, many=False, read_only=True
+        source='shipment',
+        order_detail=False,
+        many=False,
+        read_only=True,
+        allow_null=True,
     )
 
 

--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -456,7 +456,9 @@ class PartParameterSerializer(
         source='template', many=False, read_only=True, allow_null=True
     )
 
-    updated_by_detail = UserSerializer(source='updated_by', many=False, read_only=True)
+    updated_by_detail = UserSerializer(
+        source='updated_by', many=False, read_only=True, allow_null=True
+    )
 
 
 class DuplicatePartSerializer(serializers.Serializer):


### PR DESCRIPTION
A couple quick fixes before I get back to working on #9969:

- Fix a few details fields that crept in without `allow_null=True` (so they're required by the schema but the fields aren't present unless requested)
- Add the list of search fields to the `search` parameter comments in the schema (similar to the `ordering` parameter handling)