### PR TITLE
Table column tweaks

### DIFF
--- a/src/frontend/src/tables/InvenTreeTable.tsx
+++ b/src/frontend/src/tables/InvenTreeTable.tsx
@@ -328,12 +328,7 @@ export function InvenTreeTable<T extends Record<string, any>>({
     ) {
       tableColumns.setColumnsOrder(dataColumnsOrder);
     }
-  }, [
-    cacheKey,
-    dataColumnsOrder,
-    tableColumns.columnsOrder,
-    tableColumns.setColumnsOrder
-  ]);
+  }, [cacheKey, dataColumnsOrder]);
 
   // Reset the pagination state when the search term changes
   useEffect(() => {


### PR DESCRIPTION
Working through some strange issues with mantine-datatable

This PR is intended to prevent re-rendering of the table as the "tableColumns.columnOrder" seems to change on each render cycle. This can, in some situations, result in an infinite render loop