### PR TITLE
Enhanced permission checks for API

### DIFF
--- a/src/backend/InvenTree/InvenTree/permissions.py
+++ b/src/backend/InvenTree/InvenTree/permissions.py
@@ -363,6 +363,9 @@ class UserSettingsPermissionsOrScope(OASTokenMixin, permissions.BasePermission):
         except AttributeError:  # pragma: no cover
             return False
 
+        if not user.is_authenticated:
+            return False
+
         return user == obj.user
 
     def has_permission(self, request, view):

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -275,6 +275,9 @@ class UserSettingsList(SettingsList):
 
         queryset = super().filter_queryset(queryset)
 
+        if not user.is_authenticated:
+            raise PermissionDenied('User must be authenticated to access user settings')
+
         queryset = queryset.filter(user=user)
 
         return queryset
@@ -351,6 +354,10 @@ class NotificationList(NotificationMessageMixin, BulkDeleteMixin, ListAPI):
             return common.models.NotificationMessage.objects.none()
 
         queryset = super().filter_queryset(queryset)
+
+        if not user.is_authenticated:
+            raise PermissionDenied('User must be authenticated to access notifications')
+
         queryset = queryset.filter(user=user)
         return queryset
 

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -275,7 +275,7 @@ class UserSettingsList(SettingsList):
 
         queryset = super().filter_queryset(queryset)
 
-        if not user.is_authenticated:
+        if not user.is_authenticated:  # pragma: no cover
             raise PermissionDenied('User must be authenticated to access user settings')
 
         queryset = queryset.filter(user=user)
@@ -355,7 +355,7 @@ class NotificationList(NotificationMessageMixin, BulkDeleteMixin, ListAPI):
 
         queryset = super().filter_queryset(queryset)
 
-        if not user.is_authenticated:
+        if not user.is_authenticated:  # pragma: no cover
             raise PermissionDenied('User must be authenticated to access notifications')
 
         queryset = queryset.filter(user=user)

--- a/src/backend/InvenTree/common/tests.py
+++ b/src/backend/InvenTree/common/tests.py
@@ -661,6 +661,21 @@ class GlobalSettingsApiTest(InvenTreeAPITestCase):
 class UserSettingsApiTest(InvenTreeAPITestCase):
     """Tests for the user settings API."""
 
+    def test_unauthenticated_user(self):
+        """Test access with unauthenticated user."""
+        self.client.logout()
+
+        # Check list API endpoint
+        url = reverse('api-user-setting-list')
+        response = self.get(url, expected_code=401).data
+        self.assertIn(
+            'Authentication credentials were not provided', str(response['detail'])
+        )
+
+        # Check the detail API endpoint
+        url = reverse('api-user-setting-detail', kwargs={'key': 'LABEL_INLINE'})
+        self.get(url, expected_code=401)
+
     def test_user_settings_api_list(self):
         """Test list URL for user settings."""
         url = reverse('api-user-setting-list')


### PR DESCRIPTION
- Ensure user is authenticated
- Raise PermissionDenied
- Issue discovered by sentry.io

```python
Traceback (most recent call last):

File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/fields/__init__.py", line 2053, in get_prep_value
return int(value)
File "/opt/inventree/env/lib/python3.10/site-packages/django/contrib/auth/models.py", line 437, in __int__
raise TypeError(
TypeError: Cannot cast AnonymousUser to int. Are you trying to use it in place of User?
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
File "/opt/inventree/env/lib/python3.10/site-packages/rest_framework/views.py", line 512, in dispatch
response = handler(request, *args, **kwargs)
File "/opt/inventree/env/lib/python3.10/site-packages/rest_framework/generics.py", line 203, in get
return self.list(request, *args, **kwargs)
File "/opt/inventree/src/backend/InvenTree/common/api.py", line 262, in list
return super().list(request, *args, **kwargs)
File "/opt/inventree/env/lib/python3.10/site-packages/rest_framework/mixins.py", line 38, in list
queryset = self.filter_queryset(self.get_queryset())
File "/opt/inventree/src/backend/InvenTree/common/api.py", line 280, in filter_queryset
queryset = queryset.filter(user=user)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/query.py", line 1436, in filter
return self._filter_or_exclude(False, args, kwargs)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/query.py", line 1454, in _filter_or_exclude
clone._filter_or_exclude_inplace(negate, args, kwargs)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/query.py", line 1461, in _filter_or_exclude_inplace
self._query.add_q(Q(*args, **kwargs))
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1546, in add_q
clause, _ = self._add_q(q_object, self.used_aliases)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1577, in _add_q
child_clause, needed_inner = self.build_filter(
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1492, in build_filter
condition = self.build_lookup(lookups, col, value)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1319, in build_lookup
lookup = lookup_class(lhs, rhs)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/lookups.py", line 27, in __init__
self.rhs = self.get_prep_lookup()
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/fields/related_lookups.py", line 166, in get_prep_lookup
self.rhs = target_field.get_prep_value(self.rhs)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/fields/__init__.py", line 2055, in get_prep_value
raise e.__class__(
TypeError: Field 'id' expected a number but got <django.contrib.auth.models.AnonymousUser object at 0x76f6772af5e0>.Traceback (most recent call last):
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/fields/__init__.py", line 2053, in get_prep_value
return int(value)
File "/opt/inventree/env/lib/python3.10/site-packages/django/contrib/auth/models.py", line 437, in __int__
raise TypeError(
TypeError: Cannot cast AnonymousUser to int. Are you trying to use it in place of User?
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
File "/opt/inventree/env/lib/python3.10/site-packages/rest_framework/views.py", line 512, in dispatch
response = handler(request, *args, **kwargs)
File "/opt/inventree/env/lib/python3.10/site-packages/rest_framework/generics.py", line 203, in get
return self.list(request, *args, **kwargs)
File "/opt/inventree/src/backend/InvenTree/common/api.py", line 262, in list
return super().list(request, *args, **kwargs)
File "/opt/inventree/env/lib/python3.10/site-packages/rest_framework/mixins.py", line 38, in list
queryset = self.filter_queryset(self.get_queryset())
File "/opt/inventree/src/backend/InvenTree/common/api.py", line 280, in filter_queryset
queryset = queryset.filter(user=user)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/query.py", line 1436, in filter
return self._filter_or_exclude(False, args, kwargs)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/query.py", line 1454, in _filter_or_exclude
clone._filter_or_exclude_inplace(negate, args, kwargs)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/query.py", line 1461, in _filter_or_exclude_inplace
self._query.add_q(Q(*args, **kwargs))
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1546, in add_q
clause, _ = self._add_q(q_object, self.used_aliases)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1577, in _add_q
child_clause, needed_inner = self.build_filter(
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1492, in build_filter
condition = self.build_lookup(lookups, col, value)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1319, in build_lookup
lookup = lookup_class(lhs, rhs)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/lookups.py", line 27, in __init__
self.rhs = self.get_prep_lookup()
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/fields/related_lookups.py", line 166, in get_prep_lookup
self.rhs = target_field.get_prep_value(self.rhs)
File "/opt/inventree/env/lib/python3.10/site-packages/django/db/models/fields/__init__.py", line 2055, in get_prep_value
raise e.__class__(
TypeError: Field 'id' expected a number but got <django.contrib.auth.models.AnonymousUser object at 0x76f6772af5e0>.
```