### PR TITLE
feat: Add support for cache password in Redis configuration

### DIFF
--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -307,6 +307,7 @@ The following cache settings are available:
 | INVENTREE_CACHE_ENABLED | cache.enabled | Enable redis caching | False |
 | INVENTREE_CACHE_HOST | cache.host | Cache server host | *Not specified* |
 | INVENTREE_CACHE_PORT | cache.port | Cache server port | 6379 |
+| INVENTREE_CACHE_PASSWORD | cache.password | Cache server password | none |
 | INVENTREE_CACHE_CONNECT_TIMEOUT | cache.connect_timeout | Cache connection timeout (seconds) | 3 |
 | INVENTREE_CACHE_TIMEOUT | cache.timeout | Cache timeout (seconds) | 3 |
 | INVENTREE_CACHE_TCP_KEEPALIVE | cache.tcp_keepalive | Cache TCP keepalive | True |

--- a/src/backend/InvenTree/InvenTree/cache.py
+++ b/src/backend/InvenTree/InvenTree/cache.py
@@ -37,6 +37,11 @@ def cache_port() -> int:
     return cache_setting('port', '6379', typecast=int)
 
 
+def cache_password():
+    """Return the cache password."""
+    return cache_setting('password', None)
+
+
 def is_global_cache_enabled() -> bool:
     """Check if the global cache is enabled.
 
@@ -77,9 +82,14 @@ def get_cache_config(global_cache: bool) -> dict:
         A dictionary containing the cache configuration options.
     """
     if global_cache:
+        # Build Redis URL with optional password
+        password = cache_password()
+        redis_url = f'redis://:{password}@{cache_host()}:{cache_port()}/0' if password \
+                     else f'redis://{cache_host()}:{cache_port()}/0'
+
         return {
             'BACKEND': 'django_redis.cache.RedisCache',
-            'LOCATION': f'redis://{cache_host()}:{cache_port()}/0',
+            'LOCATION': redis_url,
             'OPTIONS': {
                 'CLIENT_CLASS': 'django_redis.client.DefaultClient',
                 'SOCKET_CONNECT_TIMEOUT': cache_setting(

--- a/src/backend/InvenTree/InvenTree/cache.py
+++ b/src/backend/InvenTree/InvenTree/cache.py
@@ -84,8 +84,11 @@ def get_cache_config(global_cache: bool) -> dict:
     if global_cache:
         # Build Redis URL with optional password
         password = cache_password()
-        redis_url = f'redis://:{password}@{cache_host()}:{cache_port()}/0' if password \
-                     else f'redis://{cache_host()}:{cache_port()}/0'
+
+        if password:
+            redis_url = f'redis://:{password}@{cache_host()}:{cache_port()}/0'
+        else:
+            redis_url = f'redis://{cache_host()}:{cache_port()}/0'
 
         return {
             'BACKEND': 'django_redis.cache.RedisCache',


### PR DESCRIPTION
This pull request introduces support for using a password in the Redis cache configuration. The changes include adding a new utility function to fetch the cache password and updating the Redis URL construction logic to include the password if provided.

### Enhancements to Redis cache configuration:
* `src/backend/InvenTree/InvenTree/cache.py`:
  - Added a new function `cache_password()` to retrieve the cache password from settings.
  - Updated the `get_cache_config` function to construct the Redis URL with an optional password, improving security by supporting password-protected Redis instances.