### PR TITLE
Fix 'issued_by' filter on BuildOrder API

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,11 +1,14 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 379
+INVENTREE_API_VERSION = 380
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v380 -> 2025-08-06 : https://github.com/inventree/InvenTree/pull/10135
+    - Fixes "issued_by" filter for the BuildOrder list API endpoint
 
 v379 -> 2025-08-04 : https://github.com/inventree/InvenTree/pull/10124
     - Removes "PartStocktakeReport" model and associated API endpoints

--- a/src/backend/InvenTree/build/api.py
+++ b/src/backend/InvenTree/build/api.py
@@ -36,7 +36,7 @@ class BuildFilter(rest_filters.FilterSet):
         """Metaclass options."""
 
         model = Build
-        fields = ['sales_order', 'external']
+        fields = ['issued_by', 'sales_order', 'external']
 
     status = rest_filters.NumberFilter(label=_('Order Status'), method='filter_status')
 
@@ -149,21 +149,6 @@ class BuildFilter(rest_filters.FilterSet):
         if value:
             return queryset.filter(responsible__in=owners)
         return queryset.exclude(responsible__in=owners)
-
-    issued_by = rest_filters.ModelChoiceFilter(
-        queryset=Owner.objects.all(), label=_('Issued By'), method='filter_issued_by'
-    )
-
-    def filter_issued_by(self, queryset, name, owner):
-        """Filter by 'owner' which issued the order."""
-        if owner.label() == 'user':
-            user = User.objects.get(pk=owner.owner_id)
-            return queryset.filter(issued_by=user)
-        elif owner.label() == 'group':
-            group = User.objects.filter(groups__pk=owner.owner_id)
-            return queryset.filter(issued_by__in=group)
-        else:
-            return queryset.none()
 
     assigned_to = rest_filters.ModelChoiceFilter(
         queryset=Owner.objects.all(), field_name='responsible', label=_('Assigned To')

--- a/src/backend/InvenTree/build/test_api.py
+++ b/src/backend/InvenTree/build/test_api.py
@@ -65,6 +65,23 @@ class TestBuildAPI(InvenTreeAPITestCase):
         response = self.get(url, {'reference': 'BO-9999XX'}, expected_code=200)
         self.assertEqual(len(response.data), 0)
 
+        # Filter by 'issued_by'
+        response = self.get(url)
+
+        build = Build.objects.first()
+
+        build.issued_by = self.user
+        build.save()
+
+        response = self.get(url, {'issued_by': self.user.pk}, expected_code=200)
+
+        self.assertEqual(len(response.data), 1)
+
+        item = response.data[0]
+
+        self.assertEqual(item['pk'], build.pk)
+        self.assertEqual(item['issued_by'], self.user.pk)
+
     def test_get_build_item_list(self):
         """Test that we can retrieve list of BuildItem objects."""
         url = reverse('api-build-item-list')


### PR DESCRIPTION
- Field is 'user', was trying to filter by 'owner'