### PR TITLE
Printing order

### DIFF
--- a/src/backend/InvenTree/report/api.py
+++ b/src/backend/InvenTree/report/api.py
@@ -175,7 +175,10 @@ class LabelPrint(GenericAPIView):
 
         instances = template.get_model().objects.filter(pk__in=items)
 
-        if instances.count() == 0:
+        # Sort the instances by the order of the provided items
+        instances = sorted(instances, key=lambda item: items.index(item.pk))
+
+        if len(instances) == 0:
             raise ValidationError(_('No valid items provided to template'))
 
         return self.print(template, instances, plugin, request)

--- a/src/backend/InvenTree/report/api.py
+++ b/src/backend/InvenTree/report/api.py
@@ -257,7 +257,10 @@ class ReportPrint(GenericAPIView):
 
         instances = template.get_model().objects.filter(pk__in=items)
 
-        if instances.count() == 0:
+        # Sort the instances by the order of the provided items
+        instances = sorted(instances, key=lambda item: items.index(item.pk))
+
+        if len(instances) == 0:
             raise ValidationError(_('No valid items provided to template'))
 
         return self.print(template, instances, request)

--- a/src/backend/InvenTree/report/tasks.py
+++ b/src/backend/InvenTree/report/tasks.py
@@ -35,6 +35,9 @@ def print_reports(template_id: int, item_ids: list[int], output_id: int, **kwarg
     model = template.get_model()
     items = model.objects.filter(pk__in=item_ids)
 
+    # Ensure they are sorted by the order of the provided item IDs
+    items = sorted(items, key=lambda item: item_ids.index(item.pk))
+
     template.print(items, output=output)
 
 

--- a/src/backend/InvenTree/report/tasks.py
+++ b/src/backend/InvenTree/report/tasks.py
@@ -68,6 +68,9 @@ def print_labels(
     model = template.get_model()
     items = model.objects.filter(pk__in=item_ids)
 
+    # Ensure they are sorted by the order of the provided item IDs
+    items = sorted(items, key=lambda item: item_ids.index(item.pk))
+
     plugin = registry.get_plugin(plugin_slug, active=True)
 
     if not plugin:


### PR DESCRIPTION
When printing reports or labels, ensure that the order of printing matches the order of ID values as provided to the API