### PR TITLE
Disable paging on purchaseOrderReceive API call

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,11 +1,14 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 387
+INVENTREE_API_VERSION = 388
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+v388 -> 2025-08-23 : https://github.com/inventree/InvenTree/pull/10213
+    - Disable paging on PurchaseOrderReceive call
+
 v387 -> 2025-08-19 : https://github.com/inventree/InvenTree/pull/10188
     - Adds "update_records" field to the DataImportSession API
 

--- a/src/backend/InvenTree/order/api.py
+++ b/src/backend/InvenTree/order/api.py
@@ -492,6 +492,7 @@ class PurchaseOrderReceive(PurchaseOrderContextMixin, CreateAPI):
 
     queryset = models.PurchaseOrderLineItem.objects.none()
     serializer_class = serializers.PurchaseOrderReceiveSerializer
+    pagination_class = None
 
     def create(self, request, *args, **kwargs):
         """Override the create method to handle stock item creation."""


### PR DESCRIPTION
#10174 changed the annotations for the schema to return a list using type `PaginatedStockItemList`

Since you can't really page through create results without creating more results on each call, the paging needs to be disabled so a raw array of `StockItem` is returned.