### PR TITLE
Fix extra query in company/part/ endpoint when manufacturer_detail=true

### DIFF
--- a/src/backend/InvenTree/company/api.py
+++ b/src/backend/InvenTree/company/api.py
@@ -335,7 +335,9 @@ class SupplierPartMixin:
         queryset = super().get_queryset(*args, **kwargs)
         queryset = SupplierPartSerializer.annotate_queryset(queryset)
 
-        queryset = queryset.prefetch_related('part', 'part__pricing_data')
+        queryset = queryset.prefetch_related(
+            'part', 'part__pricing_data', 'manufacturer_part__tags'
+        )
 
         return queryset
 


### PR DESCRIPTION
This patch improves performance by preventing an unnecessary database query triggered when manufacturer_detail=true in the company/part/ endpoint.

The extra query was causing avoidable overhead; now it has been eliminated.

<img width="402" height="203" alt="Screenshot from 2025-08-23 20-11-59" src="https://github.com/user-attachments/assets/599d78a2-81a2-416c-a7c9-0f319ab04f83" />
