### PR TITLE
[bug] Authentication endpoint may return expired token

### DIFF
--- a/src/backend/InvenTree/users/api.py
+++ b/src/backend/InvenTree/users/api.py
@@ -1,6 +1,5 @@
 """DRF API definition for the 'users' app."""
 
-import datetime
 import logging
 
 from django.contrib.auth import authenticate, get_user, login, logout
@@ -326,24 +325,7 @@ class GetAuthToken(APIView):
             user = request.user
             name = request.query_params.get('name', '')
 
-            name = ApiToken.sanitize_name(name)
-
-            today = datetime.date.today()
-
-            # Find existing token, which has not expired
-            token = ApiToken.objects.filter(
-                user=user, name=name, revoked=False, expiry__gte=today
-            ).first()
-
-            if not token:
-                # User is authenticated, and requesting a token against the provided name.
-                token = ApiToken.objects.create(user=request.user, name=name)
-
-                logger.info(
-                    "Created new API token for user '%s' (name='%s')",
-                    user.username,
-                    name,
-                )
+            token = ApiToken.get_or_create(user=user, token_name=name)
 
             # Add some metadata about the request
             token.set_metadata('user_agent', request.headers.get('user-agent', ''))


### PR DESCRIPTION
This PR fixes issue #10228.

PUI login via the `/api/auth/login` endpoint is handeled by a (modified) dj_rest_auth `LoginView`, which uses the TOKEN_CREATOR to get the token to return. The configured token creator [`users.models.create_token_expiry()`](https://github.com/inventree/InvenTree/blob/bca375dae5ac1d49bb5388393360c461639dbbb8/src/backend/InvenTree/users/models.py#L59) doesn't account for expired tokens and returns the first matching token for the user, even if it may be expired.

In contrast, the [`users.api.GetAuthToken()`](https://github.com/inventree/InvenTree/blob/bca375dae5ac1d49bb5388393360c461639dbbb8/src/backend/InvenTree/users/api.py#L312) view handles this correctly and creates a new token for authenticated users if no vaild token exists.

This is fixed by consolidating the logic for retrieving or creating an `ApiToken` into a single classmethod.