### PR TITLE
Build task fix

### DIFF
--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -767,7 +767,9 @@ class Build(
             from build.tasks import check_build_stock
 
             # Run checks on required parts
-            InvenTree.tasks.offload_task(check_build_stock, self, group='build')
+            InvenTree.tasks.offload_task(
+                check_build_stock, self, group='build', force_async=True
+            )
 
     @transaction.atomic
     def hold_build(self):


### PR DESCRIPTION
- Ensure stock check task runs in the background worker
- Prevent expensive email task from running in foreground worker