### PR TITLE
[UI] Fix Quantity calculation in OrderPartsWizard

### DIFF
--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -1263,6 +1263,7 @@ class PartRequirementsSerializer(InvenTree.serializers.InvenTreeModelSerializer)
             'allocated_to_build_orders',
             'required_for_sales_orders',
             'allocated_to_sales_orders',
+            'minimum_stock',
         ]
 
     total_stock = serializers.FloatField(read_only=True, label=_('Total Stock'))
@@ -1305,6 +1306,10 @@ class PartRequirementsSerializer(InvenTree.serializers.InvenTreeModelSerializer)
 
     allocated_to_sales_orders = serializers.SerializerMethodField(
         read_only=True, label=_('Allocated to Sales Orders')
+    )
+
+    minimum_stock = serializers.FloatField(
+        required=False, label=_('Minimum Stock'), default=0
     )
 
     def get_allocated_to_sales_orders(self, part) -> float:


### PR DESCRIPTION
Previously, the Quantity field was calculated as 0 when opening the Order Parts Wizard from certain stock views, e.g.:
- Stock → Stock Details → Order
- Stock → Stock Items → Order
- etc.

The Part object used in the wizard did not contain the required fields for quantity calculation.
Now the wizard fetches the required data directly from the API instead of relying on incomplete Part object data.

<img width="926" height="461" alt="vivaldi_XSrhh3ffvc" src="https://github.com/user-attachments/assets/8bcb99e5-401c-4e96-ae45-6718c5cd6586" />
