### PR TITLE
Exclude field from stock-item import

### DIFF
--- a/src/backend/InvenTree/stock/serializers.py
+++ b/src/backend/InvenTree/stock/serializers.py
@@ -329,7 +329,7 @@ class StockItemSerializer(
         'supplier_part_detail.MPN',
     ]
 
-    import_exclude_fields = ['use_pack_size', 'location_path']
+    import_exclude_fields = ['location_path', 'serial_numbers', 'use_pack_size']
 
     class Meta:
         """Metaclass options."""


### PR DESCRIPTION
- Serial numbers field is not a 1:1 import field
- Exclude from the import process