### PR TITLE
Fix Duplicate EmailAddress Create Bug for LDAP users

### DIFF
--- a/src/backend/InvenTree/users/models.py
+++ b/src/backend/InvenTree/users/models.py
@@ -63,7 +63,10 @@ if settings.LDAP_AUTH:
         user.save()
 
         # if they got an email address from LDAP, create it now and make it the primary
-        if user.email:
+        if (
+            user.email
+            and not EmailAddress.objects.filter(user=user, email=user.email).exists()
+        ):
             EmailAddress.objects.create(user=user, email=user.email, primary=True)
 
 


### PR DESCRIPTION
Slightly embarrassing... but in #9350 I added a signal to create a primary `EmailAddress` for LDAP users. 

However, I failed to realize this runs on each login, not just the first time a user is created from LDAP. This led to duplicate key errors on subsequent logins.

```text
django.db.utils.IntegrityError: duplicate key value violates unique constraint "account_emailaddress_user_id_email_987c8728_uniq"
DETAIL:  Key (user_id, email)=(194, jfelknor@example.com) already exists.
```

This PR fixes this bug by first checking if the `EmailAddress` already exists before attempting to create it.

I had not back ported this change to our 0.17x instance so only now experienced the bug in production. Apologies for the oversight.