### PR TITLE
Show revision in stock item details

### DIFF
--- a/src/frontend/src/pages/stock/StockDetail.tsx
+++ b/src/frontend/src/pages/stock/StockDetail.tsx
@@ -157,6 +157,14 @@ export default function StockDetail() {
         hidden: !part.IPN
       },
       {
+        name: 'part_detail.revision',
+        label: t`Revision`,
+        type: 'string',
+        copy: true,
+        icon: 'revision',
+        hidden: !part.revision
+      },
+      {
         name: 'status',
         type: 'status',
         label: t`Status`,


### PR DESCRIPTION
Adding the Revision field to stock item details

<img width="851" height="276" alt="image" src="https://github.com/user-attachments/assets/852d88ba-7189-4470-b411-109ab6643202" />
