### PR TITLE
[UI] Consume tracked

### DIFF
--- a/src/frontend/src/tables/build/BuildAllocatedStockTable.tsx
+++ b/src/frontend/src/tables/build/BuildAllocatedStockTable.tsx
@@ -183,9 +183,13 @@ export default function BuildAllocatedStockTable({
 
   const [selectedItems, setSelectedItems] = useState<any[]>([]);
 
+  const itemsToConsume = useMemo(() => {
+    return selectedItems.filter((item) => !item.part_detail?.trackable);
+  }, [selectedItems]);
+
   const consumeStock = useConsumeBuildItemsForm({
     buildId: buildId ?? 0,
-    allocatedItems: selectedItems,
+    allocatedItems: itemsToConsume,
     onFormSuccess: () => {
       table.clearSelectedRecords();
       table.refreshTable();
@@ -225,13 +229,16 @@ export default function BuildAllocatedStockTable({
 
   const rowActions = useCallback(
     (record: any): RowAction[] => {
+      const part = record.part_detail ?? {};
+      const trackable: boolean = part?.trackable ?? false;
+
       return [
         {
           color: 'green',
           icon: <IconCircleDashedCheck />,
           title: t`Consume`,
           tooltip: t`Consume Stock`,
-          hidden: !buildId || !user.hasChangeRole(UserRoles.build),
+          hidden: !buildId || trackable || !user.hasChangeRole(UserRoles.build),
           onClick: () => {
             setSelectedItems([record]);
             consumeStock.open();

--- a/src/frontend/src/tables/build/BuildLineTable.tsx
+++ b/src/frontend/src/tables/build/BuildLineTable.tsx
@@ -665,9 +665,10 @@ export default function BuildLineTable({
     (record: any): RowAction[] => {
       const part = record.part_detail ?? {};
       const in_production = build.status == buildStatus.PRODUCTION;
-      const consumable = record.bom_item_detail?.consumable ?? false;
+      const consumable: boolean = record.bom_item_detail?.consumable ?? false;
+      const trackable: boolean = part?.trackable ?? false;
 
-      const hasOutput = !!output?.pk;
+      const hasOutput: boolean = !!output?.pk;
 
       const required = Math.max(
         0,
@@ -678,6 +679,7 @@ export default function BuildLineTable({
       const canConsume =
         in_production &&
         !consumable &&
+        !trackable &&
         record.allocated > 0 &&
         user.hasChangeRole(UserRoles.build);
 


### PR DESCRIPTION
Hide "consume" options for tracked components. These are "consumed" when the output is completed.
