### PR TITLE
chore: cleanup changelog for 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
-## [Unreleased - 1.0.0 ] - 2025-07-xx
+## [1.0.0 ] - 2025-09-15
 
 The first "stable" release following semver but not extensively other than the previous releases. The use of 1.0 indicates the stability that users already expect from InvenTree.
 
@@ -24,10 +24,5 @@ An overarching theme of this release is the complete switch to a new UI framewor
 
 Our blog holds [a few articles](https://inventree.org/blog/2024/09/23/ui-roadmap) on the topic. This journey started in [March 2022](https://github.com/inventree/InvenTree/issues/2789) and was announced [in 2023](https://inventree.org/blog/2023/08/28/react).
 
-### Added
 
-
-### Changed
-
-
-### Removed
+Specific entries to the changelog will be kept for all stable channel minor releases, for changes in 1.0 please refer to the [blog posts](https://inventree.org/blog/2025/09/15/1.0.0) and the [milestone](https://github.com/inventree/InvenTree/milestone/17)


### PR DESCRIPTION
It was recently pointed out that we never filed out the 1.0 release, so this declares that entries will start with 1.1 as I do not see much value in back-filling this after it is already released