### PR TITLE
chore: pin images in workflows

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -405,7 +405,7 @@ jobs:
           - 5432:5432
 
       redis:
-        image: redis
+        image: redis:8
         ports:
           - 6379:6379
 
@@ -446,7 +446,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:latest
+        image: mysql:lts
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: ${{ env.INVENTREE_DB_NAME }}


### PR DESCRIPTION
Addresses a few zimor checks:
- https://github.com/inventree/InvenTree/security/code-scanning/275
- https://github.com/inventree/InvenTree/security/code-scanning/234

A bit less lax pins should make the CI more reliable too