### PR TITLE
fix: log ENV key as it needs to be set

### DIFF
--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -646,7 +646,9 @@ db_config = {key.upper(): value for key, value in db_config.items()}
 
 for key in required_keys:
     if key not in db_config:  # pragma: no cover
-        error_msg = f'Missing required database configuration value {key}'
+        error_msg = (
+            f'Missing required database configuration value `INVENTREE_DB_{key}`'
+        )
         logger.error(error_msg)
 
         print('Error: ' + error_msg)


### PR DESCRIPTION
Currently the error if you are missing important database keys is listing different names than the environment values - that is confusing. This simple PR fixes that.