### PR TITLE
chore(backend): improve error message in api tests

### DIFF
--- a/src/backend/InvenTree/InvenTree/unit_test.py
+++ b/src/backend/InvenTree/InvenTree/unit_test.py
@@ -452,7 +452,7 @@ class InvenTreeAPITestCase(
 ):
     """Base class for running InvenTree API tests."""
 
-    def check_response(self, url, response, expected_code=None):
+    def check_response(self, url, response, expected_code=None, msg=None):
         """Debug output for an unexpected response."""
         # Check that the response returned the expected status code
 
@@ -469,7 +469,7 @@ class InvenTreeAPITestCase(
                 if hasattr(response, 'content'):
                     print('content:', response.content)
 
-            self.assertEqual(response.status_code, expected_code)
+            self.assertEqual(response.status_code, expected_code, msg)
 
     def getActions(self, url):
         """Return a dict of the 'actions' available at a given endpoint.
@@ -490,6 +490,7 @@ class InvenTreeAPITestCase(
         kwargs['format'] = kwargs.get('format', 'json')
 
         expected_code = kwargs.pop('expected_code', None)
+        msg = kwargs.pop('msg', None)
         max_queries = kwargs.pop('max_query_count', self.MAX_QUERY_COUNT)
         max_query_time = kwargs.pop('max_query_time', self.MAX_QUERY_TIME)
 
@@ -501,7 +502,7 @@ class InvenTreeAPITestCase(
         t2 = time.time()
         dt = t2 - t1
 
-        self.check_response(url, response, expected_code=expected_code)
+        self.check_response(url, response, expected_code=expected_code, msg=msg)
 
         if dt > max_query_time:
             print(

--- a/src/backend/InvenTree/build/test_api.py
+++ b/src/backend/InvenTree/build/test_api.py
@@ -131,7 +131,7 @@ class TestBuildAPI(InvenTreeAPITestCase):
 class BuildAPITest(InvenTreeAPITestCase):
     """Series of tests for the Build DRF API."""
 
-    fixtures = ['category', 'part', 'location', 'bom', 'build', 'build_line', 'stock']
+    fixtures = ['category', 'part', 'location', 'build', 'build_line', 'stock', 'bom']
 
     # Required roles to access Build API endpoints
     roles = ['build.change', 'build.add']
@@ -1474,7 +1474,7 @@ class BuildLineTests(BuildAPITest):
         response = self.get(
             url, {'build': build.pk, 'available': True}, max_query_time=30
         )
-
+        #
         # We expect 2 lines to have "available" stock
         self.assertEqual(len(response.data), 2)
 

--- a/src/backend/InvenTree/build/test_api.py
+++ b/src/backend/InvenTree/build/test_api.py
@@ -1389,7 +1389,12 @@ class BuildLineTests(BuildAPITest):
 
         for param, field in test_cases:
             # Test with parameter set to 'true'
-            response = self.get(url, {param: 'true'}, expected_code=200)
+            response = self.get(
+                url,
+                {param: 'true'},
+                expected_code=200,
+                msg=f'Testing {param}=true returns 200',
+            )
             self.assertIn(
                 field,
                 response.data,
@@ -1397,7 +1402,12 @@ class BuildLineTests(BuildAPITest):
             )
 
             # Test with parameter set to 'false'
-            response = self.get(url, {param: 'false'}, expected_code=200)
+            response = self.get(
+                url,
+                {param: 'false'},
+                expected_code=200,
+                msg=f'Testing {param}=false returns 200',
+            )
             self.assertNotIn(
                 field,
                 response.data,

--- a/src/backend/InvenTree/build/test_api.py
+++ b/src/backend/InvenTree/build/test_api.py
@@ -131,7 +131,7 @@ class TestBuildAPI(InvenTreeAPITestCase):
 class BuildAPITest(InvenTreeAPITestCase):
     """Series of tests for the Build DRF API."""
 
-    fixtures = ['category', 'part', 'location', 'build', 'build_line', 'stock', 'bom']
+    fixtures = ['category', 'part', 'location', 'bom', 'build', 'build_line', 'stock']
 
     # Required roles to access Build API endpoints
     roles = ['build.change', 'build.add']
@@ -1484,7 +1484,7 @@ class BuildLineTests(BuildAPITest):
         response = self.get(
             url, {'build': build.pk, 'available': True}, max_query_time=30
         )
-        #
+
         # We expect 2 lines to have "available" stock
         self.assertEqual(len(response.data), 2)
 

--- a/src/backend/InvenTree/build/test_api.py
+++ b/src/backend/InvenTree/build/test_api.py
@@ -1393,7 +1393,7 @@ class BuildLineTests(BuildAPITest):
                 url,
                 {param: 'true'},
                 expected_code=200,
-                msg=f'Testing {param}=true returns 200',
+                msg=f'Testing {param}=true returns anything but 200',
             )
             self.assertIn(
                 field,
@@ -1406,7 +1406,7 @@ class BuildLineTests(BuildAPITest):
                 url,
                 {param: 'false'},
                 expected_code=200,
-                msg=f'Testing {param}=false returns 200',
+                msg=f'Testing {param}=false returns anything but 200',
             )
             self.assertNotIn(
                 field,


### PR DESCRIPTION
Improve error message capabilities for InvenTreeAPITestCase. This lets us pass better explanations of what might be going wrong in a test (mostly for procedural tests).