### PR TITLE
Add to serializers to fix missing return types in config/flags schema

### DIFF
--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -624,6 +624,9 @@ class FlagList(ListAPI):
     serializer_class = common.serializers.FlagSerializer
     permission_classes = [AllowAnyOrReadScope]
 
+    # Specifically disable pagination for this view
+    pagination_class = None
+
 
 class FlagDetail(RetrieveAPI):
     """Detail view for an individual feature flag."""

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -340,6 +340,12 @@ class ConfigSerializer(serializers.Serializer):
     This is a read-only serializer.
     """
 
+    key = serializers.CharField(read_only=True)
+    env_var = serializers.CharField(read_only=True, allow_null=True)
+    config_key = serializers.CharField(read_only=True, allow_null=True)
+    source = serializers.CharField(read_only=True)
+    accessed = serializers.DateTimeField(read_only=True)
+
     def to_representation(self, instance):
         """Return the configuration data as a dictionary."""
         if not isinstance(instance, str):
@@ -405,6 +411,12 @@ class CustomStateSerializer(DataImportExportSerializerMixin, InvenTreeModelSeria
 
 class FlagSerializer(serializers.Serializer):
     """Serializer for feature flags."""
+
+    key = serializers.CharField(read_only=True)
+    state = serializers.CharField(read_only=True)
+    conditions = serializers.ListField(
+        child=serializers.DictField(), read_only=True, allow_null=True
+    )
 
     def to_representation(self, instance):
         """Return the configuration data as a dictionary."""


### PR DESCRIPTION
I noticed that a couple of list/retrieve endpoints (`/api/admin/config/{key}`, `/api/flags/{key}`) were missing return types in the schema and eventually tracked it back to custom serializers that didn't conform to the pattern drf-spectacular can parse when it generates the schema.

Additionally, trying to page through the flags failed because `settings.FLAGS` wasn't a list so I disabled pagination on that field to match admin/config.

For reference, here's the difference in schema for the `/api/admin/config` and `/api/admin/config/{key}` endpoints:
```diff
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Config'
+          description: ''
...
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Config'
+          description: ''
```