### PR TITLE
Tweak docker setup

### DIFF
--- a/contrib/container/.env
+++ b/contrib/container/.env
@@ -13,6 +13,11 @@ INVENTREE_SITE_URL="http://inventree.localhost"
 #INVENTREE_SITE_URL="http://192.168.1.2"  # You can specify a local IP address here
 #INVENTREE_SITE_URL="https://inventree.my-domain.com"  # Or a public domain name (which you control)
 
+# InvenTree proxy forwarding settings
+INVENTREE_USE_X_FORWARDED_HOST=True
+INVENTREE_USE_X_FORWARDED_PORT=True
+INVENTREE_USE_X_FORWARDED_PROTO=True
+
 # Specify the location of the external data volume
 # By default, placed in local directory 'inventree-data'
 INVENTREE_EXT_VOLUME=./inventree-data
@@ -23,7 +28,8 @@ INVENTREE_LOG_LEVEL=WARNING
 # Enable custom plugins?
 INVENTREE_PLUGINS_ENABLED=True
 
-# Run migrations automatically?
+# Run database migrations automatically?
+# Note: This does not negate the need to run "invoke update"
 INVENTREE_AUTO_UPDATE=True
 
 # InvenTree superuser account details


### PR DESCRIPTION
- Set default proxy forwarding values for docker
- Ref: https://github.com/inventree/InvenTree/issues/10465#issuecomment-3364377166

Should make setup easier for the default docker proxy. All bets are off if the users set their own up.