### PR TITLE
add-minimum-stock-to-brief-part-serializer

### DIFF
--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -336,6 +336,7 @@ class PartBriefSerializer(InvenTree.serializers.InvenTreeModelSerializer):
             'locked',
             'assembly',
             'component',
+            'minimum_stock',
             'is_template',
             'purchaseable',
             'salable',
@@ -362,6 +363,8 @@ class PartBriefSerializer(InvenTree.serializers.InvenTreeModelSerializer):
     category_default_location = serializers.IntegerField(
         read_only=True, allow_null=True
     )
+
+    minimum_stock = serializers.FloatField(required=False, default=0)
 
     image = InvenTree.serializers.InvenTreeImageSerializerField(
         read_only=True, allow_null=True


### PR DESCRIPTION
Adding `minimum_stock` param to `PartBriefSerializer`. 

See this discussion for context:
https://github.com/inventree/InvenTree/discussions/10458#discussioncomment-14596310