### PR TITLE
allow mobile check ignore

### DIFF
--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -35,6 +35,7 @@ declare global {
       api_host?: string;
       sentry_dsn?: string;
       environment?: string;
+      mobile_mode?: 'default' | 'allow-ignore' | 'allow-always';
     };
     react: typeof React;
     React: typeof React;

--- a/src/frontend/src/views/MainView.tsx
+++ b/src/frontend/src/views/MainView.tsx
@@ -40,7 +40,11 @@ export default function MainView() {
   }, []);
 
   // Check if mobile
-  if (!allowMobile && checkMobile()) {
+  if (
+    !allowMobile &&
+    window.INVENTREE_SETTINGS.mobile_mode !== 'allow-always' &&
+    checkMobile()
+  ) {
     return <MobileAppView />;
   }
 

--- a/src/frontend/src/views/MobileAppView.tsx
+++ b/src/frontend/src/views/MobileAppView.tsx
@@ -33,8 +33,12 @@ export default function MobileAppView() {
             <Anchor href={docLinks.app}>
               <Trans>Read the docs</Trans>
             </Anchor>
-            {IS_DEV && (
-              <Text onClick={ignore}>
+            {(IS_DEV ||
+              window.INVENTREE_SETTINGS.mobile_mode === 'allow-ignore') && (
+              <Text
+                onClick={ignore}
+                style={{ cursor: 'pointer', textDecoration: 'underline' }}
+              >
                 <Trans>Ignore and continue to Desktop view</Trans>
               </Text>
             )}


### PR DESCRIPTION
This PR adds a new setting to the `FRONTEND_SETTINGS` which enables me to allow to use the PUI interface, of course at my OWN RISK also on mobile devices.

```env
INVENTREE_FRONTEND_SETTINGS='{"mobile_mode": "allow-ignore"}'
```

There are 3 modes now:
- `default` - (default) no changes, works like it worked before
- `allow-ignore` - shows a ignore banner with a link to ignore this warning
- `allow-always` - skips the mobile check and allows mobile devices (of course at the server admins OWN RISK)