### PR TITLE
Report maths tweaks

### DIFF
--- a/docs/docs/report/helpers.md
+++ b/docs/docs/report/helpers.md
@@ -263,7 +263,11 @@ Total Price: {% render_currency order.total_price currency='NZD' decimal_places=
 
 ## Maths Operations
 
-Simple mathematical operators are available, as demonstrated in the example template below:
+Simple mathematical operators are available, as demonstrated in the example template below. These operators can be used to perform basic arithmetic operations within the report template.
+
+### Input Types
+
+These mathematical functions accept inputs of various input types, and attempt to perform the operation accordingly. Note that any inputs which are provided as strings will be converted to floating point numbers before the operation is performed.
 
 ### add
 
@@ -289,6 +293,13 @@ Simple mathematical operators are available, as demonstrated in the example temp
 ### divide
 
 ::: report.templatetags.report.divide
+    options:
+        show_docstring_description: false
+        show_source: False
+
+### modulo
+
+::: report.templatetags.report.modulo
     options:
         show_docstring_description: false
         show_source: False

--- a/src/backend/InvenTree/report/templatetags/report.py
+++ b/src/backend/InvenTree/report/templatetags/report.py
@@ -457,6 +457,12 @@ def divide(x: Any, y: Any) -> Any:
     return destringify(x) / destringify(y)
 
 
+@register.simple_tag()
+def modulo(x: Any, y: Any) -> Any:
+    """Calculate the modulo of one number (or number-like value) by another."""
+    return destringify(x) % destringify(y)
+
+
 @register.simple_tag
 def render_currency(money, **kwargs):
     """Render a currency / Money object."""

--- a/src/backend/InvenTree/report/test_tags.py
+++ b/src/backend/InvenTree/report/test_tags.py
@@ -203,6 +203,9 @@ class ReportTagTest(PartImageTestMixin, InvenTreeTestCase):
         self.assertEqual(report_tags.multiply('-2', 4), -8.0)
         self.assertEqual(report_tags.divide(100, 5), 20)
 
+        self.assertEqual(report_tags.modulo(10, 3), 1)
+        self.assertEqual(report_tags.modulo('10', '4'), 2)
+
         with self.assertRaises(ZeroDivisionError):
             report_tags.divide(100, 0)
 


### PR DESCRIPTION
Adjust the maths functions exposed to reports, to handle data types other than just floating point values.

- Now data types such as `Money` and `Decimal` can be provided and operated on
- String values are first converted to floats
- Function will raise an error if the operation cannot be performed on the provided types
- Closes https://github.com/inventree/InvenTree/issues/10603