### PR TITLE
Fix selection list items not displaying values

### DIFF
--- a/src/frontend/src/forms/selectionListFields.tsx
+++ b/src/frontend/src/forms/selectionListFields.tsx
@@ -1,11 +1,9 @@
+import type { ApiFormFieldSet, ApiFormFieldType } from '@lib/types/Forms';
 import { t } from '@lingui/core/macro';
 import { Table } from '@mantine/core';
 import { useMemo } from 'react';
-
 import RemoveRowButton from '../components/buttons/RemoveRowButton';
 import { StandaloneField } from '../components/forms/StandaloneField';
-
-import type { ApiFormFieldSet, ApiFormFieldType } from '@lib/types/Forms';
 import type { TableFieldRowProps } from '../components/forms/fields/TableField';
 
 function BuildAllocateLineRow({
@@ -62,7 +60,7 @@ function BuildAllocateLineRow({
   }, [props]);
 
   return (
-    <Table.Tr key={`table-row-${props.item.pk}`}>
+    <Table.Tr key={`table-row-${props.item.id ?? props.idx}`}>
       <Table.Td>
         <StandaloneField fieldName='value' fieldDefinition={valueField} />
       </Table.Td>


### PR DESCRIPTION
Fixes #10701

The issue was that the table row key was using 'props.item.pk', but the API returns 'id' instead. This caused React to not properly render the rows with their values.

Changed the key to use 'props.item.id' with a fallback to 'props.idx' for new rows that don't have an ID yet.