### PR TITLE
Move "view" actions to the end of the list

### DIFF
--- a/src/frontend/src/tables/build/BuildLineTable.tsx
+++ b/src/frontend/src/tables/build/BuildLineTable.tsx
@@ -102,12 +102,6 @@ export function BuildLineSubTable({
   const rowActions = useCallback(
     (record: any): RowAction[] => {
       return [
-        RowViewAction({
-          title: t`View Stock Item`,
-          modelType: ModelType.stockitem,
-          modelId: record.stock_item,
-          navigate: navigate
-        }),
         RowEditAction({
           hidden: !onEditAllocation || !user.hasChangeRole(UserRoles.build),
           onClick: () => {
@@ -119,6 +113,12 @@ export function BuildLineSubTable({
           onClick: () => {
             onDeleteAllocation?.(record.pk);
           }
+        }),
+        RowViewAction({
+          title: t`View Stock Item`,
+          modelType: ModelType.stockitem,
+          modelId: record.stock_item,
+          navigate: navigate
         })
       ];
     },

--- a/src/frontend/src/tables/build/BuildOutputTable.tsx
+++ b/src/frontend/src/tables/build/BuildOutputTable.tsx
@@ -494,12 +494,6 @@ export default function BuildOutputTable({
       const production = build?.status == buildStatus.PRODUCTION;
 
       return [
-        RowViewAction({
-          title: t`View Build Output`,
-          modelId: record.pk,
-          modelType: ModelType.stockitem,
-          navigate: navigate
-        }),
         {
           title: t`Allocate`,
           tooltip: t`Allocate stock to build output`,
@@ -575,7 +569,13 @@ export default function BuildOutputTable({
             setSelectedOutputs([record]);
             cancelBuildOutputsForm.open();
           }
-        }
+        },
+        RowViewAction({
+          title: t`View Build Output`,
+          modelId: record.pk,
+          modelType: ModelType.stockitem,
+          navigate: navigate
+        })
       ];
     },
     [buildStatus, user, partId, hasTrackedItems]

--- a/src/frontend/src/tables/purchasing/PurchaseOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/purchasing/PurchaseOrderLineItemTable.tsx
@@ -355,13 +355,6 @@ export function PurchaseOrderLineItemTable({
             receiveLineItems.open();
           }
         },
-        RowViewAction({
-          hidden: !record.build_order,
-          title: t`View Build Order`,
-          modelType: ModelType.build,
-          modelId: record.build_order,
-          navigate: navigate
-        }),
         RowEditAction({
           hidden: !canEdit,
           onClick: () => {
@@ -382,6 +375,13 @@ export function PurchaseOrderLineItemTable({
             setSelectedLine(record.pk);
             deleteLine.open();
           }
+        }),
+        RowViewAction({
+          hidden: !record.build_order,
+          title: t`View Build Order`,
+          modelType: ModelType.build,
+          modelId: record.build_order,
+          navigate: navigate
         })
       ];
     },

--- a/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
@@ -395,13 +395,6 @@ export default function SalesOrderLineItemTable({
       const virtual = record?.part_detail?.virtual ?? false;
 
       return [
-        RowViewAction({
-          title: t`View Part`,
-          modelType: ModelType.part,
-          modelId: record.part,
-          navigate: navigate,
-          hidden: !user.hasViewRole(UserRoles.part)
-        }),
         {
           hidden:
             allocated ||
@@ -487,6 +480,13 @@ export default function SalesOrderLineItemTable({
             setSelectedLineId(record.pk);
             deleteLine.open();
           }
+        }),
+        RowViewAction({
+          title: t`View Part`,
+          modelType: ModelType.part,
+          modelId: record.part,
+          navigate: navigate,
+          hidden: !user.hasViewRole(UserRoles.part)
         })
       ];
     },


### PR DESCRIPTION
Consistent UX, ensure the "view item" actions are at the *end* of the table actions list