### PR TITLE
Remove custom token middleware

### DIFF
--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -356,7 +356,6 @@ MIDDLEWARE = CONFIG.get(
         'allauth.account.middleware.AccountMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-        'InvenTree.middleware.AuthRequiredMiddleware',
         'InvenTree.middleware.Check2FAMiddleware',  # Check if the user should be forced to use MFA
         'oauth2_provider.middleware.OAuth2TokenMiddleware',  # oauth2_provider
         'maintenance_mode.middleware.MaintenanceModeMiddleware',

--- a/src/backend/InvenTree/InvenTree/test_middleware.py
+++ b/src/backend/InvenTree/InvenTree/test_middleware.py
@@ -21,7 +21,7 @@ class MiddlewareTests(InvenTreeTestCase):
         self.assertEqual(response.status_code, code)
         return response
 
-    def test_AuthRequiredMiddleware(self):
+    def test_auth_middleware(self):
         """Test the auth middleware."""
         # test that /api/ routes go through
         self.check_path(reverse('api-inventree-info'))


### PR DESCRIPTION
- Token auth handled by allauth now
- Ref: https://github.com/inventree/InvenTree/issues/10754
- Ref: https://github.com/inventree/InvenTree/pull/10775

This fixes the auth issues in the app when MFA tokens are enforced. The custom token check middleware interferes with allauth middleware layer. I have tested with the app, this code works well.

- Closes https://github.com/inventree/inventree-app/issues/705