### PR TITLE
[Docker] Allow gunicorn webserver bind address to be adjusted

### DIFF
--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -149,7 +149,7 @@ COPY --from=builder_stage ${INVENTREE_BACKEND_DIR}/InvenTree/web/static/web ${IN
 COPY --from=builder_stage /root/.local /root/.local
 
 # Launch the production server
-CMD ["sh", "-c", "exec gunicorn -c ./gunicorn.conf.py InvenTree.wsgi -b 0.0.0.0:8000 --chdir ${INVENTREE_BACKEND_DIR}/InvenTree"]
+CMD ["sh", "-c", "exec gunicorn -c ./gunicorn.conf.py InvenTree.wsgi -b ${INVENTREE_WEB_ADDR}:${INVENTREE_WEB_PORT} --chdir ${INVENTREE_BACKEND_DIR}/InvenTree"]
 
 FROM builder_stage AS dev
 


### PR DESCRIPTION
Very minor fix, discussed here: https://github.com/inventree/InvenTree/discussions/10893#discussioncomment-15055253

I could make an argument for a new small section (`Web Server Settings`) next to the `Email Settings` on `docs/docs/start/config.md` but figured I'd ask, first.