### PR TITLE
[devcontainer] revert postgres version

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17
+    image: postgres:15
     restart: unless-stopped
     ports:
       - 5432/tcp


### PR DESCRIPTION
- Our debian image (bookworm) supports only postgres:15
- Revert from postgres:17 to postgres:15 in the devcontainer
- Closes https://github.com/inventree/InvenTree/issues/10936