### PR TITLE
Rearrange python package installs in are metal setup 

### DIFF
--- a/docs/docs/start/install.md
+++ b/docs/docs/start/install.md
@@ -131,21 +131,6 @@ If all packages have been installed run:
 invoke install
 ```
 
-#### Install Python Bindings
-
-Depending on your database the python bindings must also be installed (into your virtual environment). 
-For PostgreSQL install:
-
-```
-pip3 install psycopg pgcli
-```
-
-For MySQL install:
-
-```
-pip3 install mysqlclient mariadb
-```
-
 This installs all required Python packages using pip package manager. It also creates a (default) database configuration file which needs to be edited to meet user needs before proceeding (see next step below).
 
 ## Create Database


### PR DESCRIPTION
the python bindings must be installed before before invoke install. Otherwise it fails with 

```
Installing plugin packages from '/home/michael/src/config/plugins.txt'
Unknown command: 'collectplugins'
Type 'manage.py help' for usage.
ERROR: InvenTree command failed: 'python3 manage.py collectplugins'
- Refer to the error messages in the log above for more information
```
At least on Ubuntu 24