### PR TITLE
Put the admin user info in one place

### DIFF
--- a/src/backend/InvenTree/config_template.yaml
+++ b/src/backend/InvenTree/config_template.yaml
@@ -46,6 +46,12 @@ debug_shell: False
 # Set the admin URL, or use the environment variable INVENTREE_ADMIN_URL
 #admin_url: 'admin'
 
+# Add new user on first startup by either adding values here or from a file
+#admin_user: admin
+#admin_email: info@example.com
+#admin_password: inventree
+#admin_password_file: '/etc/inventree/admin_password.txt'
+
 # Configure the system logging level (or use environment variable INVENTREE_LOG_LEVEL)
 # Options: DEBUG / INFO / WARNING / ERROR / CRITICAL
 log_level: WARNING
@@ -68,13 +74,6 @@ language: en-us
 
 # System time-zone (default is UTC). Reference: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 timezone: UTC
-
-
-# Add new user on first startup by either adding values here or from a file
-#admin_user: admin
-#admin_email: info@example.com
-#admin_password: inventree
-#admin_password_file: '/etc/inventree/admin_password.txt'
 
 # Email backend configuration
 # See https://docs.inventree.org/en/stable/settings/email for more information on email configuration


### PR DESCRIPTION
Info about the admin feature and user in the configuration template is currently in two areas.  Combine to one.