### PR TITLE
ci(gc): add missing oidc permissions

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -286,6 +286,9 @@ jobs:
 
     needs: ["pre-commit", "paths-filter"]
     if: needs.paths-filter.outputs.server == 'true' || needs.paths-filter.outputs.force == 'true'
+    permissions:
+      contents: read
+      id-token: write
 
     env:
       WRAPPER_NAME: inventree-python


### PR DESCRIPTION
Hello, CodSpeed team member here.

New performance tests were added in #11080. However, contrary to 'Tests - Performance' job, OIDC is not used to authenticate the new job with CodSpeed. We don't currently gracefully handle the case where one job is using OIDC and the other one is not.

More details on how CodSpeed uses OIDC to authenticate workflows [here](https://codspeed.io/docs/integrations/ci/github-actions/configuration\#oidc-recommended).