### PR TITLE
Switch away from codspeed-macro to ubuntu-24.04

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -392,7 +392,7 @@ jobs:
 
   performance:
     name: Tests - Performance
-    runs-on: codspeed-macro
+    runs-on: ubuntu-24.04 # codspeed-macro
 
     needs: ["pre-commit", "paths-filter"]
     if: needs.paths-filter.outputs.server == 'true' || needs.paths-filter.outputs.force == 'true'


### PR DESCRIPTION
The current usage limits are not feasible for our CI/CD model