### PR TITLE
BuildItem quantity fix

### DIFF
--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -1845,8 +1845,6 @@ class BuildItem(InvenTree.models.InvenTreeMetadataModel):
         """
         error = None
 
-        print('check_allocated_quantity:', raise_error)
-
         # Allocated quantity must be positive
         if self.quantity <= 0:
             self.quantity = 0
@@ -1884,9 +1882,6 @@ class BuildItem(InvenTree.models.InvenTreeMetadataModel):
 
         if total_allocation > available:
             error = {'quantity': _('Stock item is over-allocated')}
-
-        if error:
-            print('FOUND AN ERROR:', error)
 
         if error and raise_error:
             raise ValidationError(error)


### PR DESCRIPTION
- Ensure that quantities are updated (without throwing an error) when a BuildItem is saved
- Raise an error (via the same function) when calling clean via a serializer
- This ensures that the background tasks for completing a build do not fail silently and leave items unconsumed