### PR TITLE
Fix OIDC logins not displaying

### DIFF
--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -523,7 +523,7 @@ django==5.2.10 \
     #   djangorestframework
     #   djangorestframework-simplejwt
     #   drf-spectacular
-django-allauth[headless, mfa, openid, saml, socialaccount]==65.13.1 \
+django-allauth[headless, mfa, openid, openid_connect, saml, socialaccount]==65.13.1 \
     --hash=sha256:2887294beedfd108b4b52ebd182e0ed373deaeb927fc5a22f77bbde3174704a6 \
     --hash=sha256:2af0d07812f8c1a8e3732feaabe6a9db5ecf3fad6b45b6a0f7fd825f656c5a15
     # via -r src/backend/requirements.in


### PR DESCRIPTION
Only openid is installed into django, but oidc is openid_connect. With any luck this should solve #10911 (though I have not tested/confirmed).