### PR TITLE
[UI] Improved flow for 409 errors

### DIFF
--- a/src/frontend/src/functions/auth.tsx
+++ b/src/frontend/src/functions/auth.tsx
@@ -119,12 +119,13 @@ export async function doBasicLogin(
             await handlePossibleMFAError(err);
             break;
           case 409:
+            doLogout(navigate);
             notifications.show({
-              title: t`Already logged in`,
-              message: t`There is a conflicting session on the server for this browser. Please logout of that first.`,
+              title: t`Logged Out`,
+              message: t`There was a conflicting session for this browser, which has been logged out.`,
               color: 'red',
               id: 'auth-login-error',
-              autoClose: false
+              autoClose: true
             });
             break;
           default:


### PR DESCRIPTION
- Fixes issue where users can be "locked out" of the browser by conflicting user sessions
- Previously was thought to only exhibit in vite dev server
- Instances have been observed in the compiled frontend 

Sometimes, users will be presented with a 409 message because there is a conflicting session logged into the browser. If they are met with this message, there is no way to login until they fix it. Currently they are presented with a warning message, but there are no options available to them - they cannot continue with the current session at this point.

To "fix" this they currently need to clear the session cache in the browser console. This is a burden (and also not documented).

The new approach in this PR is to force a logout on a 409 error which clears the session cache and redirects the user to the login screen.