### PR TITLE
[ui] Show generated serial numbers as placeholder when receving stock

### DIFF
--- a/src/frontend/src/forms/PurchaseOrderForms.tsx
+++ b/src/frontend/src/forms/PurchaseOrderForms.tsx
@@ -361,12 +361,7 @@ function LineItemFormRow({
 
   // Serial number generator
   const serialNumberGenerator = useSerialNumberGenerator({
-    isEnabled: () => batchOpen && trackable,
-    onGenerate: (value: any) => {
-      if (value) {
-        props.changeFn(props.idx, 'serial_numbers', value);
-      }
-    }
+    isEnabled: () => batchOpen && trackable
   });
 
   const [packagingOpen, packagingHandlers] = useDisclosure(false, {
@@ -726,7 +721,10 @@ function LineItemFormRow({
           field_type: 'string',
           label: t`Serial Numbers`,
           description: t`Enter serial numbers for received items`,
-          value: props.item.serial_numbers
+          value: props.item.serial_numbers,
+          placeholderAutofill: true,
+          placeholder:
+            serialNumberGenerator.result && `${serialNumberGenerator.result}`
         }}
         error={props.rowErrors?.serial_numbers?.message}
       />


### PR DESCRIPTION
Update the "receive stock" dialog on the purchase orders page to show generated serial numbers for trackable parts as a placeholder that can be accepted, rather than a concrete value. This is in line with the behavior in the "add stock item" dialog.

I've tested this locally and it behaves as I'd expect, also when receiving multiple stock items at once. But I'm not that knowledgable about react so please do check to see if there's some edge case I've missed!

Looks like this:
<img width="1220" height="583" alt="image" src="https://github.com/user-attachments/assets/24579f4e-2d15-487e-9514-ebc3e9f89781" />

Resolves #11146 