### PR TITLE
fix(auth): Use correct data for SSO group sync

### DIFF
--- a/src/backend/InvenTree/InvenTree/sso.py
+++ b/src/backend/InvenTree/InvenTree/sso.py
@@ -96,7 +96,9 @@ def ensure_sso_groups(sender, sociallogin: SocialLogin, **kwargs):
     group_map = json.loads(get_global_setting('SSO_GROUP_MAP'))
     # map SSO groups to InvenTree groups
     group_names = []
-    for sso_group in sociallogin.account.extra_data.get(group_key, []):
+    for sso_group in sociallogin.account.extra_data.get('userinfo', {}).get(
+        group_key, []
+    ):
         if mapped_name := group_map.get(sso_group):
             group_names.append(mapped_name)
 

--- a/src/backend/InvenTree/InvenTree/test_auth.py
+++ b/src/backend/InvenTree/InvenTree/test_auth.py
@@ -38,7 +38,7 @@ class TestSsoGroupSync(TransactionTestCase):
             'SSO_GROUP_MAP', '{"idp_group": "inventree_group"}'
         )
         # configure sociallogin
-        extra_data = {'groups': ['idp_group']}
+        extra_data = {'userinfo': {'groups': ['idp_group']}}
         self.group = Group(name='inventree_group')
         self.group.save()
         # ensure default group exists


### PR DESCRIPTION
https://docs.allauth.org/en/latest/release-notes/recent.html#id18
Since django-allauth 65.11.0 (InvenTree v1.1.X), the extra_data is divided into separate userinfo and id_token objects.

I just upgraded to Inventree v1.1.8 from v1.0.X yesterday, hence I didn't notice this for a longer time. I would love to see a hotfix release since group sync is broken for the entire v1.1.X release line if I am not mistaken. Broken means that new groups are not synchronized and if group removal is disabled, all groups are deleted from the user on each signin.