### PR TITLE
Split "Assign Batch Code" and "Assign Serials" in PO Receive

### DIFF
--- a/src/frontend/src/forms/PurchaseOrderForms.tsx
+++ b/src/frontend/src/forms/PurchaseOrderForms.tsx
@@ -361,7 +361,7 @@ function LineItemFormRow({
 
   // Serial number generator
   const serialNumberGenerator = useSerialNumberGenerator({
-    isEnabled: () => batchOpen && trackable
+    isEnabled: () => trackable
   });
 
   const [packagingOpen, packagingHandlers] = useDisclosure(false, {
@@ -379,7 +379,6 @@ function LineItemFormRow({
   const [batchOpen, batchHandlers] = useDisclosure(false, {
     onClose: () => {
       props.changeFn(props.idx, 'batch_code', undefined);
-      props.changeFn(props.idx, 'serial_numbers', undefined);
     },
     onOpen: () => {
       // Generate a new batch code
@@ -387,6 +386,14 @@ function LineItemFormRow({
         part: record?.supplier_part_detail?.part,
         order: record?.order
       });
+    }
+  });
+
+  const [serialOpen, serialHandlers] = useDisclosure(false, {
+    onClose: () => {
+      props.changeFn(props.idx, 'serial_numbers', undefined);
+    },
+    onOpen: () => {
       // Generate new serial numbers
       if (trackable) {
         serialNumberGenerator.update({
@@ -429,14 +436,6 @@ function LineItemFormRow({
   useEffect(() => {
     props.changeFn(props.idx, 'barcode', barcode);
   }, [barcode]);
-
-  const batchToolTip: string = useMemo(() => {
-    if (trackable) {
-      return t`Assign Batch Code and Serial Numbers`;
-    } else {
-      return t`Assign Batch Code`;
-    }
-  }, [trackable]);
 
   // Update location field description on state change
   useEffect(() => {
@@ -559,10 +558,21 @@ function LineItemFormRow({
               size='sm'
               onClick={() => batchHandlers.toggle()}
               icon={<InvenTreeIcon icon='batch_code' />}
-              tooltip={batchToolTip}
+              tooltip={t`Assign Batch Code`}
               tooltipAlignment='top'
               variant={batchOpen ? 'outline' : 'transparent'}
             />
+            {trackable && (
+              <ActionButton
+                size='sm'
+                onClick={() => serialHandlers.toggle()}
+                icon={<InvenTreeIcon icon='serial' />}
+                tooltip={t`Assign Serial Numbers`}
+                tooltipAlignment='top'
+                variant={serialOpen ? 'outline' : 'transparent'}
+              />
+            )}
+
             {settings.isSet('STOCK_ENABLE_EXPIRY') && (
               <ActionButton
                 size='sm'
@@ -712,7 +722,7 @@ function LineItemFormRow({
         error={props.rowErrors?.batch_code?.message}
       />
       <TableFieldExtraRow
-        visible={batchOpen && trackable}
+        visible={serialOpen}
         onValueChange={(value) =>
           props.changeFn(props.idx, 'serial_numbers', value)
         }


### PR DESCRIPTION
Split batch and serial input toggles on PO receive.

Depending on the project, our practices change whether we want to assign a batch code, serialize, or both at receive time. This lets us individually toggle these form fields rather than require receiving to clear the generated serial numbers in cases we don't want to serialize immediately.