### PR TITLE
[build] Check for allocated items which are in production

### DIFF
--- a/src/backend/InvenTree/build/models.py
+++ b/src/backend/InvenTree/build/models.py
@@ -1222,6 +1222,13 @@ class Build(
         # List the allocated BuildItem objects for the given output
         allocated_items = output.items_to_install.all()
 
+        # Ensure that none of the allocated items are themselves still "in production"
+        for build_item in allocated_items:
+            if build_item.stock_item.is_building:
+                raise ValidationError(
+                    _('Allocated stock items are still in production')
+                )
+
         # If a partial quantity is provided, split the stock output
         if quantity is not None and quantity != output.quantity:
             # Cannot split a build output with allocated items


### PR DESCRIPTION
Ensure that attempting to complete a build output, which has allocated items that are still in production, raises a sensible error message