### PR TITLE
BO Allocation Table MultiSelect with Change Role

### DIFF
--- a/src/frontend/src/tables/build/BuildAllocatedStockTable.tsx
+++ b/src/frontend/src/tables/build/BuildAllocatedStockTable.tsx
@@ -311,7 +311,7 @@ export default function BuildAllocatedStockTable({
           },
           enableBulkDelete: allowEdit && user.hasDeleteRole(UserRoles.build),
           enableDownload: true,
-          enableSelection: allowEdit && user.hasDeleteRole(UserRoles.build),
+          enableSelection: allowEdit && user.hasChangeRole(UserRoles.build),
           rowActions: rowActions,
           tableActions: tableActions,
           tableFilters: tableFilters,


### PR DESCRIPTION
The multiselect check boxes on the Build Order Allocations table is currently tied to the BO delete role. This PR changes that to the BO modify role.

My justification is that users with change role already can consume allocated stock, but this must currently be done on a one-by-one basis unless they also have the delete role.