### PR TITLE
Add missing part/stocktake nullable annotations for schema

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,13 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 448
+INVENTREE_API_VERSION = 449
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v449 -> 2026-02-07 : https://github.com/inventree/InvenTree/pull/11266
+    - Add missing nullable annotations to PartStocktakeSerializer
 
 v448 -> 2026-02-05 : https://github.com/inventree/InvenTree/pull/11257
     - Adds API endpoint for manually generating a stocktake entry

--- a/src/backend/InvenTree/part/serializers.py
+++ b/src/backend/InvenTree/part/serializers.py
@@ -1240,15 +1240,20 @@ class PartStocktakeSerializer(
     )
 
     part_ipn = serializers.CharField(
-        source='part.IPN', read_only=True, label=_('Part IPN')
+        source='part.IPN', read_only=True, allow_null=True, label=_('Part IPN')
     )
 
     part_description = serializers.CharField(
-        source='part.description', read_only=True, label=_('Part Description')
+        source='part.description',
+        read_only=True,
+        allow_null=True,
+        label=_('Part Description'),
     )
 
     part_detail = enable_filter(
-        PartBriefSerializer(source='part', read_only=True, many=False, pricing=False),
+        PartBriefSerializer(
+            source='part', read_only=True, allow_null=True, many=False, pricing=False
+        ),
         default_include=False,
     )
 


### PR DESCRIPTION
I tested querying the updated types from schema v448 and got nulls in a couple of fields that the schema thought weren't nullable. This adds the missing annotations.