### PR TITLE
Prevent migration check if performing DB update operations

### DIFF
--- a/src/backend/InvenTree/InvenTree/apps.py
+++ b/src/backend/InvenTree/InvenTree/apps.py
@@ -331,6 +331,11 @@ class InvenTreeConfig(AppConfig):
         if MIGRATIONS_CHECK_DONE:
             return
 
+        # Exit early if we are not in a state where we can access the database,
+        # otherwise we might end up in a deadlock situation
+        if not InvenTree.ready.canAppAccessDatabase():
+            return
+
         if not InvenTree.tasks.check_for_migrations():
             # Detect if this an empty database - if so, start with a fresh migration
             if (

--- a/src/backend/InvenTree/InvenTree/tasks.py
+++ b/src/backend/InvenTree/InvenTree/tasks.py
@@ -590,7 +590,7 @@ def update_exchange_rates(force: bool = False):
     from InvenTree.ready import canAppAccessDatabase
 
     # Do not update exchange rates if we cannot access the database
-    if not canAppAccessDatabase():
+    if not canAppAccessDatabase(allow_test=True, allow_shell=True):
         return
 
     try:

--- a/src/backend/InvenTree/InvenTree/tasks.py
+++ b/src/backend/InvenTree/InvenTree/tasks.py
@@ -587,6 +587,12 @@ def update_exchange_rates(force: bool = False):
     Arguments:
         force: If True, force the update to run regardless of the last update time
     """
+    from InvenTree.ready import canAppAccessDatabase
+
+    # Do not update exchange rates if we cannot access the database
+    if not canAppAccessDatabase():
+        return
+
     try:
         from djmoney.contrib.exchange.models import Rate
 

--- a/src/backend/InvenTree/common/settings.py
+++ b/src/backend/InvenTree/common/settings.py
@@ -44,6 +44,13 @@ def get_global_setting(key, backup_value=None, environment_key=None, **kwargs):
 def set_global_setting(key, value, change_user=None, create=True, **kwargs):
     """Set the value of a global setting using the provided key."""
     from common.models import InvenTreeSetting
+    from InvenTree.ready import canAppAccessDatabase
+
+    if not canAppAccessDatabase(allow_shell=True, allow_test=True):
+        logger.warning(
+            f'Cannot set global setting "{key}" - database is not accessible'
+        )
+        return False
 
     kwargs['change_user'] = change_user
     kwargs['create'] = create


### PR DESCRIPTION
- Prevent system exiting (due to pending migrations) when trying to restore from a backup
- Prevent forced running of migrations (in docker) when trying to restore or dump data
- Prevent writing global settings during data management comments
- Prevent exchange rate updates during data management commands

### References

- https://github.com/inventree/InvenTree/issues/11338#issuecomment-3913246624