### PR TITLE
Batch update of records during migration

### DIFF
--- a/src/backend/InvenTree/stock/migrations/0118_auto_20260205_1218.py
+++ b/src/backend/InvenTree/stock/migrations/0118_auto_20260205_1218.py
@@ -10,6 +10,11 @@ def add_part_links(apps, schema_editor):
 
     history_entries = []
 
+    N = StockItemTracking.objects.count()
+
+    if N > 0:
+        print(f"\nUpdating {N} StockItemTracking entries with part links...")
+
     for tracking in StockItemTracking.objects.all():
 
         item = tracking.item
@@ -24,10 +29,15 @@ def add_part_links(apps, schema_editor):
 
         tracking.part = part
         history_entries.append(tracking)
-    
+
+        # Process in batches to avoid issues with very large datasets
+        if len(history_entries) >= 100:
+            StockItemTracking.objects.bulk_update(history_entries, ['part'])
+            history_entries = []
+            print(".", end='', flush=True)
+
     if len(history_entries) > 0:
         StockItemTracking.objects.bulk_update(history_entries, ['part'])
-        print(f"\nUpdated {len(history_entries)} StockItemTracking entries with part links")
 
 
 def remove_null_items(apps, schema_editor):

--- a/src/backend/InvenTree/stock/migrations/0118_auto_20260205_1218.py
+++ b/src/backend/InvenTree/stock/migrations/0118_auto_20260205_1218.py
@@ -19,12 +19,18 @@ def add_part_links(apps, schema_editor):
 
         item = tracking.item
 
+        # No item link - skip
         if item is None:
             continue
 
         part = item.part
 
+        # No part link - skip
         if part is None:
+            continue
+
+        # Already linked to the correct part - skip
+        if tracking.part == part:
             continue
 
         tracking.part = part

--- a/src/backend/InvenTree/stock/migrations/0118_auto_20260205_1218.py
+++ b/src/backend/InvenTree/stock/migrations/0118_auto_20260205_1218.py
@@ -15,7 +15,7 @@ def add_part_links(apps, schema_editor):
     if N > 0:
         print(f"\nUpdating {N} StockItemTracking entries with part links...")
 
-    for tracking in StockItemTracking.objects.all():
+    for tracking in StockItemTracking.objects.filter(part__isnull=True).select_related('item__part'):
 
         item = tracking.item
 


### PR DESCRIPTION
Reduce issues with data migration for very large datasets:

- Prefetch the queryset to significantly reduce database overhead
- Batch the "bulk update" operation to reduce memory and CPU usage