### PR TITLE
[bug] fix short-circuit for isGeneratingSchema

### DIFF
--- a/src/backend/InvenTree/InvenTree/ready.py
+++ b/src/backend/InvenTree/InvenTree/ready.py
@@ -111,6 +111,18 @@ def isGeneratingSchema():
     if isCollectingPlugins():
         return False
 
+    # Additional set of commands which should not trigger schema generation
+    excluded_commands = [
+        'collectstatic',
+        'wait_for_db',
+        'makemessages',
+        'compilemessages',
+        'check',
+    ]
+
+    if any(cmd in sys.argv for cmd in excluded_commands):
+        return False
+
     if 'schema' in sys.argv:
         return True
 

--- a/src/backend/InvenTree/InvenTree/ready.py
+++ b/src/backend/InvenTree/InvenTree/ready.py
@@ -115,9 +115,12 @@ def isGeneratingSchema():
     excluded_commands = [
         'compilemessages',
         'createsuperuser',
+        'clean_settings',
         'collectstatic',
         'makemessages',
         'wait_for_db',
+        'gunicorn',
+        'qcluster',
         'check',
         'shell',
     ]

--- a/src/backend/InvenTree/InvenTree/ready.py
+++ b/src/backend/InvenTree/InvenTree/ready.py
@@ -113,11 +113,13 @@ def isGeneratingSchema():
 
     # Additional set of commands which should not trigger schema generation
     excluded_commands = [
-        'collectstatic',
-        'wait_for_db',
-        'makemessages',
         'compilemessages',
+        'createsuperuser',
+        'collectstatic',
+        'makemessages',
+        'wait_for_db',
         'check',
+        'shell',
     ]
 
     if any(cmd in sys.argv for cmd in excluded_commands):

--- a/src/backend/InvenTree/InvenTree/ready.py
+++ b/src/backend/InvenTree/InvenTree/ready.py
@@ -86,6 +86,11 @@ def isRunningBackup():
     )
 
 
+def isCollectingPlugins():
+    """Return True if the 'collectplugins' command is being executed."""
+    return 'collectplugins' in sys.argv
+
+
 def isGeneratingSchema():
     """Return true if schema generation is being executed."""
     if isInServerThread() or isInWorkerThread():
@@ -101,6 +106,9 @@ def isGeneratingSchema():
         return False
 
     if isWaitingForDatabase():
+        return False
+
+    if isCollectingPlugins():
         return False
 
     if 'schema' in sys.argv:

--- a/src/backend/InvenTree/InvenTree/ready.py
+++ b/src/backend/InvenTree/InvenTree/ready.py
@@ -136,7 +136,7 @@ def isGeneratingSchema():
 
     if not result:
         # We should only get here if we *are* generating schema
-        # Any other time this is called, it should be from a server thread, worker thread, or test mode
+        # Raise a warning, so that deevlopers can add extra checks above
 
         if settings.DEBUG:
             logger.warning(


### PR DESCRIPTION
Add some short-circuit checks to prevent expensive calls within `isGeneratingSchema`

Identified using new warning message
