### PR TITLE
[UI] Bug fix for stock column ordering (#11376)

### DIFF
--- a/src/frontend/src/tables/ColumnRenderers.tsx
+++ b/src/frontend/src/tables/ColumnRenderers.tsx
@@ -114,9 +114,10 @@ export type StockColumnProps = TableColumnProps & {
 // Render a StockItem instance within a table
 export function StockColumn(props: StockColumnProps): TableColumn {
   return {
-    accessor: props.accessor ?? 'stock_item',
     title: t`Stock Item`,
     ...props,
+    ordering: props.ordering || 'stock',
+    accessor: props.accessor || 'stock',
     render: (record: any) => {
       const stock_item =
         resolveItem(record, props.accessor ?? 'stock_item_detail') ?? {};

--- a/src/frontend/src/tables/InvenTreeTable.tsx
+++ b/src/frontend/src/tables/InvenTreeTable.tsx
@@ -486,6 +486,10 @@ export function InvenTreeTable<T extends Record<string, any>>({
       tableState.setPage(1);
       setSortStatus(status);
 
+      if (!status.columnAccessor) {
+        console.error('Invalid column accessor provided for table sorting');
+      }
+
       setTableSorting(cacheKey)(status);
     },
     [cacheKey]


### PR DESCRIPTION
- Cannot have a blank accessor
- Backport of https://github.com/inventree/InvenTree/pull/11376