### PR TITLE
[API] Enhanced filtering for generic parameters

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,15 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 454
+INVENTREE_API_VERSION = 455
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v455 -> 2026-02-19 : https://github.com/inventree/InvenTree/pull/11383
+    - Adds "exists_for_model_id" filter to ParameterTemplate API endpoint
+    - Adds "exists_for_related_model" filter to ParameterTemplate API endpoint
+    - Adds "exists_for_related_model_id" filter to ParameterTemplate API endpoint
 
 v454 -> 2026-02-19 : https://github.com/inventree/InvenTree/pull/11379
     - Adds "purchase_price" ordering option to StockItem API endpoint

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -867,7 +867,6 @@ class ParameterTemplateFilter(FilterSet):
 
         Notes:
             - This filter can only be applied if the 'exists_for_model' filter is also applied, as the model_id is only meaningful in the context of a particular model type.
-            - This filter also can use the value supplied in 'exists_for_model_relation' to map to a particular field on the model, e.g. category for parts, which allows for more complex relationships to be mapped.
 
         Reference: https://github.com/inventree/InvenTree/issues/11381
         """
@@ -934,7 +933,6 @@ class ParameterTemplateFilter(FilterSet):
         Notes:
             - This filter can only be applied if the 'exists_for_model' filter is also applied, as the model_id is only meaningful in the context of a base model
             - This filter can only be applied if the 'exists_for_related_model' filter is also applied, as the related model id is only meaningful in the context of a particular model relation
-            - This filter also can use the value supplied in 'exists_for_model_relation' to map to a particular field on the model, e.g. category for parts, which allows for more complex relationships to be mapped.
 
         Example: To filter part parameters which have at least one parameter defined for any part in category 5, you could apply the following filters:
             - exists_for_model=part

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -918,7 +918,7 @@ class ParameterTemplateFilter(FilterSet):
 
         Note:
             - This filter has no effect on its own
-            - It requires the 'exits_for_model' filter to be applied (to specify the base model)
+            - It requires the 'exists_for_model' filter to be applied (to specify the base model)
             - It requires the 'exists_for_related_model_id' filter to be applied also (to specify the related model id)
         """
         return queryset

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -891,7 +891,6 @@ class ParameterTemplateFilter(FilterSet):
             id_values = list(
                 instance.get_descendants(include_self=True).values_list('pk', flat=True)
             )
-            print(' instance is tree -> id_values:', id_values)
         else:
             id_values = [instance.pk]
 

--- a/src/backend/InvenTree/common/test_api.py
+++ b/src/backend/InvenTree/common/test_api.py
@@ -338,7 +338,6 @@ class ParameterAPITests(InvenTreeAPITestCase):
             'part': 3,
             'company': 0,
             'build': 0,
-            'wonky_model': 0,
         }.items():
             response = self.get(url, data={'exists_for_model': model_name})
             n = len(response.data)

--- a/src/backend/requirements-3.14.txt
+++ b/src/backend/requirements-3.14.txt
@@ -1659,9 +1659,9 @@ pynacl==1.6.2 \
     # via
     #   -c src/backend/requirements.txt
     #   paramiko
-pypdf==6.7.1 \
-    --hash=sha256:6b7a63be5563a0a35d54c6d6b550d75c00b8ccf36384be96365355e296e6b3b0 \
-    --hash=sha256:a02ccbb06463f7c334ce1612e91b3e68a8e827f3cee100b9941771e6066b094e
+pypdf==6.6.2 \
+    --hash=sha256:0a3ea3b3303982333404e22d8f75d7b3144f9cf4b2970b96856391a516f9f016 \
+    --hash=sha256:44c0c9811cfb3b83b28f1c3d054531d5b8b81abaedee0d8cb403650d023832ba
     # via
     #   -c src/backend/requirements.txt
     #   -r src/backend/requirements.in

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -1467,9 +1467,9 @@ pynacl==1.6.2 \
     --hash=sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2 \
     --hash=sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9
     # via paramiko
-pypdf==6.7.1 \
-    --hash=sha256:6b7a63be5563a0a35d54c6d6b550d75c00b8ccf36384be96365355e296e6b3b0 \
-    --hash=sha256:a02ccbb06463f7c334ce1612e91b3e68a8e827f3cee100b9941771e6066b094e
+pypdf==6.6.2 \
+    --hash=sha256:0a3ea3b3303982333404e22d8f75d7b3144f9cf4b2970b96856391a516f9f016 \
+    --hash=sha256:44c0c9811cfb3b83b28f1c3d054531d5b8b81abaedee0d8cb403650d023832ba
     # via -r src/backend/requirements.in
 pyphen==0.17.2 \
     --hash=sha256:3a07fb017cb2341e1d9ff31b8634efb1ae4dc4b130468c7c39dd3d32e7c3affd \

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -1467,9 +1467,9 @@ pynacl==1.6.2 \
     --hash=sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2 \
     --hash=sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9
     # via paramiko
-pypdf==6.6.2 \
-    --hash=sha256:0a3ea3b3303982333404e22d8f75d7b3144f9cf4b2970b96856391a516f9f016 \
-    --hash=sha256:44c0c9811cfb3b83b28f1c3d054531d5b8b81abaedee0d8cb403650d023832ba
+pypdf==6.7.1 \
+    --hash=sha256:6b7a63be5563a0a35d54c6d6b550d75c00b8ccf36384be96365355e296e6b3b0 \
+    --hash=sha256:a02ccbb06463f7c334ce1612e91b3e68a8e827f3cee100b9941771e6066b094e
     # via -r src/backend/requirements.in
 pyphen==0.17.2 \
     --hash=sha256:3a07fb017cb2341e1d9ff31b8634efb1ae4dc4b130468c7c39dd3d32e7c3affd \

--- a/src/frontend/src/tables/general/ParametricDataTable.tsx
+++ b/src/frontend/src/tables/general/ParametricDataTable.tsx
@@ -101,12 +101,18 @@ function ParameterCell({
  */
 export default function ParametricDataTable({
   modelType,
+  modelId,
+  relatedModel,
+  relatedModelId,
   endpoint,
   queryParams,
   customFilters,
   customColumns
 }: {
   modelType: ModelType;
+  modelId?: number;
+  relatedModel?: string;
+  relatedModelId?: number;
   endpoint: ApiEndpoints | string;
   queryParams?: Record<string, any>;
   customFilters?: TableFilter[];
@@ -125,8 +131,12 @@ export default function ParametricDataTable({
         .get(apiUrl(ApiEndpoints.parameter_template_list), {
           params: {
             active: true,
+            ordering: 'name',
             for_model: modelType,
-            exists_for_model: modelType
+            exists_for_model: modelType,
+            exists_for_model_id: modelId ?? undefined,
+            exists_for_related_model: relatedModel ?? undefined,
+            exists_for_related_model_id: relatedModelId ?? undefined
           }
         })
         .then((response) => response.data);

--- a/src/frontend/src/tables/part/ParametricPartTable.tsx
+++ b/src/frontend/src/tables/part/ParametricPartTable.tsx
@@ -56,6 +56,8 @@ export default function ParametricPartTable({
   return (
     <ParametricDataTable
       modelType={ModelType.part}
+      relatedModel={'category'}
+      relatedModelId={categoryId}
       endpoint={ApiEndpoints.part_list}
       customColumns={customColumns}
       customFilters={customFilters}

--- a/src/frontend/tests/helpers.ts
+++ b/src/frontend/tests/helpers.ts
@@ -180,3 +180,33 @@ export const toggleColumnSorting = async (page: Page, columnName: string) => {
   await page.waitForTimeout(50);
   await page.waitForLoadState('networkidle');
 };
+
+// Display the 'table' view
+export const showTableView = async (page: Page) => {
+  await page
+    .getByRole('button', { name: 'segmented-icon-control-table' })
+    .click();
+  await page.waitForLoadState('networkidle');
+};
+
+// Display the 'parameteric' view
+export const showParametricView = async (page: Page) => {
+  await page
+    .getByRole('button', { name: 'segmented-icon-control-parametric' })
+    .click();
+  await page.waitForLoadState('networkidle');
+};
+
+// Display the 'calendar' view
+export const showCalendarView = async (page: Page) => {
+  await page
+    .getByRole('button', { name: 'segmented-icon-control-calendar' })
+    .click();
+  await page.waitForLoadState('networkidle');
+};
+
+// Check for an expected number of columns in the visible table
+export const expectTableColumnCount = async (page: Page, count: number) => {
+  const columns = page.locator('table thead tr th');
+  await expect(columns).toHaveCount(count);
+};

--- a/src/frontend/tests/pages/pui_build.spec.ts
+++ b/src/frontend/tests/pages/pui_build.spec.ts
@@ -7,7 +7,10 @@ import {
   getRowFromCell,
   loadTab,
   navigate,
-  setTableChoiceFilter
+  setTableChoiceFilter,
+  showCalendarView,
+  showParametricView,
+  showTableView
 } from '../helpers.ts';
 import { doCachedLogin } from '../login.ts';
 
@@ -17,18 +20,10 @@ test('Build - Index', async ({ browser }) => {
   await loadTab(page, 'Build Orders');
 
   // Ensure all data views are available
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
-
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-calendar' })
-    .click();
+  await showParametricView(page);
+  await showCalendarView(page);
   await page.getByRole('button', { name: 'action-button-next-month' }).click();
-
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-table' })
-    .click();
+  await showTableView(page);
 });
 
 test('Build Order - Basic Tests', async ({ browser }) => {

--- a/src/frontend/tests/pages/pui_company.spec.ts
+++ b/src/frontend/tests/pages/pui_company.spec.ts
@@ -1,5 +1,10 @@
 import { test } from '../baseFixtures.js';
-import { clickOnParamFilter, loadTab, navigate } from '../helpers.js';
+import {
+  clickOnParamFilter,
+  loadTab,
+  navigate,
+  showParametricView
+} from '../helpers.js';
 import { doCachedLogin } from '../login.js';
 
 test('Company', async ({ browser }) => {
@@ -49,9 +54,7 @@ test('Company - Parameters', async ({ browser }) => {
   });
 
   // Show parametric view
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
+  await showParametricView(page);
 
   // Filter by "payment terms" parameter value
   await clickOnParamFilter(page, 'Payment Terms');

--- a/src/frontend/tests/pages/pui_part.spec.ts
+++ b/src/frontend/tests/pages/pui_part.spec.ts
@@ -4,10 +4,13 @@ import {
   clickOnParamFilter,
   clickOnRowMenu,
   deletePart,
+  expectTableColumnCount,
   getRowFromCell,
   loadTab,
   navigate,
-  setTableChoiceFilter
+  setTableChoiceFilter,
+  showParametricView,
+  showTableView
 } from '../helpers';
 import { doCachedLogin } from '../login';
 import { setPluginState, setSettingState } from '../settings';
@@ -499,6 +502,58 @@ test('Parts - Attachments', async ({ browser }) => {
   await page.getByRole('button', { name: 'Cancel' }).click();
 });
 
+test('Parts - Parameters by Category', async ({ browser }) => {
+  const page = await doCachedLogin(browser, { url: 'part/category/4/parts' });
+
+  await showParametricView(page);
+
+  // Check for expected parameter columns
+  for (const col of [
+    'Total Stock',
+    'Capacitance [F]',
+    'Power [W]',
+    'Resistance [ohms]'
+  ]) {
+    await page.getByRole('button', { name: col }).waitFor();
+  }
+
+  await expectTableColumnCount(page, 9);
+
+  // Now let's go to the "resistors" category
+  await navigate(page, 'part/category/5/parts');
+  await showParametricView(page);
+
+  // Fewer parameter templates displayed here
+  await expectTableColumnCount(page, 7);
+
+  // Check for expected parameter columns
+  for (const col of [
+    'Total Stock',
+    'Tolerance [percent]',
+    'Power [W]',
+    'Resistance [ohms]'
+  ]) {
+    await page.getByRole('button', { name: col }).waitFor();
+  }
+
+  // Finally, let's go to the "capacitors" category, which has a different set of parameter templates
+  await navigate(page, 'part/category/6/parts');
+  await showParametricView(page);
+  await expectTableColumnCount(page, 7);
+
+  for (const col of [
+    'Total Stock',
+    'Tolerance [percent]',
+    'Polarized',
+    'Capacitance [F]'
+  ]) {
+    await page.getByRole('button', { name: col }).waitFor();
+  }
+
+  // Reset to the table view
+  await showTableView(page);
+});
+
 test('Parts - Parameters', async ({ browser }) => {
   const page = await doCachedLogin(browser, { url: 'part/69/parameters' });
 
@@ -562,10 +617,8 @@ test('Parts - Parameter Filtering', async ({ browser }) => {
   const page = await doCachedLogin(browser, { url: 'part/' });
 
   await loadTab(page, 'Parts', true);
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
 
+  await showParametricView(page);
   await clearTableFilters(page);
 
   // All parts should be available (no filters applied)

--- a/src/frontend/tests/pages/pui_purchase_order.spec.ts
+++ b/src/frontend/tests/pages/pui_purchase_order.spec.ts
@@ -9,7 +9,10 @@ import {
   loadTab,
   navigate,
   openFilterDrawer,
-  setTableChoiceFilter
+  setTableChoiceFilter,
+  showCalendarView,
+  showParametricView,
+  showTableView
 } from '../helpers.ts';
 import { doCachedLogin } from '../login.ts';
 
@@ -18,26 +21,14 @@ test('Purchasing - Index', async ({ browser }) => {
 
   // Purchase Orders tab
   await loadTab(page, 'Purchase Orders');
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
-
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-calendar' })
-    .click();
-  await page.getByRole('button', { name: 'calendar-select-month' }).waitFor();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-table' })
-    .click();
+  await showParametricView(page);
+  await showCalendarView(page);
+  await showTableView(page);
 
   // Suppliers tab
   await loadTab(page, 'Suppliers');
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-table' })
-    .click();
+  await showParametricView(page);
+  await showTableView(page);
 
   // Check for expected values
   await clearTableFilters(page);
@@ -45,12 +36,8 @@ test('Purchasing - Index', async ({ browser }) => {
 
   // Supplier parts tab
   await loadTab(page, 'Supplier Parts');
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-table' })
-    .click();
+  await showParametricView(page);
+  await showTableView(page);
 
   // Check for expected values
   await clearTableFilters(page);
@@ -60,12 +47,8 @@ test('Purchasing - Index', async ({ browser }) => {
 
   // Manufacturers tab
   await loadTab(page, 'Manufacturers');
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-table' })
-    .click();
+  await showParametricView(page);
+  await showTableView(page);
 
   // Check for expected values
   await clearTableFilters(page);
@@ -76,12 +59,8 @@ test('Purchasing - Index', async ({ browser }) => {
 
   // Manufacturer parts tab
   await loadTab(page, 'Manufacturer Parts');
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-table' })
-    .click();
+  await showParametricView(page);
+  await showTableView(page);
 
   // Check for expected values
   await clearTableFilters(page);

--- a/src/frontend/tests/pages/pui_sales_order.spec.ts
+++ b/src/frontend/tests/pages/pui_sales_order.spec.ts
@@ -5,7 +5,10 @@ import {
   clickOnRowMenu,
   globalSearch,
   loadTab,
-  setTableChoiceFilter
+  setTableChoiceFilter,
+  showCalendarView,
+  showParametricView,
+  showTableView
 } from '../helpers.ts';
 import { doCachedLogin } from '../login.ts';
 
@@ -18,15 +21,9 @@ test('Sales Orders - Tabs', async ({ browser }) => {
   await loadTab(page, 'Sales Orders');
   await page.waitForURL('**/web/sales/index/salesorders');
 
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-calendar' })
-    .click();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-table' })
-    .click();
+  await showParametricView(page);
+  await showCalendarView(page);
+  await showTableView(page);
 
   // Pending Shipments panel
   await loadTab(page, 'Pending Shipments');
@@ -37,25 +34,15 @@ test('Sales Orders - Tabs', async ({ browser }) => {
   await loadTab(page, 'Return Orders');
   await page.getByRole('cell', { name: 'NOISE-COMPLAINT' }).waitFor();
 
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-calendar' })
-    .click();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-table' })
-    .click();
+  await showParametricView(page);
+  await showCalendarView(page);
+  await showTableView(page);
 
   // Customers
   await loadTab(page, 'Customers');
 
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-parametric' })
-    .click();
-  await page
-    .getByRole('button', { name: 'segmented-icon-control-table' })
-    .click();
+  await showParametricView(page);
+  await showTableView(page);
 
   await page.getByText('Customer A').click();
   await loadTab(page, 'Notes');


### PR DESCRIPTION
Ref: https://github.com/inventree/InvenTree/issues/11381

### Problem Description

With the introduction of [generic parameters](https://github.com/inventree/InvenTree/pull/10699) the filtering of "part parameters" based on the part category has been broken.

This means that when viewing a given part category, the parametric data table displays columns for every parameter which exists for a part, and is *not scope limited to the category*. This creates a visually cluttered table with a lot of irrelevant parameters.

e.g. for the "capacitors" category, all parameter templates are displayed including "resistance" "thread" (etc)

<img width="2478" height="1005" alt="image" src="https://github.com/user-attachments/assets/91050c45-87af-4028-afa6-09849608e613" />

### Solution

The solution is to add some new "generic" filters for the `ParameterTemplate` API

| Filter | Description |
| ----- | ------------- |
| `exists_for_model_id` | Restrict template results to those which have parameters associated with the given model ID. Extends the functionality of the `exists_for_model` filter |
| `exists_for_related_model` | Lookup a related model on the provided base model. e.g. `category` for `part`. Needs to be used in conjunction with the `exists_for_related_model_id` filter |
| `exists_for_related_model_id` | Specify the instance ID for the related field |

So this approach lets us make queries such as:

*Return all ParameterTemplate instances for which there are greater than zero Template instances linked with the Part model, for any Part which exists within a provided category*

And the API query to achieve the above is structured as:

`/api/parameter/template/?active=true&ordering=name&for_model=part&exists_for_model=part&exists_for_related_model=category&exists_for_related_model_id=6`

### Result

And here we can see that back in the "capacitors" category, only the relevant columns are displayed:

<img width="2481" height="1016" alt="image" src="https://github.com/user-attachments/assets/d0168611-f49c-416f-acc9-33c7c21a4ecd" />

### Testing

- [x] Playwright testing for tables
- [x] API unit testing for new filters