### PR TITLE
[bug] Check for null plugin config

### DIFF
--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -477,7 +477,15 @@ class PluginsRegistry:
                     # Ensure mandatory plugins are marked as active
                     if config.is_mandatory() and not config.active:
                         config.active = True
-                        config.save(no_reload=True)
+
+                        try:
+                            config.save(no_reload=True)
+                        except (OperationalError, ProgrammingError):
+                            # Database is not ready, cannot save config
+                            logger.warning(
+                                "Database not ready - cannot set mandatory flag for plugin '%s'",
+                                plugin.slug,
+                            )
 
         except Exception as e:
             logger.exception('Unexpected error during plugin reload: %s', e)

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -473,12 +473,11 @@ class PluginsRegistry:
 
             # Ensure that each loaded plugin has a valid configuration object in the database
             for plugin in self.plugins.values():
-                config = self.get_plugin_config(plugin.slug)
-
-                # Ensure mandatory plugins are marked as active
-                if config.is_mandatory() and not config.active:
-                    config.active = True
-                    config.save(no_reload=True)
+                if config := self.get_plugin_config(plugin.slug):
+                    # Ensure mandatory plugins are marked as active
+                    if config.is_mandatory() and not config.active:
+                        config.active = True
+                        config.save(no_reload=True)
 
         except Exception as e:
             logger.exception('Unexpected error during plugin reload: %s', e)


### PR DESCRIPTION
- Fixes https://github.com/inventree/InvenTree/issues/11392
- Check for null `PluginConfig` object before accessing