### PR TITLE
[UI] Default table filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+[#11405](https://github.com/inventree/InvenTree/pull/11405) adds default table filters, which hide inactive items by default. The default table filters are overridden by user filter selection, and only apply to the table view initially presented to the user. This means that users can still view inactive items if they choose to, but they will not be shown by default.
+
 [#11222](https://github.com/inventree/InvenTree/pull/11222) adds support for data import using natural keys, allowing for easier association of related objects without needing to know their internal database IDs.
 
 [#11383](https://github.com/inventree/InvenTree/pull/11383) adds "exists_for_model_id", "exists_for_related_model", and "exists_for_related_model_id" filters to the ParameterTemplate API endpoint. These filters allow users to check for the existence of parameters associated with specific models or related models, improving the flexibility and usability of the API.

--- a/src/frontend/lib/types/Filters.tsx
+++ b/src/frontend/lib/types/Filters.tsx
@@ -39,7 +39,7 @@ export type TableFilterType = 'boolean' | 'choice' | 'date' | 'text' | 'api';
  */
 export type TableFilter = {
   name: string;
-  label: string;
+  label?: string;
   description?: string;
   type?: TableFilterType;
   choices?: TableFilterChoice[];

--- a/src/frontend/src/hooks/UseFilterSet.tsx
+++ b/src/frontend/src/hooks/UseFilterSet.tsx
@@ -1,20 +1,42 @@
 import type { FilterSetState, TableFilter } from '@lib/types/Filters';
 import { useLocalStorage } from '@mantine/hooks';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
-export function useFilterSet(filterKey: string): FilterSetState {
+export function useFilterSet(
+  filterKey: string,
+  initialFilters?: TableFilter[]
+): FilterSetState {
   // Array of active filters (saved to local storage)
-  const [activeFilters, setActiveFilters] = useLocalStorage<TableFilter[]>({
+  const [storedFilters, setStoredFilters] = useLocalStorage<
+    TableFilter[] | null
+  >({
     key: `inventree-filterset-${filterKey}`,
-    defaultValue: [],
+    defaultValue: null,
     sync: false,
     getInitialValueInEffect: false
   });
 
+  const activeFilters: TableFilter[] = useMemo(() => {
+    if (storedFilters == null) {
+      // If there are no stored filters, set initial values
+      const filters = initialFilters || [];
+      setStoredFilters(filters);
+      return filters;
+    }
+    return storedFilters || [];
+  }, [storedFilters]);
+
   // Callback to clear all active filters from the table
   const clearActiveFilters = useCallback(() => {
-    setActiveFilters([]);
+    setStoredFilters([]);
   }, []);
+
+  const setActiveFilters = useCallback(
+    (filters: TableFilter[]) => {
+      setStoredFilters(filters);
+    },
+    [setStoredFilters]
+  );
 
   return {
     filterKey,

--- a/src/frontend/src/hooks/UseTable.tsx
+++ b/src/frontend/src/hooks/UseTable.tsx
@@ -2,9 +2,14 @@ import { randomId } from '@mantine/hooks';
 import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import type { FilterSetState } from '@lib/types/Filters';
+import type { FilterSetState, TableFilter } from '@lib/types/Filters';
 import type { TableState } from '@lib/types/Tables';
 import { useFilterSet } from './UseFilterSet';
+
+export type TableStateExtraProps = {
+  idAccessor?: string;
+  initialFilters?: TableFilter[];
+};
 
 /**
  * A custom hook for managing the state of an <InvenTreeTable> component.
@@ -12,7 +17,13 @@ import { useFilterSet } from './UseFilterSet';
  * Refer to the TableState type definition for more information.
  */
 
-export function useTable(tableName: string, idAccessor = 'pk'): TableState {
+export function useTable(
+  tableName: string,
+  tableProps: TableStateExtraProps = {
+    idAccessor: 'pk',
+    initialFilters: []
+  }
+): TableState {
   // Function to generate a new ID (to refresh the table)
   function generateTableName() {
     return `${tableName.replaceAll('-', '')}-${randomId()}`;
@@ -38,7 +49,10 @@ export function useTable(tableName: string, idAccessor = 'pk'): TableState {
     [generateTableName]
   );
 
-  const filterSet: FilterSetState = useFilterSet(`table-${tableName}`);
+  const filterSet: FilterSetState = useFilterSet(
+    `table-${tableName}`,
+    tableProps.initialFilters
+  );
 
   // Array of expanded records
   const [expandedRecords, setExpandedRecords] = useState<any[]>([]);
@@ -59,7 +73,7 @@ export function useTable(tableName: string, idAccessor = 'pk'): TableState {
 
   // Array of selected primary key values
   const selectedIds = useMemo(
-    () => selectedRecords.map((r) => r[idAccessor || 'pk']),
+    () => selectedRecords.map((r) => r[tableProps.idAccessor || 'pk']),
     [selectedRecords]
   );
 
@@ -89,7 +103,7 @@ export function useTable(tableName: string, idAccessor = 'pk'): TableState {
 
       // Find the matching record in the table
       const index = _records.findIndex(
-        (r) => r[idAccessor || 'pk'] === record.pk
+        (r) => r[tableProps.idAccessor || 'pk'] === record.pk
       );
 
       if (index >= 0) {
@@ -104,6 +118,11 @@ export function useTable(tableName: string, idAccessor = 'pk'): TableState {
       setRecords(_records);
     },
     [records]
+  );
+
+  const idAccessor = useMemo(
+    () => tableProps.idAccessor || 'pk',
+    [tableProps.idAccessor]
   );
 
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/src/frontend/src/pages/Index/Settings/AdminCenter/CurrencyManagementPanel.tsx
+++ b/src/frontend/src/pages/Index/Settings/AdminCenter/CurrencyManagementPanel.tsx
@@ -20,7 +20,7 @@ import { InvenTreeTable } from '../../../../tables/InvenTreeTable';
 export function CurrencyTable({
   setInfo
 }: Readonly<{ setInfo: (info: any) => void }>) {
-  const table = useTable('currency', 'currency');
+  const table = useTable('currency', { idAccessor: 'currency' });
   const columns = useMemo(() => {
     return [
       {

--- a/src/frontend/src/pages/Index/Settings/AdminCenter/UnitManagementPanel.tsx
+++ b/src/frontend/src/pages/Index/Settings/AdminCenter/UnitManagementPanel.tsx
@@ -11,7 +11,7 @@ import { InvenTreeTable } from '../../../../tables/InvenTreeTable';
 import CustomUnitsTable from '../../../../tables/settings/CustomUnitsTable';
 
 function AllUnitTable() {
-  const table = useTable('all-units', 'name');
+  const table = useTable('all-units', { idAccessor: 'name' });
   const columns = useMemo(() => {
     return [
       {

--- a/src/frontend/src/pages/build/BuildDetail.tsx
+++ b/src/frontend/src/pages/build/BuildDetail.tsx
@@ -469,6 +469,7 @@ export default function BuildDetail() {
             tableName='build-consumed'
             showLocation={false}
             allowReturn
+            defaultInStock={null}
             params={{
               consumed_by: id
             }}

--- a/src/frontend/src/pages/company/CompanyDetail.tsx
+++ b/src/frontend/src/pages/company/CompanyDetail.tsx
@@ -248,6 +248,7 @@ export default function CompanyDetail(props: Readonly<CompanyDetailProps>) {
             tableName='assigned-stock'
             showLocation={false}
             allowReturn
+            defaultInStock={null}
             params={{ customer: company.pk }}
           />
         ) : (

--- a/src/frontend/src/pages/purchasing/PurchasingIndex.tsx
+++ b/src/frontend/src/pages/purchasing/PurchasingIndex.tsx
@@ -108,6 +108,7 @@ export default function PurchasingIndex() {
             icon: <IconTable />,
             content: (
               <CompanyTable
+                companyType='supplier'
                 path='purchasing/supplier'
                 params={{ is_supplier: true }}
               />
@@ -157,6 +158,7 @@ export default function PurchasingIndex() {
             icon: <IconTable />,
             content: (
               <CompanyTable
+                companyType='manufacturer'
                 path='purchasing/manufacturer'
                 params={{ is_manufacturer: true }}
               />

--- a/src/frontend/src/pages/sales/SalesIndex.tsx
+++ b/src/frontend/src/pages/sales/SalesIndex.tsx
@@ -141,6 +141,7 @@ export default function SalesIndex() {
             icon: <IconTable />,
             content: (
               <CompanyTable
+                companyType='customer'
                 path='sales/customer'
                 params={{ is_customer: true }}
               />

--- a/src/frontend/src/tables/FilterSelectDrawer.tsx
+++ b/src/frontend/src/tables/FilterSelectDrawer.tsx
@@ -93,8 +93,12 @@ function FilterItem({
             {flt.displayValue ??
               filterDisplayValue(flt.name, flt.value, availableFilters)}
           </Badge>
-          <Tooltip label={t`Remove filter`} withinPortal={true}>
-            <CloseButton size='md' color='red' onClick={removeFilter} />
+          <Tooltip
+            label={t`Remove filter`}
+            withinPortal={true}
+            position='top-end'
+          >
+            <CloseButton size='md' c='red' onClick={removeFilter} />
           </Tooltip>
         </Group>
       </Group>

--- a/src/frontend/src/tables/InvenTreeTableHeader.tsx
+++ b/src/frontend/src/tables/InvenTreeTableHeader.tsx
@@ -9,7 +9,6 @@ import {
   Paper,
   Space,
   Stack,
-  Text,
   Tooltip
 } from '@mantine/core';
 import {
@@ -37,7 +36,7 @@ import { StylishText } from '../components/items/StylishText';
 import useDataExport from '../hooks/UseDataExport';
 import { useDeleteApiFormModal } from '../hooks/UseForm';
 import { TableColumnSelect } from './ColumnSelect';
-import { FilterSelectDrawer } from './FilterSelectDrawer';
+import { FilterPreview, FilterSelectDrawer } from './FilterSelectDrawer';
 
 /**
  * Render a composite header for an InvenTree table
@@ -272,15 +271,10 @@ export default function InvenTreeTableHeader({
                         <StylishText size='md'>{t`Active Filters`}</StylishText>
                         <Divider />
                         {tableState.filterSet.activeFilters?.map((filter) => (
-                          <Group
-                            key={filter.name}
-                            justify='space-between'
-                            gap='xl'
-                            wrap='nowrap'
-                          >
-                            <Text size='sm'>{filter.label}</Text>
-                            <Text size='xs'>{filter.displayValue}</Text>
-                          </Group>
+                          <FilterPreview
+                            filter={filter}
+                            filters={tableProps.tableFilters}
+                          />
                         ))}
                       </Stack>
                     </Paper>

--- a/src/frontend/src/tables/build/BuildOrderTable.tsx
+++ b/src/frontend/src/tables/build/BuildOrderTable.tsx
@@ -64,7 +64,14 @@ export function BuildOrderTable({
   salesOrderId?: number;
 }>) {
   const globalSettings = useGlobalSettingsState();
-  const table = useTable(!!partId ? 'buildorder-part' : 'buildorder-index');
+  const table = useTable(!!partId ? 'buildorder-part' : 'buildorder-index', {
+    initialFilters: [
+      {
+        name: 'outstanding',
+        value: 'true'
+      }
+    ]
+  });
 
   const tableColumns = useMemo(() => {
     return [

--- a/src/frontend/src/tables/company/CompanyTable.tsx
+++ b/src/frontend/src/tables/company/CompanyTable.tsx
@@ -29,13 +29,22 @@ import { InvenTreeTable } from '../InvenTreeTable';
  * based on the provided filter parameters
  */
 export function CompanyTable({
+  companyType,
   params,
   path
 }: Readonly<{
+  companyType?: string;
   params?: any;
   path?: string;
 }>) {
-  const table = useTable('company');
+  const table = useTable(`company-${companyType ?? 'index'}`, {
+    initialFilters: [
+      {
+        name: 'active',
+        value: 'true'
+      }
+    ]
+  });
 
   const navigate = useNavigate();
   const user = useUserState();

--- a/src/frontend/src/tables/general/BarcodeScanTable.tsx
+++ b/src/frontend/src/tables/general/BarcodeScanTable.tsx
@@ -26,7 +26,7 @@ export default function BarcodeScanTable({
   const navigate = useNavigate();
   const user = useUserState();
 
-  const table = useTable('barcode-scan-results', 'id');
+  const table = useTable('barcode-scan-results', { idAccessor: 'id' });
 
   const tableColumns: TableColumn[] = useMemo(() => {
     return [

--- a/src/frontend/src/tables/part/PartTable.tsx
+++ b/src/frontend/src/tables/part/PartTable.tsx
@@ -338,17 +338,26 @@ export function PartListTable({
   enableImport = true,
   basePartInstance,
   props,
+  tableName = 'part-list',
   defaultPartData
 }: Readonly<{
   enableImport?: boolean;
   props?: InvenTreeTableProps;
   basePartInstance?: any;
+  tableName?: string;
   defaultPartData?: any;
 }>) {
   const tableColumns = useMemo(() => partTableColumns(), []);
   const tableFilters = useMemo(() => partTableFilters(), []);
 
-  const table = useTable('part-list');
+  const table = useTable(tableName ?? 'part-list', {
+    initialFilters: [
+      {
+        name: 'active',
+        value: 'true'
+      }
+    ]
+  });
   const user = useUserState();
   const globalSettings = useGlobalSettingsState();
 

--- a/src/frontend/src/tables/part/PartVariantTable.tsx
+++ b/src/frontend/src/tables/part/PartVariantTable.tsx
@@ -43,6 +43,7 @@ export function PartVariantTable({ part }: Readonly<{ part: any }>) {
           ancestor: part.pk
         }
       }}
+      tableName='part-variants'
       basePartInstance={part}
       defaultPartData={{
         ...part,

--- a/src/frontend/src/tables/plugin/PluginErrorTable.tsx
+++ b/src/frontend/src/tables/plugin/PluginErrorTable.tsx
@@ -19,7 +19,9 @@ export interface PluginRegistryErrorI {
  * Table displaying list of plugin registry errors
  */
 export default function PluginErrorTable() {
-  const table = useTable('registryErrors', 'id');
+  const table = useTable('registryErrors', {
+    idAccessor: 'id'
+  });
 
   const registryErrorTableColumns: TableColumn<PluginRegistryErrorI>[] =
     useMemo(

--- a/src/frontend/src/tables/purchasing/ManufacturerPartTable.tsx
+++ b/src/frontend/src/tables/purchasing/ManufacturerPartTable.tsx
@@ -54,7 +54,18 @@ export function ManufacturerPartTable({
     return tId;
   }, [manufacturerId, partId]);
 
-  const table = useTable(tableId);
+  const table = useTable(tableId, {
+    initialFilters: [
+      {
+        name: 'manufacturer_active',
+        value: 'true'
+      },
+      {
+        name: 'part_active',
+        value: 'true'
+      }
+    ]
+  });
 
   const user = useUserState();
 

--- a/src/frontend/src/tables/purchasing/ManufacturerPartTable.tsx
+++ b/src/frontend/src/tables/purchasing/ManufacturerPartTable.tsx
@@ -54,17 +54,28 @@ export function ManufacturerPartTable({
     return tId;
   }, [manufacturerId, partId]);
 
-  const table = useTable(tableId, {
-    initialFilters: [
-      {
+  const initialFilters = useMemo(() => {
+    const filters: TableFilter[] = [];
+
+    if (!manufacturerId) {
+      filters.push({
         name: 'manufacturer_active',
         value: 'true'
-      },
-      {
+      });
+    }
+
+    if (!partId) {
+      filters.push({
         name: 'part_active',
         value: 'true'
-      }
-    ]
+      });
+    }
+
+    return filters;
+  }, [manufacturerId, partId]);
+
+  const table = useTable(tableId, {
+    initialFilters: initialFilters
   });
 
   const user = useUserState();

--- a/src/frontend/src/tables/purchasing/PurchaseOrderTable.tsx
+++ b/src/frontend/src/tables/purchasing/PurchaseOrderTable.tsx
@@ -60,7 +60,14 @@ export function PurchaseOrderTable({
   supplierPartId?: number;
   externalBuildId?: number;
 }>) {
-  const table = useTable('purchase-order');
+  const table = useTable('purchase-order', {
+    initialFilters: [
+      {
+        name: 'outstanding',
+        value: 'true'
+      }
+    ]
+  });
   const user = useUserState();
 
   const tableFilters: TableFilter[] = useMemo(() => {

--- a/src/frontend/src/tables/purchasing/SupplierPartTable.tsx
+++ b/src/frontend/src/tables/purchasing/SupplierPartTable.tsx
@@ -54,21 +54,33 @@ export function SupplierPartTable({
   partId?: number;
   supplierId?: number;
 }>): ReactNode {
-  const table = useTable('supplierparts', {
-    initialFilters: [
+  const initialFilters = useMemo(() => {
+    const filters: TableFilter[] = [
       {
         name: 'active',
         value: 'true'
-      },
-      {
-        name: 'part_active',
-        value: 'true'
-      },
-      {
+      }
+    ];
+
+    if (!supplierId) {
+      filters.push({
         name: 'supplier_active',
         value: 'true'
-      }
-    ]
+      });
+    }
+
+    if (!partId) {
+      filters.push({
+        name: 'part_active',
+        value: 'true'
+      });
+    }
+
+    return filters;
+  }, [supplierId, partId]);
+
+  const table = useTable('supplierparts', {
+    initialFilters: initialFilters
   });
 
   const user = useUserState();

--- a/src/frontend/src/tables/purchasing/SupplierPartTable.tsx
+++ b/src/frontend/src/tables/purchasing/SupplierPartTable.tsx
@@ -54,7 +54,22 @@ export function SupplierPartTable({
   partId?: number;
   supplierId?: number;
 }>): ReactNode {
-  const table = useTable('supplierparts');
+  const table = useTable('supplierparts', {
+    initialFilters: [
+      {
+        name: 'active',
+        value: 'true'
+      },
+      {
+        name: 'part_active',
+        value: 'true'
+      },
+      {
+        name: 'supplier_active',
+        value: 'true'
+      }
+    ]
+  });
 
   const user = useUserState();
 

--- a/src/frontend/src/tables/sales/ReturnOrderTable.tsx
+++ b/src/frontend/src/tables/sales/ReturnOrderTable.tsx
@@ -56,7 +56,18 @@ export function ReturnOrderTable({
   partId?: number;
   customerId?: number;
 }>) {
-  const table = useTable(!!partId ? 'returnorders-part' : 'returnorders-index');
+  const table = useTable(
+    !!partId ? 'returnorders-part' : 'returnorders-index',
+    {
+      initialFilters: [
+        {
+          name: 'outstanding',
+          value: 'true'
+        }
+      ]
+    }
+  );
+
   const user = useUserState();
 
   const tableFilters: TableFilter[] = useMemo(() => {

--- a/src/frontend/src/tables/sales/SalesOrderTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderTable.tsx
@@ -58,7 +58,14 @@ export function SalesOrderTable({
   partId?: number;
   customerId?: number;
 }>) {
-  const table = useTable(!!partId ? 'salesorder-part' : 'salesorder-index');
+  const table = useTable(!!partId ? 'salesorder-part' : 'salesorder-index', {
+    initialFilters: [
+      {
+        name: 'outstanding',
+        value: 'true'
+      }
+    ]
+  });
   const user = useUserState();
 
   const tableFilters: TableFilter[] = useMemo(() => {

--- a/src/frontend/src/tables/settings/ApiTokenTable.tsx
+++ b/src/frontend/src/tables/settings/ApiTokenTable.tsx
@@ -48,7 +48,7 @@ export function ApiTokenTable({
     return [];
   }, [only_myself]);
 
-  const table = useTable('api-tokens', 'id');
+  const table = useTable('api-tokens', { idAccessor: 'id' });
 
   const tableColumns = useMemo(() => {
     const cols = [

--- a/src/frontend/src/tables/settings/EmailTable.tsx
+++ b/src/frontend/src/tables/settings/EmailTable.tsx
@@ -61,7 +61,7 @@ export function EmailTable() {
     ];
   }, []);
 
-  const table = useTable('emails', 'pk');
+  const table = useTable('emails', { idAccessor: 'pk' });
 
   const [selectedEmailId, setSelectedEmailId] = useState<string>('');
 

--- a/src/frontend/src/tables/stock/StockItemTable.tsx
+++ b/src/frontend/src/tables/stock/StockItemTable.tsx
@@ -315,6 +315,8 @@ export function StockItemTable({
   showLocation = true,
   showPricing = true,
   allowReturn = false,
+  initialFilters,
+  defaultInStock = true,
   tableName = 'stockitems'
 }: Readonly<{
   params?: any;
@@ -322,15 +324,32 @@ export function StockItemTable({
   showLocation?: boolean;
   showPricing?: boolean;
   allowReturn?: boolean;
+  defaultInStock?: boolean | null;
+  initialFilters?: TableFilter[];
   tableName: string;
 }>) {
-  const table = useTable(tableName, {
-    initialFilters: [
-      {
+  const initialStockFilters: TableFilter[] = useMemo(() => {
+    if (!!initialFilters) {
+      return initialFilters;
+    }
+
+    const filters: TableFilter[] = [];
+
+    // Optionally set the default "in_stock" filter
+    // Typically, we default to only displaying "in_stock" items,
+    // but this can be overridden by the caller if required
+    if (defaultInStock != undefined && defaultInStock != null) {
+      filters.push({
         name: 'in_stock',
-        value: 'true'
-      }
-    ]
+        value: defaultInStock ? 'true' : 'false'
+      });
+    }
+
+    return filters;
+  }, [defaultInStock, initialFilters]);
+
+  const table = useTable(tableName, {
+    initialFilters: initialStockFilters
   });
 
   const user = useUserState();

--- a/src/frontend/src/tables/stock/StockItemTable.tsx
+++ b/src/frontend/src/tables/stock/StockItemTable.tsx
@@ -324,7 +324,15 @@ export function StockItemTable({
   allowReturn?: boolean;
   tableName: string;
 }>) {
-  const table = useTable(tableName);
+  const table = useTable(tableName, {
+    initialFilters: [
+      {
+        name: 'in_stock',
+        value: 'true'
+      }
+    ]
+  });
+
   const user = useUserState();
 
   const settings = useGlobalSettingsState();

--- a/src/frontend/tests/pages/pui_build.spec.ts
+++ b/src/frontend/tests/pages/pui_build.spec.ts
@@ -723,6 +723,8 @@ test('Build Order - External', async ({ browser }) => {
   await navigate(page, 'manufacturing/build-order/26/details');
   await loadTab(page, 'External Orders');
 
+  await clearTableFilters(page);
+
   await page.getByRole('cell', { name: 'PO0017' }).waitFor();
   await page.getByRole('cell', { name: 'PO0018' }).waitFor();
 });

--- a/src/frontend/tests/pages/pui_company.spec.ts
+++ b/src/frontend/tests/pages/pui_company.spec.ts
@@ -15,21 +15,28 @@ test('Company', async ({ browser }) => {
   await navigate(page, 'company/1/details');
   await page.getByLabel('Details').getByText('DigiKey Electronics').waitFor();
   await page.getByRole('cell', { name: 'https://www.digikey.com/' }).waitFor();
+
   await loadTab(page, 'Supplied Parts');
   await page
     .getByRole('cell', { name: 'RR05P100KDTR-ND', exact: true })
     .waitFor();
+
   await loadTab(page, 'Purchase Orders');
+  await clearTableFilters(page);
   await page.getByRole('cell', { name: 'Molex connectors' }).first().waitFor();
+
   await loadTab(page, 'Stock Items');
   await page
     .getByRole('cell', { name: 'Blue plastic enclosure' })
     .first()
     .waitFor();
+
   await loadTab(page, 'Contacts');
   await page.getByRole('cell', { name: 'jimmy.mcleod@digikey.com' }).waitFor();
+
   await loadTab(page, 'Addresses');
   await page.getByRole('cell', { name: 'Carla Tunnel' }).waitFor();
+
   await loadTab(page, 'Attachments');
   await loadTab(page, 'Notes');
 

--- a/src/frontend/tests/pages/pui_part.spec.ts
+++ b/src/frontend/tests/pages/pui_part.spec.ts
@@ -66,12 +66,14 @@ test('Parts - Tabs', async ({ browser }) => {
 });
 
 test('Parts - Manufacturer Parts', async ({ browser }) => {
-  const page = await doCachedLogin(browser, { url: 'part/84/suppliers' });
+  const page = await doCachedLogin(browser, { url: 'part/84/' });
 
-  await page.getByText('1551ACLR - 1551ACLR').waitFor();
-
+  // Load the "suppliers" tab
   await loadTab(page, 'Suppliers');
   await page.getByText('Hammond Manufacturing').click();
+
+  // Wait for manufacturer part page to load
+  await page.getByText('1551ACLR - 1551ACLR').waitFor();
   await loadTab(page, 'Parameters');
   await loadTab(page, 'Attachments');
 });

--- a/src/frontend/tests/pages/pui_part.spec.ts
+++ b/src/frontend/tests/pages/pui_part.spec.ts
@@ -68,12 +68,12 @@ test('Parts - Tabs', async ({ browser }) => {
 test('Parts - Manufacturer Parts', async ({ browser }) => {
   const page = await doCachedLogin(browser, { url: 'part/84/suppliers' });
 
+  await page.getByText('1551ACLR - 1551ACLR').waitFor();
+
   await loadTab(page, 'Suppliers');
   await page.getByText('Hammond Manufacturing').click();
   await loadTab(page, 'Parameters');
-  await loadTab(page, 'Suppliers');
   await loadTab(page, 'Attachments');
-  await page.getByText('1551ACLR - 1551ACLR').waitFor();
 });
 
 test('Parts - Supplier Parts', async ({ browser }) => {

--- a/src/frontend/tests/pages/pui_purchase_order.spec.ts
+++ b/src/frontend/tests/pages/pui_purchase_order.spec.ts
@@ -27,9 +27,11 @@ test('Purchasing - Index', async ({ browser }) => {
 
   // Check default filters are applied
   // By default, only outstanding orders are visible
-  await page.getByText('1 - 8 / 8').waitFor();
+  await page.getByText(/1 - \d+ \/ \d+/).waitFor();
+
+  // Clearing the filters, more orders should be visible
   await clearTableFilters(page);
-  await page.getByText('1 - 18 / 18').waitFor();
+  await page.getByText(/1 - 1\d \/ 1\d/).waitFor();
 
   // Suppliers tab
   await loadTab(page, 'Suppliers');

--- a/src/frontend/tests/pages/pui_purchase_order.spec.ts
+++ b/src/frontend/tests/pages/pui_purchase_order.spec.ts
@@ -25,6 +25,12 @@ test('Purchasing - Index', async ({ browser }) => {
   await showCalendarView(page);
   await showTableView(page);
 
+  // Check default filters are applied
+  // By default, only outstanding orders are visible
+  await page.getByText('1 - 8 / 8').waitFor();
+  await clearTableFilters(page);
+  await page.getByText('1 - 18 / 18').waitFor();
+
   // Suppliers tab
   await loadTab(page, 'Suppliers');
   await showParametricView(page);

--- a/src/frontend/tests/pui_exporting.spec.ts
+++ b/src/frontend/tests/pui_exporting.spec.ts
@@ -33,7 +33,7 @@ test('Exporting - Orders', async ({ browser }) => {
   await page.getByText('Process completed successfully').waitFor();
 
   // Download list of purchase order items
-  await page.getByRole('cell', { name: 'PO0011' }).click();
+  await page.getByRole('cell', { name: 'PO0014' }).click();
   await loadTab(page, 'Line Items');
   await openExportDialog(page);
   await page.getByRole('button', { name: 'Export', exact: true }).click();

--- a/src/frontend/tests/pui_printing.spec.ts
+++ b/src/frontend/tests/pui_printing.spec.ts
@@ -62,7 +62,7 @@ test('Printing - Report Printing', async ({ browser }) => {
   await loadTab(page, 'Purchase Orders');
   await activateTableView(page);
 
-  await page.getByRole('cell', { name: 'PO0009' }).click();
+  await page.getByRole('cell', { name: 'PO0013' }).click();
 
   // Select "print report"
   await page.getByLabel('action-menu-printing-actions').click();


### PR DESCRIPTION
Adds option for default table filters to be applied to a given table view.

This sets the "initial" filterset, without overriding user selected filtering. For a "new" setup, these filters are applied. Once cleared, they remain cleared (as per the user request).

This is useful to by default hide inactive items, completed orders, etc.