### PR TITLE
[UI] Default locale

### DIFF
--- a/docs/docs/concepts/user_interface.md
+++ b/docs/docs/concepts/user_interface.md
@@ -291,3 +291,11 @@ Users may opt to disable the spotlight search functionality if they do not find 
 Many aspects of the user interface are controlled by user permissions, which determine what actions and features are available to each user based on their assigned roles and permissions within the system. This allows for a highly customizable user experience, where different users can have access to different features and functionality based on their specific needs and responsibilities within the organization.
 
 If a user does not have permission to access a particular feature or section of the system, that feature will be hidden from their view in the user interface. This helps to ensure that users only see the features and information that are relevant to their role, reducing clutter and improving usability.
+
+## Language Support
+
+The InvenTree user interface supports multiple languages, allowing users to interact with the system in their preferred language.
+
+The default system language can by configured by the system administrator in the [server configuration options](../start/config.md#basic-options).
+
+Additionally, users can select their preferred language in their [user settings](../settings/user.md), allowing them to override the system default language with their own choice. This provides a personalized experience for each user, ensuring that they can interact with the system in the language they are most comfortable with.

--- a/docs/docs/concepts/user_interface.md
+++ b/docs/docs/concepts/user_interface.md
@@ -296,6 +296,6 @@ If a user does not have permission to access a particular feature or section of 
 
 The InvenTree user interface supports multiple languages, allowing users to interact with the system in their preferred language.
 
-The default system language can by configured by the system administrator in the [server configuration options](../start/config.md#basic-options).
+The default system language can be configured by the system administrator in the [server configuration options](../start/config.md#basic-options).
 
 Additionally, users can select their preferred language in their [user settings](../settings/user.md), allowing them to override the system default language with their own choice. This provides a personalized experience for each user, ensuring that they can interact with the system in the language they are most comfortable with.

--- a/src/frontend/src/components/calendar/Calendar.tsx
+++ b/src/frontend/src/components/calendar/Calendar.tsx
@@ -29,6 +29,10 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
+import {
+  defaultLocale,
+  getPriorityLocale
+} from '../../contexts/LanguageContext';
 import type { CalendarState } from '../../hooks/UseCalendar';
 import { useLocalState } from '../../states/LocalState';
 import { FilterSelectDrawer } from '../../tables/FilterSelectDrawer';
@@ -60,7 +64,19 @@ export default function Calendar({
   const [locale] = useLocalState(useShallow((s) => [s.language]));
 
   // Ensure underscore is replaced with dash
-  const calendarLocale = useMemo(() => locale?.replace('_', '-'), [locale]);
+  const calendarLocale = useMemo(() => {
+    let _locale: string | null = locale;
+
+    if (!_locale) {
+      _locale = getPriorityLocale();
+    }
+
+    _locale = _locale || defaultLocale;
+
+    _locale = _locale.replace('_', '-');
+
+    return _locale;
+  }, [locale]);
 
   const selectMonth = useCallback(
     (date: DateValue) => {

--- a/src/frontend/src/components/calendar/Calendar.tsx
+++ b/src/frontend/src/components/calendar/Calendar.tsx
@@ -60,7 +60,7 @@ export default function Calendar({
   const [locale] = useLocalState(useShallow((s) => [s.language]));
 
   // Ensure underscore is replaced with dash
-  const calendarLocale = useMemo(() => locale.replace('_', '-'), [locale]);
+  const calendarLocale = useMemo(() => locale?.replace('_', '-'), [locale]);
 
   const selectMonth = useCallback(
     (date: DateValue) => {

--- a/src/frontend/src/components/items/LanguageSelect.tsx
+++ b/src/frontend/src/components/items/LanguageSelect.tsx
@@ -1,6 +1,7 @@
 import { Select } from '@mantine/core';
 import { useEffect, useState } from 'react';
 
+import { t } from '@lingui/core/macro';
 import { useShallow } from 'zustand/react/shallow';
 import { getSupportedLanguages } from '../../contexts/LanguageContext';
 import { useLocalState } from '../../states/LocalState';
@@ -27,14 +28,22 @@ export function LanguageSelect({ width = 80 }: Readonly<{ width?: number }>) {
       label: languages[key as string]
     }));
     setLangOptions(newLangOptions);
+
     setValue(locale);
   }, [locale]);
 
   return (
     <Select
       w={width}
-      data={langOptions}
+      data={[
+        {
+          value: '',
+          label: t`Default Language`
+        },
+        ...langOptions
+      ]}
       value={value}
+      defaultValue={''}
       onChange={setValue}
       searchable
       aria-label='Select language'

--- a/src/frontend/src/components/items/LanguageSelect.tsx
+++ b/src/frontend/src/components/items/LanguageSelect.tsx
@@ -3,7 +3,10 @@ import { useEffect, useState } from 'react';
 
 import { t } from '@lingui/core/macro';
 import { useShallow } from 'zustand/react/shallow';
-import { getSupportedLanguages } from '../../contexts/LanguageContext';
+import {
+  activateLocale,
+  getSupportedLanguages
+} from '../../contexts/LanguageContext';
 import { useLocalState } from '../../states/LocalState';
 
 export function LanguageSelect({ width = 80 }: Readonly<{ width?: number }>) {
@@ -28,8 +31,8 @@ export function LanguageSelect({ width = 80 }: Readonly<{ width?: number }>) {
       label: languages[key as string]
     }));
     setLangOptions(newLangOptions);
-
     setValue(locale);
+    activateLocale(locale); // Ensure the locale is activated on component load
   }, [locale]);
 
   return (

--- a/src/frontend/src/components/plugins/PluginContext.tsx
+++ b/src/frontend/src/components/plugins/PluginContext.tsx
@@ -18,6 +18,7 @@ import {
   type InvenTreePluginContext
 } from '@lib/types/Plugins';
 import { i18n } from '@lingui/core';
+import { defaultLocale } from '../../contexts/LanguageContext';
 import {
   useAddStockItem,
   useAssignStockItem,
@@ -35,10 +36,12 @@ import {
   useDeleteApiFormModal,
   useEditApiFormModal
 } from '../../hooks/UseForm';
+import { useServerApiState } from '../../states/ServerApiState';
 import { RenderInstance } from '../render/Instance';
 
 export const useInvenTreeContext = () => {
   const [locale, host] = useLocalState(useShallow((s) => [s.language, s.host]));
+  const [server] = useServerApiState(useShallow((s) => [s.server]));
   const navigate = useNavigate();
   const user = useUserState();
   const { colorScheme } = useMantineColorScheme();
@@ -57,7 +60,7 @@ export const useInvenTreeContext = () => {
       user: user,
       host: host,
       i18n: i18n,
-      locale: locale,
+      locale: locale || server.default_locale || defaultLocale,
       api: api,
       queryClient: queryClient,
       navigate: navigate,

--- a/src/frontend/src/contexts/LanguageContext.tsx
+++ b/src/frontend/src/contexts/LanguageContext.tsx
@@ -176,19 +176,17 @@ export function LanguageContext({
   return <I18nProvider i18n={i18n}>{children}</I18nProvider>;
 }
 
+// This function is used to determine the locale to activate based on the prioritization rules.
+export function getPriorityLocale(): string {
+  const serverDefault = useServerApiState.getState().server.default_locale;
+  const userDefault = useLocalState.getState().language;
+
+  return userDefault || serverDefault || defaultLocale;
+}
+
 export async function activateLocale(locale: string | null) {
   if (!locale) {
-    // No locale provided, iterate through priority list
-    const serverDefault = useServerApiState.getState().server.default_locale;
-    const userDefault = useLocalState.getState().language;
-
-    if (userDefault) {
-      locale = userDefault;
-    } else if (serverDefault) {
-      locale = serverDefault;
-    } else {
-      locale = defaultLocale;
-    }
+    locale = getPriorityLocale();
   }
 
   const localeDir = locale.split('-')[0]; // Extract the base locale (e.g., 'en' from 'en-US')

--- a/src/frontend/src/contexts/LanguageContext.tsx
+++ b/src/frontend/src/contexts/LanguageContext.tsx
@@ -84,7 +84,6 @@ export function LanguageContext({
     }
 
     if (locale != activeLocale) {
-      console.info('Changing locale from', activeLocale, 'to', locale);
       setActiveLocale(locale);
       activateLocale(locale);
     }

--- a/src/frontend/src/contexts/ThemeContext.tsx
+++ b/src/frontend/src/contexts/ThemeContext.tsx
@@ -1,6 +1,10 @@
 import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react';
-import { MantineProvider, createTheme } from '@mantine/core';
+import {
+  MantineProvider,
+  type MantineThemeOverride,
+  createTheme
+} from '@mantine/core';
 import { ModalsProvider } from '@mantine/modals';
 import { Notifications } from '@mantine/notifications';
 import { ContextMenuProvider } from 'mantine-contextmenu';
@@ -20,23 +24,31 @@ export function ThemeContext({
 }: Readonly<{ children: JSX.Element }>) {
   const [userTheme] = useLocalState(useShallow((state) => [state.userTheme]));
 
+  let customUserTheme: MantineThemeOverride | undefined = undefined;
+
   // Theme
-  const myTheme = createTheme({
-    primaryColor: userTheme.primaryColor,
-    white: userTheme.whiteColor,
-    black: userTheme.blackColor,
-    defaultRadius: userTheme.radius,
-    breakpoints: {
-      xs: '30em',
-      sm: '48em',
-      md: '64em',
-      lg: '74em',
-      xl: '90em'
-    }
-  });
+  try {
+    customUserTheme = createTheme({
+      primaryColor: userTheme.primaryColor,
+      white: userTheme.whiteColor,
+      black: userTheme.blackColor,
+      defaultRadius: userTheme.radius,
+      breakpoints: {
+        xs: '30em',
+        sm: '48em',
+        md: '64em',
+        lg: '74em',
+        xl: '90em'
+      }
+    });
+  } catch (error) {
+    console.error('Error creating theme with user settings:', error);
+    // Fallback to default theme if there's an error
+    customUserTheme = undefined;
+  }
 
   return (
-    <MantineProvider theme={myTheme} colorSchemeManager={colorSchema}>
+    <MantineProvider theme={customUserTheme} colorSchemeManager={colorSchema}>
       <ContextMenuProvider>
         <LanguageContext>
           <ModalsProvider

--- a/src/frontend/src/states/LocalState.tsx
+++ b/src/frontend/src/states/LocalState.tsx
@@ -17,8 +17,8 @@ interface LocalStateProps {
   hostKey: string;
   hostList: HostList;
   setHostList: (newHostList: HostList) => void;
-  language: string;
-  setLanguage: (newLanguage: string, noPatch?: boolean) => void;
+  language: string | null;
+  setLanguage: (newLanguage: string | null, noPatch?: boolean) => void;
   userTheme: UserTheme;
   setTheme: (
     newValues: {
@@ -78,7 +78,7 @@ export const useLocalState = create<LocalStateProps>()(
       hostKey: '',
       hostList: {},
       setHostList: (newHostList) => set({ hostList: newHostList }),
-      language: 'en',
+      language: null,
       setLanguage: (newLanguage, noPatch = false) => {
         set({ language: newLanguage });
         if (!noPatch) patchUser('language', newLanguage);


### PR DESCRIPTION
As part of the investigation for https://github.com/inventree/InvenTree/issues/11408 I discovered that the server default locale is not honored in the user interface.

This PR adds the following:

- Ensure that the UI language initially defaults to the server "default locale" setting
- Add a user profile option to select "default language"