### PR TITLE
Add poppler-utils to packager.io dependencies

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -20,6 +20,7 @@ before:
   - contrib/packager.io/before.sh
 dependencies:
   - curl
+  - poppler-utils
   - "python3.11 | python3.12 | python3.13 | python3.14"
   - "python3.11-venv | python3.12-venv | python3.13-venv | python3.14-venv"
   - "python3.11-dev | python3.12-dev | python3.13-dev | python3.14-dev"


### PR DESCRIPTION
Required for label printing - pdf2image cannot convert PDFs to images without poppler's pdfinfo binary being present on the system.

fixes https://github.com/inventree/InvenTree/issues/11506