### PR TITLE
Fix table for s3 backup in docs

### DIFF
--- a/docs/docs/start/config.md
+++ b/docs/docs/start/config.md
@@ -401,14 +401,10 @@ It is also possible to use alternative storage backends for static and media fil
 | Environment Variable | Configuration File | Description | Default |
 | --- | --- | --- | --- |
 | INVENTREE_S3_ACCESS_KEY | storage.s3.access_key | Access key | *Not specified* |
-| INVENTREE_S3_SECRET_KEY | storage.s3.secret_key | Secret key |
-| *Not specified* |
-| INVENTREE_S3_BUCKET_NAME | storage.s3.bucket_name | Bucket name, required by most providers |
-| *Not specified* |
-| INVENTREE_S3_REGION_NAME | storage.s3.region_name | S3 region name |
-| *Not specified* |
-| INVENTREE_S3_ENDPOINT_URL | storage.s3.endpoint_url | Custom S3 endpoint URL, defaults to AWS endpoints if not set |
-| *Not specified* |
+| INVENTREE_S3_SECRET_KEY | storage.s3.secret_key | Secret key | *Not specified* |
+| INVENTREE_S3_BUCKET_NAME | storage.s3.bucket_name | Bucket name, required by most providers | *Not specified* |
+| INVENTREE_S3_REGION_NAME | storage.s3.region_name | S3 region name | *Not specified* |
+| INVENTREE_S3_ENDPOINT_URL | storage.s3.endpoint_url | Custom S3 endpoint URL, defaults to AWS endpoints if not set | *Not specified* |
 | INVENTREE_S3_LOCATION | storage.s3.location | Sub-Location that should be used | inventree-server |
 | INVENTREE_S3_DEFAULT_ACL | storage.s3.default_acl | Default ACL for uploaded files, defaults to provider default if not set | *Not specified* |
 | INVENTREE_S3_VERIFY_SSL | storage.s3.verify_ssl | Verify SSL certificate for S3 endpoint | True |


### PR DESCRIPTION
The default value for some options for s3 backup configuration are on a seperate line. This moves them to the correct position.