### PR TITLE
Disable broken unit test

### DIFF
--- a/src/backend/InvenTree/plugin/samples/supplier/test_supplier_sample.py
+++ b/src/backend/InvenTree/plugin/samples/supplier/test_supplier_sample.py
@@ -69,8 +69,11 @@ class SampleSupplierTest(InvenTreeAPITestCase):
         self.assertEqual(len(res.data), 15)
         self.assertEqual(res.data[0]['sku'], 'BOLT-Steel-M5-5')
 
-    def test_import_part(self):
-        """Test importing a part by supplier."""
+    def _disabled_test_import_part(self):
+        """Test importing a part by supplier.
+
+        Note: This test is disabled for the 1.2.x branch, as a fix has not been back-ported for the broken test
+        """
         # Activate plugin
         plugin = registry.get_plugin('samplesupplier', active=None)
         config = plugin.plugin_config()


### PR DESCRIPTION
- Test is broken due to some changes in the github rate limiting.
- Test has been fixed in master
- Disabling the test for the 1.2.x branch