### PR TITLE
Fix error generation on failed background task

### DIFF
--- a/src/backend/InvenTree/InvenTree/models.py
+++ b/src/backend/InvenTree/InvenTree/models.py
@@ -1410,32 +1410,22 @@ def after_failed_task(sender, instance: Task, created: bool, **kwargs):
     """Callback when a new task failure log is generated."""
     from django.conf import settings
 
+    from InvenTree.exceptions import log_error
+
     max_attempts = int(settings.Q_CLUSTER.get('max_attempts', 5))
     n = instance.attempt_count
 
     # Only notify once the maximum number of attempts has been reached
     if not instance.success and n >= max_attempts:
-        try:
-            url = InvenTree.helpers_model.construct_absolute_url(
-                reverse(
-                    'admin:django_q_failure_change', kwargs={'object_id': instance.pk}
-                )
-            )
-        except (ValueError, NoReverseMatch):
-            url = ''
+        # Create a new Error object associated with this failed task
+        # This will, in turn, trigger a notification to staff users via the Error post_save signal
 
-        # Function name
-        f = instance.func
-
-        notify_staff_users_of_error(
-            instance,
-            'inventree.task_failure',
-            {
-                'failure': instance,
-                'name': _('Task Failure'),
-                'message': _(f"Background worker task '{f}' failed after {n} attempts"),
-                'link': url,
-            },
+        log_error(
+            'task_failure',
+            scope='worker',
+            error_name='Task Failure',
+            error_info=f"Task '{instance.pk}' failed after {n} attempts",
+            error_data=str(instance.result) if instance.result else '',
         )
 
 

--- a/src/backend/InvenTree/InvenTree/test_tasks.py
+++ b/src/backend/InvenTree/InvenTree/test_tasks.py
@@ -234,11 +234,8 @@ class InvenTreeTaskTests(PluginRegistryMixin, TestCase):
 
         msg = NotificationMessage.objects.last()
 
-        self.assertEqual(msg.name, 'Task Failure')
-        self.assertEqual(
-            msg.message,
-            "Background worker task 'InvenTree.tasks.failed_task' failed after 10 attempts",
-        )
+        self.assertEqual(msg.name, 'Server Error')
+        self.assertEqual(msg.message, 'An error has been logged by the server.')
 
     def test_delete_old_emails(self):
         """Test the delete_old_emails task."""


### PR DESCRIPTION
- Fixes bug which prevent error from being logged if a background task fails multiple times
- Now correctly notifies admin users of an error condition, if the background task fails completely
- Should help to prevent failed tasks going unnoticed