### PR TITLE
feat(backend): add inventree version to every response

### DIFF
--- a/src/backend/InvenTree/InvenTree/middleware.py
+++ b/src/backend/InvenTree/InvenTree/middleware.py
@@ -19,7 +19,11 @@ from error_report.middleware import ExceptionProcessor
 from common.settings import get_global_setting
 from InvenTree.cache import create_session_cache, delete_session_cache
 from InvenTree.config import CONFIG_LOOKUPS, inventreeInstaller
-from InvenTree.version import inventreeVersion
+from InvenTree.version import (
+    inventreeApiVersion,
+    inventreePythonVersion,
+    inventreeVersion,
+)
 from users.models import ApiToken
 
 logger = structlog.get_logger('inventree')
@@ -402,4 +406,7 @@ class InvenTreeVersionHeaderMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         """Add the InvenTree version header to the response."""
         response['X-InvenTree-Version'] = inventreeVersion()
+        response['X-InvenTree-API'] = inventreeApiVersion()
+        response['X-InvenTree-Python'] = inventreePythonVersion()
+        response['X-InvenTree-Installer'] = inventreeInstaller()
         return response

--- a/src/backend/InvenTree/InvenTree/middleware.py
+++ b/src/backend/InvenTree/InvenTree/middleware.py
@@ -19,6 +19,7 @@ from error_report.middleware import ExceptionProcessor
 from common.settings import get_global_setting
 from InvenTree.cache import create_session_cache, delete_session_cache
 from InvenTree.config import CONFIG_LOOKUPS, inventreeInstaller
+from InvenTree.version import inventreeVersion
 from users.models import ApiToken
 
 logger = structlog.get_logger('inventree')
@@ -393,3 +394,12 @@ class InvenTreeHostSettingsMiddleware(MiddlewareMixin):
 
         # All checks passed
         return None
+
+
+class InvenTreeVersionHeaderMiddleware(MiddlewareMixin):
+    """Middleware to add the InvenTree version header to all responses."""
+
+    def process_response(self, request, response):
+        """Add the InvenTree version header to the response."""
+        response['X-InvenTree-Version'] = inventreeVersion()
+        return response

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -372,6 +372,7 @@ MIDDLEWARE = CONFIG.get(
         'InvenTree.middleware.InvenTreeRequestCacheMiddleware',  # Request caching
         'InvenTree.middleware.InvenTreeHostSettingsMiddleware',  # Ensuring correct hosting/security settings
         'django_structlog.middlewares.RequestMiddleware',  # Structured logging
+        'InvenTree.middleware.InvenTreeVersionHeaderMiddleware',
     ],
 )
 


### PR DESCRIPTION
Having a header with the version on response objects helps with making client-side checks for correct parsing easier and can help reduce the number of required calls in stateless CLI usage as there is no need to call /api/ to determine API version. 