### PR TITLE
Receive virtual parts

### DIFF
--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1038,6 +1038,14 @@ class PurchaseOrder(TotalPriceMixin, Order):
 
             base_part = supplier_part.part
 
+            # Update the line item quantity
+            line.received += quantity
+            line_items_to_update.append(line)
+
+            if base_part.virtual:
+                # Virtual parts are not received into stock, so skip the rest of the loop
+                continue
+
             stock_location = item.get('location', location) or line.get_destination()
 
             # Calculate the received quantity in base part units
@@ -1143,10 +1151,6 @@ class PurchaseOrder(TotalPriceMixin, Order):
                     new_item.assign_barcode(barcode_data=barcode, save=False)
 
                 bulk_create_items.append(new_item)
-
-            # Update the line item quantity
-            line.received += quantity
-            line_items_to_update.append(line)
 
         # Bulk create new stock items
         if len(bulk_create_items) > 0:

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1042,8 +1042,23 @@ class PurchaseOrder(TotalPriceMixin, Order):
             line.received += quantity
             line_items_to_update.append(line)
 
+            # Extract optional serial numbers
+            serials = item.get('serials', None)
+
+            if serials and type(serials) is list and len(serials) > 0:
+                serialize = True
+            else:
+                serialize = False
+                serials = [None]
+
             if base_part.virtual:
                 # Virtual parts are not received into stock, so skip the rest of the loop
+
+                if serialize:
+                    raise ValidationError(
+                        _('Serial numbers cannot be assigned to virtual parts')
+                    )
+
                 continue
 
             stock_location = item.get('location', location) or line.get_destination()
@@ -1059,15 +1074,6 @@ class PurchaseOrder(TotalPriceMixin, Order):
                     purchase_price = convert_money(purchase_price, default_currency)
             else:
                 purchase_price = None
-
-            # Extract optional serial numbers
-            serials = item.get('serials', None)
-
-            if serials and type(serials) is list and len(serials) > 0:
-                serialize = True
-            else:
-                serialize = False
-                serials = [None]
 
             # Construct dataset for creating a new StockItem instances
             stock_data = {

--- a/src/backend/InvenTree/order/test_api.py
+++ b/src/backend/InvenTree/order/test_api.py
@@ -1336,6 +1336,33 @@ class PurchaseOrderReceiveTest(OrderTest):
         # Check that the expected number of stock items has been created
         self.assertEqual(n + 4, StockItem.objects.count())
 
+    def test_virtual(self):
+        """Test receipt of "virtual" items (i.e. items which do not create a StockItem)."""
+        line = models.PurchaseOrderLineItem.objects.get(pk=1)
+        base_part = line.part.part
+        base_part.virtual = True
+        base_part.save()
+
+        self.assertEqual(line.received, 0)
+
+        data = {
+            'items': [{'line_item': line.pk, 'quantity': line.quantity}],
+            'location': 1,
+        }
+
+        N_ITEMS = base_part.stock_entries().count()
+        N_STOCK = base_part.get_stock_count()
+
+        self.post(self.url, data, expected_code=201)
+
+        # No new stock items should have been created
+        self.assertEqual(base_part.stock_entries().count(), N_ITEMS)
+        self.assertEqual(base_part.get_stock_count(), N_STOCK)
+
+        # Check that the line item has been fully received
+        line.refresh_from_db()
+        self.assertEqual(line.received, line.quantity)
+
 
 class SalesOrderTest(OrderTest):
     """Tests for the SalesOrder API."""

--- a/src/backend/InvenTree/order/test_api.py
+++ b/src/backend/InvenTree/order/test_api.py
@@ -1345,13 +1345,27 @@ class PurchaseOrderReceiveTest(OrderTest):
 
         self.assertEqual(line.received, 0)
 
+        N_ITEMS = base_part.stock_entries().count()
+        N_STOCK = base_part.get_stock_count()
+
+        # Try with serial numbers (expect to fail)
+        data = {
+            'items': [{'line_item': line.pk, 'quantity': 1, 'serial_numbers': '999'}],
+            'location': 1,
+        }
+
+        response = self.post(self.url, data, expected_code=400)
+
+        self.assertIn(
+            'Serial numbers cannot be assigned to virtual parts',
+            str(response.data['non_field_errors']),
+        )
+
+        # Try without serial numbers (expect to succeed)
         data = {
             'items': [{'line_item': line.pk, 'quantity': line.quantity}],
             'location': 1,
         }
-
-        N_ITEMS = base_part.stock_entries().count()
-        N_STOCK = base_part.get_stock_count()
 
         self.post(self.url, data, expected_code=201)
 

--- a/src/frontend/src/forms/PartForms.tsx
+++ b/src/frontend/src/forms/PartForms.tsx
@@ -106,7 +106,7 @@ export function usePartFields({
     };
 
     // Additional fields for creation
-    if (create) {
+    if (create && !virtual) {
       fields.copy_category_parameters = {};
 
       if (virtual != false) {

--- a/src/frontend/src/forms/PurchaseOrderForms.tsx
+++ b/src/frontend/src/forms/PurchaseOrderForms.tsx
@@ -1,9 +1,12 @@
 import { t } from '@lingui/core/macro';
 import {
+  ActionIcon,
+  Alert,
   Container,
   Flex,
   FocusTrap,
   Group,
+  HoverCard,
   Modal,
   Table,
   TextInput
@@ -15,6 +18,7 @@ import {
   IconCoins,
   IconCurrencyDollar,
   IconHash,
+  IconInfoCircle,
   IconLink,
   IconList,
   IconNotes,
@@ -488,6 +492,12 @@ function LineItemFormRow({
     return text;
   }, [location]);
 
+  // Handle virtual parts
+  const virtual = useMemo(
+    () => record.part_detail?.virtual ?? false,
+    [record.part_detail]
+  );
+
   return (
     <>
       <Modal
@@ -506,14 +516,30 @@ function LineItemFormRow({
       </Modal>
       <Table.Tr>
         <Table.Td>
-          <Flex gap='sm' align='center'>
-            <Thumbnail
-              size={40}
-              src={record.part_detail.thumbnail}
-              align='center'
-            />
-            <div>{record.part_detail.name}</div>
-          </Flex>
+          <Group gap='xs' justify='space-between'>
+            <Group gap='xs' justify='left'>
+              <Thumbnail
+                size={40}
+                src={record.part_detail.thumbnail}
+                align='center'
+              />
+              <div>{record.part_detail.name}</div>
+            </Group>
+            {virtual && (
+              <HoverCard>
+                <HoverCard.Target>
+                  <ActionIcon color='blue' variant='transparent'>
+                    <IconInfoCircle />
+                  </ActionIcon>
+                </HoverCard.Target>
+                <HoverCard.Dropdown>
+                  <Alert color='blue' title={t`Virtual Part`}>
+                    {t`This part is virtual, no physical stock will be received.`}
+                  </Alert>
+                </HoverCard.Dropdown>
+              </HoverCard>
+            )}
+          </Group>
         </Table.Td>
         <Table.Td>{record.supplier_part_detail.SKU}</Table.Td>
         <Table.Td>
@@ -546,6 +572,7 @@ function LineItemFormRow({
               tooltip={t`Set Location`}
               tooltipAlignment='top'
               variant={locationOpen ? 'outline' : 'transparent'}
+              disabled={virtual}
             />
             <ActionButton
               size='sm'
@@ -554,6 +581,7 @@ function LineItemFormRow({
               tooltip={t`Assign Batch Code`}
               tooltipAlignment='top'
               variant={batchOpen ? 'outline' : 'transparent'}
+              disabled={virtual}
             />
             {trackable && (
               <ActionButton
@@ -563,6 +591,7 @@ function LineItemFormRow({
                 tooltip={t`Assign Serial Numbers`}
                 tooltipAlignment='top'
                 variant={serialOpen ? 'outline' : 'transparent'}
+                disabled={virtual}
               />
             )}
 
@@ -574,6 +603,7 @@ function LineItemFormRow({
                 tooltip={t`Set Expiry Date`}
                 tooltipAlignment='top'
                 variant={expiryDateOpen ? 'outline' : 'transparent'}
+                disabled={virtual}
               />
             )}
             <ActionButton
@@ -583,6 +613,7 @@ function LineItemFormRow({
               tooltipAlignment='top'
               onClick={() => packagingHandlers.toggle()}
               variant={packagingOpen ? 'outline' : 'transparent'}
+              disabled={virtual}
             />
             <ActionButton
               onClick={() => statusHandlers.toggle()}
@@ -590,6 +621,7 @@ function LineItemFormRow({
               tooltip={t`Change Status`}
               tooltipAlignment='top'
               variant={statusOpen ? 'outline' : 'transparent'}
+              disabled={virtual}
             />
             <ActionButton
               icon={<InvenTreeIcon icon='note' />}
@@ -597,6 +629,7 @@ function LineItemFormRow({
               tooltipAlignment='top'
               variant={noteOpen ? 'outline' : 'transparent'}
               onClick={() => noteHandlers.toggle()}
+              disabled={virtual}
             />
             {barcode ? (
               <ActionButton
@@ -606,6 +639,7 @@ function LineItemFormRow({
                 variant='filled'
                 color='red'
                 onClick={() => setBarcode(undefined)}
+                disabled={virtual}
               />
             ) : (
               <ActionButton
@@ -614,6 +648,7 @@ function LineItemFormRow({
                 tooltipAlignment='top'
                 variant='transparent'
                 onClick={() => open()}
+                disabled={virtual}
               />
             )}
           </Flex>

--- a/src/frontend/src/tables/part/PartTable.tsx
+++ b/src/frontend/src/tables/part/PartTable.tsx
@@ -281,11 +281,7 @@ function partTableFilters(): TableFilter[] {
       name: 'virtual',
       label: t`Virtual`,
       description: t`Filter by parts which are virtual`,
-      type: 'choice',
-      choices: [
-        { value: 'true', label: t`Virtual` },
-        { value: 'false', label: t`Not Virtual` }
-      ]
+      type: 'boolean'
     },
     {
       name: 'is_template',

--- a/src/frontend/tests/pages/pui_company.spec.ts
+++ b/src/frontend/tests/pages/pui_company.spec.ts
@@ -82,13 +82,13 @@ test('Company - Supplier Parts', async ({ browser }) => {
   await loadTab(page, 'Supplier Parts');
   await clearTableFilters(page);
 
-  await page.getByText('- 25 / 777').waitFor();
+  await page.getByText(/1 \- 25 \/ 77\d/).waitFor();
 
   await setTableChoiceFilter(page, 'Primary', 'Yes');
-  await page.getByText('- 25 / 318').waitFor();
+  await page.getByText(/1 \- 25 \/ 31\d/).waitFor();
 
   await clearTableFilters(page);
 
   await setTableChoiceFilter(page, 'Primary', 'No');
-  await page.getByText('- 25 / 459').waitFor();
+  await page.getByText(/1 \- 25 \/ 45\d/).waitFor();
 });

--- a/src/frontend/tests/pages/pui_purchase_order.spec.ts
+++ b/src/frontend/tests/pages/pui_purchase_order.spec.ts
@@ -500,6 +500,39 @@ test('Purchase Orders - Receive Items', async ({ browser }) => {
   await page.getByRole('cell', { name: 'my-batch-code' }).first().waitFor();
 });
 
+test('Purchase Orders - Receive Virtual Items', async ({ browser }) => {
+  const page = await doCachedLogin(browser, {
+    url: 'purchasing/purchase-order/19'
+  });
+
+  // Duplicate this order
+  await page.getByRole('button', { name: 'action-menu-order-actions' }).click();
+  await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+  await page.getByRole('button', { name: 'Submit' }).click();
+  await page.getByRole('tab', { name: 'Order Details' }).waitFor();
+
+  // Issue the new order
+  await page.getByRole('button', { name: 'Issue Order' }).click();
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  // Receive the line item
+  await loadTab(page, 'Line Items');
+  await page.getByRole('checkbox', { name: 'Select all records' }).click();
+  await page
+    .getByRole('button', { name: 'action-button-receive-items' })
+    .click();
+
+  await page
+    .getByRole('combobox', { name: 'related-field-location' })
+    .fill('factory');
+  await page.getByText('Factory/Storage Room A').click();
+
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  // 1/1 items received
+  await page.getByText('1 / 1', { exact: true }).waitFor();
+});
+
 test('Purchase Orders - Duplicate', async ({ browser }) => {
   const page = await doCachedLogin(browser, {
     url: 'purchasing/purchase-order/13/detail'


### PR DESCRIPTION
- Fix logic for receiving "virtual" parts against a purchase order
- Update the line item with the required received quantity
- Do not actually create any new stock items

### Tasks

- [x] Implement logic
- [x] Update unit test
- [x] Add virtual purchaseable part to the demo dataset - https://github.com/inventree/demo-dataset/pull/105
- [x] Add playwright testing