### PR TITLE
Enforce deterministic ordering for plugin settings

### DIFF
--- a/src/backend/InvenTree/machine/api.py
+++ b/src/backend/InvenTree/machine/api.py
@@ -97,6 +97,10 @@ class MachineSettingList(APIView):
             )
             all_settings.extend(list(settings_dict.values()))
 
+        # Sort settings by the 'key' field before returning,
+        # to ensure a deterministic order in the API response
+        all_settings = sorted(all_settings, key=lambda x: x.key)
+
         results = MachineSerializers.MachineSettingSerializer(
             all_settings, many=True
         ).data

--- a/src/backend/InvenTree/plugin/api.py
+++ b/src/backend/InvenTree/plugin/api.py
@@ -380,8 +380,12 @@ class PluginAllSettingList(APIView):
             settings_definition=settings, plugin=plugin.plugin_config()
         )
 
+        # Sort settings by the 'key' field before returning,
+        # to ensure a deterministic order in the API response
+        settings_values = sorted(settings_dict.values(), key=lambda x: x.key)
+
         results = PluginSerializers.PluginSettingSerializer(
-            list(settings_dict.values()), many=True
+            settings_values, many=True
         ).data
         return Response(results)
 
@@ -444,8 +448,12 @@ class PluginUserSettingList(APIView):
             user=request.user,
         )
 
+        # Sort settings by the 'key' field before returning,
+        # to ensure a deterministic order in the API response
+        settings_values = sorted(settings_dict.values(), key=lambda x: x.key0)
+
         results = PluginSerializers.PluginUserSettingSerializer(
-            list(settings_dict.values()), many=True
+            settings_values, many=True
         ).data
         return Response(results)
 

--- a/src/backend/InvenTree/plugin/api.py
+++ b/src/backend/InvenTree/plugin/api.py
@@ -450,7 +450,7 @@ class PluginUserSettingList(APIView):
 
         # Sort settings by the 'key' field before returning,
         # to ensure a deterministic order in the API response
-        settings_values = sorted(settings_dict.values(), key=lambda x: x.key0)
+        settings_values = sorted(settings_dict.values(), key=lambda x: x.key)
 
         results = PluginSerializers.PluginUserSettingSerializer(
             settings_values, many=True


### PR DESCRIPTION
- Plugin settings display in a "random" order in the UI
- Unlike built-in settings we cannot enumerate them ahead of time
- Editing a setting can cause the order of displayed settings to change
- This PR enforces a standard enumeration order in the API (based on KEY property)