### PR TITLE
fix(backend): API description ordering more deterministic

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -9,7 +9,6 @@ INVENTREE_API_TEXT = """
 v468 -> 2026-03-31 : https://github.com/inventree/InvenTree/pull/11649
     - Add ordering to contetype related fields - no functional changes
 
-
 v467 -> 2026-03-20 : https://github.com/inventree/InvenTree/pull/11573
     - Fix definition for the "parent" field on the StockItemSerializer
 

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,14 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 467
+INVENTREE_API_VERSION = 468
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v468 -> 2026-03-31 : https://github.com/inventree/InvenTree/pull/11649
+    - Add ordering to contetype related fields - no functional changes
+
 
 v467 -> 2026-03-20 : https://github.com/inventree/InvenTree/pull/11573
     - Fix definition for the "parent" field on the StockItemSerializer

--- a/src/backend/InvenTree/InvenTree/helpers_model.py
+++ b/src/backend/InvenTree/InvenTree/helpers_model.py
@@ -288,6 +288,8 @@ def getModelsWithMixin(mixin_class) -> list:
     models_with_mixin = [
         x for x in db_models if x is not None and issubclass(x, mixin_class)
     ]
+    # sort to make resulting list deterministic (and easier to test)
+    models_with_mixin.sort(key=lambda x: x._meta.label_lower)
 
     # Store the result in the session cache
     set_session_cache(cache_key, models_with_mixin)


### PR DESCRIPTION
This makes references to content types sorted by label (appname.modelname) by default, should help make the API schema more predictable - see https://github.com/inventree/InvenTree/pull/11641#issuecomment-4161467935