### PR TITLE
Worker debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,9 @@
       "program": "${workspaceFolder}/src/backend/InvenTree/manage.py",
       "args": [
         "runserver",
-        "0.0.0.0:8000"
+        "0.0.0.0:8000",
+        // "--sync",// Synchronize worker tasks to foreground thread
+        // "--noreload", // disable auto-reload
       ],
       "django": true,
       "justMyCode": false

--- a/docs/docs/develop/devcontainer.md
+++ b/docs/docs/develop/devcontainer.md
@@ -60,7 +60,12 @@ If you only need a superuser, run the `superuser` task. It should prompt you for
 
 #### Run background workers
 
-If you need to process your queue with background workers, run the `worker` task. This is a foreground task which will execute in the terminal.
+If you need to process your queue with background workers, open a new terminal and run the `worker` task with `invoke worker`. This is a foreground task which will execute in the terminal.
+
+If you are developing functions that will be executed by background workers there are a few debugging options.
+
+- If the workers are started with the `worker` task you can add `print` or `logger` statements to the code and monitor the output in the terminal.
+- All tasks can be forced to run in the foreground worker by temporarily changing the Q_CLUSTER settings (in settings.py) - and set sync=True. With this setting you do not need to start the background worker at all, instead you start the `InvenTree Server` from the `Run and Debug` side panel as described in the [Running InvenTree](#running-inventree) section. As all task will now run in one single process you can set breakpoints, inspect variables and single step also tasks that normally will be offloaded to background workers. It should be noted that with this setting the GUI will be unresponsive while tasks are executed.
 
 ### Running InvenTree
 

--- a/docs/docs/develop/devcontainer.md
+++ b/docs/docs/develop/devcontainer.md
@@ -62,10 +62,10 @@ If you only need a superuser, run the `superuser` task. It should prompt you for
 
 If you need to process your queue with background workers, open a new terminal and run the `worker` task with `invoke worker`. This is a foreground task which will execute in the terminal.
 
-If you are developing functions that will be executed by background workers there are a few debugging options.
+If you are developing functions that will be executed by background workers there are a two debugging options.
 
 - If the workers are started with the `worker` task you can add `print` or `logger` statements to the code and monitor the output in the terminal.
-- All tasks can be forced to run in the foreground worker by temporarily changing the Q_CLUSTER settings (in settings.py) - and set sync=True. With this setting you do not need to start the background worker at all, instead you start the `InvenTree Server` from the `Run and Debug` side panel as described in the [Running InvenTree](#running-inventree) section. As all task will now run in one single process you can set breakpoints, inspect variables and single step also tasks that normally will be offloaded to background workers. It should be noted that with this setting the GUI will be unresponsive while tasks are executed.
+- All tasks can be forced to run in the foreground worker by uncommenting the `--sync` and `--noreload` arguments under the `InvenTree Server - 3rd party` entry in `.vscode/launch.json`. With this setting you should not start a separate background worker, instead you start the `InvenTree Server - 3rd party` from the `Run and Debug` side panel. All task will now run in one single process and you can set breakpoints, inspect variables and single step also tasks that normally are offloaded to background workers. It should be noted that with this setting the GUI will be unresponsive while tasks are executed.
 
 ### Running InvenTree
 

--- a/docs/docs/plugins/mixins/event.md
+++ b/docs/docs/plugins/mixins/event.md
@@ -13,6 +13,9 @@ When a certain (server-side) event occurs, the background worker passes the even
 
 {{ image("plugin/enable_events.png", "Enable event integration") }}
 
+!!! info "Worker debugging"
+    As the events are offloaded to a background worker debugging the `process_event()` function need some extra consideration. Please see  the [Run background workers](../../develop/devcontainer.md#run-background-workers) section for further information.
+
 ## Events
 
 Events are passed through using a string identifier, e.g. `build.completed`

--- a/src/backend/InvenTree/InvenTree/settings.py
+++ b/src/backend/InvenTree/InvenTree/settings.py
@@ -860,6 +860,16 @@ BACKGROUND_WORKER_ATTEMPTS = int(
     get_setting('INVENTREE_BACKGROUND_MAX_ATTEMPTS', 'background.max_attempts', 5)
 )
 
+# Check if '--sync' was passed in the command line
+if '--sync' in sys.argv and '--noreload' in sys.argv and DEBUG:
+    SYNC_TASKS = True
+else:
+    SYNC_TASKS = False
+
+# Clean up sys.argv so Django doesn't complain about an unknown argument
+if SYNC_TASKS:
+    sys.argv.remove('--sync')
+
 # django-q background worker configuration
 Q_CLUSTER = {
     'name': 'InvenTree',
@@ -874,7 +884,7 @@ Q_CLUSTER = {
     'bulk': 10,
     'orm': 'default',
     'cache': 'default',
-    'sync': False,
+    'sync': SYNC_TASKS,
     'poll': 1.5,
 }
 


### PR DESCRIPTION
Ref #11665

Open questions:

- Should an option to start debugging with the sync=True setting be added and covered in docs update in this PR or is a manual change in settings.py enough for now?
- When I built the docs I noted that the API version in schema.md was also updated from 449 to 470. I see in the repo that the version is 449 but in the documentation it's 470. Should I just dropt that?