### PR TITLE
fix: 补全简体中文未翻译条目 (zh_Hans)

### DIFF
--- a/src/backend/InvenTree/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/src/backend/InvenTree/locale/zh_Hans/LC_MESSAGES/django.po
@@ -165,19 +165,19 @@ msgstr "数据包含禁止的 markdown 内容"
 
 #: InvenTree/helpers_model.py:109
 msgid "Invalid URL: no hostname"
-msgstr ""
+msgstr "无效 URL：无主机名"
 
 #: InvenTree/helpers_model.py:114
 msgid "Invalid URL: hostname could not be resolved"
-msgstr ""
+msgstr "无效 URL：无法解析主机名"
 
 #: InvenTree/helpers_model.py:120
 msgid "URL points to a private or reserved IP address"
-msgstr ""
+msgstr "URL 指向私有或保留 IP 地址"
 
 #: InvenTree/helpers_model.py:195
 msgid "Too many redirects"
-msgstr ""
+msgstr "重定向次数过多"
 
 #: InvenTree/helpers_model.py:200
 msgid "Connection error"
@@ -5063,11 +5063,11 @@ msgstr "项目数量"
 
 #: order/models.py:1801
 msgid "Line Number"
-msgstr ""
+msgstr "行号"
 
 #: order/models.py:1802
 msgid "Line number for this item (optional)"
-msgstr ""
+msgstr "此项目的行号（可选）"
 
 #: order/models.py:1809
 msgid "Line item reference"
@@ -7625,7 +7625,7 @@ msgstr "作为‘TME’的供应商"
 #: plugin/installer.py:240 plugin/installer.py:344 plugin/serializers.py:169
 #: plugin/serializers.py:275
 msgid "Only superuser accounts can administer plugins"
-msgstr ""
+msgstr "只有超级用户账户才能管理插件"
 
 #: plugin/installer.py:243
 msgid "Plugin installation is disabled"
@@ -7633,11 +7633,11 @@ msgstr "插件安装已禁用"
 
 #: plugin/installer.py:273
 msgid "No package name or URL provided for installation"
-msgstr ""
+msgstr "未提供安装所需的包名或 URL"
 
 #: plugin/installer.py:277
 msgid "Invalid characters in package name or URL"
-msgstr ""
+msgstr "包名或 URL 中存在无效字符"
 
 #: plugin/installer.py:287
 msgid "Installed plugin successfully"
@@ -9606,11 +9606,11 @@ msgstr "用户的电子邮件地址"
 
 #: users/serializers.py:244
 msgid "User must be authenticated"
-msgstr ""
+msgstr "用户必须经过身份验证"
 
 #: users/serializers.py:253
 msgid "Only a superuser can create a token for another user"
-msgstr ""
+msgstr "只有超级用户才能为其他用户创建令牌"
 
 #: users/serializers.py:322
 msgid "Administrator"
@@ -9654,11 +9654,11 @@ msgstr "覆盖有关密码规则的警告"
 
 #: users/serializers.py:410
 msgid "Staff"
-msgstr ""
+msgstr "职员"
 
 #: users/serializers.py:411
 msgid "Does this user have staff permissions"
-msgstr ""
+msgstr "此用户是否具有职员权限"
 
 #: users/serializers.py:461
 msgid "You do not have permission to create users"

--- a/src/backend/InvenTree/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/src/backend/InvenTree/locale/zh_Hans/LC_MESSAGES/django.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: inventree\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-08 09:17+0000\n"
-"PO-Revision-Date: 2026-04-08 09:20\n"
+"POT-Creation-Date: 2026-02-02 23:23+0000\n"
+"PO-Revision-Date: 2026-02-02 23:26\n"
 "Last-Translator: \n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
@@ -21,35 +21,43 @@ msgstr ""
 msgid "API endpoint not found"
 msgstr "未找到 API 端点"
 
-#: InvenTree/api.py:438
-msgid "List of items must be provided for bulk operation"
-msgstr "批量操作必须提供物料清单"
+#: InvenTree/api.py:442
+msgid "List of items or filters must be provided for bulk operation"
+msgstr "批量操作必须提供物品或过滤器列表"
 
-#: InvenTree/api.py:445
+#: InvenTree/api.py:449
 msgid "Items must be provided as a list"
 msgstr "必须以列表形式提供项目"
 
-#: InvenTree/api.py:453
+#: InvenTree/api.py:457
 msgid "Invalid items list provided"
 msgstr "提供了无效的单位"
 
-#: InvenTree/api.py:458
+#: InvenTree/api.py:463
+msgid "Filters must be provided as a dict"
+msgstr "必须以字典形式提供筛选器"
+
+#: InvenTree/api.py:470
+msgid "Invalid filters provided"
+msgstr "提供了无效的过滤器"
+
+#: InvenTree/api.py:475
 msgid "All filter must only be used with true"
 msgstr "所有过滤器只能使用true"
 
-#: InvenTree/api.py:463
+#: InvenTree/api.py:480
 msgid "No items match the provided criteria"
 msgstr "没有符合所供条件的项目"
 
-#: InvenTree/api.py:487
+#: InvenTree/api.py:504
 msgid "No data provided"
 msgstr "未提供数据"
 
-#: InvenTree/api.py:503
+#: InvenTree/api.py:520
 msgid "This field must be unique."
 msgstr "此字段的值必须是唯一的。"
 
-#: InvenTree/api.py:805
+#: InvenTree/api.py:815
 msgid "User does not have permission to view this model"
 msgstr "用户没有权限查阅当前模型。"
 
@@ -88,7 +96,7 @@ msgid "Could not convert {original} to {unit}"
 msgstr "不能将 {original} 转换到 {unit}"
 
 #: InvenTree/conversion.py:286 InvenTree/conversion.py:300
-#: InvenTree/helpers.py:613 order/models.py:734 order/models.py:1029
+#: InvenTree/helpers.py:597 order/models.py:722 order/models.py:1017
 msgid "Invalid quantity provided"
 msgstr "提供的数量无效"
 
@@ -104,13 +112,13 @@ msgstr "输入日期"
 msgid "Invalid decimal value"
 msgstr "无效的数值"
 
-#: InvenTree/fields.py:218 InvenTree/models.py:1233 build/serializers.py:497
-#: build/serializers.py:568 build/serializers.py:1765 company/models.py:827
-#: order/models.py:1815
+#: InvenTree/fields.py:218 InvenTree/models.py:1233 build/serializers.py:499
+#: build/serializers.py:570 build/serializers.py:1760 company/models.py:798
+#: order/models.py:1782
 #: report/templates/report/inventree_build_order_report.html:172
-#: stock/models.py:2954 stock/models.py:3078 stock/serializers.py:732
-#: stock/serializers.py:908 stock/serializers.py:1050 stock/serializers.py:1378
-#: stock/serializers.py:1467 stock/serializers.py:1666
+#: stock/models.py:2922 stock/models.py:3046 stock/serializers.py:721
+#: stock/serializers.py:897 stock/serializers.py:1039 stock/serializers.py:1357
+#: stock/serializers.py:1446 stock/serializers.py:1645
 msgid "Notes"
 msgstr "备注"
 
@@ -123,91 +131,75 @@ msgstr "值' {name}' 未出现在模式格式中"
 msgid "Provided value does not match required pattern: "
 msgstr "提供的值与所需模式不匹配："
 
-#: InvenTree/helpers.py:617
+#: InvenTree/helpers.py:601
 msgid "Cannot serialize more than 1000 items at once"
 msgstr "无法一次序列化超过 1000 个项目"
 
-#: InvenTree/helpers.py:623
+#: InvenTree/helpers.py:607
 msgid "Empty serial number string"
 msgstr "序列号为空白"
 
-#: InvenTree/helpers.py:652
+#: InvenTree/helpers.py:636
 msgid "Duplicate serial"
 msgstr "重复的序列号"
 
-#: InvenTree/helpers.py:684 InvenTree/helpers.py:727 InvenTree/helpers.py:745
-#: InvenTree/helpers.py:752 InvenTree/helpers.py:771
+#: InvenTree/helpers.py:668 InvenTree/helpers.py:711 InvenTree/helpers.py:729
+#: InvenTree/helpers.py:736 InvenTree/helpers.py:755
 #, python-brace-format
 msgid "Invalid group: {group}"
 msgstr "无效群组: {group}"
 
-#: InvenTree/helpers.py:715
+#: InvenTree/helpers.py:699
 #, python-brace-format
 msgid "Group range {group} exceeds allowed quantity ({expected_quantity})"
 msgstr "组范围 {group} 超出了允许的数量 ({expected_quantity})"
 
-#: InvenTree/helpers.py:781
+#: InvenTree/helpers.py:765
 msgid "No serial numbers found"
 msgstr "未找到序列号"
 
-#: InvenTree/helpers.py:788
+#: InvenTree/helpers.py:772
 #, python-brace-format
 msgid "Number of unique serial numbers ({n}) must match quantity ({q})"
 msgstr "唯一序列号 ({n}) 必须匹配数量 ({q})"
 
-#: InvenTree/helpers.py:918
+#: InvenTree/helpers.py:902
 msgid "Remove HTML tags from this value"
 msgstr "从这个值中删除 HTML 标签"
 
-#: InvenTree/helpers.py:995
+#: InvenTree/helpers.py:981
 msgid "Data contains prohibited markdown content"
 msgstr "数据包含禁止的 markdown 内容"
 
-#: InvenTree/helpers_model.py:109
-msgid "Invalid URL: no hostname"
-msgstr "无效 URL：无主机名"
-
-#: InvenTree/helpers_model.py:114
-msgid "Invalid URL: hostname could not be resolved"
-msgstr "无效 URL：无法解析主机名"
-
-#: InvenTree/helpers_model.py:120
-msgid "URL points to a private or reserved IP address"
-msgstr "URL 指向私有或保留 IP 地址"
-
-#: InvenTree/helpers_model.py:195
-msgid "Too many redirects"
-msgstr "重定向次数过多"
-
-#: InvenTree/helpers_model.py:200
+#: InvenTree/helpers_model.py:139
 msgid "Connection error"
 msgstr "连接错误"
 
-#: InvenTree/helpers_model.py:205 InvenTree/helpers_model.py:214
+#: InvenTree/helpers_model.py:144 InvenTree/helpers_model.py:151
 msgid "Server responded with invalid status code"
 msgstr "服务器响应状态码无效"
 
-#: InvenTree/helpers_model.py:210
+#: InvenTree/helpers_model.py:147
 msgid "Exception occurred"
 msgstr "发生异常"
 
-#: InvenTree/helpers_model.py:220
+#: InvenTree/helpers_model.py:157
 msgid "Server responded with invalid Content-Length value"
 msgstr "服务器响应的内容长度值无效"
 
-#: InvenTree/helpers_model.py:223
+#: InvenTree/helpers_model.py:160
 msgid "Image size is too large"
 msgstr "图片尺寸过大"
 
-#: InvenTree/helpers_model.py:235
+#: InvenTree/helpers_model.py:172
 msgid "Image download exceeded maximum size"
 msgstr "图片下载超出最大尺寸"
 
-#: InvenTree/helpers_model.py:240
+#: InvenTree/helpers_model.py:177
 msgid "Remote server returned empty response"
 msgstr "远程服务器返回了空响应"
 
-#: InvenTree/helpers_model.py:248
+#: InvenTree/helpers_model.py:185
 msgid "Supplied URL is not a valid image file"
 msgstr "提供的 URL 不是一个有效的图片文件"
 
@@ -215,11 +207,11 @@ msgstr "提供的 URL 不是一个有效的图片文件"
 msgid "Log in to the app"
 msgstr "登录应用程序"
 
-#: InvenTree/magic_login.py:41 company/models.py:175 users/serializers.py:201
+#: InvenTree/magic_login.py:41 company/models.py:173 users/serializers.py:201
 msgid "Email"
 msgstr "电子邮件"
 
-#: InvenTree/middleware.py:183
+#: InvenTree/middleware.py:178
 msgid "You must enable two-factor authentication before doing anything else."
 msgstr "您必须启用双重身份验证才能进行后续操作。"
 
@@ -267,29 +259,29 @@ msgstr "参考编号过大"
 msgid "Invalid choice"
 msgstr "无效选项"
 
-#: InvenTree/models.py:1022 common/models.py:1438 common/models.py:1865
-#: common/models.py:2126 common/models.py:2251 common/models.py:2520
-#: common/serializers.py:638 generic/states/serializers.py:20
-#: machine/models.py:25 part/models.py:1101 plugin/models.py:54
-#: report/models.py:216 stock/models.py:86
+#: InvenTree/models.py:1022 common/models.py:1430 common/models.py:1857
+#: common/models.py:2118 common/models.py:2243 common/models.py:2510
+#: common/serializers.py:566 generic/states/serializers.py:20
+#: machine/models.py:25 part/models.py:1108 plugin/models.py:54
+#: report/models.py:216 stock/models.py:84
 msgid "Name"
 msgstr "名称"
 
-#: InvenTree/models.py:1028 build/models.py:265 common/models.py:178
-#: common/models.py:2258 common/models.py:2371 common/models.py:2535
-#: company/models.py:558 company/models.py:818 order/models.py:447
-#: order/models.py:1860 part/models.py:1124 report/models.py:222
+#: InvenTree/models.py:1028 build/models.py:253 common/models.py:175
+#: common/models.py:2250 common/models.py:2363 common/models.py:2525
+#: company/models.py:551 company/models.py:789 order/models.py:444
+#: order/models.py:1827 part/models.py:1131 report/models.py:222
 #: report/models.py:815 report/models.py:841
 #: report/templates/report/inventree_build_order_report.html:117
-#: stock/models.py:92
+#: stock/models.py:90
 msgid "Description"
 msgstr "描述"
 
-#: InvenTree/models.py:1029 stock/models.py:93
+#: InvenTree/models.py:1029 stock/models.py:91
 msgid "Description (optional)"
 msgstr "描述（选填）"
 
-#: InvenTree/models.py:1044 common/models.py:2841
+#: InvenTree/models.py:1044 common/models.py:2831
 msgid "Path"
 msgstr "路径"
 
@@ -321,66 +313,75 @@ msgstr "条码数据的唯一哈希值"
 msgid "Existing barcode found"
 msgstr "检测到已存在条码"
 
-#: InvenTree/models.py:1453
+#: InvenTree/models.py:1435
+msgid "Task Failure"
+msgstr "任务失败"
+
+#: InvenTree/models.py:1436
+#, python-brace-format
+msgid "Background worker task '{f}' failed after {n} attempts"
+msgstr "后台工作任务“{f}”在 {n} 次尝试后失败"
+
+#: InvenTree/models.py:1463
 msgid "Server Error"
 msgstr "服务器错误"
 
-#: InvenTree/models.py:1454
+#: InvenTree/models.py:1464
 msgid "An error has been logged by the server."
 msgstr "服务器记录了一个错误。"
 
-#: InvenTree/models.py:1496 common/models.py:1776
+#: InvenTree/models.py:1506 common/models.py:1768
 #: report/templates/report/inventree_bill_of_materials_report.html:126
 #: report/templates/report/inventree_bill_of_materials_report.html:148
 #: report/templates/report/inventree_return_order_report.html:35
 msgid "Image"
 msgstr "图像"
 
-#: InvenTree/serializers.py:324 part/models.py:4168
+#: InvenTree/serializers.py:327 part/models.py:4189
 msgid "Must be a valid number"
 msgstr "必须是有效数字"
 
-#: InvenTree/serializers.py:366 company/models.py:217 part/models.py:3307
+#: InvenTree/serializers.py:369 company/models.py:215 part/models.py:3330
 msgid "Currency"
 msgstr "货币"
 
-#: InvenTree/serializers.py:369 part/serializers.py:1355
+#: InvenTree/serializers.py:372 part/serializers.py:1231
 msgid "Select currency from available options"
 msgstr "从可用选项中选择货币"
 
-#: InvenTree/serializers.py:719
+#: InvenTree/serializers.py:726
 msgid "This field may not be null."
 msgstr "此字段不能为空。"
 
-#: InvenTree/serializers.py:725
+#: InvenTree/serializers.py:732
 msgid "Invalid value"
 msgstr "无效值"
 
-#: InvenTree/serializers.py:762
+#: InvenTree/serializers.py:769
 msgid "Remote Image"
 msgstr "远程图片"
 
-#: InvenTree/serializers.py:763
+#: InvenTree/serializers.py:770
 msgid "URL of remote image file"
 msgstr "远程图片文件的 URL"
 
-#: InvenTree/serializers.py:781
+#: InvenTree/serializers.py:788
 msgid "Downloading images from remote URL is not enabled"
 msgstr "未启用从远程 URL下载图片"
 
-#: InvenTree/serializers.py:788
+#: InvenTree/serializers.py:795
 msgid "Failed to download image from remote URL"
 msgstr "从远程URL下载图像失败"
 
-#: InvenTree/serializers.py:871
+#: InvenTree/serializers.py:878
 msgid "Invalid content type format"
 msgstr "无效的内容类型格式"
 
-#: InvenTree/serializers.py:874
+#: InvenTree/serializers.py:881
 msgid "Content type not found"
 msgstr "未找到内容类型"
 
-#: InvenTree/serializers.py:880
+#: InvenTree/serializers.py:887
 msgid "Content type does not match required mixin class"
 msgstr "内容类型不匹配所需的 mixin 类"
 
@@ -536,11 +537,11 @@ msgstr "中文 (简体)"
 msgid "Chinese (Traditional)"
 msgstr "中文 (繁体)"
 
-#: InvenTree/tasks.py:678
+#: InvenTree/tasks.py:576
 msgid "Update Available"
 msgstr "有可用更新"
 
-#: InvenTree/tasks.py:679
+#: InvenTree/tasks.py:577
 msgid "An update for InvenTree is available"
 msgstr "InvenTree有可用更新"
 
@@ -552,30 +553,30 @@ msgstr "无效的物理单位"
 msgid "Not a valid currency code"
 msgstr "无效的货币代码"
 
-#: build/api.py:55 order/api.py:114 order/api.py:281 order/api.py:1384
-#: order/serializers.py:123
+#: build/api.py:54 order/api.py:116 order/api.py:275 order/api.py:1370
+#: order/serializers.py:122
 msgid "Order Status"
 msgstr "订单状态"
 
-#: build/api.py:81 build/models.py:277
+#: build/api.py:80 build/models.py:265
 msgid "Parent Build"
 msgstr "父级生产订单"
 
-#: build/api.py:85 build/api.py:904 order/api.py:558 order/api.py:783
-#: order/api.py:1185 order/api.py:1486 stock/api.py:572
+#: build/api.py:84 build/api.py:824 order/api.py:551 order/api.py:774
+#: order/api.py:1171 order/api.py:1446 stock/api.py:573
 msgid "Include Variants"
 msgstr "包含变体"
 
-#: build/api.py:101 build/api.py:461 build/api.py:918 build/models.py:283
-#: build/serializers.py:1205 build/serializers.py:1376
-#: build/serializers.py:1462 company/models.py:1037 company/serializers.py:435
-#: order/api.py:309 order/api.py:313 order/api.py:940 order/api.py:1198
-#: order/api.py:1201 order/models.py:1978 order/models.py:2146
-#: order/models.py:2147 part/api.py:1132 part/api.py:1135 part/api.py:1348
-#: part/models.py:527 part/models.py:3318 part/models.py:3461
-#: part/models.py:3519 part/models.py:3540 part/models.py:3562
-#: part/models.py:3703 part/models.py:3965 part/models.py:4384
-#: part/serializers.py:1304 part/serializers.py:1926
+#: build/api.py:100 build/api.py:456 build/api.py:838 build/models.py:271
+#: build/serializers.py:1215 build/serializers.py:1371
+#: build/serializers.py:1457 company/models.py:1008 company/serializers.py:434
+#: order/api.py:303 order/api.py:307 order/api.py:930 order/api.py:1184
+#: order/api.py:1187 order/models.py:1943 order/models.py:2109
+#: order/models.py:2110 part/api.py:1160 part/api.py:1163 part/api.py:1318
+#: part/models.py:528 part/models.py:3341 part/models.py:3484
+#: part/models.py:3542 part/models.py:3563 part/models.py:3585
+#: part/models.py:3724 part/models.py:3986 part/models.py:4405
+#: part/serializers.py:1790
 #: report/templates/report/inventree_bill_of_materials_report.html:110
 #: report/templates/report/inventree_bill_of_materials_report.html:137
 #: report/templates/report/inventree_build_order_report.html:109
@@ -584,9 +585,9 @@ msgstr "包含变体"
 #: report/templates/report/inventree_sales_order_report.html:27
 #: report/templates/report/inventree_sales_order_shipment_report.html:28
 #: report/templates/report/inventree_stock_location_report.html:102
-#: stock/api.py:585 stock/api.py:1529 stock/serializers.py:120
-#: stock/serializers.py:172 stock/serializers.py:419 stock/serializers.py:602
-#: stock/serializers.py:941 templates/email/build_order_completed.html:17
+#: stock/api.py:586 stock/serializers.py:120 stock/serializers.py:172
+#: stock/serializers.py:410 stock/serializers.py:591 stock/serializers.py:930
+#: templates/email/build_order_completed.html:17
 #: templates/email/build_order_required_stock.html:17
 #: templates/email/low_stock_notification.html:15
 #: templates/email/overdue_build_order.html:16
@@ -595,197 +596,192 @@ msgstr "包含变体"
 msgid "Part"
 msgstr "零件"
 
-#: build/api.py:121 build/api.py:124 build/serializers.py:1475 part/api.py:967
-#: part/api.py:1359 part/models.py:412 part/models.py:1142 part/models.py:3590
-#: part/serializers.py:1314 part/serializers.py:1742 stock/api.py:868
+#: build/api.py:120 build/api.py:123 build/serializers.py:1470 part/api.py:975
+#: part/api.py:1329 part/models.py:413 part/models.py:1149 part/models.py:3613
+#: part/serializers.py:1606 stock/api.py:869
 msgid "Category"
 msgstr "类别"
 
-#: build/api.py:132 build/api.py:136
+#: build/api.py:131 build/api.py:135
 msgid "Ancestor Build"
 msgstr "可测试部分"
 
-#: build/api.py:153 order/api.py:132
+#: build/api.py:152 order/api.py:134
 msgid "Assigned to me"
 msgstr "分配给我"
 
-#: build/api.py:168
+#: build/api.py:167
 msgid "Assigned To"
 msgstr "负责人"
 
-#: build/api.py:203
+#: build/api.py:202
 msgid "Created before"
 msgstr "创建时间早于"
 
-#: build/api.py:207
+#: build/api.py:206
 msgid "Created after"
 msgstr "创建时间晚于"
 
-#: build/api.py:211
+#: build/api.py:210
 msgid "Has start date"
 msgstr "有开始日期"
 
-#: build/api.py:219
+#: build/api.py:218
 msgid "Start date before"
 msgstr "开始日期早于"
 
-#: build/api.py:223
+#: build/api.py:222
 msgid "Start date after"
 msgstr "开始日期晚于"
 
-#: build/api.py:227
+#: build/api.py:226
 msgid "Has target date"
 msgstr "有目标日期"
 
-#: build/api.py:235
+#: build/api.py:234
 msgid "Target date before"
 msgstr "目标日期早于"
 
-#: build/api.py:239
+#: build/api.py:238
 msgid "Target date after"
 msgstr "目标日期晚于"
 
-#: build/api.py:243
+#: build/api.py:242
 msgid "Completed before"
 msgstr "完成日期早于"
 
-#: build/api.py:247
+#: build/api.py:246
 msgid "Completed after"
 msgstr "完成日期晚于"
 
-#: build/api.py:250 order/api.py:237
+#: build/api.py:249 order/api.py:231
 msgid "Min Date"
 msgstr "最小日期"
 
-#: build/api.py:273 order/api.py:256
+#: build/api.py:272 order/api.py:250
 msgid "Max Date"
 msgstr "最大日期"
 
-#: build/api.py:298 build/api.py:301 part/api.py:197 stock/api.py:960
+#: build/api.py:297 build/api.py:300 part/api.py:212 stock/api.py:961
 msgid "Exclude Tree"
 msgstr "排除树"
 
-#: build/api.py:400
+#: build/api.py:395
 msgid "Build must be cancelled before it can be deleted"
 msgstr "生产订单必须取消后才能删除"
 
-#: build/api.py:444 build/serializers.py:1406 part/models.py:3999
+#: build/api.py:439 build/serializers.py:1401 part/models.py:4020
 msgid "Consumable"
 msgstr "耗材"
 
-#: build/api.py:447 build/serializers.py:1409 part/models.py:3993
+#: build/api.py:442 build/serializers.py:1404 part/models.py:4014
 msgid "Optional"
 msgstr "可选项"
 
-#: build/api.py:450 build/serializers.py:1449 common/setting/system.py:471
-#: part/models.py:1247 part/serializers.py:1696 part/serializers.py:1715
-#: stock/api.py:638
+#: build/api.py:445 build/serializers.py:1444 common/setting/system.py:470
+#: part/models.py:1271 part/serializers.py:1560 part/serializers.py:1579
+#: stock/api.py:639
 msgid "Assembly"
 msgstr "装配件"
 
-#: build/api.py:453
+#: build/api.py:448
 msgid "Tracked"
 msgstr "可追溯"
 
-#: build/api.py:456 build/serializers.py:1412 part/models.py:1265
+#: build/api.py:451 build/serializers.py:1407 part/models.py:1289
 msgid "Testable"
 msgstr "需检测"
 
-#: build/api.py:466 order/api.py:1004 order/api.py:1374
+#: build/api.py:461 order/api.py:994 order/api.py:1360
 msgid "Order Outstanding"
 msgstr "未结算订单"
 
-#: build/api.py:476 build/serializers.py:1502 order/api.py:963
+#: build/api.py:471 build/serializers.py:1497 order/api.py:953
 msgid "Allocated"
 msgstr "已分配"
 
-#: build/api.py:485 build/models.py:1786 build/serializers.py:1425
+#: build/api.py:480 build/models.py:1672 build/serializers.py:1420
 msgid "Consumed"
 msgstr "已消耗"
 
-#: build/api.py:494 company/models.py:882 company/serializers.py:414
+#: build/api.py:489 company/models.py:853 company/serializers.py:413
 #: templates/email/build_order_required_stock.html:19
 #: templates/email/low_stock_notification.html:17
 #: templates/email/part_event_notification.html:18
 msgid "Available"
 msgstr "可用数量"
 
-#: build/api.py:518 build/serializers.py:1504 company/serializers.py:411
-#: order/serializers.py:1284 part/serializers.py:849 part/serializers.py:1170
-#: part/serializers.py:1751
+#: build/api.py:513 build/serializers.py:1499 company/serializers.py:410
+#: order/serializers.py:1270 part/serializers.py:831 part/serializers.py:1152
+#: part/serializers.py:1615
 msgid "On Order"
 msgstr "已订购"
 
-#: build/api.py:671
-msgid "Build not found"
-msgstr "未找到版本"
-
-#: build/api.py:941 build/models.py:120 order/models.py:2011
+#: build/api.py:861 build/models.py:118 order/models.py:1976
 #: report/templates/report/inventree_build_order_report.html:105
 #: stock/serializers.py:93 templates/email/build_order_completed.html:16
 #: templates/email/overdue_build_order.html:15
 msgid "Build Order"
 msgstr "生产订单"
 
-#: build/api.py:955 build/api.py:959 build/serializers.py:360
-#: build/serializers.py:485 build/serializers.py:555 build/serializers.py:1253
-#: build/serializers.py:1258 order/api.py:1245 order/api.py:1250
-#: order/serializers.py:804 order/serializers.py:944 order/serializers.py:2031
-#: part/serializers.py:1324 stock/api.py:986 stock/serializers.py:111
-#: stock/serializers.py:609 stock/serializers.py:725 stock/serializers.py:903
-#: stock/serializers.py:1460 stock/serializers.py:1781
-#: stock/serializers.py:1830 templates/email/stale_stock_notification.html:18
-#: users/models.py:549
+#: build/api.py:875 build/api.py:879 build/serializers.py:362
+#: build/serializers.py:487 build/serializers.py:557 build/serializers.py:1248
+#: build/serializers.py:1253 order/api.py:1231 order/api.py:1236
+#: order/serializers.py:791 order/serializers.py:931 order/serializers.py:2039
+#: stock/api.py:987 stock/serializers.py:111 stock/serializers.py:598
+#: stock/serializers.py:714 stock/serializers.py:892 stock/serializers.py:1439
+#: stock/serializers.py:1760 stock/serializers.py:1809
+#: templates/email/stale_stock_notification.html:18 users/models.py:549
 msgid "Location"
 msgstr "库存位置"
 
-#: build/api.py:967 part/serializers.py:1349
+#: build/api.py:887
 msgid "Output"
 msgstr "产出"
 
-#: build/api.py:969
+#: build/api.py:889
 msgid "Filter by output stock item ID. Use 'null' to find uninstalled build items."
 msgstr "按产出库存项ID筛选，使用“null”查找未安装的生产项。"
 
-#: build/models.py:121 users/ruleset.py:31
+#: build/models.py:119 users/ruleset.py:31
 msgid "Build Orders"
 msgstr "生产订单"
 
-#: build/models.py:181
+#: build/models.py:169
 msgid "Assembly BOM has not been validated"
 msgstr "装配物料清单尚未验证"
 
-#: build/models.py:188
+#: build/models.py:176
 msgid "Build order cannot be created for an inactive part"
 msgstr "无法为未激活的零件创建生产订单"
 
-#: build/models.py:195
+#: build/models.py:183
 msgid "Build order cannot be created for an unlocked part"
 msgstr "无法为已解锁的零件创建生产订单"
 
-#: build/models.py:213
+#: build/models.py:201
 msgid "Build orders can only be externally fulfilled for purchaseable parts"
 msgstr "生产订单仅能通过外部采购可购买零件来完成"
 
-#: build/models.py:220 order/models.py:373
+#: build/models.py:208 order/models.py:370
 msgid "Responsible user or group must be specified"
 msgstr "必须指定负责的用户或组"
 
-#: build/models.py:225
+#: build/models.py:213
 msgid "Build order part cannot be changed"
 msgstr "生产订单关联零件不可变更"
 
-#: build/models.py:230 order/models.py:386
+#: build/models.py:218 order/models.py:383
 msgid "Target date must be after start date"
 msgstr "目标日期必须在开始日期之后"
 
-#: build/models.py:258
+#: build/models.py:246
 msgid "Build Order Reference"
 msgstr "生产订单编号"
 
-#: build/models.py:259 build/serializers.py:1403 order/models.py:628
-#: order/models.py:1337 order/models.py:1808 order/models.py:2744
-#: part/models.py:4039
+#: build/models.py:247 build/serializers.py:1398 order/models.py:616
+#: order/models.py:1313 order/models.py:1775 order/models.py:2713
+#: part/models.py:4060
 #: report/templates/report/inventree_bill_of_materials_report.html:139
 #: report/templates/report/inventree_purchase_order_report.html:35
 #: report/templates/report/inventree_return_order_report.html:26
@@ -793,234 +789,230 @@ msgstr "生产订单编号"
 msgid "Reference"
 msgstr "编号"
 
-#: build/models.py:268
+#: build/models.py:256
 msgid "Brief description of the build (optional)"
 msgstr "生产订单的简要说明（可选）"
 
-#: build/models.py:278
+#: build/models.py:266
 msgid "Build Order to which this build is allocated"
 msgstr "该生产订单所属的上级生产订单"
 
-#: build/models.py:287
+#: build/models.py:275
 msgid "Select part to build"
 msgstr "选择要生产的零件"
 
-#: build/models.py:292
+#: build/models.py:280
 msgid "Sales Order Reference"
 msgstr "销售订单编号"
 
-#: build/models.py:297
+#: build/models.py:285
 msgid "Sales Order to which this build is allocated"
 msgstr "该生产订单关联的销售订单"
 
-#: build/models.py:302 build/serializers.py:1085
+#: build/models.py:290 build/serializers.py:1087
 msgid "Source Location"
 msgstr "源库位"
 
-#: build/models.py:308
+#: build/models.py:296
 msgid "Select location to take stock from for this build (leave blank to take from any stock location)"
 msgstr "指定本次生产领料的来源库位（留空可从任意库位调拨）"
 
-#: build/models.py:314
+#: build/models.py:302
 msgid "External Build"
 msgstr "外协生产"
 
-#: build/models.py:315
+#: build/models.py:303
 msgid "This build order is fulfilled externally"
 msgstr "该生产订单由外部供应商完成"
 
-#: build/models.py:320
+#: build/models.py:308
 msgid "Destination Location"
 msgstr "目标库位"
 
-#: build/models.py:325
+#: build/models.py:313
 msgid "Select location where the completed items will be stored"
 msgstr "选择生产完成品的存放库位"
 
-#: build/models.py:329
+#: build/models.py:317
 msgid "Build Quantity"
 msgstr "生产数量"
 
-#: build/models.py:332
+#: build/models.py:320
 msgid "Number of stock items to build"
 msgstr "需要生产的库存品数量"
 
-#: build/models.py:336
+#: build/models.py:324
 msgid "Completed items"
 msgstr "已完成项目"
 
-#: build/models.py:338
+#: build/models.py:326
 msgid "Number of stock items which have been completed"
 msgstr "已完成并入库的库存物品数量"
 
-#: build/models.py:342
+#: build/models.py:330
 msgid "Build Status"
 msgstr "生产状态"
 
-#: build/models.py:347
+#: build/models.py:335
 msgid "Build status code"
 msgstr "生产状态代码"
 
-#: build/models.py:356 build/serializers.py:347 order/serializers.py:820
-#: stock/models.py:1107 stock/serializers.py:85 stock/serializers.py:1633
+#: build/models.py:344 build/serializers.py:349 order/serializers.py:807
+#: stock/models.py:1102 stock/serializers.py:85 stock/serializers.py:1612
 msgid "Batch Code"
 msgstr "批号"
 
-#: build/models.py:360 build/serializers.py:348
+#: build/models.py:348 build/serializers.py:350
 msgid "Batch code for this build output"
 msgstr "本批产出的批次编号"
 
-#: build/models.py:364 order/models.py:484 order/serializers.py:166
-#: part/models.py:1328
+#: build/models.py:352 order/models.py:481 order/serializers.py:165
+#: part/models.py:1352
 msgid "Creation Date"
 msgstr "建立日期"
 
-#: build/models.py:370
+#: build/models.py:358
 msgid "Build start date"
 msgstr "生产开始日期"
 
-#: build/models.py:371
+#: build/models.py:359
 msgid "Scheduled start date for this build order"
 msgstr "此生产订单的计划开始日期"
 
-#: build/models.py:377
+#: build/models.py:365
 msgid "Target completion date"
 msgstr "计划完成日期"
 
-#: build/models.py:379
+#: build/models.py:367
 msgid "Target date for build completion. Build will be overdue after this date."
 msgstr "生产订单的计划完成时间，逾期后系统将标记为超期。"
 
-#: build/models.py:384 order/models.py:681 order/models.py:2783
+#: build/models.py:372 order/models.py:669 order/models.py:2752
 msgid "Completion Date"
 msgstr "完成日期"
 
-#: build/models.py:392
+#: build/models.py:380
 msgid "completed by"
 msgstr "完成人"
 
-#: build/models.py:401
+#: build/models.py:389
 msgid "Issued by"
 msgstr "发起人"
 
-#: build/models.py:402
+#: build/models.py:390
 msgid "User who issued this build order"
 msgstr "创建该生产订单的用户"
 
-#: build/models.py:411 common/models.py:187 order/api.py:182
-#: order/models.py:516 part/models.py:1345
+#: build/models.py:399 common/models.py:184 order/api.py:184
+#: order/models.py:506 part/models.py:1369
 #: report/templates/report/inventree_build_order_report.html:158
 msgid "Responsible"
 msgstr "责任方"
 
-#: build/models.py:412
+#: build/models.py:400
 msgid "User or group responsible for this build order"
 msgstr "该生产订单的责任人或责任团队"
 
-#: build/models.py:417 stock/models.py:1100
+#: build/models.py:405 stock/models.py:1095
 msgid "External Link"
 msgstr "外部链接"
 
-#: build/models.py:419 common/models.py:2014 part/models.py:1176
-#: stock/models.py:1102
+#: build/models.py:407 common/models.py:2006 part/models.py:1183
+#: stock/models.py:1097
 msgid "Link to external URL"
 msgstr "指向外部资源的URL链接"
 
-#: build/models.py:424
+#: build/models.py:412
 msgid "Build Priority"
 msgstr "生产优先级"
 
-#: build/models.py:427
+#: build/models.py:415
 msgid "Priority of this build order"
 msgstr "此生产订单的优先级"
 
-#: build/models.py:435 common/models.py:157 common/models.py:171
-#: order/api.py:168 order/models.py:456 order/models.py:1840
+#: build/models.py:423 common/models.py:154 common/models.py:168
+#: order/api.py:170 order/models.py:453 order/models.py:1807
 msgid "Project Code"
 msgstr "项目编号"
 
-#: build/models.py:436
+#: build/models.py:424
 msgid "Project code for this build order"
 msgstr "该生产订单归属的项目编号"
 
-#: build/models.py:689
+#: build/models.py:677
 msgid "Cannot complete build order with open child builds"
 msgstr "无法完成生产订单，存在未关闭的子生产订单"
 
-#: build/models.py:694
+#: build/models.py:682
 msgid "Cannot complete build order with incomplete outputs"
 msgstr "无法完成生产订单，存在未完成的产出项"
 
-#: build/models.py:713 build/models.py:843
+#: build/models.py:701 build/models.py:831
 msgid "Failed to offload task to complete build allocations"
 msgstr "生产分配任务卸载失败"
 
-#: build/models.py:736
+#: build/models.py:724
 #, python-brace-format
 msgid "Build order {build} has been completed"
 msgstr "生产订单 {build} 已完成"
 
-#: build/models.py:742
+#: build/models.py:730
 msgid "A build order has been completed"
 msgstr "生产订单已完成"
 
-#: build/models.py:924 build/serializers.py:395
+#: build/models.py:912 build/serializers.py:397
 msgid "Serial numbers must be provided for trackable parts"
 msgstr "可追溯零件必须填写序列号"
 
-#: build/models.py:1016 build/models.py:1103
+#: build/models.py:1043 build/models.py:1130
 msgid "No build output specified"
 msgstr "未指定产出"
 
-#: build/models.py:1019
+#: build/models.py:1046
 msgid "Build output is already completed"
 msgstr "产出已完成"
 
-#: build/models.py:1022
+#: build/models.py:1049
 msgid "Build output does not match Build Order"
 msgstr "产出与生产订单不匹配"
 
-#: build/models.py:1110 build/models.py:1216 build/serializers.py:273
-#: build/serializers.py:323 build/serializers.py:953 build/serializers.py:1716
-#: order/models.py:731 order/serializers.py:615 order/serializers.py:815
-#: part/serializers.py:1689 stock/models.py:947 stock/models.py:1437
-#: stock/models.py:1902 stock/serializers.py:703 stock/serializers.py:1622
+#: build/models.py:1137 build/models.py:1235 build/serializers.py:275
+#: build/serializers.py:325 build/serializers.py:955 build/serializers.py:1711
+#: order/models.py:719 order/serializers.py:602 order/serializers.py:802
+#: part/serializers.py:1554 stock/models.py:942 stock/models.py:1432
+#: stock/models.py:1889 stock/serializers.py:692 stock/serializers.py:1601
 msgid "Quantity must be greater than zero"
 msgstr "数量必须大于零"
 
-#: build/models.py:1114 build/models.py:1221 build/serializers.py:278
+#: build/models.py:1141 build/models.py:1240 build/serializers.py:280
 msgid "Quantity cannot be greater than the output quantity"
 msgstr "数量不能大于产出数量"
 
-#: build/models.py:1189 build/serializers.py:594
+#: build/models.py:1215 build/serializers.py:596
 msgid "Build output has not passed all required tests"
 msgstr "产出未通过所有必要测试"
 
-#: build/models.py:1192 build/serializers.py:589
+#: build/models.py:1218 build/serializers.py:591
 #, python-brace-format
 msgid "Build output {serial} has not passed all required tests"
 msgstr "产出 {serial} 未通过所有必要测试"
 
-#: build/models.py:1203
-msgid "Allocated stock items are still in production"
-msgstr "已分配的库存物料仍在生产中"
-
-#: build/models.py:1211
+#: build/models.py:1230
 msgid "Cannot partially complete a build output with allocated items"
 msgstr "存在已分配物料时无法部分完成生产输出"
 
-#: build/models.py:1740
+#: build/models.py:1627
 msgid "Build Order Line Item"
 msgstr "生产订单行项目"
 
-#: build/models.py:1765
+#: build/models.py:1651
 msgid "Build object"
 msgstr "生产对象"
 
-#: build/models.py:1777 build/models.py:2102 build/serializers.py:259
-#: build/serializers.py:308 build/serializers.py:1424 common/models.py:1368
-#: order/models.py:1782 order/models.py:2627 order/serializers.py:1683
-#: order/serializers.py:2120 part/models.py:3475 part/models.py:3987
+#: build/models.py:1663 build/models.py:1985 build/serializers.py:261
+#: build/serializers.py:310 build/serializers.py:1419 common/models.py:1360
+#: order/models.py:1758 order/models.py:2598 order/serializers.py:1692
+#: order/serializers.py:2128 part/models.py:3498 part/models.py:4008
 #: report/templates/report/inventree_bill_of_materials_report.html:138
 #: report/templates/report/inventree_build_order_report.html:113
 #: report/templates/report/inventree_purchase_order_report.html:36
@@ -1032,445 +1024,425 @@ msgstr "生产对象"
 #: report/templates/report/inventree_stock_report_merge.html:113
 #: report/templates/report/inventree_test_report.html:90
 #: report/templates/report/inventree_test_report.html:169
-#: stock/serializers.py:136 stock/serializers.py:180 stock/serializers.py:691
+#: stock/serializers.py:136 stock/serializers.py:180 stock/serializers.py:680
 #: templates/email/build_order_completed.html:18
 #: templates/email/stale_stock_notification.html:19
 msgid "Quantity"
 msgstr "数量"
 
-#: build/models.py:1778
+#: build/models.py:1664
 msgid "Required quantity for build order"
 msgstr "生产订单所需数量"
 
-#: build/models.py:1787
+#: build/models.py:1673
 msgid "Quantity of consumed stock"
 msgstr "库存消耗量"
 
-#: build/models.py:1888
+#: build/models.py:1771
 msgid "Build item must specify a build output, as master part is marked as trackable"
 msgstr "生产项必须指定产出，因为主零件已经被标记为可追踪的"
 
-#: build/models.py:1951
+#: build/models.py:1834
 msgid "Selected stock item does not match BOM line"
 msgstr "所选库存项与物料清单行项不匹配"
 
-#: build/models.py:1970
+#: build/models.py:1853
 msgid "Allocated quantity must be greater than zero"
 msgstr "分配的数量必须大于零"
 
-#: build/models.py:1976
+#: build/models.py:1859
 msgid "Quantity must be 1 for serialized stock"
 msgstr "序列化物料的数量必须为1"
 
-#: build/models.py:1986
+#: build/models.py:1869
 #, python-brace-format
 msgid "Allocated quantity ({q}) must not exceed available stock quantity ({a})"
 msgstr "分配数量 ({q}) 不得超过可用库存数量 ({a})"
 
-#: build/models.py:2003 order/models.py:2576
+#: build/models.py:1886 order/models.py:2547
 msgid "Stock item is over-allocated"
 msgstr "库存品项超额分配"
 
-#: build/models.py:2092 build/serializers.py:936 build/serializers.py:1221
-#: order/serializers.py:1520 order/serializers.py:1541
+#: build/models.py:1975 build/serializers.py:938 build/serializers.py:1231
+#: order/serializers.py:1529 order/serializers.py:1550
 #: report/templates/report/inventree_sales_order_shipment_report.html:29
-#: stock/api.py:1417 stock/models.py:445 stock/serializers.py:102
-#: stock/serializers.py:815 stock/serializers.py:1316 stock/serializers.py:1428
+#: stock/api.py:1404 stock/models.py:442 stock/serializers.py:102
+#: stock/serializers.py:804 stock/serializers.py:1295 stock/serializers.py:1407
 msgid "Stock Item"
 msgstr "库存项"
 
-#: build/models.py:2093
+#: build/models.py:1976
 msgid "Source stock item"
 msgstr "源库存项"
 
-#: build/models.py:2103
+#: build/models.py:1986
 msgid "Stock quantity to allocate to build"
 msgstr "分配给该生产任务的库存量"
 
-#: build/models.py:2112
+#: build/models.py:1995
 msgid "Install into"
 msgstr "安裝到"
 
-#: build/models.py:2113
+#: build/models.py:1996
 msgid "Destination stock item"
 msgstr "目标库存项"
 
-#: build/serializers.py:115
+#: build/serializers.py:118
 msgid "Build Level"
 msgstr "生产等级"
 
-#: build/serializers.py:128 part/serializers.py:1256
+#: build/serializers.py:131
 msgid "Part Name"
 msgstr "零件名称"
 
-#: build/serializers.py:207 build/serializers.py:962
+#: build/serializers.py:209 build/serializers.py:964
 msgid "Build Output"
 msgstr "产出"
 
-#: build/serializers.py:219
+#: build/serializers.py:221
 msgid "Build output does not match the parent build"
 msgstr "生产产出与上级订单不匹配"
 
-#: build/serializers.py:223
+#: build/serializers.py:225
 msgid "Output part does not match BuildOrder part"
 msgstr "产出零件与生产订单零件不匹配"
 
-#: build/serializers.py:227
+#: build/serializers.py:229
 msgid "This build output has already been completed"
 msgstr "此产出已经完成"
 
-#: build/serializers.py:241
+#: build/serializers.py:243
 msgid "This build output is not fully allocated"
 msgstr "此产出尚未完全分配"
 
-#: build/serializers.py:260 build/serializers.py:309
+#: build/serializers.py:262 build/serializers.py:311
 msgid "Enter quantity for build output"
 msgstr "输入产出数量"
 
-#: build/serializers.py:331
+#: build/serializers.py:333
 msgid "Integer quantity required for trackable parts"
 msgstr "可追踪的零件数量必须为整数"
 
-#: build/serializers.py:337
+#: build/serializers.py:339
 msgid "Integer quantity required, as the bill of materials contains trackable parts"
 msgstr "因为物料清单包含可追踪的零件，所以数量必须为整数"
 
-#: build/serializers.py:354 order/serializers.py:836 order/serializers.py:1687
-#: stock/serializers.py:714
+#: build/serializers.py:356 order/serializers.py:823 order/serializers.py:1696
+#: stock/serializers.py:703
 msgid "Serial Numbers"
 msgstr "序列号"
 
-#: build/serializers.py:355
+#: build/serializers.py:357
 msgid "Enter serial numbers for build outputs"
 msgstr "输入产出的序列号"
 
-#: build/serializers.py:361
+#: build/serializers.py:363
 msgid "Stock location for build output"
 msgstr "生产产出的库存地点"
 
-#: build/serializers.py:376
+#: build/serializers.py:378
 msgid "Auto Allocate Serial Numbers"
 msgstr "自动分配序列号"
 
-#: build/serializers.py:378
+#: build/serializers.py:380
 msgid "Automatically allocate required items with matching serial numbers"
 msgstr "自动为所需项目分配对应的序列号"
 
-#: build/serializers.py:411 order/serializers.py:922 stock/api.py:1186
-#: stock/models.py:1925
+#: build/serializers.py:413 order/serializers.py:909 stock/api.py:1183
+#: stock/models.py:1912
 msgid "The following serial numbers already exist or are invalid"
 msgstr "以下序列号已存在或无效"
 
-#: build/serializers.py:453 build/serializers.py:509 build/serializers.py:601
+#: build/serializers.py:455 build/serializers.py:511 build/serializers.py:603
 msgid "A list of build outputs must be provided"
 msgstr "必须提供产出清单"
 
-#: build/serializers.py:486
+#: build/serializers.py:488
 msgid "Stock location for scrapped outputs"
 msgstr "报废品库存地点"
 
-#: build/serializers.py:492
+#: build/serializers.py:494
 msgid "Discard Allocations"
 msgstr "放弃分配"
 
-#: build/serializers.py:493
+#: build/serializers.py:495
 msgid "Discard any stock allocations for scrapped outputs"
 msgstr "取消对报废产品的库存分配"
 
-#: build/serializers.py:498
+#: build/serializers.py:500
 msgid "Reason for scrapping build output(s)"
 msgstr "废品产出的原因"
 
-#: build/serializers.py:556
+#: build/serializers.py:558
 msgid "Location for completed build outputs"
 msgstr "完工产出存放库位"
 
-#: build/serializers.py:564
+#: build/serializers.py:566
 msgid "Accept Incomplete Allocation"
 msgstr "接受不完整的分配"
 
-#: build/serializers.py:565
+#: build/serializers.py:567
 msgid "Complete outputs if stock has not been fully allocated"
 msgstr "如果库存尚未全部分配，则完成产出"
 
-#: build/serializers.py:690
+#: build/serializers.py:692
 msgid "Consume Allocated Stock"
 msgstr "消耗已分配库存"
 
-#: build/serializers.py:691
+#: build/serializers.py:693
 msgid "Consume any stock which has already been allocated to this build"
 msgstr "立即扣除已分配给该生产任务的库存"
 
-#: build/serializers.py:697
+#: build/serializers.py:699
 msgid "Remove Incomplete Outputs"
 msgstr "移除未完成的产出"
 
-#: build/serializers.py:698
+#: build/serializers.py:700
 msgid "Delete any build outputs which have not been completed"
 msgstr "删除所有未完成的产出"
 
-#: build/serializers.py:725
+#: build/serializers.py:727
 msgid "Not permitted"
 msgstr "禁止操作"
 
-#: build/serializers.py:726
+#: build/serializers.py:728
 msgid "Accept as consumed by this build order"
 msgstr "标记为当前生产订单消耗"
 
-#: build/serializers.py:727
+#: build/serializers.py:729
 msgid "Deallocate before completing this build order"
 msgstr "完成此生产订单前取消分配"
 
-#: build/serializers.py:754
+#: build/serializers.py:756
 msgid "Overallocated Stock"
 msgstr "超额分配库存"
 
-#: build/serializers.py:757
+#: build/serializers.py:759
 msgid "How do you want to handle extra stock items assigned to the build order"
 msgstr "如何处理分配给生产订单的超额库存"
 
-#: build/serializers.py:768
+#: build/serializers.py:770
 msgid "Some stock items have been overallocated"
 msgstr "存在超额分配的库存项"
 
-#: build/serializers.py:773
+#: build/serializers.py:775
 msgid "Accept Unallocated"
 msgstr "接受未分配"
 
-#: build/serializers.py:775
+#: build/serializers.py:777
 msgid "Accept that stock items have not been fully allocated to this build order"
 msgstr "接受库存项未被完全分配至生产订单"
 
-#: build/serializers.py:786
+#: build/serializers.py:788
 msgid "Required stock has not been fully allocated"
 msgstr "必需库存未完成全量分配"
 
-#: build/serializers.py:791 order/serializers.py:491 order/serializers.py:1588
+#: build/serializers.py:793 order/serializers.py:478 order/serializers.py:1597
 msgid "Accept Incomplete"
 msgstr "接受未完工"
 
-#: build/serializers.py:793
+#: build/serializers.py:795
 msgid "Accept that the required number of build outputs have not been completed"
 msgstr "允许所需数量的产出未完成"
 
-#: build/serializers.py:804
+#: build/serializers.py:806
 msgid "Required build quantity has not been completed"
 msgstr "生产需求数量未完成"
 
-#: build/serializers.py:816
+#: build/serializers.py:818
 msgid "Build order has open child build orders"
 msgstr "生产订单有打开的子生产订单"
 
-#: build/serializers.py:819
+#: build/serializers.py:821
 msgid "Build order must be in production state"
 msgstr "生产订单必须处于生产状态"
 
-#: build/serializers.py:822
+#: build/serializers.py:824
 msgid "Build order has incomplete outputs"
 msgstr "生产订单有未完成的产出"
 
-#: build/serializers.py:861
+#: build/serializers.py:863
 msgid "Build Line"
 msgstr "生产行"
 
-#: build/serializers.py:869
+#: build/serializers.py:871
 msgid "Build output"
 msgstr "产出"
 
-#: build/serializers.py:877
+#: build/serializers.py:879
 msgid "Build output must point to the same build"
 msgstr "生产产出必须指向相同的生产"
 
-#: build/serializers.py:908
+#: build/serializers.py:910
 msgid "Build Line Item"
 msgstr "生产行项目"
 
-#: build/serializers.py:926
+#: build/serializers.py:928
 msgid "bom_item.part must point to the same part as the build order"
 msgstr "bom_item.part 必须与生产订单零件相同"
 
-#: build/serializers.py:942 stock/serializers.py:1329
+#: build/serializers.py:944 stock/serializers.py:1308
 msgid "Item must be in stock"
 msgstr "项目必须在库存中"
 
-#: build/serializers.py:985 order/serializers.py:1574
+#: build/serializers.py:987 order/serializers.py:1583
 #, python-brace-format
 msgid "Available quantity ({q}) exceeded"
 msgstr "可用量 ({q}) 超出限制"
 
-#: build/serializers.py:991
+#: build/serializers.py:993
 msgid "Build output must be specified for allocation of tracked parts"
 msgstr "对于被追踪的零件的分配，必须指定生产产出"
 
-#: build/serializers.py:999
+#: build/serializers.py:1001
 msgid "Build output cannot be specified for allocation of untracked parts"
 msgstr "对于未被追踪的零件，无法指定生产产出"
 
-#: build/serializers.py:1023 order/serializers.py:1847
+#: build/serializers.py:1025 order/serializers.py:1856
 msgid "Allocation items must be provided"
 msgstr "必须提供分配项目"
 
-#: build/serializers.py:1087
+#: build/serializers.py:1089
 msgid "Stock location where parts are to be sourced (leave blank to take from any location)"
 msgstr "零件来源的库存地点(留空则可来源于任何库存地点)"
 
-#: build/serializers.py:1096
+#: build/serializers.py:1098
 msgid "Exclude Location"
 msgstr "排除位置"
 
-#: build/serializers.py:1097
+#: build/serializers.py:1099
 msgid "Exclude stock items from this selected location"
 msgstr "从该选定的库存地点排除库存项"
 
-#: build/serializers.py:1102
+#: build/serializers.py:1104
 msgid "Interchangeable Stock"
 msgstr "可互换库存"
 
-#: build/serializers.py:1103
+#: build/serializers.py:1105
 msgid "Stock items in multiple locations can be used interchangeably"
 msgstr "在多个位置的库存项目可以互换使用"
 
-#: build/serializers.py:1108
+#: build/serializers.py:1110
 msgid "Substitute Stock"
 msgstr "替代品库存"
 
-#: build/serializers.py:1109
+#: build/serializers.py:1111
 msgid "Allow allocation of substitute parts"
 msgstr "允许分配可替换的零件"
 
-#: build/serializers.py:1114
+#: build/serializers.py:1116
 msgid "Optional Items"
 msgstr "可选项目"
 
-#: build/serializers.py:1115
+#: build/serializers.py:1117
 msgid "Allocate optional BOM items to build order"
 msgstr "分配可选的物料清单给生产订单"
 
-#: build/serializers.py:1121
-msgid "All Items"
-msgstr "所有物料"
+#: build/serializers.py:1138
+msgid "Failed to start auto-allocation task"
+msgstr "启动自动分配任务失败"
 
-#: build/serializers.py:1122
-msgid "Untracked Items"
-msgstr "未跟踪的物品"
-
-#: build/serializers.py:1123
-msgid "Tracked Items"
-msgstr "已跟踪的物品"
-
-#: build/serializers.py:1125
-msgid "Item Type"
-msgstr "物品类型"
-
-#: build/serializers.py:1126
-msgid "Select item type to auto-allocate"
-msgstr "选择要自动分配的条目类型"
-
-#: build/serializers.py:1180
+#: build/serializers.py:1190
 msgid "BOM Reference"
 msgstr "物料清单参考"
 
-#: build/serializers.py:1186
+#: build/serializers.py:1196
 msgid "BOM Part ID"
 msgstr "物料清单零件识别号码"
 
-#: build/serializers.py:1193
+#: build/serializers.py:1203
 msgid "BOM Part Name"
 msgstr "物料清单零件名称"
 
-#: build/serializers.py:1242
-msgid "Install Into"
-msgstr "安裝到"
-
-#: build/serializers.py:1269 build/serializers.py:1487
+#: build/serializers.py:1264 build/serializers.py:1482
 msgid "Build"
 msgstr "生产"
 
-#: build/serializers.py:1288 company/models.py:638 order/api.py:322
-#: order/api.py:327 order/api.py:554 order/serializers.py:607
-#: stock/models.py:1043 stock/serializers.py:582
+#: build/serializers.py:1283 company/models.py:628 order/api.py:316
+#: order/api.py:321 order/api.py:547 order/serializers.py:594
+#: stock/models.py:1038 stock/serializers.py:571
 msgid "Supplier Part"
 msgstr "供应商零件"
 
-#: build/serializers.py:1304 stock/serializers.py:635
+#: build/serializers.py:1299 stock/serializers.py:624
 msgid "Allocated Quantity"
 msgstr "已分配数量"
 
-#: build/serializers.py:1371
+#: build/serializers.py:1366
 msgid "Build Reference"
 msgstr "生产订单编号"
 
-#: build/serializers.py:1381
+#: build/serializers.py:1376
 msgid "Part Category Name"
 msgstr "零件类别名称"
 
-#: build/serializers.py:1415 common/setting/system.py:495 part/models.py:1259
+#: build/serializers.py:1410 common/setting/system.py:494 part/models.py:1283
 msgid "Trackable"
 msgstr "可追踪"
 
-#: build/serializers.py:1418
+#: build/serializers.py:1413
 msgid "Inherited"
 msgstr "已继承的"
 
-#: build/serializers.py:1421 part/models.py:4072
+#: build/serializers.py:1416 part/models.py:4093
 msgid "Allow Variants"
 msgstr "允许变体"
 
-#: build/serializers.py:1427 build/serializers.py:1432 part/models.py:3793
-#: part/models.py:4376 stock/api.py:881
+#: build/serializers.py:1422 build/serializers.py:1427 part/models.py:3814
+#: part/models.py:4397 stock/api.py:882
 msgid "BOM Item"
 msgstr "物料清单项"
 
-#: build/serializers.py:1505 order/serializers.py:1285 part/serializers.py:1174
-#: part/serializers.py:1755
+#: build/serializers.py:1500 order/serializers.py:1271 part/serializers.py:1156
+#: part/serializers.py:1619
 msgid "In Production"
 msgstr "生产中"
 
-#: build/serializers.py:1507 part/serializers.py:840 part/serializers.py:1178
+#: build/serializers.py:1502 part/serializers.py:822 part/serializers.py:1160
 msgid "Scheduled to Build"
 msgstr "生产计划"
 
-#: build/serializers.py:1510 part/serializers.py:873
+#: build/serializers.py:1505 part/serializers.py:855
 msgid "External Stock"
 msgstr "外部库存"
 
-#: build/serializers.py:1511 part/serializers.py:1164 part/serializers.py:1798
+#: build/serializers.py:1506 part/serializers.py:1146 part/serializers.py:1662
 msgid "Available Stock"
 msgstr "可用库存"
 
-#: build/serializers.py:1513
+#: build/serializers.py:1508
 msgid "Available Substitute Stock"
 msgstr "可用的替代品库存"
 
-#: build/serializers.py:1516
+#: build/serializers.py:1511
 msgid "Available Variant Stock"
 msgstr "可用的变体库存"
 
-#: build/serializers.py:1729
+#: build/serializers.py:1724
 msgid "Consumed quantity exceeds allocated quantity"
 msgstr "消耗数量超过分配数量"
 
-#: build/serializers.py:1766
+#: build/serializers.py:1761
 msgid "Optional notes for the stock consumption"
 msgstr "库存消耗可选备注"
 
-#: build/serializers.py:1783
+#: build/serializers.py:1778
 msgid "Build item must point to the correct build order"
 msgstr "生产物料项必须关联到正确的生产订单"
 
-#: build/serializers.py:1788
+#: build/serializers.py:1783
 msgid "Duplicate build item allocation"
 msgstr "重复的生产物料项分配"
 
-#: build/serializers.py:1806
+#: build/serializers.py:1801
 msgid "Build line must point to the correct build order"
 msgstr "订单行项目必须关联到正确的生产订单"
 
-#: build/serializers.py:1811
+#: build/serializers.py:1806
 msgid "Duplicate build line allocation"
 msgstr "重复的订单行项目分配"
 
-#: build/serializers.py:1823
+#: build/serializers.py:1818
 msgid "At least one item or line must be provided"
 msgstr "必须提供至少一个物料项或行项目"
 
@@ -1494,59 +1466,59 @@ msgstr "已暂停"
 msgid "Cancelled"
 msgstr "已取消"
 
-#: build/status_codes.py:15 generic/states/tests.py:23 importer/models.py:580
+#: build/status_codes.py:15 generic/states/tests.py:23 importer/models.py:552
 #: importer/status_codes.py:27 order/status_codes.py:15
 #: order/status_codes.py:52 order/status_codes.py:83
 msgid "Complete"
 msgstr "完成"
 
-#: build/tasks.py:218
+#: build/tasks.py:231
 msgid "Stock required for build order"
 msgstr "生产订单所需库存"
 
-#: build/tasks.py:228
+#: build/tasks.py:241
 #, python-brace-format
 msgid "Build order {build} requires additional stock"
 msgstr "生产订单{build}需补充库存"
 
-#: build/tasks.py:252
+#: build/tasks.py:265
 msgid "Overdue Build Order"
 msgstr "逾期的生产订单"
 
-#: build/tasks.py:257
+#: build/tasks.py:270
 #, python-brace-format
 msgid "Build order {bo} is now overdue"
 msgstr "生产订单 {bo} 现已逾期"
 
-#: common/api.py:723
+#: common/api.py:709
 msgid "Is Link"
 msgstr "是否链接"
 
-#: common/api.py:731
+#: common/api.py:717
 msgid "Is File"
 msgstr "是否为文件"
 
-#: common/api.py:778
+#: common/api.py:764
 msgid "User does not have permission to delete these attachments"
 msgstr "用户没有权限删除此附件"
 
-#: common/api.py:791
+#: common/api.py:777
 msgid "User does not have permission to delete this attachment"
 msgstr "用户没有权限删除此附件"
 
-#: common/currency.py:135
+#: common/currency.py:130
 msgid "Invalid currency code"
 msgstr "无效的货币代码"
 
-#: common/currency.py:137
+#: common/currency.py:132
 msgid "Duplicate currency code"
 msgstr "重复的货币代码"
 
-#: common/currency.py:142
+#: common/currency.py:137
 msgid "No valid currency codes provided"
 msgstr "未提供有效的货币代码"
 
-#: common/currency.py:159
+#: common/currency.py:154
 msgid "No plugin"
 msgstr "暂无插件"
 
@@ -1554,794 +1526,794 @@ msgstr "暂无插件"
 msgid "Project Code Label"
 msgstr "项目编号标签"
 
-#: common/models.py:106 common/models.py:131 common/models.py:3176
+#: common/models.py:105 common/models.py:130 common/models.py:3166
 msgid "Updated"
 msgstr "已是最新"
 
-#: common/models.py:107 common/models.py:132 order/models.py:507
+#: common/models.py:106 common/models.py:131
 msgid "Timestamp of last update"
 msgstr "最后更新时间戳"
 
-#: common/models.py:144
+#: common/models.py:143
 msgid "Update By"
 msgstr "更新于"
 
-#: common/models.py:145
+#: common/models.py:144
 msgid "User who last updated this object"
 msgstr "上次修改该对象的用户"
 
-#: common/models.py:172
+#: common/models.py:169
 msgid "Unique project code"
 msgstr "唯一项目编码"
 
-#: common/models.py:179
+#: common/models.py:176
 msgid "Project description"
 msgstr "项目描述"
 
-#: common/models.py:188
+#: common/models.py:185
 msgid "User or group responsible for this project"
 msgstr "负责此项目的用户或团队"
 
-#: common/models.py:784 common/models.py:1300 common/models.py:1338
+#: common/models.py:775 common/models.py:1292 common/models.py:1330
 msgid "Settings key"
 msgstr "设置密钥"
 
-#: common/models.py:788
+#: common/models.py:779
 msgid "Settings value"
 msgstr "设定值"
 
-#: common/models.py:843
+#: common/models.py:834
 msgid "Chosen value is not a valid option"
 msgstr "所选值不是一个有效的选项"
 
-#: common/models.py:859
+#: common/models.py:850
 msgid "Value must be a boolean value"
 msgstr "该值必须是布尔值"
 
-#: common/models.py:867
+#: common/models.py:858
 msgid "Value must be an integer value"
 msgstr "该值必须为整数"
 
-#: common/models.py:875
+#: common/models.py:866
 msgid "Value must be a valid number"
 msgstr "必须是有效数字"
 
-#: common/models.py:900
+#: common/models.py:891
 msgid "Value does not pass validation checks"
 msgstr "值未通过验证检查"
 
-#: common/models.py:922
+#: common/models.py:913
 msgid "Key string must be unique"
 msgstr "键字符串必须是唯一的"
 
-#: common/models.py:1346 common/models.py:1347 common/models.py:1451
-#: common/models.py:1452 common/models.py:1697 common/models.py:1698
-#: common/models.py:2030 common/models.py:2031 common/models.py:2829
-#: importer/models.py:101 part/models.py:3569 part/models.py:3597
+#: common/models.py:1338 common/models.py:1339 common/models.py:1443
+#: common/models.py:1444 common/models.py:1689 common/models.py:1690
+#: common/models.py:2022 common/models.py:2023 common/models.py:2819
+#: importer/models.py:100 part/models.py:3592 part/models.py:3620
 #: plugin/models.py:355 plugin/models.py:356
 #: report/templates/report/inventree_test_report.html:105 users/models.py:124
 #: users/models.py:501
 msgid "User"
 msgstr "使用者"
 
-#: common/models.py:1369
+#: common/models.py:1361
 msgid "Price break quantity"
 msgstr "批发价数量"
 
-#: common/models.py:1376 company/serializers.py:316 order/models.py:1877
-#: order/models.py:3080
+#: common/models.py:1368 company/serializers.py:316 order/models.py:1844
+#: order/models.py:3044
 msgid "Price"
 msgstr "价格"
 
-#: common/models.py:1377
+#: common/models.py:1369
 msgid "Unit price at specified quantity"
 msgstr "指定数量的单位价格"
 
-#: common/models.py:1428 common/models.py:1613
+#: common/models.py:1420 common/models.py:1605
 msgid "Endpoint"
 msgstr "端点"
 
-#: common/models.py:1429
+#: common/models.py:1421
 msgid "Endpoint at which this webhook is received"
 msgstr "接收此网络钩子的端点"
 
-#: common/models.py:1439
+#: common/models.py:1431
 msgid "Name for this webhook"
 msgstr "此网络钩子的名称"
 
-#: common/models.py:1443 common/models.py:2271 common/models.py:2378
-#: company/models.py:194 company/models.py:786 machine/models.py:40
-#: part/models.py:1282 plugin/models.py:69 stock/api.py:641 users/models.py:195
-#: users/models.py:554 users/serializers.py:332 users/serializers.py:424
+#: common/models.py:1435 common/models.py:2263 common/models.py:2370
+#: company/models.py:192 company/models.py:763 machine/models.py:40
+#: part/models.py:1306 plugin/models.py:69 stock/api.py:642 users/models.py:195
+#: users/models.py:554 users/serializers.py:319
 msgid "Active"
 msgstr "激活"
 
-#: common/models.py:1443
+#: common/models.py:1435
 msgid "Is this webhook active"
 msgstr "网络钩子是否已启用"
 
-#: common/models.py:1459 users/models.py:172
+#: common/models.py:1451 users/models.py:172
 msgid "Token"
 msgstr "令牌"
 
-#: common/models.py:1460
+#: common/models.py:1452
 msgid "Token for access"
 msgstr "访问令牌"
 
-#: common/models.py:1468
+#: common/models.py:1460
 msgid "Secret"
 msgstr "密钥"
 
-#: common/models.py:1469
+#: common/models.py:1461
 msgid "Shared secret for HMAC"
 msgstr "HMAC共享密钥"
 
-#: common/models.py:1577 common/models.py:3066
+#: common/models.py:1569 common/models.py:3056
 msgid "Message ID"
 msgstr "消息ID"
 
-#: common/models.py:1578 common/models.py:3056
+#: common/models.py:1570 common/models.py:3046
 msgid "Unique identifier for this message"
 msgstr "此邮件的唯一标识符"
 
-#: common/models.py:1586
+#: common/models.py:1578
 msgid "Host"
 msgstr "主机"
 
-#: common/models.py:1587
+#: common/models.py:1579
 msgid "Host from which this message was received"
 msgstr "接收此消息的主机"
 
-#: common/models.py:1595
+#: common/models.py:1587
 msgid "Header"
 msgstr "标题"
 
-#: common/models.py:1596
+#: common/models.py:1588
 msgid "Header of this message"
 msgstr "此消息的标题"
 
-#: common/models.py:1603
+#: common/models.py:1595
 msgid "Body"
 msgstr "正文"
 
-#: common/models.py:1604
+#: common/models.py:1596
 msgid "Body of this message"
 msgstr "此消息的正文"
 
-#: common/models.py:1614
+#: common/models.py:1606
 msgid "Endpoint on which this message was received"
 msgstr "接收此消息的终点"
 
-#: common/models.py:1619
+#: common/models.py:1611
 msgid "Worked on"
 msgstr "工作于"
 
-#: common/models.py:1620
+#: common/models.py:1612
 msgid "Was the work on this message finished?"
 msgstr "这条消息的工作完成了吗？"
 
-#: common/models.py:1746
+#: common/models.py:1738
 msgid "Id"
 msgstr "标识"
 
-#: common/models.py:1748
+#: common/models.py:1740
 msgid "Title"
 msgstr "标题"
 
-#: common/models.py:1750 common/models.py:2013 company/models.py:188
-#: company/models.py:479 company/models.py:549 company/models.py:809
-#: order/models.py:462 order/models.py:1821 order/models.py:2382
-#: part/models.py:1175
+#: common/models.py:1742 common/models.py:2005 company/models.py:186
+#: company/models.py:474 company/models.py:542 company/models.py:780
+#: order/models.py:459 order/models.py:1788 order/models.py:2344
+#: part/models.py:1182
 #: report/templates/report/inventree_build_order_report.html:164
 msgid "Link"
 msgstr "链接"
 
-#: common/models.py:1752
+#: common/models.py:1744
 msgid "Published"
 msgstr "已发布"
 
-#: common/models.py:1754
+#: common/models.py:1746
 msgid "Author"
 msgstr "作者"
 
-#: common/models.py:1756
+#: common/models.py:1748
 msgid "Summary"
 msgstr "摘要"
 
-#: common/models.py:1759 common/models.py:3033
+#: common/models.py:1751 common/models.py:3023
 msgid "Read"
 msgstr "阅读"
 
-#: common/models.py:1759
+#: common/models.py:1751
 msgid "Was this news item read?"
 msgstr "这条新闻被阅读了吗？"
 
-#: common/models.py:1776
+#: common/models.py:1768
 msgid "Image file"
 msgstr "图像文件"
 
-#: common/models.py:1788
+#: common/models.py:1780
 msgid "Target model type for this image"
 msgstr "此图像的目标模型类型"
 
-#: common/models.py:1792
+#: common/models.py:1784
 msgid "Target model ID for this image"
 msgstr "此图像的目标型号ID"
 
-#: common/models.py:1814
+#: common/models.py:1806
 msgid "Custom Unit"
 msgstr "自定义单位"
 
-#: common/models.py:1832
+#: common/models.py:1824
 msgid "Unit symbol must be unique"
 msgstr "单位符号必须唯一"
 
-#: common/models.py:1847
+#: common/models.py:1839
 msgid "Unit name must be a valid identifier"
 msgstr "单位名称必须是有效的标识符"
 
-#: common/models.py:1866
+#: common/models.py:1858
 msgid "Unit name"
 msgstr "单位名称"
 
-#: common/models.py:1873
+#: common/models.py:1865
 msgid "Symbol"
 msgstr "符号"
 
-#: common/models.py:1874
+#: common/models.py:1866
 msgid "Optional unit symbol"
 msgstr "可选单位符号"
 
-#: common/models.py:1880
+#: common/models.py:1872
 msgid "Definition"
 msgstr "定义"
 
-#: common/models.py:1881
+#: common/models.py:1873
 msgid "Unit definition"
 msgstr "单位定义"
 
-#: common/models.py:1941 common/models.py:2004 stock/models.py:3073
-#: stock/serializers.py:258
+#: common/models.py:1933 common/models.py:1996 stock/models.py:3041
+#: stock/serializers.py:249
 msgid "Attachment"
 msgstr "附件"
 
-#: common/models.py:1958
+#: common/models.py:1950
 msgid "Missing file"
 msgstr "缺少文件"
 
-#: common/models.py:1959
+#: common/models.py:1951
 msgid "Missing external link"
 msgstr "缺少外部链接"
 
-#: common/models.py:1996 common/models.py:2514
+#: common/models.py:1988 common/models.py:2504
 msgid "Model type"
 msgstr "模型类型"
 
-#: common/models.py:1997
+#: common/models.py:1989
 msgid "Target model type for image"
 msgstr "图片的目标模型类型"
 
-#: common/models.py:2005
+#: common/models.py:1997
 msgid "Select file to attach"
 msgstr "选择附件"
 
-#: common/models.py:2021
+#: common/models.py:2013
 msgid "Comment"
 msgstr "备注"
 
-#: common/models.py:2022
+#: common/models.py:2014
 msgid "Attachment comment"
 msgstr "附件备注"
 
-#: common/models.py:2038
+#: common/models.py:2030
 msgid "Upload date"
 msgstr "上传日期"
 
-#: common/models.py:2039
+#: common/models.py:2031
 msgid "Date the file was uploaded"
 msgstr "上传文件的日期"
 
-#: common/models.py:2043
+#: common/models.py:2035
 msgid "File size"
 msgstr "文件大小"
 
-#: common/models.py:2043
+#: common/models.py:2035
 msgid "File size in bytes"
 msgstr "文件大小，以字节为单位"
 
-#: common/models.py:2081 common/serializers.py:787
+#: common/models.py:2073 common/serializers.py:715
 msgid "Invalid model type specified for attachment"
 msgstr "为附件指定的模型类型无效"
 
-#: common/models.py:2102
+#: common/models.py:2094
 msgid "Custom State"
 msgstr "自定状态"
 
-#: common/models.py:2103
+#: common/models.py:2095
 msgid "Custom States"
 msgstr "定制状态"
 
-#: common/models.py:2108
+#: common/models.py:2100
 msgid "Reference Status Set"
 msgstr "参考状态设置"
 
-#: common/models.py:2109
+#: common/models.py:2101
 msgid "Status set that is extended with this custom state"
 msgstr "使用此自定义状态扩展状态的状态集"
 
-#: common/models.py:2113 generic/states/serializers.py:18
+#: common/models.py:2105 generic/states/serializers.py:18
 msgid "Logical Key"
 msgstr "逻辑密钥"
 
-#: common/models.py:2115
+#: common/models.py:2107
 msgid "State logical key that is equal to this custom state in business logic"
 msgstr "等同于商业逻辑中自定义状态的状态逻辑键"
 
-#: common/models.py:2120 common/models.py:2359 machine/serializers.py:27
-#: report/templates/report/inventree_test_report.html:104 stock/models.py:3065
+#: common/models.py:2112 common/models.py:2351 machine/serializers.py:27
+#: report/templates/report/inventree_test_report.html:104 stock/models.py:3033
 msgid "Value"
 msgstr "值"
 
-#: common/models.py:2121
+#: common/models.py:2113
 msgid "Numerical value that will be saved in the models database"
 msgstr "将保存至模型数据库的数值"
 
-#: common/models.py:2127
+#: common/models.py:2119
 msgid "Name of the state"
 msgstr "状态名"
 
-#: common/models.py:2136 common/models.py:2365 generic/states/serializers.py:22
+#: common/models.py:2128 common/models.py:2357 generic/states/serializers.py:22
 msgid "Label"
 msgstr "标签"
 
-#: common/models.py:2137
+#: common/models.py:2129
 msgid "Label that will be displayed in the frontend"
 msgstr "将在前端显示的标签"
 
-#: common/models.py:2144 generic/states/serializers.py:24
+#: common/models.py:2136 generic/states/serializers.py:24
 msgid "Color"
 msgstr "颜色"
 
-#: common/models.py:2145
+#: common/models.py:2137
 msgid "Color that will be displayed in the frontend"
 msgstr "将在前端显示颜色"
 
-#: common/models.py:2153
+#: common/models.py:2145
 msgid "Model"
 msgstr "型号"
 
-#: common/models.py:2154
+#: common/models.py:2146
 msgid "Model this state is associated with"
 msgstr "该状态关联的模型"
 
-#: common/models.py:2169
+#: common/models.py:2161
 msgid "Model must be selected"
 msgstr "必须选定模型"
 
-#: common/models.py:2172
+#: common/models.py:2164
 msgid "Key must be selected"
 msgstr "必须选取密钥"
 
-#: common/models.py:2175
+#: common/models.py:2167
 msgid "Logical key must be selected"
 msgstr "必须选中逻辑密钥"
 
-#: common/models.py:2179
+#: common/models.py:2171
 msgid "Key must be different from logical key"
 msgstr "密钥必须不同于逻辑密钥"
 
-#: common/models.py:2186
+#: common/models.py:2178
 msgid "Valid reference status class must be provided"
 msgstr "必须提供有效的参考状态类"
 
-#: common/models.py:2192
+#: common/models.py:2184
 msgid "Key must be different from the logical keys of the reference status"
 msgstr "密钥必须不同于参考状态的逻辑密钥"
 
-#: common/models.py:2199
+#: common/models.py:2191
 msgid "Logical key must be in the logical keys of the reference status"
 msgstr "逻辑密钥必须在参考状态的逻辑键中"
 
-#: common/models.py:2206
+#: common/models.py:2198
 msgid "Name must be different from the names of the reference status"
 msgstr "名称必须不同于参考状态的名称"
 
-#: common/models.py:2246 common/models.py:2353 common/models.py:2559
+#: common/models.py:2238 common/models.py:2345 common/models.py:2549
 msgid "Selection List"
 msgstr "选择列表"
 
-#: common/models.py:2247
+#: common/models.py:2239
 msgid "Selection Lists"
 msgstr "选择列表"
 
-#: common/models.py:2252
+#: common/models.py:2244
 msgid "Name of the selection list"
 msgstr "选择列表的名称"
 
-#: common/models.py:2259
+#: common/models.py:2251
 msgid "Description of the selection list"
 msgstr "选择列表的描述"
 
-#: common/models.py:2265 part/models.py:1287
+#: common/models.py:2257 part/models.py:1311
 msgid "Locked"
 msgstr "已锁定"
 
-#: common/models.py:2266
+#: common/models.py:2258
 msgid "Is this selection list locked?"
 msgstr "此选择列表是否已锁定？"
 
-#: common/models.py:2272
+#: common/models.py:2264
 msgid "Can this selection list be used?"
 msgstr "能否使用此选择列表？"
 
-#: common/models.py:2280
+#: common/models.py:2272
 msgid "Source Plugin"
 msgstr "源插件"
 
-#: common/models.py:2281
+#: common/models.py:2273
 msgid "Plugin which provides the selection list"
 msgstr "提供选择列表的插件"
 
-#: common/models.py:2286
+#: common/models.py:2278
 msgid "Source String"
 msgstr "源字符串"
 
-#: common/models.py:2287
+#: common/models.py:2279
 msgid "Optional string identifying the source used for this list"
 msgstr "可选字符串，用于标识本列表的数据来源"
 
-#: common/models.py:2296
+#: common/models.py:2288
 msgid "Default Entry"
 msgstr "缺省项"
 
-#: common/models.py:2297
+#: common/models.py:2289
 msgid "Default entry for this selection list"
 msgstr "本选择列表的默认选项"
 
-#: common/models.py:2302 common/models.py:3171
+#: common/models.py:2294 common/models.py:3161
 msgid "Created"
 msgstr "已创建"
 
-#: common/models.py:2303
+#: common/models.py:2295
 msgid "Date and time that the selection list was created"
 msgstr "选择列表的创建日期和时间"
 
-#: common/models.py:2308
+#: common/models.py:2300
 msgid "Last Updated"
 msgstr "最近更新"
 
-#: common/models.py:2309
+#: common/models.py:2301
 msgid "Date and time that the selection list was last updated"
 msgstr "选择列表的最后更新时间"
 
-#: common/models.py:2343
+#: common/models.py:2335
 msgid "Selection List Entry"
 msgstr "选择列表项"
 
-#: common/models.py:2344
+#: common/models.py:2336
 msgid "Selection List Entries"
 msgstr "选择列表项"
 
-#: common/models.py:2354
+#: common/models.py:2346
 msgid "Selection list to which this entry belongs"
 msgstr "此选项归属的选择列表"
 
-#: common/models.py:2360
+#: common/models.py:2352
 msgid "Value of the selection list entry"
 msgstr "选择列表项的值"
 
-#: common/models.py:2366
+#: common/models.py:2358
 msgid "Label for the selection list entry"
 msgstr "选择列表项的标签"
 
-#: common/models.py:2372
+#: common/models.py:2364
 msgid "Description of the selection list entry"
 msgstr "选择列表项的描述"
 
-#: common/models.py:2379
+#: common/models.py:2371
 msgid "Is this selection list entry active?"
 msgstr "该选择列表项是否处于激活状态？"
 
-#: common/models.py:2413
+#: common/models.py:2403
 msgid "Parameter Template"
 msgstr "参数模板"
 
-#: common/models.py:2414
+#: common/models.py:2404
 msgid "Parameter Templates"
 msgstr "参数模板"
 
-#: common/models.py:2451
+#: common/models.py:2441
 msgid "Checkbox parameters cannot have units"
 msgstr "勾选框参数不能有单位"
 
-#: common/models.py:2456
+#: common/models.py:2446
 msgid "Checkbox parameters cannot have choices"
 msgstr "复选框参数不能有选项"
 
-#: common/models.py:2476 part/models.py:3667
+#: common/models.py:2466 part/models.py:3688
 msgid "Choices must be unique"
 msgstr "选择必须是唯一的"
 
-#: common/models.py:2493
+#: common/models.py:2483
 msgid "Parameter template name must be unique"
 msgstr "参数模板名称必须是唯一的"
 
-#: common/models.py:2515
+#: common/models.py:2505
 msgid "Target model type for this parameter template"
 msgstr "此参数模板的目标模型类型"
 
-#: common/models.py:2521
+#: common/models.py:2511
 msgid "Parameter Name"
 msgstr "参数名称"
 
-#: common/models.py:2527 part/models.py:1240
+#: common/models.py:2517 part/models.py:1264
 msgid "Units"
 msgstr "单位"
 
-#: common/models.py:2528
+#: common/models.py:2518
 msgid "Physical units for this parameter"
 msgstr "此参数的物理单位"
 
-#: common/models.py:2536
+#: common/models.py:2526
 msgid "Parameter description"
 msgstr "参数说明"
 
-#: common/models.py:2542
+#: common/models.py:2532
 msgid "Checkbox"
 msgstr "勾选框"
 
-#: common/models.py:2543
+#: common/models.py:2533
 msgid "Is this parameter a checkbox?"
 msgstr "此参数是否为勾选框？"
 
-#: common/models.py:2548 part/models.py:3754
+#: common/models.py:2538 part/models.py:3775
 msgid "Choices"
 msgstr "选项"
 
-#: common/models.py:2549
+#: common/models.py:2539
 msgid "Valid choices for this parameter (comma-separated)"
 msgstr "此参数的有效选择 (逗号分隔)"
 
-#: common/models.py:2560
+#: common/models.py:2550
 msgid "Selection list for this parameter"
 msgstr "此参数的选择列表"
 
-#: common/models.py:2565 part/models.py:3729 report/models.py:287
+#: common/models.py:2555 part/models.py:3750 report/models.py:287
 msgid "Enabled"
 msgstr "已启用"
 
-#: common/models.py:2566
+#: common/models.py:2556
 msgid "Is this parameter template enabled?"
 msgstr "此参数模板是否启用？"
 
-#: common/models.py:2607
+#: common/models.py:2597
 msgid "Parameter"
 msgstr "参数"
 
-#: common/models.py:2608
+#: common/models.py:2598
 msgid "Parameters"
 msgstr "参数"
 
-#: common/models.py:2654
+#: common/models.py:2644
 msgid "Invalid choice for parameter value"
 msgstr "无效的参数值选择"
 
-#: common/models.py:2724 common/serializers.py:882
+#: common/models.py:2714 common/serializers.py:810
 msgid "Invalid model type specified for parameter"
 msgstr "为附件指定的模型类型无效"
 
-#: common/models.py:2760
+#: common/models.py:2750
 msgid "Model ID"
 msgstr "型号ID"
 
-#: common/models.py:2761
+#: common/models.py:2751
 msgid "ID of the target model for this parameter"
 msgstr "此参数的目标模型的 ID"
 
-#: common/models.py:2770 common/setting/system.py:465 report/models.py:373
+#: common/models.py:2760 common/setting/system.py:464 report/models.py:373
 #: report/models.py:669 report/serializers.py:94 report/serializers.py:135
-#: stock/serializers.py:244
+#: stock/serializers.py:235
 msgid "Template"
 msgstr "模板"
 
-#: common/models.py:2771
+#: common/models.py:2761
 msgid "Parameter template"
 msgstr "参数模板"
 
-#: common/models.py:2776 common/models.py:2818 importer/models.py:574
+#: common/models.py:2766 common/models.py:2808 importer/models.py:546
 msgid "Data"
 msgstr "数据"
 
-#: common/models.py:2777
+#: common/models.py:2767
 msgid "Parameter Value"
 msgstr "参数值"
 
-#: common/models.py:2786 company/models.py:826 order/serializers.py:854
-#: order/serializers.py:2036 part/models.py:4047 part/models.py:4416
+#: common/models.py:2776 company/models.py:797 order/serializers.py:841
+#: order/serializers.py:2044 part/models.py:4068 part/models.py:4437
 #: report/templates/report/inventree_bill_of_materials_report.html:140
 #: report/templates/report/inventree_purchase_order_report.html:39
 #: report/templates/report/inventree_return_order_report.html:27
 #: report/templates/report/inventree_sales_order_report.html:32
 #: report/templates/report/inventree_stock_location_report.html:105
-#: stock/serializers.py:828
+#: stock/serializers.py:817
 msgid "Note"
 msgstr "备注"
 
-#: common/models.py:2787 stock/serializers.py:733
+#: common/models.py:2777 stock/serializers.py:722
 msgid "Optional note field"
 msgstr "可选注释字段"
 
-#: common/models.py:2814
+#: common/models.py:2804
 msgid "Barcode Scan"
 msgstr "扫描条码"
 
-#: common/models.py:2819
+#: common/models.py:2809
 msgid "Barcode data"
 msgstr "条码数据"
 
-#: common/models.py:2830
+#: common/models.py:2820
 msgid "User who scanned the barcode"
 msgstr "扫描条码的用户"
 
-#: common/models.py:2835 importer/models.py:70
+#: common/models.py:2825 importer/models.py:69
 msgid "Timestamp"
 msgstr "时间戳"
 
-#: common/models.py:2836
+#: common/models.py:2826
 msgid "Date and time of the barcode scan"
 msgstr "扫描条形码的日期和时间"
 
-#: common/models.py:2842
+#: common/models.py:2832
 msgid "URL endpoint which processed the barcode"
 msgstr "处理条码的 URL 端点"
 
-#: common/models.py:2849 order/models.py:1867 plugin/serializers.py:93
+#: common/models.py:2839 order/models.py:1834 plugin/serializers.py:93
 msgid "Context"
 msgstr "上下文"
 
-#: common/models.py:2850
+#: common/models.py:2840
 msgid "Context data for the barcode scan"
 msgstr "扫描条形码的上下文数据"
 
-#: common/models.py:2857
+#: common/models.py:2847
 msgid "Response"
 msgstr "响应"
 
-#: common/models.py:2858
+#: common/models.py:2848
 msgid "Response data from the barcode scan"
 msgstr "扫描条形码的响应数据"
 
-#: common/models.py:2864 report/templates/report/inventree_test_report.html:103
-#: stock/models.py:3059
+#: common/models.py:2854 report/templates/report/inventree_test_report.html:103
+#: stock/models.py:3027
 msgid "Result"
 msgstr "结果"
 
-#: common/models.py:2865
+#: common/models.py:2855
 msgid "Was the barcode scan successful?"
 msgstr "条码扫描成功吗？"
 
-#: common/models.py:2947
+#: common/models.py:2937
 msgid "An error occurred"
 msgstr "发生错误"
 
-#: common/models.py:2968
+#: common/models.py:2958
 msgid "INVE-E8: Email log deletion is protected. Set INVENTREE_PROTECT_EMAIL_LOG to False to allow deletion."
 msgstr "INVE-E8：邮件日志删除受保护。需设置 INVENTREE_PROTECT_EMAIL_LOG 为 False 以允许删除。"
 
-#: common/models.py:3015
+#: common/models.py:3005
 msgid "Email Message"
 msgstr "电子邮件信息"
 
-#: common/models.py:3016
+#: common/models.py:3006
 msgid "Email Messages"
 msgstr "电子邮箱信息"
 
-#: common/models.py:3023
+#: common/models.py:3013
 msgid "Announced"
 msgstr "已发布"
 
-#: common/models.py:3025
+#: common/models.py:3015
 msgid "Sent"
 msgstr "已发送"
 
-#: common/models.py:3026
+#: common/models.py:3016
 msgid "Failed"
 msgstr "失败"
 
-#: common/models.py:3029
+#: common/models.py:3019
 msgid "Delivered"
 msgstr "已送达"
 
-#: common/models.py:3037
+#: common/models.py:3027
 msgid "Confirmed"
 msgstr "已确认"
 
-#: common/models.py:3043
+#: common/models.py:3033
 msgid "Inbound"
 msgstr "入站"
 
-#: common/models.py:3044
+#: common/models.py:3034
 msgid "Outbound"
 msgstr "出站"
 
-#: common/models.py:3049
+#: common/models.py:3039
 msgid "No Reply"
 msgstr "暂无回复消息"
 
-#: common/models.py:3050
+#: common/models.py:3040
 msgid "Track Delivery"
 msgstr "跟踪交付"
 
-#: common/models.py:3051
+#: common/models.py:3041
 msgid "Track Read"
 msgstr "已读追踪"
 
-#: common/models.py:3052
+#: common/models.py:3042
 msgid "Track Click"
 msgstr "点击追踪"
 
-#: common/models.py:3055 common/models.py:3158
+#: common/models.py:3045 common/models.py:3148
 msgid "Global ID"
 msgstr "全局ID"
 
-#: common/models.py:3068
+#: common/models.py:3058
 msgid "Identifier for this message (might be supplied by external system)"
 msgstr "此消息的标识符 (可能由外部系统提供)"
 
-#: common/models.py:3075
+#: common/models.py:3065
 msgid "Thread ID"
 msgstr "主题 ID"
 
-#: common/models.py:3077
+#: common/models.py:3067
 msgid "Identifier for this message thread (might be supplied by external system)"
 msgstr "此消息主题的标识符 (可能由外部系统提供)"
 
-#: common/models.py:3086
+#: common/models.py:3076
 msgid "Thread"
 msgstr "主题"
 
-#: common/models.py:3087
+#: common/models.py:3077
 msgid "Linked thread for this message"
 msgstr "链接到此消息的主题"
 
-#: common/models.py:3103
+#: common/models.py:3093
 msgid "Priority"
 msgstr "优先"
 
-#: common/models.py:3145
+#: common/models.py:3135
 msgid "Email Thread"
 msgstr "邮件主题"
 
-#: common/models.py:3146
+#: common/models.py:3136
 msgid "Email Threads"
 msgstr "邮件主题"
 
-#: common/models.py:3152 generic/states/serializers.py:16
+#: common/models.py:3142 generic/states/serializers.py:16
 #: machine/serializers.py:24 plugin/models.py:46 users/models.py:113
 msgid "Key"
 msgstr "键"
 
-#: common/models.py:3155
+#: common/models.py:3145
 msgid "Unique key for this thread (used to identify the thread)"
 msgstr "此主题的唯一密钥 (用于识别主题)"
 
-#: common/models.py:3159
+#: common/models.py:3149
 msgid "Unique identifier for this thread"
 msgstr "此主题的唯一标识符"
 
-#: common/models.py:3166
+#: common/models.py:3156
 msgid "Started Internal"
 msgstr "内部服务已启动"
 
-#: common/models.py:3167
+#: common/models.py:3157
 msgid "Was this thread started internally?"
 msgstr "该线程是否为内部启动的？"
 
-#: common/models.py:3172
+#: common/models.py:3162
 msgid "Date and time that the thread was created"
 msgstr "创建主题的日期和时间"
 
-#: common/models.py:3177
+#: common/models.py:3167
 msgid "Date and time that the thread was last updated"
 msgstr "主题最后更新的日期和时间"
 
@@ -2363,7 +2335,7 @@ msgstr "{verbose_name} 已取消"
 msgid "A order that is assigned to you was canceled"
 msgstr "分配给您的订单已取消"
 
-#: common/notifications.py:73 common/notifications.py:80 order/api.py:605
+#: common/notifications.py:73 common/notifications.py:80 order/api.py:598
 msgid "Items Received"
 msgstr "收到的物品"
 
@@ -2391,1243 +2363,1218 @@ msgstr "表示设置是否被环境变量覆盖"
 msgid "Override"
 msgstr "覆盖"
 
-#: common/serializers.py:601
+#: common/serializers.py:529
 msgid "Is Running"
 msgstr "正在运行"
 
-#: common/serializers.py:607
+#: common/serializers.py:535
 msgid "Pending Tasks"
 msgstr "等待完成的任务"
 
-#: common/serializers.py:613
+#: common/serializers.py:541
 msgid "Scheduled Tasks"
 msgstr "预定的任务"
 
-#: common/serializers.py:619
+#: common/serializers.py:547
 msgid "Failed Tasks"
 msgstr "失败的任务"
 
-#: common/serializers.py:634
+#: common/serializers.py:562
 msgid "Task ID"
 msgstr "任务ID"
 
-#: common/serializers.py:634
+#: common/serializers.py:562
 msgid "Unique task ID"
 msgstr "唯一任务ID"
 
-#: common/serializers.py:636
+#: common/serializers.py:564
 msgid "Lock"
 msgstr "锁定"
 
-#: common/serializers.py:636
+#: common/serializers.py:564
 msgid "Lock time"
 msgstr "锁定时间"
 
-#: common/serializers.py:638
+#: common/serializers.py:566
 msgid "Task name"
 msgstr "任务名称"
 
-#: common/serializers.py:640
+#: common/serializers.py:568
 msgid "Function"
 msgstr "功能"
 
-#: common/serializers.py:640
+#: common/serializers.py:568
 msgid "Function name"
 msgstr "功能名称"
 
-#: common/serializers.py:642
+#: common/serializers.py:570
 msgid "Arguments"
 msgstr "参数"
 
-#: common/serializers.py:642
+#: common/serializers.py:570
 msgid "Task arguments"
 msgstr "任务参数"
 
-#: common/serializers.py:645
+#: common/serializers.py:573
 msgid "Keyword Arguments"
 msgstr "关键字参数"
 
-#: common/serializers.py:645
+#: common/serializers.py:573
 msgid "Task keyword arguments"
 msgstr "任务关键词参数"
 
-#: common/serializers.py:755
+#: common/serializers.py:683
 msgid "Filename"
 msgstr "文件名"
 
-#: common/serializers.py:762 common/serializers.py:829
-#: common/serializers.py:904 importer/models.py:90 report/api.py:41
+#: common/serializers.py:690 common/serializers.py:757
+#: common/serializers.py:832 importer/models.py:89 report/api.py:41
 #: report/models.py:293 report/serializers.py:52
 msgid "Model Type"
 msgstr "模型类型"
 
-#: common/serializers.py:790
+#: common/serializers.py:718
 msgid "User does not have permission to create or edit attachments for this model"
 msgstr "用户无权为此模式创建或编辑附件"
 
-#: common/serializers.py:885
+#: common/serializers.py:813
 msgid "User does not have permission to create or edit parameters for this model"
 msgstr "用户没有权限为此模型创建或编辑参数"
 
-#: common/serializers.py:955 common/serializers.py:1058
+#: common/serializers.py:883 common/serializers.py:986
 msgid "Selection list is locked"
 msgstr "选择列表已锁定"
 
-#: common/setting/system.py:97
+#: common/setting/system.py:96
 msgid "No group"
 msgstr "无分组"
 
-#: common/setting/system.py:170
+#: common/setting/system.py:169
 msgid "Site URL is locked by configuration"
 msgstr "网站 URL 已配置为锁定"
 
-#: common/setting/system.py:187
+#: common/setting/system.py:186
 msgid "Restart required"
 msgstr "需要重启"
 
-#: common/setting/system.py:188
+#: common/setting/system.py:187
 msgid "A setting has been changed which requires a server restart"
 msgstr "设置已更改，需要服务器重启"
 
-#: common/setting/system.py:194
+#: common/setting/system.py:193
 msgid "Pending migrations"
 msgstr "等待迁移"
 
-#: common/setting/system.py:195
+#: common/setting/system.py:194
 msgid "Number of pending database migrations"
 msgstr "待处理的数据库迁移数"
 
-#: common/setting/system.py:200
+#: common/setting/system.py:199
 msgid "Active warning codes"
 msgstr "活动的警告代码"
 
-#: common/setting/system.py:201
+#: common/setting/system.py:200
 msgid "A dict of active warning codes"
 msgstr "活跃警告代码的字典"
 
-#: common/setting/system.py:207
+#: common/setting/system.py:206
 msgid "Instance ID"
 msgstr "实例ID"
 
-#: common/setting/system.py:208
+#: common/setting/system.py:207
 msgid "Unique identifier for this InvenTree instance"
 msgstr "此 InvenTree 实例的唯一标识符"
 
-#: common/setting/system.py:213
+#: common/setting/system.py:212
 msgid "Announce ID"
 msgstr "公告 ID"
 
-#: common/setting/system.py:215
+#: common/setting/system.py:214
 msgid "Announce the instance ID of the server in the server status info (unauthenticated)"
 msgstr "在服务器状态信息中公开实例ID（未认证状态下）"
 
-#: common/setting/system.py:221
+#: common/setting/system.py:220
 msgid "Server Instance Name"
 msgstr "服务器实例名称"
 
-#: common/setting/system.py:223
+#: common/setting/system.py:222
 msgid "String descriptor for the server instance"
 msgstr "服务器实例的字符串描述符"
 
-#: common/setting/system.py:227
+#: common/setting/system.py:226
 msgid "Use instance name"
 msgstr "使用实例名称"
 
-#: common/setting/system.py:228
+#: common/setting/system.py:227
 msgid "Use the instance name in the title-bar"
 msgstr "在标题栏中使用实例名称"
 
-#: common/setting/system.py:233
+#: common/setting/system.py:232
 msgid "Restrict showing `about`"
 msgstr "限制显示 `关于` 信息"
 
-#: common/setting/system.py:234
+#: common/setting/system.py:233
 msgid "Show the `about` modal only to superusers"
 msgstr "只向超级管理员显示关于信息"
 
-#: common/setting/system.py:239 company/models.py:147 company/models.py:148
+#: common/setting/system.py:238 company/models.py:145 company/models.py:146
 msgid "Company name"
 msgstr "公司名称"
 
-#: common/setting/system.py:240
+#: common/setting/system.py:239
 msgid "Internal company name"
 msgstr "内部公司名称"
 
-#: common/setting/system.py:244
+#: common/setting/system.py:243
 msgid "Base URL"
 msgstr "基本 URL"
 
-#: common/setting/system.py:245
+#: common/setting/system.py:244
 msgid "Base URL for server instance"
 msgstr "服务器实例的基准 URL"
 
-#: common/setting/system.py:251
+#: common/setting/system.py:250
 msgid "Default Currency"
 msgstr "默认货币"
 
-#: common/setting/system.py:252
+#: common/setting/system.py:251
 msgid "Select base currency for pricing calculations"
 msgstr "系统价格计算使用的基准货币"
 
-#: common/setting/system.py:258
+#: common/setting/system.py:257
 msgid "Supported Currencies"
 msgstr "支持币种"
 
-#: common/setting/system.py:259
+#: common/setting/system.py:258
 msgid "List of supported currency codes"
 msgstr "支持的货币代码列表"
 
-#: common/setting/system.py:265
+#: common/setting/system.py:264
 msgid "Currency Update Interval"
 msgstr "货币更新间隔时间"
 
-#: common/setting/system.py:266
+#: common/setting/system.py:265
 msgid "How often to update exchange rates (set to zero to disable)"
 msgstr "检查更新的频率(设置为零以禁用)"
 
-#: common/setting/system.py:268 common/setting/system.py:308
-#: common/setting/system.py:321 common/setting/system.py:329
-#: common/setting/system.py:336 common/setting/system.py:345
-#: common/setting/system.py:354 common/setting/system.py:595
-#: common/setting/system.py:623 common/setting/system.py:730
-#: common/setting/system.py:1131 common/setting/system.py:1147
-#: common/setting/system.py:1164
+#: common/setting/system.py:267 common/setting/system.py:307
+#: common/setting/system.py:320 common/setting/system.py:328
+#: common/setting/system.py:335 common/setting/system.py:344
+#: common/setting/system.py:353 common/setting/system.py:594
+#: common/setting/system.py:622 common/setting/system.py:721
+#: common/setting/system.py:1122 common/setting/system.py:1138
 msgid "days"
 msgstr "天"
 
-#: common/setting/system.py:272
+#: common/setting/system.py:271
 msgid "Currency Update Plugin"
 msgstr "币种更新插件"
 
-#: common/setting/system.py:273
+#: common/setting/system.py:272
 msgid "Currency update plugin to use"
 msgstr "使用货币更新插件"
 
-#: common/setting/system.py:278
+#: common/setting/system.py:277
 msgid "Download from URL"
 msgstr "从URL下载"
 
-#: common/setting/system.py:279
+#: common/setting/system.py:278
 msgid "Allow download of remote images and files from external URL"
 msgstr "允许从外部 URL 下载远程图片和文件"
 
-#: common/setting/system.py:284
+#: common/setting/system.py:283
 msgid "Download Size Limit"
 msgstr "下载大小限制"
 
-#: common/setting/system.py:285
+#: common/setting/system.py:284
 msgid "Maximum allowable download size for remote image"
 msgstr "远程图片的最大允许下载大小"
 
-#: common/setting/system.py:291
+#: common/setting/system.py:290
 msgid "User-agent used to download from URL"
 msgstr "用于从 URL 下载的 User-agent"
 
-#: common/setting/system.py:293
+#: common/setting/system.py:292
 msgid "Allow to override the user-agent used to download images and files from external URL (leave blank for the default)"
 msgstr "允许覆盖用于从外部 URL 下载图片和文件的 user-agent(留空为默认值)"
 
-#: common/setting/system.py:298
+#: common/setting/system.py:297
 msgid "Strict URL Validation"
 msgstr "严格的 URL 验证"
 
-#: common/setting/system.py:299
+#: common/setting/system.py:298
 msgid "Require schema specification when validating URLs"
 msgstr "验证 URL 时需要 schema 规范"
 
-#: common/setting/system.py:304
+#: common/setting/system.py:303
 msgid "Update Check Interval"
 msgstr "更新检查间隔"
 
-#: common/setting/system.py:305
+#: common/setting/system.py:304
 msgid "How often to check for updates (set to zero to disable)"
 msgstr "检查更新的频率(设置为零以禁用)"
 
-#: common/setting/system.py:311
+#: common/setting/system.py:310
 msgid "Automatic Backup"
 msgstr "自动备份"
 
-#: common/setting/system.py:312
+#: common/setting/system.py:311
 msgid "Enable automatic backup of database and media files"
 msgstr "启用数据库和媒体文件的自动备份"
 
-#: common/setting/system.py:317
+#: common/setting/system.py:316
 msgid "Auto Backup Interval"
 msgstr "自动备份间隔"
 
-#: common/setting/system.py:318
+#: common/setting/system.py:317
 msgid "Specify number of days between automated backup events"
 msgstr "指定自动备份之间的间隔天数"
 
-#: common/setting/system.py:324
+#: common/setting/system.py:323
 msgid "Task Deletion Interval"
 msgstr "任务删除间隔"
 
-#: common/setting/system.py:326
+#: common/setting/system.py:325
 msgid "Background task results will be deleted after specified number of days"
 msgstr "后台任务结果将在指定天数后删除"
 
-#: common/setting/system.py:333
+#: common/setting/system.py:332
 msgid "Error Log Deletion Interval"
 msgstr "错误日志删除间隔"
 
-#: common/setting/system.py:334
+#: common/setting/system.py:333
 msgid "Error logs will be deleted after specified number of days"
 msgstr "错误日志将在指定天数后被删除"
 
-#: common/setting/system.py:340
+#: common/setting/system.py:339
 msgid "Notification Deletion Interval"
 msgstr "通知删除间隔"
 
-#: common/setting/system.py:342
+#: common/setting/system.py:341
 msgid "User notifications will be deleted after specified number of days"
 msgstr "用户通知将在指定天数后被删除"
 
-#: common/setting/system.py:349
+#: common/setting/system.py:348
 msgid "Email Deletion Interval"
 msgstr "邮件自动清理周期"
 
-#: common/setting/system.py:351
+#: common/setting/system.py:350
 msgid "Email messages will be deleted after specified number of days"
 msgstr "邮件将在指定天数后删除"
 
-#: common/setting/system.py:358
+#: common/setting/system.py:357
 msgid "Protect Email Log"
 msgstr "保护邮件日志"
 
-#: common/setting/system.py:359
+#: common/setting/system.py:358
 msgid "Prevent deletion of email log entries"
 msgstr "防止邮件日志条目被删除"
 
-#: common/setting/system.py:364
+#: common/setting/system.py:363
 msgid "Barcode Support"
 msgstr "条形码支持"
 
-#: common/setting/system.py:365
+#: common/setting/system.py:364
 msgid "Enable barcode scanner support in the web interface"
 msgstr "在网页界面启用条形码扫描器支持"
 
-#: common/setting/system.py:370
+#: common/setting/system.py:369
 msgid "Store Barcode Results"
 msgstr "存储条形码结果"
 
-#: common/setting/system.py:371
+#: common/setting/system.py:370
 msgid "Store barcode scan results in the database"
 msgstr "存储条形码扫描结果"
 
-#: common/setting/system.py:376
+#: common/setting/system.py:375
 msgid "Barcode Scans Maximum Count"
 msgstr "条形码扫描最大计数"
 
-#: common/setting/system.py:377
+#: common/setting/system.py:376
 msgid "Maximum number of barcode scan results to store"
 msgstr "保存的条形码扫描结果的最大数量"
 
-#: common/setting/system.py:382
+#: common/setting/system.py:381
 msgid "Barcode Input Delay"
 msgstr "条形码扫描延迟设置"
 
-#: common/setting/system.py:383
+#: common/setting/system.py:382
 msgid "Barcode input processing delay time"
 msgstr "条形码输入处理延迟时间"
 
-#: common/setting/system.py:389
+#: common/setting/system.py:388
 msgid "Barcode Webcam Support"
 msgstr "启用摄像头扫码支持"
 
-#: common/setting/system.py:390
+#: common/setting/system.py:389
 msgid "Allow barcode scanning via webcam in browser"
 msgstr "允许通过网络摄像头扫描条形码"
 
-#: common/setting/system.py:395
+#: common/setting/system.py:394
 msgid "Barcode Show Data"
 msgstr "显示条形码数据"
 
-#: common/setting/system.py:396
+#: common/setting/system.py:395
 msgid "Display barcode data in browser as text"
 msgstr "在浏览器中将条形码数据显示为文本"
 
-#: common/setting/system.py:401
+#: common/setting/system.py:400
 msgid "Barcode Generation Plugin"
 msgstr "条形码生成插件"
 
-#: common/setting/system.py:402
+#: common/setting/system.py:401
 msgid "Plugin to use for internal barcode data generation"
 msgstr "用于内部条形码数据生成的插件"
 
-#: common/setting/system.py:407
+#: common/setting/system.py:406
 msgid "Part Revisions"
 msgstr "零件修订"
 
-#: common/setting/system.py:408
+#: common/setting/system.py:407
 msgid "Enable revision field for Part"
 msgstr "启用零件修订字段"
 
-#: common/setting/system.py:413
+#: common/setting/system.py:412
 msgid "Assembly Revision Only"
 msgstr "仅限装配修订版本"
 
-#: common/setting/system.py:414
+#: common/setting/system.py:413
 msgid "Only allow revisions for assembly parts"
 msgstr "仅允许对装配零件进行修订"
 
-#: common/setting/system.py:419
+#: common/setting/system.py:418
 msgid "Allow Deletion from Assembly"
 msgstr "允许从装配中删除"
 
-#: common/setting/system.py:420
+#: common/setting/system.py:419
 msgid "Allow deletion of parts which are used in an assembly"
 msgstr "允许删除已在装配中使用的零件"
 
-#: common/setting/system.py:425
+#: common/setting/system.py:424
 msgid "IPN Regex"
 msgstr "IPN（内部零件号）正则规则"
 
-#: common/setting/system.py:426
+#: common/setting/system.py:425
 msgid "Regular expression pattern for matching Part IPN"
 msgstr "用于匹配IPN（内部零件号）格式的正则表达式"
 
-#: common/setting/system.py:429
+#: common/setting/system.py:428
 msgid "Allow Duplicate IPN"
 msgstr "允许重复的 IPN（内部零件号）"
 
-#: common/setting/system.py:430
+#: common/setting/system.py:429
 msgid "Allow multiple parts to share the same IPN"
 msgstr "允许多个零件共享相同的 IPN（内部零件号）"
 
-#: common/setting/system.py:435
+#: common/setting/system.py:434
 msgid "Allow Editing IPN"
 msgstr "允许编辑 IPN（内部零件号）"
 
-#: common/setting/system.py:436
+#: common/setting/system.py:435
 msgid "Allow changing the IPN value while editing a part"
 msgstr "允许编辑零件时更改IPN（内部零件号）"
 
-#: common/setting/system.py:441
+#: common/setting/system.py:440
 msgid "Copy Part BOM Data"
 msgstr "复制零件物料清单数据"
 
-#: common/setting/system.py:442
+#: common/setting/system.py:441
 msgid "Copy BOM data by default when duplicating a part"
 msgstr "复制零件时默认复制物料清单数据"
 
-#: common/setting/system.py:447
+#: common/setting/system.py:446
 msgid "Copy Part Parameter Data"
 msgstr "复制零件参数数据"
 
-#: common/setting/system.py:448
+#: common/setting/system.py:447
 msgid "Copy parameter data by default when duplicating a part"
 msgstr "复制零件时默认复制参数数据"
 
-#: common/setting/system.py:453
+#: common/setting/system.py:452
 msgid "Copy Part Test Data"
 msgstr "复制零件测试数据"
 
-#: common/setting/system.py:454
+#: common/setting/system.py:453
 msgid "Copy test data by default when duplicating a part"
 msgstr "复制零件时默认复制测试数据"
 
-#: common/setting/system.py:459
+#: common/setting/system.py:458
 msgid "Copy Category Parameter Templates"
 msgstr "复制类别参数模板"
 
-#: common/setting/system.py:460
+#: common/setting/system.py:459
 msgid "Copy category parameter templates when creating a part"
 msgstr "创建零件时复制类别参数模板"
 
-#: common/setting/system.py:466
+#: common/setting/system.py:465
 msgid "Parts are templates by default"
 msgstr "零件默认为模板"
 
-#: common/setting/system.py:472
+#: common/setting/system.py:471
 msgid "Parts can be assembled from other components by default"
 msgstr "默认情况下，元件可由其他零件组装而成"
 
-#: common/setting/system.py:477 part/models.py:1253 part/serializers.py:1724
-#: part/serializers.py:1731
+#: common/setting/system.py:476 part/models.py:1277 part/serializers.py:1588
+#: part/serializers.py:1595
 msgid "Component"
 msgstr "组件"
 
-#: common/setting/system.py:478
+#: common/setting/system.py:477
 msgid "Parts can be used as sub-components by default"
 msgstr "默认情况下，零件可用作子部件"
 
-#: common/setting/system.py:483 part/models.py:1271
+#: common/setting/system.py:482 part/models.py:1295
 msgid "Purchaseable"
 msgstr "可购买"
 
-#: common/setting/system.py:484
+#: common/setting/system.py:483
 msgid "Parts are purchaseable by default"
 msgstr "默认情况下可购买零件"
 
-#: common/setting/system.py:489 part/models.py:1277 stock/api.py:642
+#: common/setting/system.py:488 part/models.py:1301 stock/api.py:643
 msgid "Salable"
 msgstr "可销售"
 
-#: common/setting/system.py:490
+#: common/setting/system.py:489
 msgid "Parts are salable by default"
 msgstr "零件默认为可销售"
 
-#: common/setting/system.py:496
+#: common/setting/system.py:495
 msgid "Parts are trackable by default"
 msgstr "默认情况下可跟踪零件"
 
-#: common/setting/system.py:501 part/models.py:1293
+#: common/setting/system.py:500 part/models.py:1317
 msgid "Virtual"
 msgstr "虚拟的"
 
-#: common/setting/system.py:502
+#: common/setting/system.py:501
 msgid "Parts are virtual by default"
 msgstr "默认情况下，零件是虚拟的"
 
-#: common/setting/system.py:507
+#: common/setting/system.py:506
 msgid "Show related parts"
 msgstr "显示关联零件"
 
-#: common/setting/system.py:508
+#: common/setting/system.py:507
 msgid "Display related parts for a part"
 msgstr "显示零件的关联零件"
 
-#: common/setting/system.py:513
+#: common/setting/system.py:512
 msgid "Initial Stock Data"
 msgstr "允许创建初始库存"
 
-#: common/setting/system.py:514
+#: common/setting/system.py:513
 msgid "Allow creation of initial stock when adding a new part"
 msgstr "允许在添加新零件时创建初始库存数据"
 
-#: common/setting/system.py:519
+#: common/setting/system.py:518
 msgid "Initial Supplier Data"
 msgstr "允许创建供应商数据"
 
-#: common/setting/system.py:521
+#: common/setting/system.py:520
 msgid "Allow creation of initial supplier data when adding a new part"
 msgstr "允许在添加新零件时创建初始供应商数据"
 
-#: common/setting/system.py:527
+#: common/setting/system.py:526
 msgid "Part Name Display Format"
 msgstr "零件名称显示格式"
 
-#: common/setting/system.py:528
+#: common/setting/system.py:527
 msgid "Format to display the part name"
 msgstr "显示零件名称的格式"
 
-#: common/setting/system.py:534
+#: common/setting/system.py:533
 msgid "Part Category Default Icon"
 msgstr "零件类别默认图标"
 
-#: common/setting/system.py:535
+#: common/setting/system.py:534
 msgid "Part category default icon (empty means no icon)"
 msgstr "零件类别默认图标 (空表示没有图标)"
 
-#: common/setting/system.py:540
+#: common/setting/system.py:539
 msgid "Minimum Pricing Decimal Places"
 msgstr "最小定价小数位数"
 
-#: common/setting/system.py:542
+#: common/setting/system.py:541
 msgid "Minimum number of decimal places to display when rendering pricing data"
 msgstr "呈现定价数据时显示的最小小数位数"
 
-#: common/setting/system.py:553
+#: common/setting/system.py:552
 msgid "Maximum Pricing Decimal Places"
 msgstr "最大定价小数位数"
 
-#: common/setting/system.py:555
+#: common/setting/system.py:554
 msgid "Maximum number of decimal places to display when rendering pricing data"
 msgstr "呈现定价数据时显示的最大小数位数"
 
-#: common/setting/system.py:566
+#: common/setting/system.py:565
 msgid "Use Supplier Pricing"
 msgstr "使用供应商定价"
 
-#: common/setting/system.py:568
+#: common/setting/system.py:567
 msgid "Include supplier price breaks in overall pricing calculations"
 msgstr "将供应商的批发价纳入整体价格计算"
 
-#: common/setting/system.py:574
+#: common/setting/system.py:573
 msgid "Purchase History Override"
 msgstr "采购历史价优先"
 
-#: common/setting/system.py:576
+#: common/setting/system.py:575
 msgid "Historical purchase order pricing overrides supplier price breaks"
 msgstr "当存在历史采购订单价格时，将忽略供应商的批发价"
 
-#: common/setting/system.py:582
+#: common/setting/system.py:581
 msgid "Use Stock Item Pricing"
 msgstr "使用库存项定价"
 
-#: common/setting/system.py:584
+#: common/setting/system.py:583
 msgid "Use pricing from manually entered stock data for pricing calculations"
 msgstr "使用手动输入的库存数据进行定价计算"
 
-#: common/setting/system.py:590
+#: common/setting/system.py:589
 msgid "Stock Item Pricing Age"
 msgstr "库存项目定价时间"
 
-#: common/setting/system.py:592
+#: common/setting/system.py:591
 msgid "Exclude stock items older than this number of days from pricing calculations"
 msgstr "从定价计算中排除超过此天数的库存项目"
 
-#: common/setting/system.py:599
+#: common/setting/system.py:598
 msgid "Use Variant Pricing"
 msgstr "使用变体定价"
 
-#: common/setting/system.py:600
+#: common/setting/system.py:599
 msgid "Include variant pricing in overall pricing calculations"
 msgstr "将产品变体的特殊定价纳入整体价格计算"
 
-#: common/setting/system.py:605
+#: common/setting/system.py:604
 msgid "Active Variants Only"
 msgstr "仅限活跃变体"
 
-#: common/setting/system.py:607
+#: common/setting/system.py:606
 msgid "Only use active variant parts for calculating variant pricing"
 msgstr "仅使用活跃变体零件计算变体价格"
 
-#: common/setting/system.py:613
+#: common/setting/system.py:612
 msgid "Auto Update Pricing"
 msgstr "自动更新定价"
 
-#: common/setting/system.py:615
+#: common/setting/system.py:614
 msgid "Automatically update part pricing when internal data changes"
 msgstr "当内部数据变化时自动更新零件价格"
 
-#: common/setting/system.py:621
+#: common/setting/system.py:620
 msgid "Pricing Rebuild Interval"
 msgstr "价格重建间隔"
 
-#: common/setting/system.py:622
+#: common/setting/system.py:621
 msgid "Number of days before part pricing is automatically updated"
 msgstr "零件价格自动更新前的天数"
 
-#: common/setting/system.py:628
+#: common/setting/system.py:627
 msgid "Internal Prices"
 msgstr "内部价格"
 
-#: common/setting/system.py:629
+#: common/setting/system.py:628
 msgid "Enable internal prices for parts"
 msgstr "为零件启用内部核算价格功能"
 
-#: common/setting/system.py:634
+#: common/setting/system.py:633
 msgid "Internal Price Override"
 msgstr "内部价格优先"
 
-#: common/setting/system.py:636
+#: common/setting/system.py:635
 msgid "If available, internal prices override price range calculations"
 msgstr "若存在内部价格，将覆盖BOM价格区间计算结果"
 
-#: common/setting/system.py:642
-msgid "Allow BOM Zero Quantity"
-msgstr "允许BOM数量为零"
-
-#: common/setting/system.py:644
-msgid "Accept a zero quantity for BOM item for part. Enables using setup quantity to define a quantity required per build, independent of build quantity"
-msgstr "允许 BOM 物料项的数量为零。启用后可使用装配 / 设置数量定义单次构建所需用量，与构建总数量无关"
-
-#: common/setting/system.py:650
+#: common/setting/system.py:641
 msgid "Enable label printing"
 msgstr "启用标签打印功能"
 
-#: common/setting/system.py:651
+#: common/setting/system.py:642
 msgid "Enable label printing from the web interface"
 msgstr "启用从网络界面打印标签"
 
-#: common/setting/system.py:656
+#: common/setting/system.py:647
 msgid "Label Image DPI"
 msgstr "标签图片 DPI"
 
-#: common/setting/system.py:658
+#: common/setting/system.py:649
 msgid "DPI resolution when generating image files to supply to label printing plugins"
 msgstr "生成图像文件以供标签打印插件使用时的 DPI 分辨率"
 
-#: common/setting/system.py:664
+#: common/setting/system.py:655
 msgid "Enable Reports"
 msgstr "启用报告"
 
-#: common/setting/system.py:665
+#: common/setting/system.py:656
 msgid "Enable generation of reports"
 msgstr "启用报告生成"
 
-#: common/setting/system.py:670
+#: common/setting/system.py:661
 msgid "Debug Mode"
 msgstr "调试模式"
 
-#: common/setting/system.py:671
+#: common/setting/system.py:662
 msgid "Generate reports in debug mode (HTML output)"
 msgstr "以调试模式生成报告（HTML 输出）"
 
-#: common/setting/system.py:676
+#: common/setting/system.py:667
 msgid "Log Report Errors"
 msgstr "日志错误报告"
 
-#: common/setting/system.py:677
+#: common/setting/system.py:668
 msgid "Log errors which occur when generating reports"
 msgstr "记录生成报告时出现的错误"
 
-#: common/setting/system.py:682 plugin/builtin/labels/label_sheet.py:29
+#: common/setting/system.py:673 plugin/builtin/labels/label_sheet.py:29
 #: report/models.py:381
 msgid "Page Size"
 msgstr "页面大小"
 
-#: common/setting/system.py:683
+#: common/setting/system.py:674
 msgid "Default page size for PDF reports"
 msgstr "PDF 报告默认页面大小"
 
-#: common/setting/system.py:688
+#: common/setting/system.py:679
 msgid "Enforce Parameter Units"
 msgstr "强制参数单位"
 
-#: common/setting/system.py:690
+#: common/setting/system.py:681
 msgid "If units are provided, parameter values must match the specified units"
 msgstr "如果提供了单位，参数值必须与指定的单位匹配"
 
-#: common/setting/system.py:696
+#: common/setting/system.py:687
 msgid "Globally Unique Serials"
 msgstr "全局唯一序列号"
 
-#: common/setting/system.py:697
+#: common/setting/system.py:688
 msgid "Serial numbers for stock items must be globally unique"
 msgstr "库存项的序列号必须全局唯一"
 
-#: common/setting/system.py:702
+#: common/setting/system.py:693
 msgid "Delete Depleted Stock"
 msgstr "删除已耗尽的库存"
 
-#: common/setting/system.py:703
+#: common/setting/system.py:694
 msgid "Determines default behavior when a stock item is depleted"
 msgstr "设置库存耗尽时的默认行为"
 
-#: common/setting/system.py:708
+#: common/setting/system.py:699
 msgid "Batch Code Template"
 msgstr "批号模板"
 
-#: common/setting/system.py:709
+#: common/setting/system.py:700
 msgid "Template for generating default batch codes for stock items"
 msgstr "为库存项生成默认批号的模板"
 
-#: common/setting/system.py:713
+#: common/setting/system.py:704
 msgid "Stock Expiry"
 msgstr "库存过期"
 
-#: common/setting/system.py:714
+#: common/setting/system.py:705
 msgid "Enable stock expiry functionality"
 msgstr "启用库存过期功能"
 
-#: common/setting/system.py:719
+#: common/setting/system.py:710
 msgid "Sell Expired Stock"
 msgstr "销售过期库存"
 
-#: common/setting/system.py:720
+#: common/setting/system.py:711
 msgid "Allow sale of expired stock"
 msgstr "允许销售过期库存"
 
-#: common/setting/system.py:725
+#: common/setting/system.py:716
 msgid "Stock Stale Time"
 msgstr "库存临期预警天数"
 
-#: common/setting/system.py:727
+#: common/setting/system.py:718
 msgid "Number of days stock items are considered stale before expiring"
 msgstr "库存项过期前被标记为\"临期\"的天数"
 
-#: common/setting/system.py:734
+#: common/setting/system.py:725
 msgid "Build Expired Stock"
 msgstr "允许使用过期库存"
 
-#: common/setting/system.py:735
+#: common/setting/system.py:726
 msgid "Allow building with expired stock"
 msgstr "允许在生产中使用已过期的库存"
 
-#: common/setting/system.py:740
+#: common/setting/system.py:731
 msgid "Stock Ownership Control"
 msgstr "库存所有权管控"
 
-#: common/setting/system.py:741
+#: common/setting/system.py:732
 msgid "Enable ownership control over stock locations and items"
 msgstr "启用对库存地点和库存物品的归属权管理"
 
-#: common/setting/system.py:746
+#: common/setting/system.py:737
 msgid "Stock Location Default Icon"
 msgstr "库存地点默认图标"
 
-#: common/setting/system.py:747
+#: common/setting/system.py:738
 msgid "Stock location default icon (empty means no icon)"
 msgstr "库存地点默认图标 (空表示没有图标)"
 
-#: common/setting/system.py:752
+#: common/setting/system.py:743
 msgid "Show Installed Stock Items"
 msgstr "显示已安装的库存项"
 
-#: common/setting/system.py:753
+#: common/setting/system.py:744
 msgid "Display installed stock items in stock tables"
 msgstr "在库存列表中显示已被安装到设备中的库存项"
 
-#: common/setting/system.py:758
+#: common/setting/system.py:749
 msgid "Check BOM when installing items"
 msgstr "在安装项目时检查物料清单"
 
-#: common/setting/system.py:760
+#: common/setting/system.py:751
 msgid "Installed stock items must exist in the BOM for the parent part"
 msgstr "已安装的库存项目必须存在于上级零件的物料清单中"
 
-#: common/setting/system.py:766
+#: common/setting/system.py:757
 msgid "Allow Out of Stock Transfer"
 msgstr "允许零库存调拨"
 
-#: common/setting/system.py:768
+#: common/setting/system.py:759
 msgid "Allow stock items which are not in stock to be transferred between stock locations"
 msgstr "允许对当前库存量为零的物品执行库位间调拨操作"
 
-#: common/setting/system.py:774
+#: common/setting/system.py:765
 msgid "Build Order Reference Pattern"
 msgstr "生产订单参考模式"
 
-#: common/setting/system.py:775
+#: common/setting/system.py:766
 msgid "Required pattern for generating Build Order reference field"
 msgstr "生成生产订单参考字段所需的模式"
 
-#: common/setting/system.py:780 common/setting/system.py:840
-#: common/setting/system.py:860 common/setting/system.py:904
+#: common/setting/system.py:771 common/setting/system.py:831
+#: common/setting/system.py:851 common/setting/system.py:895
 msgid "Require Responsible Owner"
 msgstr "要求负责人"
 
-#: common/setting/system.py:781 common/setting/system.py:841
-#: common/setting/system.py:861 common/setting/system.py:905
+#: common/setting/system.py:772 common/setting/system.py:832
+#: common/setting/system.py:852 common/setting/system.py:896
 msgid "A responsible owner must be assigned to each order"
 msgstr "必须为每个订单分配一个负责人"
 
-#: common/setting/system.py:786
+#: common/setting/system.py:777
 msgid "Require Active Part"
 msgstr "需要活动零件"
 
-#: common/setting/system.py:787
+#: common/setting/system.py:778
 msgid "Prevent build order creation for inactive parts"
 msgstr "防止为非活动零件创建生产订单"
 
-#: common/setting/system.py:792
+#: common/setting/system.py:783
 msgid "Require Locked Part"
 msgstr "需要锁定零件"
 
-#: common/setting/system.py:793
+#: common/setting/system.py:784
 msgid "Prevent build order creation for unlocked parts"
 msgstr "防止为未锁定的零件创建生产订单"
 
-#: common/setting/system.py:798
+#: common/setting/system.py:789
 msgid "Require Valid BOM"
 msgstr "需要有效的物料清单"
 
-#: common/setting/system.py:799
+#: common/setting/system.py:790
 msgid "Prevent build order creation unless BOM has been validated"
 msgstr "除非物料清单已验证，否则禁止创建生产订单"
 
-#: common/setting/system.py:804
+#: common/setting/system.py:795
 msgid "Require Closed Child Orders"
 msgstr "需要关闭子订单"
 
-#: common/setting/system.py:806
+#: common/setting/system.py:797
 msgid "Prevent build order completion until all child orders are closed"
 msgstr "在所有子订单关闭之前，阻止生产订单的完成"
 
-#: common/setting/system.py:812
+#: common/setting/system.py:803
 msgid "External Build Orders"
 msgstr "外部生产订单"
 
-#: common/setting/system.py:813
+#: common/setting/system.py:804
 msgid "Enable external build order functionality"
 msgstr "启用外部生产订单功能"
 
-#: common/setting/system.py:818
+#: common/setting/system.py:809
 msgid "Block Until Tests Pass"
 msgstr "阻止直到测试通过"
 
-#: common/setting/system.py:820
+#: common/setting/system.py:811
 msgid "Prevent build outputs from being completed until all required tests pass"
 msgstr "在所有必要的测试通过之前，阻止产出完成"
 
-#: common/setting/system.py:826
+#: common/setting/system.py:817
 msgid "Enable Return Orders"
 msgstr "启用订单退货"
 
-#: common/setting/system.py:827
+#: common/setting/system.py:818
 msgid "Enable return order functionality in the user interface"
 msgstr "在用户界面中启用订单退货功能"
 
-#: common/setting/system.py:832
+#: common/setting/system.py:823
 msgid "Return Order Reference Pattern"
 msgstr "退货订单参考模式"
 
-#: common/setting/system.py:834
+#: common/setting/system.py:825
 msgid "Required pattern for generating Return Order reference field"
 msgstr "生成退货订单参考字段所需的模式"
 
-#: common/setting/system.py:846
+#: common/setting/system.py:837
 msgid "Edit Completed Return Orders"
 msgstr "编辑已完成的退货订单"
 
-#: common/setting/system.py:848
+#: common/setting/system.py:839
 msgid "Allow editing of return orders after they have been completed"
 msgstr "允许编辑已完成的退货订单"
 
-#: common/setting/system.py:854
+#: common/setting/system.py:845
 msgid "Sales Order Reference Pattern"
 msgstr "销售订单参考模式"
 
-#: common/setting/system.py:855
+#: common/setting/system.py:846
 msgid "Required pattern for generating Sales Order reference field"
 msgstr "生成销售订单参考字段所需参照模式"
 
-#: common/setting/system.py:866
+#: common/setting/system.py:857
 msgid "Sales Order Default Shipment"
 msgstr "销售订单默认配送方式"
 
-#: common/setting/system.py:867
+#: common/setting/system.py:858
 msgid "Enable creation of default shipment with sales orders"
 msgstr "启用创建销售订单的默认配送功能"
 
-#: common/setting/system.py:872
+#: common/setting/system.py:863
 msgid "Edit Completed Sales Orders"
 msgstr "编辑已完成的销售订单"
 
-#: common/setting/system.py:874
+#: common/setting/system.py:865
 msgid "Allow editing of sales orders after they have been shipped or completed"
 msgstr "允许在订单配送或完成后编辑销售订单"
 
-#: common/setting/system.py:880
+#: common/setting/system.py:871
 msgid "Shipment Requires Checking"
 msgstr "货件需核对"
 
-#: common/setting/system.py:882
+#: common/setting/system.py:873
 msgid "Prevent completion of shipments until items have been checked"
 msgstr "只有所有物品均经核对，才能确认发货完成"
 
-#: common/setting/system.py:888
+#: common/setting/system.py:879
 msgid "Mark Shipped Orders as Complete"
 msgstr "标记该订单为已完成？"
 
-#: common/setting/system.py:890
+#: common/setting/system.py:881
 msgid "Sales orders marked as shipped will automatically be completed, bypassing the \"shipped\" status"
 msgstr "标记为已发货的销售订单将自动完成，绕过“已发货”状态"
 
-#: common/setting/system.py:896
+#: common/setting/system.py:887
 msgid "Purchase Order Reference Pattern"
 msgstr "采购订单参考模式"
 
-#: common/setting/system.py:898
+#: common/setting/system.py:889
 msgid "Required pattern for generating Purchase Order reference field"
 msgstr "生成采购订单参考字段所需的模式"
 
-#: common/setting/system.py:910
+#: common/setting/system.py:901
 msgid "Edit Completed Purchase Orders"
 msgstr "编辑已完成的采购订单"
 
-#: common/setting/system.py:912
+#: common/setting/system.py:903
 msgid "Allow editing of purchase orders after they have been shipped or completed"
 msgstr "允许在采购订单已配送或完成后编辑订单"
 
-#: common/setting/system.py:918
+#: common/setting/system.py:909
 msgid "Convert Currency"
 msgstr "货币转换"
 
-#: common/setting/system.py:919
+#: common/setting/system.py:910
 msgid "Convert item value to base currency when receiving stock"
 msgstr "收货时将物料价值折算为基准货币"
 
-#: common/setting/system.py:924
+#: common/setting/system.py:915
 msgid "Auto Complete Purchase Orders"
 msgstr "自动完成采购订单"
 
-#: common/setting/system.py:926
+#: common/setting/system.py:917
 msgid "Automatically mark purchase orders as complete when all line items are received"
 msgstr "当收到所有行项目时，自动将采购订单标记为完成"
 
-#: common/setting/system.py:933
+#: common/setting/system.py:924
 msgid "Enable password forgot"
 msgstr "忘记启用密码"
 
-#: common/setting/system.py:934
+#: common/setting/system.py:925
 msgid "Enable password forgot function on the login pages"
 msgstr "在登录页面上启用忘记密码功能"
 
-#: common/setting/system.py:939
+#: common/setting/system.py:930
 msgid "Enable registration"
 msgstr "启用注册"
 
-#: common/setting/system.py:940
+#: common/setting/system.py:931
 msgid "Enable self-registration for users on the login pages"
 msgstr "在登录页面为用户启用自行注册功能"
 
-#: common/setting/system.py:945
+#: common/setting/system.py:936
 msgid "Enable SSO"
 msgstr "启用SSO登录"
 
-#: common/setting/system.py:946
+#: common/setting/system.py:937
 msgid "Enable SSO on the login pages"
 msgstr "在登录页面启用单点登录(SSO)功能"
 
-#: common/setting/system.py:951
+#: common/setting/system.py:942
 msgid "Enable SSO registration"
 msgstr "启用SSO注册"
 
-#: common/setting/system.py:953
+#: common/setting/system.py:944
 msgid "Enable self-registration via SSO for users on the login pages"
 msgstr "允许用户通过登录页面的SSO系统注册账号"
 
-#: common/setting/system.py:959
+#: common/setting/system.py:950
 msgid "Enable SSO group sync"
 msgstr "启用SSO组同步"
 
-#: common/setting/system.py:961
+#: common/setting/system.py:952
 msgid "Enable synchronizing InvenTree groups with groups provided by the IdP"
 msgstr "启用后，将自动同步InvenTree用户组与身份提供商(IdP)提供的用户组"
 
-#: common/setting/system.py:967
+#: common/setting/system.py:958
 msgid "SSO group key"
 msgstr "SSO组属性键"
 
-#: common/setting/system.py:968
+#: common/setting/system.py:959
 msgid "The name of the groups claim attribute provided by the IdP"
 msgstr "身份提供商(IdP)返回的组信息声明属性名称"
 
-#: common/setting/system.py:973
+#: common/setting/system.py:964
 msgid "SSO group map"
 msgstr "SSO组映射关系"
 
-#: common/setting/system.py:975
+#: common/setting/system.py:966
 msgid "A mapping from SSO groups to local InvenTree groups. If the local group does not exist, it will be created."
 msgstr "将SSO用户组映射到本地InvenTree用户组的对应关系表。如果本地组不存在，系统会自动创建对应的用户组。"
 
-#: common/setting/system.py:981
+#: common/setting/system.py:972
 msgid "Remove groups outside of SSO"
 msgstr "移除非SSO来源的用户组"
 
-#: common/setting/system.py:983
+#: common/setting/system.py:974
 msgid "Whether groups assigned to the user should be removed if they are not backend by the IdP. Disabling this setting might cause security issues"
 msgstr "当用户组未被身份提供商(IdP)支持时，是否移除该用户组。禁用此选项可能导致安全风险"
 
-#: common/setting/system.py:989
+#: common/setting/system.py:980
 msgid "Email required"
 msgstr "必须提供邮箱"
 
-#: common/setting/system.py:990
+#: common/setting/system.py:981
 msgid "Require user to supply mail on signup"
 msgstr "用户注册时必须提供邮箱"
 
-#: common/setting/system.py:995
+#: common/setting/system.py:986
 msgid "Auto-fill SSO users"
 msgstr "自动填充SSO用户信息"
 
-#: common/setting/system.py:996
+#: common/setting/system.py:987
 msgid "Automatically fill out user-details from SSO account-data"
 msgstr "自动从SSO账户数据中填充用户详细信息"
 
-#: common/setting/system.py:1001
+#: common/setting/system.py:992
 msgid "Mail twice"
 msgstr "发两次邮件"
 
-#: common/setting/system.py:1002
+#: common/setting/system.py:993
 msgid "On signup ask users twice for their mail"
 msgstr "注册时询问用户他们的电子邮件两次"
 
-#: common/setting/system.py:1007
+#: common/setting/system.py:998
 msgid "Password twice"
 msgstr "两次输入密码"
 
-#: common/setting/system.py:1008
+#: common/setting/system.py:999
 msgid "On signup ask users twice for their password"
 msgstr "当注册时请用户输入密码两次"
 
-#: common/setting/system.py:1013
+#: common/setting/system.py:1004
 msgid "Allowed domains"
 msgstr "域名白名单"
 
-#: common/setting/system.py:1015
+#: common/setting/system.py:1006
 msgid "Restrict signup to certain domains (comma-separated, starting with @)"
 msgstr "限制注册到某些域名 (逗号分隔，以 @ 开头)"
 
-#: common/setting/system.py:1021
+#: common/setting/system.py:1012
 msgid "Group on signup"
 msgstr "注册默认分组"
 
-#: common/setting/system.py:1023
+#: common/setting/system.py:1014
 msgid "Group to which new users are assigned on registration. If SSO group sync is enabled, this group is only set if no group can be assigned from the IdP."
 msgstr "新用户注册时被分配的默认用户组。 如果启用了SSO组同步功能，当无法从身份提供商(IdP)分配组时才会应用此分组。"
 
-#: common/setting/system.py:1029
+#: common/setting/system.py:1020
 msgid "Enforce MFA"
 msgstr "强制启用多因素安全认证"
 
-#: common/setting/system.py:1030
+#: common/setting/system.py:1021
 msgid "Users must use multifactor security."
 msgstr "用户必须使用多因素安全认证。"
 
-#: common/setting/system.py:1035
+#: common/setting/system.py:1026
 msgid "Enabling this setting will require all users to set up multifactor authentication. All sessions will be disconnected immediately."
 msgstr "启用此设置将要求所有用户设置多元素认证。所有会话将立即断开连接。"
 
-#: common/setting/system.py:1040
+#: common/setting/system.py:1031
 msgid "Check plugins on startup"
 msgstr "启动时检查插件"
 
-#: common/setting/system.py:1042
+#: common/setting/system.py:1033
 msgid "Check that all plugins are installed on startup - enable in container environments"
 msgstr "启动时检查全部插件是否已安装 - 在容器环境中启用"
 
-#: common/setting/system.py:1049
+#: common/setting/system.py:1040
 msgid "Check for plugin updates"
 msgstr "检查插件更新"
 
-#: common/setting/system.py:1050
+#: common/setting/system.py:1041
 msgid "Enable periodic checks for updates to installed plugins"
 msgstr "启用定期检查已安装插件的更新"
 
-#: common/setting/system.py:1056
+#: common/setting/system.py:1047
 msgid "Enable URL integration"
 msgstr "启用统一资源定位符集成"
 
-#: common/setting/system.py:1057
+#: common/setting/system.py:1048
 msgid "Enable plugins to add URL routes"
 msgstr "启用插件以添加统一资源定位符路由"
 
-#: common/setting/system.py:1063
+#: common/setting/system.py:1054
 msgid "Enable navigation integration"
 msgstr "启用导航集成"
 
-#: common/setting/system.py:1064
+#: common/setting/system.py:1055
 msgid "Enable plugins to integrate into navigation"
 msgstr "启用插件以集成到导航中"
 
-#: common/setting/system.py:1070
+#: common/setting/system.py:1061
 msgid "Enable app integration"
 msgstr "启用应用集成"
 
-#: common/setting/system.py:1071
+#: common/setting/system.py:1062
 msgid "Enable plugins to add apps"
 msgstr "启用插件添加应用"
 
-#: common/setting/system.py:1077
+#: common/setting/system.py:1068
 msgid "Enable schedule integration"
 msgstr "启用调度集成"
 
-#: common/setting/system.py:1078
+#: common/setting/system.py:1069
 msgid "Enable plugins to run scheduled tasks"
 msgstr "启用插件来运行预定任务"
 
-#: common/setting/system.py:1084
+#: common/setting/system.py:1075
 msgid "Enable event integration"
 msgstr "启用事件集成"
 
-#: common/setting/system.py:1085
+#: common/setting/system.py:1076
 msgid "Enable plugins to respond to internal events"
 msgstr "启用插件响应内部事件"
 
-#: common/setting/system.py:1091
+#: common/setting/system.py:1082
 msgid "Enable interface integration"
 msgstr "启用界面集成"
 
-#: common/setting/system.py:1092
+#: common/setting/system.py:1083
 msgid "Enable plugins to integrate into the user interface"
 msgstr "启用插件集成到用户界面"
 
-#: common/setting/system.py:1098
+#: common/setting/system.py:1089
 msgid "Enable mail integration"
 msgstr "启用邮件集成"
 
-#: common/setting/system.py:1099
+#: common/setting/system.py:1090
 msgid "Enable plugins to process outgoing/incoming mails"
 msgstr "启用插件来处理发送/接收邮件"
 
-#: common/setting/system.py:1105
+#: common/setting/system.py:1096
 msgid "Enable project codes"
 msgstr "启用项目编码"
 
-#: common/setting/system.py:1106
+#: common/setting/system.py:1097
 msgid "Enable project codes for tracking projects"
 msgstr "启用项目编码来跟踪项目"
 
-#: common/setting/system.py:1111
-msgid "Enable Stocktake"
-msgstr "启用盘点"
+#: common/setting/system.py:1102
+msgid "Enable Stock History"
+msgstr "启用库存历史"
 
-#: common/setting/system.py:1113
+#: common/setting/system.py:1104
 msgid "Enable functionality for recording historical stock levels and value"
 msgstr "启用历史库存水平及价值记录功能"
 
-#: common/setting/system.py:1119
+#: common/setting/system.py:1110
 msgid "Exclude External Locations"
 msgstr "排除外部地点"
 
-#: common/setting/system.py:1121
-msgid "Exclude stock items in external locations from stocktake calculations"
-msgstr "将外部库位的库存物料排除在盘点计算之外"
+#: common/setting/system.py:1112
+msgid "Exclude stock items in external locations from stock history calculations"
+msgstr "在库存历史统计中排除外部库位的库存项"
 
-#: common/setting/system.py:1127
+#: common/setting/system.py:1118
 msgid "Automatic Stocktake Period"
 msgstr "自动盘点周期"
 
-#: common/setting/system.py:1128
-msgid "Number of days between automatic stocktake recording"
-msgstr "自动库存盘点记录的间隔天数"
+#: common/setting/system.py:1119
+msgid "Number of days between automatic stock history recording"
+msgstr "自动记录库存历史的间隔天数"
 
-#: common/setting/system.py:1134
-msgid "Delete Old Stocktake Entries"
-msgstr "删除旧的盘点记录条目"
+#: common/setting/system.py:1125
+msgid "Delete Old Stock History Entries"
+msgstr "删除旧的库存历史记录"
 
-#: common/setting/system.py:1136
-msgid "Delete stocktake entries older than the specified number of days"
-msgstr "删除超过指定天数的库存盘点记录"
+#: common/setting/system.py:1127
+msgid "Delete stock history entries older than the specified number of days"
+msgstr "删除超过指定天数的库存历史记录"
+
+#: common/setting/system.py:1133
+msgid "Stock History Deletion Interval"
+msgstr "库存历史删除间隔"
+
+#: common/setting/system.py:1135
+msgid "Stock history entries will be deleted after specified number of days"
+msgstr "库存历史记录将在指定天数后删除"
 
 #: common/setting/system.py:1142
-msgid "Stocktake Deletion Interval"
-msgstr "库存盘点记录删除周期"
-
-#: common/setting/system.py:1144
-msgid "Stocktake entries will be deleted after specified number of days"
-msgstr "库存盘点记录将在指定天数后自动删除"
-
-#: common/setting/system.py:1151
-msgid "Delete Old Stock Tracking Entries"
-msgstr "删除旧的库存跟踪记录"
-
-#: common/setting/system.py:1153
-msgid "Delete stock tracking entries older than the specified number of days"
-msgstr "删除超过指定天数的库存跟踪记录"
-
-#: common/setting/system.py:1159
-msgid "Stock Tracking Deletion Interval"
-msgstr "库存跟踪记录删除周期"
-
-#: common/setting/system.py:1161
-msgid "Stock tracking entries will be deleted after specified number of days"
-msgstr "库存跟踪记录将在指定天数后自动删除"
-
-#: common/setting/system.py:1168
 msgid "Display Users full names"
 msgstr "显示用户全名"
 
-#: common/setting/system.py:1169
+#: common/setting/system.py:1143
 msgid "Display Users full names instead of usernames"
 msgstr "显示用户全名而不是用户名"
 
-#: common/setting/system.py:1174
+#: common/setting/system.py:1148
 msgid "Display User Profiles"
 msgstr "显示用户配置"
 
-#: common/setting/system.py:1175
+#: common/setting/system.py:1149
 msgid "Display Users Profiles on their profile page"
 msgstr "在用户个人资料页展示其档案信息"
 
-#: common/setting/system.py:1180
+#: common/setting/system.py:1154
 msgid "Enable Test Station Data"
 msgstr "启用测试站数据"
 
-#: common/setting/system.py:1181
+#: common/setting/system.py:1155
 msgid "Enable test station data collection for test results"
 msgstr "启用测试站数据收集以获取测试结果"
 
-#: common/setting/system.py:1186
+#: common/setting/system.py:1160
 msgid "Enable Machine Ping"
 msgstr "启用设备状态检测"
 
-#: common/setting/system.py:1188
+#: common/setting/system.py:1162
 msgid "Enable periodic ping task of registered machines to check their status"
 msgstr "启用定期 Ping 检测，确认注册设备的运行状态"
 
@@ -3974,346 +3921,334 @@ msgstr "零件已激活"
 msgid "Manufacturer is Active"
 msgstr "制造商处于活动状态"
 
-#: company/api.py:251
+#: company/api.py:242
 msgid "Supplier Part is Active"
 msgstr "供应商零件处于激活状态"
 
-#: company/api.py:253
-msgid "Primary Supplier Part"
-msgstr "主供应商部件"
-
-#: company/api.py:257
+#: company/api.py:246
 msgid "Internal Part is Active"
 msgstr "内部零件已激活"
 
-#: company/api.py:262
+#: company/api.py:251
 msgid "Supplier is Active"
 msgstr "供应商已激活"
 
-#: company/api.py:274 company/models.py:535 company/serializers.py:455
-#: part/serializers.py:488
+#: company/api.py:263 company/models.py:528 company/serializers.py:454
+#: part/serializers.py:477
 msgid "Manufacturer"
 msgstr "制造商"
 
-#: company/api.py:281 company/models.py:124 company/models.py:404
-#: stock/api.py:899
+#: company/api.py:270 company/models.py:122 company/models.py:399
+#: stock/api.py:900
 msgid "Company"
 msgstr "公司"
 
-#: company/api.py:291
+#: company/api.py:280
 msgid "Has Stock"
 msgstr "有库存"
 
-#: company/models.py:125
+#: company/models.py:123
 msgid "Companies"
 msgstr "公司"
 
-#: company/models.py:153
+#: company/models.py:151
 msgid "Company description"
 msgstr "公司简介"
 
-#: company/models.py:154
+#: company/models.py:152
 msgid "Description of the company"
 msgstr "公司简介"
 
-#: company/models.py:160
+#: company/models.py:158
 msgid "Website"
 msgstr "网站"
 
-#: company/models.py:161
+#: company/models.py:159
 msgid "Company website URL"
 msgstr "公司网站"
 
-#: company/models.py:167
+#: company/models.py:165
 msgid "Phone number"
 msgstr "电话号码"
 
-#: company/models.py:169
+#: company/models.py:167
 msgid "Contact phone number"
 msgstr "联系电话"
 
-#: company/models.py:176
+#: company/models.py:174
 msgid "Contact email address"
 msgstr "联系人电子邮箱地址"
 
-#: company/models.py:181 company/models.py:311 order/models.py:525
+#: company/models.py:179 company/models.py:303 order/models.py:515
 #: users/models.py:561
 msgid "Contact"
 msgstr "联系人"
 
-#: company/models.py:183
+#: company/models.py:181
 msgid "Point of contact"
 msgstr "联络点"
 
-#: company/models.py:189
+#: company/models.py:187
 msgid "Link to external company information"
 msgstr "外部公司信息链接"
 
-#: company/models.py:194
+#: company/models.py:192
 msgid "Is this company active?"
 msgstr "这家公司是否激活？"
 
-#: company/models.py:199
+#: company/models.py:197
 msgid "Is customer"
 msgstr "是客户"
 
-#: company/models.py:200
+#: company/models.py:198
 msgid "Do you sell items to this company?"
 msgstr "你是否向该公司出售商品？"
 
-#: company/models.py:205
+#: company/models.py:203
 msgid "Is supplier"
 msgstr "是否为供应商"
 
-#: company/models.py:206
+#: company/models.py:204
 msgid "Do you purchase items from this company?"
 msgstr "你从这家公司买东西吗？"
 
-#: company/models.py:211
+#: company/models.py:209
 msgid "Is manufacturer"
 msgstr "是制造商吗"
 
-#: company/models.py:212
+#: company/models.py:210
 msgid "Does this company manufacture parts?"
 msgstr "这家公司生产零件吗？"
 
-#: company/models.py:220
+#: company/models.py:218
 msgid "Default currency used for this company"
 msgstr "此公司使用的默认货币"
 
-#: company/models.py:227
+#: company/models.py:225
 msgid "Tax ID"
 msgstr "税号"
 
-#: company/models.py:228
+#: company/models.py:226
 msgid "Company Tax ID"
 msgstr "公司税号"
 
-#: company/models.py:350 order/models.py:535 order/models.py:2327
+#: company/models.py:342 order/models.py:525 order/models.py:2289
 msgid "Address"
 msgstr "地址"
 
-#: company/models.py:351
+#: company/models.py:343
 msgid "Addresses"
 msgstr "地址"
 
-#: company/models.py:405
+#: company/models.py:400
 msgid "Select company"
 msgstr "选择公司"
 
-#: company/models.py:410
+#: company/models.py:405
 msgid "Address title"
 msgstr "地址标题"
 
-#: company/models.py:411
+#: company/models.py:406
 msgid "Title describing the address entry"
 msgstr "描述地址条目的标题"
 
-#: company/models.py:417
+#: company/models.py:412
 msgid "Primary address"
 msgstr "主要地址"
 
-#: company/models.py:418
+#: company/models.py:413
 msgid "Set as primary address"
 msgstr "设置主要地址"
 
-#: company/models.py:423
+#: company/models.py:418
 msgid "Line 1"
 msgstr "第1行"
 
-#: company/models.py:424
+#: company/models.py:419
 msgid "Address line 1"
 msgstr "地址行1"
 
-#: company/models.py:430
+#: company/models.py:425
 msgid "Line 2"
 msgstr "第2行"
 
-#: company/models.py:431
+#: company/models.py:426
 msgid "Address line 2"
 msgstr "地址行2"
 
-#: company/models.py:437 company/models.py:438
+#: company/models.py:432 company/models.py:433
 msgid "Postal code"
 msgstr "邮政编码"
 
-#: company/models.py:444
+#: company/models.py:439
 msgid "City/Region"
 msgstr "城市/地区"
 
-#: company/models.py:445
+#: company/models.py:440
 msgid "Postal code city/region"
 msgstr "邮政编码城市/地区"
 
-#: company/models.py:451
+#: company/models.py:446
 msgid "State/Province"
 msgstr "省/市/自治区"
 
-#: company/models.py:452
+#: company/models.py:447
 msgid "State or province"
 msgstr "省、自治区或直辖市"
 
-#: company/models.py:458
+#: company/models.py:453
 msgid "Country"
 msgstr "国家/地区"
 
-#: company/models.py:459
+#: company/models.py:454
 msgid "Address country"
 msgstr "地址所在国家"
 
-#: company/models.py:465
+#: company/models.py:460
 msgid "Courier shipping notes"
 msgstr "快递运单"
 
-#: company/models.py:466
+#: company/models.py:461
 msgid "Notes for shipping courier"
 msgstr "运输快递注意事项"
 
-#: company/models.py:472
+#: company/models.py:467
 msgid "Internal shipping notes"
 msgstr "内部装运通知单"
 
-#: company/models.py:473
+#: company/models.py:468
 msgid "Shipping notes for internal use"
 msgstr "内部使用的装运通知单"
 
-#: company/models.py:480
+#: company/models.py:475
 msgid "Link to address information (external)"
 msgstr "链接地址信息 (外部)"
 
-#: company/models.py:507 company/models.py:802 company/serializers.py:475
-#: stock/api.py:560
+#: company/models.py:500 company/models.py:773 company/serializers.py:474
+#: stock/api.py:561
 msgid "Manufacturer Part"
 msgstr "制造商零件"
 
-#: company/models.py:524 company/models.py:764 stock/models.py:1032
-#: stock/serializers.py:418
+#: company/models.py:517 company/models.py:741 stock/models.py:1027
+#: stock/serializers.py:409
 msgid "Base Part"
 msgstr "基础零件"
 
-#: company/models.py:526 company/models.py:766
+#: company/models.py:519 company/models.py:743
 msgid "Select part"
 msgstr "选择零件"
 
-#: company/models.py:536
+#: company/models.py:529
 msgid "Select manufacturer"
 msgstr "选择制造商"
 
-#: company/models.py:542 company/serializers.py:486 order/serializers.py:705
-#: part/serializers.py:498
+#: company/models.py:535 company/serializers.py:485 order/serializers.py:692
+#: part/serializers.py:487
 msgid "MPN"
 msgstr "制造商零件编号"
 
-#: company/models.py:543 stock/serializers.py:575
+#: company/models.py:536 stock/serializers.py:564
 msgid "Manufacturer Part Number"
 msgstr "制造商零件编号"
 
-#: company/models.py:550
+#: company/models.py:543
 msgid "URL for external manufacturer part link"
 msgstr "外部制造商零件链接的URL"
 
-#: company/models.py:559
+#: company/models.py:552
 msgid "Manufacturer part description"
 msgstr "制造商零件说明"
 
-#: company/models.py:691
+#: company/models.py:681
 msgid "Pack units must be compatible with the base part units"
 msgstr "包装单位必须与基础零件单位兼容"
 
-#: company/models.py:698
+#: company/models.py:688
 msgid "Pack units must be greater than zero"
 msgstr "包装单位必须大于零"
 
-#: company/models.py:712
+#: company/models.py:702
 msgid "Linked manufacturer part must reference the same base part"
 msgstr "链接的制造商零件必须引用相同的基础零件"
 
-#: company/models.py:774 company/serializers.py:443 company/serializers.py:470
-#: order/models.py:653 part/serializers.py:472
+#: company/models.py:751 company/serializers.py:442 company/serializers.py:469
+#: order/models.py:641 part/serializers.py:461
 #: plugin/builtin/suppliers/digikey.py:26 plugin/builtin/suppliers/lcsc.py:27
 #: plugin/builtin/suppliers/mouser.py:25 plugin/builtin/suppliers/tme.py:27
-#: stock/api.py:566 templates/email/overdue_purchase_order.html:16
+#: stock/api.py:567 templates/email/overdue_purchase_order.html:16
 msgid "Supplier"
 msgstr "供应商"
 
-#: company/models.py:775
+#: company/models.py:752
 msgid "Select supplier"
 msgstr "选择供应商"
 
-#: company/models.py:781 part/serializers.py:483
+#: company/models.py:758 part/serializers.py:472
 msgid "Supplier stock keeping unit"
 msgstr "供应商库存管理单位"
 
-#: company/models.py:787
+#: company/models.py:764
 msgid "Is this supplier part active?"
 msgstr "此供应商零件是否处于活动状态？"
 
-#: company/models.py:792
-msgid "Primary"
-msgstr "主要的"
-
-#: company/models.py:793
-msgid "Is this the primary supplier part for the linked Part?"
-msgstr "这是否为关联物料的主供应商物料？"
-
-#: company/models.py:803
+#: company/models.py:774
 msgid "Select manufacturer part"
 msgstr "选择制造商零件"
 
-#: company/models.py:810
+#: company/models.py:781
 msgid "URL for external supplier part link"
 msgstr "外部供应商零件链接的URL"
 
-#: company/models.py:819
+#: company/models.py:790
 msgid "Supplier part description"
 msgstr "供应商零件说明"
 
-#: company/models.py:835 part/models.py:2295
+#: company/models.py:806 part/models.py:2319
 msgid "base cost"
 msgstr "基本费用"
 
-#: company/models.py:836 part/models.py:2296
+#: company/models.py:807 part/models.py:2320
 msgid "Minimum charge (e.g. stocking fee)"
 msgstr "最低费用(例如库存费)"
 
-#: company/models.py:843 order/serializers.py:846 stock/models.py:1063
-#: stock/serializers.py:1648
+#: company/models.py:814 order/serializers.py:833 stock/models.py:1058
+#: stock/serializers.py:1627
 msgid "Packaging"
 msgstr "打包"
 
-#: company/models.py:844
+#: company/models.py:815
 msgid "Part packaging"
 msgstr "零件打包"
 
-#: company/models.py:849
+#: company/models.py:820
 msgid "Pack Quantity"
 msgstr "包装数量"
 
-#: company/models.py:851
+#: company/models.py:822
 msgid "Total quantity supplied in a single pack. Leave empty for single items."
 msgstr "单包供应的总数量。为单个项目留空。"
 
-#: company/models.py:870 part/models.py:2302
+#: company/models.py:841 part/models.py:2326
 msgid "multiple"
 msgstr "多个"
 
-#: company/models.py:871
+#: company/models.py:842
 msgid "Order multiple"
 msgstr "订购多个"
 
-#: company/models.py:883
+#: company/models.py:854
 msgid "Quantity available from supplier"
 msgstr "供应商提供的数量"
 
-#: company/models.py:889
+#: company/models.py:860
 msgid "Availability Updated"
 msgstr "可用性已更新"
 
-#: company/models.py:890
+#: company/models.py:861
 msgid "Date of last update of availability data"
 msgstr "上次更新可用性数据的日期"
 
-#: company/models.py:1018
+#: company/models.py:989
 msgid "Supplier Price Break"
 msgstr "供应商批发价"
 
@@ -4325,19 +4260,19 @@ msgstr "此供应商使用的默认货币"
 msgid "Company Name"
 msgstr "公司名称"
 
-#: company/serializers.py:407 part/serializers.py:845 stock/serializers.py:441
+#: company/serializers.py:406 part/serializers.py:827 stock/serializers.py:430
 msgid "In Stock"
 msgstr "有库存"
 
-#: company/serializers.py:424
+#: company/serializers.py:423
 msgid "Price Breaks"
 msgstr "批发价"
 
-#: data_exporter/mixins.py:328 data_exporter/mixins.py:417
+#: data_exporter/mixins.py:323 data_exporter/mixins.py:412
 msgid "Error occurred during data export"
 msgstr "数据导出过程中发生错误"
 
-#: data_exporter/mixins.py:395
+#: data_exporter/mixins.py:390
 msgid "Data export plugin returned incorrect data format"
 msgstr "数据导出插件返回的数据格式不正确"
 
@@ -4385,119 +4320,119 @@ msgstr "放置"
 msgid "Invalid status code"
 msgstr "无效状态码"
 
-#: importer/models.py:74
+#: importer/models.py:73
 msgid "Data File"
 msgstr "数据文件"
 
-#: importer/models.py:75
+#: importer/models.py:74
 msgid "Data file to import"
 msgstr "要导入的数据文件"
 
-#: importer/models.py:84
+#: importer/models.py:83
 msgid "Columns"
 msgstr "列"
 
-#: importer/models.py:91
+#: importer/models.py:90
 msgid "Target model type for this import session"
 msgstr "本次导入会话的目标模型类型"
 
-#: importer/models.py:97
+#: importer/models.py:96
 msgid "Import status"
 msgstr "导入状态"
 
-#: importer/models.py:107
+#: importer/models.py:106
 msgid "Field Defaults"
 msgstr "字段默认值"
 
-#: importer/models.py:114
+#: importer/models.py:113
 msgid "Field Overrides"
 msgstr "字段覆盖"
 
-#: importer/models.py:121
+#: importer/models.py:120
 msgid "Field Filters"
 msgstr "字段筛选器"
 
-#: importer/models.py:127
+#: importer/models.py:126
 msgid "Update Existing Records"
 msgstr "更新现有记录"
 
-#: importer/models.py:128
+#: importer/models.py:127
 msgid "If enabled, existing records will be updated with new data"
 msgstr "若启用，现有记录将被新数据更新"
 
-#: importer/models.py:281
+#: importer/models.py:259
 msgid "Some required fields have not been mapped"
 msgstr "某些必填字段尚未映射"
 
-#: importer/models.py:388
+#: importer/models.py:366
 msgid "ID"
 msgstr "ID"
 
-#: importer/models.py:389
+#: importer/models.py:367
 msgid "Existing database identifier for the record"
 msgstr "记录的现有数据库标识符"
 
-#: importer/models.py:452
+#: importer/models.py:430
 msgid "Column is already mapped to a database field"
 msgstr "列已映射到数据库字段"
 
-#: importer/models.py:457
+#: importer/models.py:435
 msgid "Field is already mapped to a data column"
 msgstr "字段已映射到数据列"
 
-#: importer/models.py:466
+#: importer/models.py:444
 msgid "Column mapping must be linked to a valid import session"
 msgstr "列映射必须链接到有效的导入会话"
 
-#: importer/models.py:471
+#: importer/models.py:449
 msgid "Column does not exist in the data file"
 msgstr "数据文件中不存在列"
 
-#: importer/models.py:478
+#: importer/models.py:456
 msgid "Field does not exist in the target model"
 msgstr "目标模型中不存在字段"
 
-#: importer/models.py:482
+#: importer/models.py:460
 msgid "Selected field is read-only"
 msgstr "所选字段为只读"
 
-#: importer/models.py:487 importer/models.py:564
+#: importer/models.py:465 importer/models.py:536
 msgid "Import Session"
 msgstr "导入会话"
 
-#: importer/models.py:491
+#: importer/models.py:469
 msgid "Field"
 msgstr "字段"
 
-#: importer/models.py:493
+#: importer/models.py:471
 msgid "Column"
 msgstr "列"
 
-#: importer/models.py:568
+#: importer/models.py:540
 msgid "Row Index"
 msgstr "行索引"
 
-#: importer/models.py:571
+#: importer/models.py:543
 msgid "Original row data"
 msgstr "原始行数据"
 
-#: importer/models.py:576 machine/models.py:111
+#: importer/models.py:548 machine/models.py:111
 msgid "Errors"
 msgstr "错误"
 
-#: importer/models.py:578 part/serializers.py:1132
+#: importer/models.py:550 part/serializers.py:1114
 msgid "Valid"
 msgstr "有效"
 
-#: importer/models.py:839
+#: importer/models.py:720
 msgid "ID is required for updating existing records."
 msgstr "更新现有记录需要提供ID。"
 
-#: importer/models.py:846
+#: importer/models.py:727
 msgid "No record found with the provided ID"
 msgstr "没有找到与提供的ID相关的记录"
 
-#: importer/models.py:852
+#: importer/models.py:733
 msgid "Invalid ID format provided"
 msgstr "提供的ID格式无效"
 
@@ -4597,7 +4532,7 @@ msgstr "每个标签要打印的份数"
 msgid "Connected"
 msgstr "已连接"
 
-#: machine/machine_types/label_printer.py:232 order/api.py:1846
+#: machine/machine_types/label_printer.py:232 order/api.py:1790
 msgid "Unknown"
 msgstr "未知"
 
@@ -4725,117 +4660,105 @@ msgstr "最大进度"
 msgid "Maximum value for progress type, required if type=progress"
 msgstr "进度类型的最大值。当 type=progress 时为必填项"
 
-#: order/api.py:128
+#: order/api.py:130
 msgid "Order Reference"
 msgstr "订单参考"
 
-#: order/api.py:156 order/api.py:1218
+#: order/api.py:158 order/api.py:1204
 msgid "Outstanding"
 msgstr "未完成"
 
-#: order/api.py:172
+#: order/api.py:174
 msgid "Has Project Code"
 msgstr "有项目编码"
 
-#: order/api.py:186 order/models.py:493
+#: order/api.py:188 order/models.py:490
 msgid "Created By"
 msgstr "创建人"
 
-#: order/api.py:190
+#: order/api.py:192
 msgid "Created Before"
 msgstr "创建时间早于"
 
-#: order/api.py:194
+#: order/api.py:196
 msgid "Created After"
 msgstr "创建时间晚于"
 
-#: order/api.py:198
+#: order/api.py:200
 msgid "Has Start Date"
 msgstr "有开始日期"
 
-#: order/api.py:206
+#: order/api.py:208
 msgid "Start Date Before"
 msgstr "开始日期早于"
 
-#: order/api.py:210
+#: order/api.py:212
 msgid "Start Date After"
 msgstr "开始日期晚于"
 
-#: order/api.py:214
+#: order/api.py:216
 msgid "Has Target Date"
 msgstr "有目标日期"
 
-#: order/api.py:222
+#: order/api.py:224
 msgid "Target Date Before"
 msgstr "目标日期早于"
 
-#: order/api.py:226
+#: order/api.py:228
 msgid "Target Date After"
 msgstr "目标日期晚于"
 
-#: order/api.py:230
-msgid "Updated Before"
-msgstr "更新时间早于"
-
-#: order/api.py:234
-msgid "Updated After"
-msgstr "更新时间晚于"
-
-#: order/api.py:285
+#: order/api.py:279
 msgid "Has Pricing"
 msgstr "有定价"
 
-#: order/api.py:338 order/api.py:825 order/api.py:1527
+#: order/api.py:332 order/api.py:816 order/api.py:1487
 msgid "Completed Before"
 msgstr "完成时间早于"
 
-#: order/api.py:342 order/api.py:829 order/api.py:1531
+#: order/api.py:336 order/api.py:820 order/api.py:1491
 msgid "Completed After"
 msgstr "完成时间晚于"
 
-#: order/api.py:348 order/api.py:352
+#: order/api.py:342 order/api.py:346
 msgid "External Build Order"
 msgstr "外部生产订单"
 
-#: order/api.py:537 order/api.py:925 order/api.py:1181 order/models.py:1959
-#: order/models.py:2085 order/models.py:2137 order/models.py:2318
-#: order/models.py:2507 order/models.py:3036 order/models.py:3102
+#: order/api.py:530 order/api.py:915 order/api.py:1167 order/models.py:1924
+#: order/models.py:2050 order/models.py:2100 order/models.py:2280
+#: order/models.py:2478 order/models.py:3000 order/models.py:3066
 msgid "Order"
 msgstr "订单"
 
-#: order/api.py:541 order/api.py:993
+#: order/api.py:534 order/api.py:983
 msgid "Order Complete"
 msgstr "订单完成"
 
-#: order/api.py:573 order/api.py:577 order/serializers.py:716
+#: order/api.py:566 order/api.py:570 order/serializers.py:703
 msgid "Internal Part"
 msgstr "内部零件"
 
-#: order/api.py:595
+#: order/api.py:588
 msgid "Order Pending"
 msgstr "订单待定"
 
-#: order/api.py:978
+#: order/api.py:968
 msgid "Completed"
 msgstr "已完成"
 
-#: order/api.py:1234
+#: order/api.py:1220
 msgid "Has Shipment"
 msgstr "有配送"
 
-#: order/api.py:1442
-msgid "Shipment not found"
-msgstr "未找到发货记录"
-
-#: order/api.py:1840 order/models.py:564 order/models.py:1960
-#: order/models.py:2086
+#: order/api.py:1784 order/models.py:554 order/models.py:1925
+#: order/models.py:2051
 #: report/templates/report/inventree_purchase_order_report.html:14
 #: stock/serializers.py:129 templates/email/overdue_purchase_order.html:15
 msgid "Purchase Order"
 msgstr "采购订单"
 
-#: order/api.py:1842 order/models.py:1275 order/models.py:2138
-#: order/models.py:2319 order/models.py:2508
+#: order/api.py:1786 order/models.py:1253 order/models.py:2101
+#: order/models.py:2281 order/models.py:2479
 #: report/templates/report/inventree_build_order_report.html:135
 #: report/templates/report/inventree_sales_order_report.html:14
 #: report/templates/report/inventree_sales_order_shipment_report.html:15
@@ -4843,8 +4766,8 @@ msgstr "采购订单"
 msgid "Sales Order"
 msgstr "销售订单"
 
-#: order/api.py:1844 order/models.py:2679 order/models.py:3037
-#: order/models.py:3103
+#: order/api.py:1788 order/models.py:2650 order/models.py:3001
+#: order/models.py:3067
 #: report/templates/report/inventree_return_order_report.html:13
 #: templates/email/overdue_return_order.html:15
 msgid "Return Order"
@@ -4860,754 +4783,730 @@ msgstr "总价格"
 msgid "Total price for this order"
 msgstr "此订单的总价"
 
-#: order/models.py:96 order/serializers.py:61
+#: order/models.py:96 order/serializers.py:67
 msgid "Order Currency"
 msgstr "订单货币"
 
-#: order/models.py:99 order/serializers.py:62
+#: order/models.py:99 order/serializers.py:68
 msgid "Currency for this order (leave blank to use company default)"
 msgstr "此订单的货币 (留空以使用公司默认值)"
 
-#: order/models.py:326
+#: order/models.py:325
 msgid "This order is locked and cannot be modified"
 msgstr "该订单已锁定，不可修改"
 
-#: order/models.py:380
+#: order/models.py:377
 msgid "Contact does not match selected company"
 msgstr "联系人与所选公司不匹配"
 
-#: order/models.py:387
+#: order/models.py:384
 msgid "Start date must be before target date"
 msgstr "开始日期必须早于目标日期"
 
-#: order/models.py:394
+#: order/models.py:391
 msgid "Address does not match selected company"
 msgstr "地址与所选公司不匹配"
 
-#: order/models.py:448
+#: order/models.py:445
 msgid "Order description (optional)"
 msgstr "订单描述 (可选)"
 
-#: order/models.py:457 order/models.py:1841
+#: order/models.py:454 order/models.py:1808
 msgid "Select project code for this order"
 msgstr "为此订单选择项目编码"
 
-#: order/models.py:463 order/models.py:1822 order/models.py:2383
+#: order/models.py:460 order/models.py:1789 order/models.py:2345
 msgid "Link to external page"
 msgstr "链接到外部页面"
 
-#: order/models.py:470
+#: order/models.py:467
 msgid "Start date"
 msgstr "开始日期"
 
-#: order/models.py:471
+#: order/models.py:468
 msgid "Scheduled start date for this order"
 msgstr "本订单的预定开始日期"
 
-#: order/models.py:477 order/models.py:1829 order/serializers.py:295
+#: order/models.py:474 order/models.py:1796 order/serializers.py:289
 #: report/templates/report/inventree_build_order_report.html:125
 msgid "Target Date"
 msgstr "预计日期"
 
-#: order/models.py:479
+#: order/models.py:476
 msgid "Expected date for order delivery. Order will be overdue after this date."
 msgstr "订单交付的预期日期。订单将在此日期后过期。"
 
-#: order/models.py:499
+#: order/models.py:496
 msgid "Issue Date"
 msgstr "签发日期"
 
-#: order/models.py:500
+#: order/models.py:497
 msgid "Date order was issued"
 msgstr "订单发出日期"
 
-#: order/models.py:506
-msgid "Updated At"
-msgstr "更新时间"
-
-#: order/models.py:515
+#: order/models.py:505
 msgid "User or group responsible for this order"
 msgstr "负责此订单的用户或组"
 
-#: order/models.py:526
+#: order/models.py:516
 msgid "Point of contact for this order"
 msgstr "此订单的联系人"
 
-#: order/models.py:536
+#: order/models.py:526
 msgid "Company address for this order"
 msgstr "此订单的公司地址"
 
-#: order/models.py:629 order/models.py:1338
+#: order/models.py:617 order/models.py:1314
 msgid "Order reference"
 msgstr "订单参考"
 
-#: order/models.py:638 order/models.py:1362 order/models.py:2769
-#: stock/serializers.py:562 stock/serializers.py:1003 users/models.py:542
+#: order/models.py:626 order/models.py:1338 order/models.py:2738
+#: stock/serializers.py:551 stock/serializers.py:992 users/models.py:542
 msgid "Status"
 msgstr "狀態"
 
-#: order/models.py:639
+#: order/models.py:627
 msgid "Purchase order status"
 msgstr "采购订单状态"
 
-#: order/models.py:654
+#: order/models.py:642
 msgid "Company from which the items are being ordered"
 msgstr "订购物品的公司"
 
-#: order/models.py:665
+#: order/models.py:653
 msgid "Supplier Reference"
 msgstr "供应商参考"
 
-#: order/models.py:666
+#: order/models.py:654
 msgid "Supplier order reference code"
 msgstr "供应商订单参考代码"
 
-#: order/models.py:675
+#: order/models.py:663
 msgid "received by"
 msgstr "接收人"
 
-#: order/models.py:682 order/models.py:2784
+#: order/models.py:670 order/models.py:2753
 msgid "Date order was completed"
 msgstr "订单完成日期"
 
-#: order/models.py:691 order/models.py:2018
+#: order/models.py:679 order/models.py:1983
 msgid "Destination"
 msgstr "目的地"
 
-#: order/models.py:692 order/models.py:2022
+#: order/models.py:680 order/models.py:1987
 msgid "Destination for received items"
 msgstr "接收物品的目标"
 
-#: order/models.py:738
+#: order/models.py:726
 msgid "Part supplier must match PO supplier"
 msgstr "零件供应商必须与采购订单供应商匹配"
 
-#: order/models.py:1008
+#: order/models.py:996
 msgid "Line item does not match purchase order"
 msgstr "行项目与采购订单不匹配"
 
-#: order/models.py:1011
+#: order/models.py:999
 msgid "Line item is missing a linked part"
 msgstr "行项目缺少关联零件"
 
-#: order/models.py:1025
+#: order/models.py:1013
 msgid "Quantity must be a positive number"
 msgstr "数量必须是正数"
 
-#: order/models.py:1059
-msgid "Serial numbers cannot be assigned to virtual parts"
-msgstr "序列号不能分配给虚拟件"
-
-#: order/models.py:1349 order/models.py:2756 stock/models.py:1085
-#: stock/models.py:1086 stock/serializers.py:1364
+#: order/models.py:1325 order/models.py:2725 stock/models.py:1080
+#: stock/models.py:1081 stock/serializers.py:1343
 #: templates/email/overdue_return_order.html:16
 #: templates/email/overdue_sales_order.html:16
 msgid "Customer"
 msgstr "客户"
 
-#: order/models.py:1350
+#: order/models.py:1326
 msgid "Company to which the items are being sold"
 msgstr "出售物品的公司"
 
-#: order/models.py:1363
+#: order/models.py:1339
 msgid "Sales order status"
 msgstr "销售订单状态"
 
-#: order/models.py:1374 order/models.py:2776
+#: order/models.py:1350 order/models.py:2745
 msgid "Customer Reference "
 msgstr "客户参考 "
 
-#: order/models.py:1375 order/models.py:2777
+#: order/models.py:1351 order/models.py:2746
 msgid "Customer order reference code"
 msgstr "客户订单参考代码"
 
-#: order/models.py:1379 order/models.py:2335
+#: order/models.py:1355 order/models.py:2297
 msgid "Shipment Date"
 msgstr "发货日期"
 
-#: order/models.py:1388
+#: order/models.py:1364
 msgid "shipped by"
 msgstr "发货人"
 
-#: order/models.py:1439
+#: order/models.py:1415
 msgid "Order is already complete"
 msgstr "订单已完成"
 
-#: order/models.py:1442
+#: order/models.py:1418
 msgid "Order is already cancelled"
 msgstr "订单已取消"
 
-#: order/models.py:1446
+#: order/models.py:1422
 msgid "Only an open order can be marked as complete"
 msgstr "只有未结订单才能标记为已完成"
 
-#: order/models.py:1450
+#: order/models.py:1426
 msgid "Order cannot be completed as there are incomplete shipments"
 msgstr "由于发货不完整，订单无法完成"
 
-#: order/models.py:1455
+#: order/models.py:1431
 msgid "Order cannot be completed as there are incomplete allocations"
 msgstr "由于缺货，订单无法完成"
 
-#: order/models.py:1464
+#: order/models.py:1440
 msgid "Order cannot be completed as there are incomplete line items"
 msgstr "订单无法完成，因为行项目不完整"
 
-#: order/models.py:1759 order/models.py:1775
+#: order/models.py:1735 order/models.py:1751
 msgid "The order is locked and cannot be modified"
 msgstr "订单已锁定，不可修改"
 
-#: order/models.py:1783
+#: order/models.py:1759
 msgid "Item quantity"
 msgstr "项目数量"
 
-#: order/models.py:1801
-msgid "Line Number"
-msgstr "行号"
-
-#: order/models.py:1802
-msgid "Line number for this item (optional)"
-msgstr "此项目的行号（可选）"
-
-#: order/models.py:1809
+#: order/models.py:1776
 msgid "Line item reference"
 msgstr "行项目参考"
 
-#: order/models.py:1816
+#: order/models.py:1783
 msgid "Line item notes"
 msgstr "行项目注释"
 
-#: order/models.py:1831
+#: order/models.py:1798
 msgid "Target date for this line item (leave blank to use the target date from the order)"
 msgstr "此行项目的目标日期 (留空以使用订单中的目标日期)"
 
-#: order/models.py:1861
+#: order/models.py:1828
 msgid "Line item description (optional)"
 msgstr "行项目描述 (可选)"
 
-#: order/models.py:1868
+#: order/models.py:1835
 msgid "Additional context for this line"
 msgstr "此行的附加上下文"
 
-#: order/models.py:1878
+#: order/models.py:1845
 msgid "Unit price"
 msgstr "单位价格"
 
-#: order/models.py:1897
+#: order/models.py:1864
 msgid "Purchase Order Line Item"
 msgstr "采购订单行项目"
 
-#: order/models.py:1926
+#: order/models.py:1891
 msgid "Supplier part must match supplier"
 msgstr "供应商零件必须与供应商匹配"
 
-#: order/models.py:1931
+#: order/models.py:1896
 msgid "Build order must be marked as external"
 msgstr "生产订单必须标记为外部"
 
-#: order/models.py:1938
+#: order/models.py:1903
 msgid "Build orders can only be linked to assembly parts"
 msgstr "生产订单仅可关联至装配零件"
 
-#: order/models.py:1944
+#: order/models.py:1909
 msgid "Build order part must match line item part"
 msgstr "生产订单零件必须与行项目零件一致"
 
-#: order/models.py:1979
+#: order/models.py:1944
 msgid "Supplier part"
 msgstr "供应商零件"
 
-#: order/models.py:1986
+#: order/models.py:1951
 msgid "Received"
 msgstr "已接收"
 
-#: order/models.py:1987
+#: order/models.py:1952
 msgid "Number of items received"
 msgstr "收到的物品数量"
 
-#: order/models.py:1995 stock/models.py:1208 stock/serializers.py:652
+#: order/models.py:1960 stock/models.py:1203 stock/serializers.py:641
 msgid "Purchase Price"
 msgstr "采购价格"
 
-#: order/models.py:1996
+#: order/models.py:1961
 msgid "Unit purchase price"
 msgstr "每单位的采购价格"
 
-#: order/models.py:2012
+#: order/models.py:1977
 msgid "External Build Order to be fulfilled by this line item"
 msgstr "外部生产订单需由此行项目履行"
 
-#: order/models.py:2074
+#: order/models.py:2039
 msgid "Purchase Order Extra Line"
 msgstr "采购订单附加行"
 
-#: order/models.py:2103
+#: order/models.py:2068
 msgid "Sales Order Line Item"
 msgstr "销售订单行项目"
 
-#: order/models.py:2130
+#: order/models.py:2093
 msgid "Only salable parts can be assigned to a sales order"
 msgstr "只有可销售的零件才能分配给销售订单"
 
-#: order/models.py:2156
+#: order/models.py:2119
 msgid "Sale Price"
 msgstr "售出价格"
 
-#: order/models.py:2157
+#: order/models.py:2120
 msgid "Unit sale price"
 msgstr "单位售出价格"
 
-#: order/models.py:2166 order/status_codes.py:50
+#: order/models.py:2129 order/status_codes.py:50
 msgid "Shipped"
 msgstr "已配送"
 
-#: order/models.py:2167
+#: order/models.py:2130
 msgid "Shipped quantity"
 msgstr "发货数量"
 
-#: order/models.py:2279
+#: order/models.py:2241
 msgid "Sales Order Shipment"
 msgstr "销售订单发货"
 
-#: order/models.py:2292
+#: order/models.py:2254
 msgid "Shipment address must match the customer"
 msgstr "收货地址必须与该客户的资料一致"
 
-#: order/models.py:2328
+#: order/models.py:2290
 msgid "Shipping address for this shipment"
 msgstr "本次发货的收货地址"
 
-#: order/models.py:2336
+#: order/models.py:2298
 msgid "Date of shipment"
 msgstr "发货日期"
 
-#: order/models.py:2342
+#: order/models.py:2304
 msgid "Delivery Date"
 msgstr "送达日期"
 
-#: order/models.py:2343
+#: order/models.py:2305
 msgid "Date of delivery of shipment"
 msgstr "装运交货日期"
 
-#: order/models.py:2351
+#: order/models.py:2313
 msgid "Checked By"
 msgstr "审核人"
 
-#: order/models.py:2352
+#: order/models.py:2314
 msgid "User who checked this shipment"
 msgstr "检查此装运的用户"
 
-#: order/models.py:2359 order/models.py:2604 order/serializers.py:1698
-#: order/serializers.py:1822
+#: order/models.py:2321 order/models.py:2575 order/serializers.py:1707
+#: order/serializers.py:1831
 #: report/templates/report/inventree_sales_order_shipment_report.html:14
 msgid "Shipment"
 msgstr "配送"
 
-#: order/models.py:2360
+#: order/models.py:2322
 msgid "Shipment number"
 msgstr "配送单号"
 
-#: order/models.py:2368
+#: order/models.py:2330
 msgid "Tracking Number"
 msgstr "跟踪单号"
 
-#: order/models.py:2369
+#: order/models.py:2331
 msgid "Shipment tracking information"
 msgstr "配送跟踪信息"
 
-#: order/models.py:2376
+#: order/models.py:2338
 msgid "Invoice Number"
 msgstr "发票编号"
 
-#: order/models.py:2377
+#: order/models.py:2339
 msgid "Reference number for associated invoice"
 msgstr "相关发票的参考号"
 
-#: order/models.py:2416
+#: order/models.py:2378
 msgid "Shipment has already been sent"
 msgstr "货物已发出"
 
-#: order/models.py:2419
+#: order/models.py:2381
 msgid "Shipment has no allocated stock items"
 msgstr "发货没有分配库存项目"
 
-#: order/models.py:2426
+#: order/models.py:2388
 msgid "Shipment must be checked before it can be completed"
 msgstr "货件必须先经核对，方可标记为完成"
 
-#: order/models.py:2496
+#: order/models.py:2467
 msgid "Sales Order Extra Line"
 msgstr "销售订单加行"
 
-#: order/models.py:2525
+#: order/models.py:2496
 msgid "Sales Order Allocation"
 msgstr "销售订单分配"
 
-#: order/models.py:2548 order/models.py:2550
+#: order/models.py:2519 order/models.py:2521
 msgid "Stock item has not been assigned"
 msgstr "库存项目尚未分配"
 
-#: order/models.py:2557
+#: order/models.py:2528
 msgid "Cannot allocate stock item to a line with a different part"
 msgstr "无法将库存项目分配给具有不同零件的行"
 
-#: order/models.py:2560
+#: order/models.py:2531
 msgid "Cannot allocate stock to a line without a part"
 msgstr "无法将库存分配给没有零件的生产线"
 
-#: order/models.py:2563
+#: order/models.py:2534
 msgid "Allocation quantity cannot exceed stock quantity"
 msgstr "分配数量不能超过库存数量"
 
-#: order/models.py:2579
+#: order/models.py:2550
 msgid "Allocation quantity must be greater than zero"
 msgstr "分配的数量必须大于零"
 
-#: order/models.py:2582 order/serializers.py:1568
+#: order/models.py:2553 order/serializers.py:1577
 msgid "Quantity must be 1 for serialized stock item"
 msgstr "序列化库存项目的数量必须为1"
 
-#: order/models.py:2585
+#: order/models.py:2556
 msgid "Sales order does not match shipment"
 msgstr "销售订单与发货不匹配"
 
-#: order/models.py:2586 plugin/base/barcodes/api.py:643
+#: order/models.py:2557 plugin/base/barcodes/api.py:643
 msgid "Shipment does not match sales order"
 msgstr "发货与销售订单不匹配"
 
-#: order/models.py:2594
+#: order/models.py:2565
 msgid "Line"
 msgstr "行"
 
-#: order/models.py:2605
+#: order/models.py:2576
 msgid "Sales order shipment reference"
 msgstr "销售订单发货参考"
 
-#: order/models.py:2618 order/models.py:3044
+#: order/models.py:2589 order/models.py:3008
 msgid "Item"
 msgstr "项目"
 
-#: order/models.py:2619
+#: order/models.py:2590
 msgid "Select stock item to allocate"
 msgstr "选择要分配的库存项目"
 
-#: order/models.py:2628
+#: order/models.py:2599
 msgid "Enter stock allocation quantity"
 msgstr "输入库存分配数量"
 
-#: order/models.py:2745
+#: order/models.py:2714
 msgid "Return Order reference"
 msgstr "退货订单参考"
 
-#: order/models.py:2757
+#: order/models.py:2726
 msgid "Company from which items are being returned"
 msgstr "退回物品的公司"
 
-#: order/models.py:2770
+#: order/models.py:2739
 msgid "Return order status"
 msgstr "退货订单状态"
 
-#: order/models.py:3002
+#: order/models.py:2966
 msgid "Return Order Line Item"
 msgstr "退货订单行项目"
 
-#: order/models.py:3015
+#: order/models.py:2979
 msgid "Stock item must be specified"
 msgstr "必须指定库存项"
 
-#: order/models.py:3019
+#: order/models.py:2983
 msgid "Return quantity exceeds stock quantity"
 msgstr "退回数量超过库存数量"
 
-#: order/models.py:3024
+#: order/models.py:2988
 msgid "Return quantity must be greater than zero"
 msgstr "退回数量必须大于零"
 
-#: order/models.py:3029
+#: order/models.py:2993
 msgid "Invalid quantity for serialized stock item"
 msgstr "序列化库存项的数量无效"
 
-#: order/models.py:3045
+#: order/models.py:3009
 msgid "Select item to return from customer"
 msgstr "选择要从客户处退回的商品"
 
-#: order/models.py:3060
+#: order/models.py:3024
 msgid "Received Date"
 msgstr "接收日期"
 
-#: order/models.py:3061
+#: order/models.py:3025
 msgid "The date this return item was received"
 msgstr "收到此退货的日期"
 
-#: order/models.py:3073
+#: order/models.py:3037
 msgid "Outcome"
 msgstr "结果"
 
-#: order/models.py:3074
+#: order/models.py:3038
 msgid "Outcome for this line item"
 msgstr "该行项目的结果"
 
-#: order/models.py:3081
+#: order/models.py:3045
 msgid "Cost associated with return or repair for this line item"
 msgstr "与此行项目的退货或维修相关的成本"
 
-#: order/models.py:3091
+#: order/models.py:3055
 msgid "Return Order Extra Line"
 msgstr "退货订单附加行"
 
-#: order/serializers.py:75
+#: order/serializers.py:81
 msgid "Order ID"
 msgstr "订单ID"
 
-#: order/serializers.py:75
+#: order/serializers.py:81
 msgid "ID of the order to duplicate"
 msgstr "要复制的订单ID"
 
-#: order/serializers.py:81
+#: order/serializers.py:87
 msgid "Copy Lines"
 msgstr "复制行"
 
-#: order/serializers.py:82
+#: order/serializers.py:88
 msgid "Copy line items from the original order"
 msgstr "从原始订单复制行项目"
 
-#: order/serializers.py:88
+#: order/serializers.py:94
 msgid "Copy Extra Lines"
 msgstr "复制额外行"
 
-#: order/serializers.py:89
+#: order/serializers.py:95
 msgid "Copy extra line items from the original order"
 msgstr "从原始订单复制额外的行项目"
 
-#: order/serializers.py:95 part/serializers.py:413
-msgid "Copy Parameters"
-msgstr "复制参数"
-
-#: order/serializers.py:96
-msgid "Copy order parameters from the original order"
-msgstr "从原始订单复制订单参数"
-
-#: order/serializers.py:111
+#: order/serializers.py:110
 #: report/templates/report/inventree_purchase_order_report.html:29
 #: report/templates/report/inventree_return_order_report.html:19
 #: report/templates/report/inventree_sales_order_report.html:22
 msgid "Line Items"
 msgstr "行项目"
 
-#: order/serializers.py:116
+#: order/serializers.py:115
 msgid "Completed Lines"
 msgstr "已完成行项目"
 
-#: order/serializers.py:172
+#: order/serializers.py:171
 msgid "Duplicate Order"
 msgstr "复制订单"
 
-#: order/serializers.py:173
+#: order/serializers.py:172
 msgid "Specify options for duplicating this order"
 msgstr "指定复制此订单的选项"
 
-#: order/serializers.py:252
+#: order/serializers.py:250
 msgid "Invalid order ID"
 msgstr "订单ID不正确"
 
-#: order/serializers.py:432
+#: order/serializers.py:419
 msgid "Supplier Name"
 msgstr "供应商名称"
 
-#: order/serializers.py:477
+#: order/serializers.py:464
 msgid "Order cannot be cancelled"
 msgstr "订单不能取消"
 
-#: order/serializers.py:492 order/serializers.py:1589
+#: order/serializers.py:479 order/serializers.py:1598
 msgid "Allow order to be closed with incomplete line items"
 msgstr "允许关闭行项目不完整的订单"
 
-#: order/serializers.py:502 order/serializers.py:1599
+#: order/serializers.py:489 order/serializers.py:1608
 msgid "Order has incomplete line items"
 msgstr "订单中的行项目不完整"
 
-#: order/serializers.py:622
+#: order/serializers.py:609
 msgid "Order is not open"
 msgstr "订单未打开"
 
-#: order/serializers.py:651
+#: order/serializers.py:638
 msgid "Auto Pricing"
 msgstr "自动定价"
 
-#: order/serializers.py:653
+#: order/serializers.py:640
 msgid "Automatically calculate purchase price based on supplier part data"
 msgstr "根据供应商零件数据自动计算采购价格"
 
-#: order/serializers.py:667
+#: order/serializers.py:654
 msgid "Purchase price currency"
 msgstr "购买价格货币"
 
-#: order/serializers.py:689
+#: order/serializers.py:676
 msgid "Merge Items"
 msgstr "合并项目"
 
-#: order/serializers.py:691
+#: order/serializers.py:678
 msgid "Merge items with the same part, destination and target date into one line item"
 msgstr "将具有相同零件、目的地和目标日期的项目合并到一个行项目中"
 
-#: order/serializers.py:698 part/serializers.py:482
+#: order/serializers.py:685 part/serializers.py:471
 msgid "SKU"
 msgstr "库存量单位"
 
-#: order/serializers.py:712 part/models.py:1151 part/serializers.py:348
+#: order/serializers.py:699 part/models.py:1158 part/serializers.py:337
 msgid "Internal Part Number"
 msgstr "内部零件编号"
 
-#: order/serializers.py:720
+#: order/serializers.py:707
 msgid "Internal Part Name"
 msgstr "内部零件名称"
 
-#: order/serializers.py:736
+#: order/serializers.py:723
 msgid "Supplier part must be specified"
 msgstr "必须指定供应商零件"
 
-#: order/serializers.py:739
+#: order/serializers.py:726
 msgid "Purchase order must be specified"
 msgstr "必须指定采购订单"
 
-#: order/serializers.py:747
+#: order/serializers.py:734
 msgid "Supplier must match purchase order"
 msgstr "供应商必须匹配采购订单"
 
-#: order/serializers.py:748
+#: order/serializers.py:735
 msgid "Purchase order must match supplier"
 msgstr "采购订单必须与供应商匹配"
 
-#: order/serializers.py:796 order/serializers.py:1669
+#: order/serializers.py:783 order/serializers.py:1678
 msgid "Line Item"
 msgstr "行项目"
 
-#: order/serializers.py:805 order/serializers.py:945 order/serializers.py:2032
+#: order/serializers.py:792 order/serializers.py:932 order/serializers.py:2040
 msgid "Select destination location for received items"
 msgstr "为收到的物品选择目的地位置"
 
-#: order/serializers.py:821
+#: order/serializers.py:808
 msgid "Enter batch code for incoming stock items"
 msgstr "输入入库项目的批号"
 
-#: order/serializers.py:828 stock/models.py:1167
+#: order/serializers.py:815 stock/models.py:1162
 #: templates/email/stale_stock_notification.html:22 users/models.py:137
 msgid "Expiry Date"
 msgstr "有效期至"
 
-#: order/serializers.py:829
+#: order/serializers.py:816
 msgid "Enter expiry date for incoming stock items"
 msgstr "输入入库库存项的有效期"
 
-#: order/serializers.py:837
+#: order/serializers.py:824
 msgid "Enter serial numbers for incoming stock items"
 msgstr "输入入库库存项目的序列号"
 
-#: order/serializers.py:847
+#: order/serializers.py:834
 msgid "Override packaging information for incoming stock items"
 msgstr "覆盖传入库存项目的包装资料"
 
-#: order/serializers.py:855 order/serializers.py:2037
+#: order/serializers.py:842 order/serializers.py:2045
 msgid "Additional note for incoming stock items"
 msgstr "传入库存项目的附加说明"
 
-#: order/serializers.py:862
+#: order/serializers.py:849
 msgid "Barcode"
 msgstr "条形码"
 
-#: order/serializers.py:863
+#: order/serializers.py:850
 msgid "Scanned barcode"
 msgstr "扫描条形码"
 
-#: order/serializers.py:879
+#: order/serializers.py:866
 msgid "Barcode is already in use"
 msgstr "条形码已被使用"
 
-#: order/serializers.py:962 order/serializers.py:2056
+#: order/serializers.py:949 order/serializers.py:2064
 msgid "Line items must be provided"
 msgstr "必须提供行项目"
 
-#: order/serializers.py:981
+#: order/serializers.py:968
 msgid "Destination location must be specified"
 msgstr "必须指定目标位置"
 
-#: order/serializers.py:988
+#: order/serializers.py:975
 msgid "Supplied barcode values must be unique"
 msgstr "提供的条形码值必须是唯一的"
 
-#: order/serializers.py:1109
+#: order/serializers.py:1095
 msgid "Shipments"
 msgstr "配送"
 
-#: order/serializers.py:1113
+#: order/serializers.py:1099
 msgid "Completed Shipments"
 msgstr "完成配送"
 
-#: order/serializers.py:1117
+#: order/serializers.py:1103
 msgid "Allocated Lines"
-msgstr "已分配的行"
+msgstr "已分配行"
 
-#: order/serializers.py:1296
+#: order/serializers.py:1282
 msgid "Sale price currency"
 msgstr "售出价格货币"
 
-#: order/serializers.py:1343
+#: order/serializers.py:1325
 msgid "Allocated Items"
 msgstr "已分配的项目"
 
-#: order/serializers.py:1500
+#: order/serializers.py:1480
 msgid "No shipment details provided"
 msgstr "未提供装运详细信息"
 
-#: order/serializers.py:1532 order/serializers.py:1678
+#: order/serializers.py:1541 order/serializers.py:1687
 msgid "Line item is not associated with this order"
 msgstr "行项目与此订单不关联"
 
-#: order/serializers.py:1551
+#: order/serializers.py:1560
 msgid "Quantity must be positive"
 msgstr "数量必须为正"
 
-#: order/serializers.py:1688
+#: order/serializers.py:1697
 msgid "Enter serial numbers to allocate"
 msgstr "输入要分配的序列号"
 
-#: order/serializers.py:1710 order/serializers.py:1830
+#: order/serializers.py:1719 order/serializers.py:1839
 msgid "Shipment has already been shipped"
 msgstr "货物已发出"
 
-#: order/serializers.py:1713 order/serializers.py:1833
+#: order/serializers.py:1722 order/serializers.py:1842
 msgid "Shipment is not associated with this order"
 msgstr "发货与此订单无关"
 
-#: order/serializers.py:1768
+#: order/serializers.py:1777
 msgid "No match found for the following serial numbers"
 msgstr "未找到以下序列号的匹配项"
 
-#: order/serializers.py:1775
+#: order/serializers.py:1784
 msgid "The following serial numbers are unavailable"
 msgstr "以下序列号不可用"
 
-#: order/serializers.py:1998
+#: order/serializers.py:2006
 msgid "Return order line item"
 msgstr "退货订单行项目"
 
-#: order/serializers.py:2008
+#: order/serializers.py:2016
 msgid "Line item does not match return order"
 msgstr "行项目与退货订单不匹配"
 
-#: order/serializers.py:2011
+#: order/serializers.py:2019
 msgid "Line item has already been received"
 msgstr "行项目已收到"
 
-#: order/serializers.py:2048
+#: order/serializers.py:2056
 msgid "Items can only be received against orders which are in progress"
 msgstr "只能根据正在进行的订单接收物品"
 
-#: order/serializers.py:2120
+#: order/serializers.py:2128
 msgid "Quantity to return"
 msgstr "退货数量"
 
-#: order/serializers.py:2137
+#: order/serializers.py:2145
 msgid "Line price currency"
 msgstr "行价格货币"
 
@@ -5643,1223 +5542,1198 @@ msgstr "退款"
 msgid "Reject"
 msgstr "拒绝"
 
-#: order/tasks.py:48
+#: order/tasks.py:47
 msgid "Overdue Purchase Order"
 msgstr "逾期采购订单"
 
-#: order/tasks.py:53
+#: order/tasks.py:52
 #, python-brace-format
 msgid "Purchase order {po} is now overdue"
 msgstr "采购订单 {po} 已逾期"
 
-#: order/tasks.py:118
+#: order/tasks.py:117
 msgid "Overdue Sales Order"
 msgstr "逾期销售订单"
 
-#: order/tasks.py:123
+#: order/tasks.py:122
 #, python-brace-format
 msgid "Sales order {so} is now overdue"
 msgstr "销售订单 {so} 已逾期"
 
-#: order/tasks.py:185
+#: order/tasks.py:184
 msgid "Overdue Return Order"
 msgstr "逾期退货订单"
 
-#: order/tasks.py:190
+#: order/tasks.py:189
 #, python-brace-format
 msgid "Return order {ro} is now overdue"
 msgstr "退货订单 {ro} 现已逾期"
 
-#: part/api.py:88
+#: part/api.py:103
 msgid "Starred"
 msgstr "已加星标"
 
-#: part/api.py:90
+#: part/api.py:105
 msgid "Filter by starred categories"
 msgstr "按星标类别筛选"
 
-#: part/api.py:107 stock/api.py:287
+#: part/api.py:122 stock/api.py:288
 msgid "Depth"
 msgstr "深度"
 
-#: part/api.py:107
+#: part/api.py:122
 msgid "Filter by category depth"
 msgstr "按类别深度筛选"
 
-#: part/api.py:125 stock/api.py:305
+#: part/api.py:140 stock/api.py:306
 msgid "Top Level"
 msgstr "顶级"
 
-#: part/api.py:127
+#: part/api.py:142
 msgid "Filter by top-level categories"
 msgstr "按顶级类别筛选"
 
-#: part/api.py:140 stock/api.py:320
+#: part/api.py:155 stock/api.py:321
 msgid "Cascade"
 msgstr "级联"
 
-#: part/api.py:142
+#: part/api.py:157
 msgid "Include sub-categories in filtered results"
 msgstr "在筛选结果中包含子类别"
 
-#: part/api.py:162
+#: part/api.py:177
 msgid "Parent"
 msgstr "父类"
 
-#: part/api.py:164
+#: part/api.py:179
 msgid "Filter by parent category"
 msgstr "按父类别筛选"
 
-#: part/api.py:199
+#: part/api.py:214
 msgid "Exclude sub-categories under the specified category"
 msgstr "排除指定类别下的子类别"
 
-#: part/api.py:424
+#: part/api.py:440
 msgid "Has Results"
 msgstr "有结果"
 
-#: part/api.py:653
+#: part/api.py:661
 msgid "Is Variant"
 msgstr "是变体"
 
-#: part/api.py:661
+#: part/api.py:669
 msgid "Is Revision"
 msgstr "是修订版本"
 
-#: part/api.py:671
+#: part/api.py:679
 msgid "Has Revisions"
 msgstr "有修订版本"
 
-#: part/api.py:852
+#: part/api.py:860
 msgid "BOM Valid"
 msgstr "物料清单合规"
 
-#: part/api.py:961
+#: part/api.py:969
 msgid "Cascade Categories"
 msgstr "级联分类"
 
-#: part/api.py:962
+#: part/api.py:970
 msgid "If true, include items in child categories of the given category"
 msgstr "如果为真，则包含给定分类下的所有子分类中的项目"
 
-#: part/api.py:968
+#: part/api.py:976
 msgid "Filter by numeric category ID or the literal 'null'"
 msgstr "按数字分类ID或字面值 \"null\" 进行筛选"
 
-#: part/api.py:1280
+#: part/api.py:1250
 msgid "Assembly part is active"
-msgstr "装配零件已启用"
+msgstr "组装零件处于激活状态"
 
-#: part/api.py:1284
+#: part/api.py:1254
 msgid "Assembly part is trackable"
-msgstr "装配零件可追踪"
+msgstr "组装零件可追溯"
 
-#: part/api.py:1288
+#: part/api.py:1258
 msgid "Assembly part is testable"
 msgstr "装配部份是可测试的"
 
-#: part/api.py:1293
+#: part/api.py:1263
 msgid "Component part is active"
-msgstr "元器件已激活"
+msgstr "组件零件处于激活状态"
 
-#: part/api.py:1297
+#: part/api.py:1267
 msgid "Component part is trackable"
-msgstr "该零部件可追溯"
+msgstr "组件零件可追溯"
 
-#: part/api.py:1301
+#: part/api.py:1271
 msgid "Component part is testable"
 msgstr "组件部份是可测试的"
 
-#: part/api.py:1305
+#: part/api.py:1275
 msgid "Component part is an assembly"
-msgstr "该零部件是一个装配件"
+msgstr "组件零件是组装件"
 
-#: part/api.py:1309
+#: part/api.py:1279
 msgid "Component part is virtual"
-msgstr "该零部件为虚拟件"
+msgstr "组件零件是虚拟件"
 
-#: part/api.py:1313
+#: part/api.py:1283
 msgid "Has available stock"
 msgstr "有可用库存"
 
-#: part/api.py:1370
+#: part/api.py:1340
 msgid "Uses"
 msgstr "使用"
 
-#: part/models.py:92 part/models.py:413
+#: part/models.py:93 part/models.py:414
 #: templates/email/part_event_notification.html:16
 msgid "Part Category"
 msgstr "零件类别"
 
-#: part/models.py:93 users/ruleset.py:27
+#: part/models.py:94 users/ruleset.py:27
 msgid "Part Categories"
 msgstr "零件类别"
 
-#: part/models.py:111 part/models.py:1187
+#: part/models.py:112 part/models.py:1194
 msgid "Default Location"
 msgstr "默认位置"
 
-#: part/models.py:112
+#: part/models.py:113
 msgid "Default location for parts in this category"
 msgstr "此类别零件的默认库存地点"
 
-#: part/models.py:117 stock/models.py:204
+#: part/models.py:118 stock/models.py:202
 msgid "Structural"
 msgstr "结构性"
 
-#: part/models.py:119
+#: part/models.py:120
 msgid "Parts may not be directly assigned to a structural category, but may be assigned to child categories."
 msgstr "零件可能无法直接分配到结构类别，但可以分配到子类别。"
 
-#: part/models.py:128
+#: part/models.py:129
 msgid "Default keywords"
 msgstr "默认关键字"
 
-#: part/models.py:129
+#: part/models.py:130
 msgid "Default keywords for parts in this category"
 msgstr "此类别零件的默认关键字"
 
-#: part/models.py:136 stock/models.py:99 stock/models.py:186
+#: part/models.py:137 stock/models.py:97 stock/models.py:184
 msgid "Icon"
 msgstr "图标"
 
-#: part/models.py:137 part/serializers.py:158 part/serializers.py:177
-#: stock/models.py:187
+#: part/models.py:138 part/serializers.py:147 part/serializers.py:166
+#: stock/models.py:185
 msgid "Icon (optional)"
 msgstr "图标(可选)"
 
-#: part/models.py:181
+#: part/models.py:182
 msgid "You cannot make this part category structural because some parts are already assigned to it!"
 msgstr "您不能使这个零件类别结构化，因为有些零件已经分配给了它！"
 
-#: part/models.py:369
+#: part/models.py:370
 msgid "Part Category Parameter Template"
 msgstr "零件类别参数模板"
 
-#: part/models.py:425
+#: part/models.py:426
 msgid "Default Value"
 msgstr "默认值"
 
-#: part/models.py:426
+#: part/models.py:427
 msgid "Default Parameter Value"
 msgstr "默认参数值"
 
-#: part/models.py:528 part/serializers.py:120 users/ruleset.py:28
+#: part/models.py:529 part/serializers.py:118 users/ruleset.py:28
 msgid "Parts"
 msgstr "零件"
 
-#: part/models.py:574
+#: part/models.py:575
 msgid "Cannot delete parameters of a locked part"
 msgstr "无法删除已锁定零件的参数"
 
-#: part/models.py:579
+#: part/models.py:580
 msgid "Cannot modify parameters of a locked part"
 msgstr "无法修改已锁定零件的参数"
 
-#: part/models.py:590
+#: part/models.py:591
 msgid "Cannot delete this part as it is locked"
 msgstr "无法删除这个零件，因为它已被锁定"
 
-#: part/models.py:593
+#: part/models.py:594
 msgid "Cannot delete this part as it is still active"
 msgstr "无法删除这个零件，因为它仍然处于活动状态"
 
-#: part/models.py:598
+#: part/models.py:599
 msgid "Cannot delete this part as it is used in an assembly"
 msgstr "无法删除这个零件，因为它被使用在了装配中"
 
-#: part/models.py:682 part/models.py:689
+#: part/models.py:683 part/models.py:690
 #, python-brace-format
 msgid "Part '{self}' cannot be used in BOM for '{parent}' (recursive)"
 msgstr "零件 \"{self}\" 不能用在 \"{parent}\" 的物料清单 (递归)"
 
-#: part/models.py:701
+#: part/models.py:702
 #, python-brace-format
 msgid "Part '{parent}' is  used in BOM for '{self}' (recursive)"
 msgstr "零件 \"{parent}\" 被使用在了 \"{self}\" 的物料清单 (递归)"
 
-#: part/models.py:768
+#: part/models.py:769
 #, python-brace-format
 msgid "IPN must match regex pattern {pattern}"
 msgstr "内部零件号必须匹配正则表达式 {pattern}"
 
-#: part/models.py:776
+#: part/models.py:777
 msgid "Part cannot be a revision of itself"
 msgstr "零件不能是对自身的修订"
 
-#: part/models.py:783
-msgid "Revision code must be specified for a part marked as a revision"
-msgstr "标记为带版本管理的物料必须指定版本代码"
+#: part/models.py:784
+msgid "Cannot make a revision of a part which is already a revision"
+msgstr "无法对已经是修订版本的零件进行修订"
 
 #: part/models.py:791
+msgid "Revision code must be specified"
+msgstr "必须指定修订代码"
+
+#: part/models.py:798
 msgid "Revisions are only allowed for assembly parts"
 msgstr "修订仅对装配零件允许"
 
-#: part/models.py:798
+#: part/models.py:805
 msgid "Cannot make a revision of a template part"
 msgstr "无法对模版零件进行修订"
 
-#: part/models.py:804
+#: part/models.py:811
 msgid "Parent part must point to the same template"
 msgstr "上级零件必须指向相同的模版"
 
-#: part/models.py:901
+#: part/models.py:908
 msgid "Stock item with this serial number already exists"
 msgstr "该序列号库存项己存在"
 
-#: part/models.py:1031
+#: part/models.py:1038
 msgid "Duplicate IPN not allowed in part settings"
 msgstr "在零件设置中不允许重复的内部零件号"
 
-#: part/models.py:1044
+#: part/models.py:1051
 msgid "Duplicate part revision already exists."
 msgstr "重复的零件修订版本已经存在。"
 
-#: part/models.py:1054
+#: part/models.py:1061
 msgid "Part with this Name, IPN and Revision already exists."
 msgstr "有这个名字，内部零件号，和修订版本的零件已经存在"
 
-#: part/models.py:1069
+#: part/models.py:1076
 msgid "Parts cannot be assigned to structural part categories!"
 msgstr "零件不能分配到结构性零件类别！"
 
-#: part/models.py:1101
+#: part/models.py:1108
 msgid "Part name"
 msgstr "零件名称"
 
-#: part/models.py:1106
+#: part/models.py:1113
 msgid "Is Template"
 msgstr "是模板"
 
-#: part/models.py:1107
+#: part/models.py:1114
 msgid "Is this part a template part?"
 msgstr "这个零件是一个模版零件吗?"
 
-#: part/models.py:1117
+#: part/models.py:1124
 msgid "Is this part a variant of another part?"
 msgstr "这个零件是另一零件的变体吗？"
 
-#: part/models.py:1118
+#: part/models.py:1125
 msgid "Variant Of"
 msgstr "变体"
 
-#: part/models.py:1125
+#: part/models.py:1132
 msgid "Part description (optional)"
 msgstr "零件描述(可选)"
 
-#: part/models.py:1132
+#: part/models.py:1139
 msgid "Keywords"
 msgstr "关键词"
 
-#: part/models.py:1133
+#: part/models.py:1140
 msgid "Part keywords to improve visibility in search results"
 msgstr "提高搜索结果可见性的零件关键字"
 
-#: part/models.py:1143
+#: part/models.py:1150
 msgid "Part category"
 msgstr "零件类别"
 
-#: part/models.py:1150 part/serializers.py:819
+#: part/models.py:1157 part/serializers.py:801
 #: report/templates/report/inventree_stock_location_report.html:103
 msgid "IPN"
 msgstr "内部零件号 IPN"
 
-#: part/models.py:1158
+#: part/models.py:1165
 msgid "Part revision or version number"
 msgstr "零件修订版本或版本号"
 
-#: part/models.py:1159 report/models.py:228
+#: part/models.py:1166 report/models.py:228
 msgid "Revision"
 msgstr "版本"
 
-#: part/models.py:1168
+#: part/models.py:1175
 msgid "Is this part a revision of another part?"
 msgstr "这零件是另一零件的修订版本吗？"
 
-#: part/models.py:1169
+#: part/models.py:1176
 msgid "Revision Of"
 msgstr "修订版本"
 
-#: part/models.py:1185
+#: part/models.py:1192
 msgid "Where is this item normally stored?"
 msgstr "该物品通常存放在哪里？"
 
-#: part/models.py:1222
+#: part/models.py:1238
+msgid "Default Supplier"
+msgstr "默认供应商"
+
+#: part/models.py:1239
+msgid "Default supplier part"
+msgstr "默认供应商零件"
+
+#: part/models.py:1246
 msgid "Default Expiry"
 msgstr "默认到期"
 
-#: part/models.py:1223
+#: part/models.py:1247
 msgid "Expiry time (in days) for stock items of this part"
 msgstr "此零件库存项的过期时间 (天)"
 
-#: part/models.py:1231 part/serializers.py:889
+#: part/models.py:1255 part/serializers.py:871
 msgid "Minimum Stock"
 msgstr "最低库存"
 
-#: part/models.py:1232
+#: part/models.py:1256
 msgid "Minimum allowed stock level"
 msgstr "允许的最小库存量"
 
-#: part/models.py:1241
+#: part/models.py:1265
 msgid "Units of measure for this part"
 msgstr "此零件的计量单位"
 
-#: part/models.py:1248
+#: part/models.py:1272
 msgid "Can this part be built from other parts?"
 msgstr "这个零件可由其他零件加工而成吗？"
 
-#: part/models.py:1254
+#: part/models.py:1278
 msgid "Can this part be used to build other parts?"
 msgstr "这个零件可用于创建其他零件吗？"
 
-#: part/models.py:1260
+#: part/models.py:1284
 msgid "Does this part have tracking for unique items?"
 msgstr "此零件是否有唯一物品的追踪功能"
 
-#: part/models.py:1266
+#: part/models.py:1290
 msgid "Can this part have test results recorded against it?"
 msgstr "这一部件能否记录到测试结果？"
 
-#: part/models.py:1272
+#: part/models.py:1296
 msgid "Can this part be purchased from external suppliers?"
 msgstr "这个零件可从外部供应商购买吗？"
 
-#: part/models.py:1278
+#: part/models.py:1302
 msgid "Can this part be sold to customers?"
 msgstr "此零件可以销售给客户吗?"
 
-#: part/models.py:1282
+#: part/models.py:1306
 msgid "Is this part active?"
 msgstr "这个零件是否已激活？"
 
-#: part/models.py:1288
+#: part/models.py:1312
 msgid "Locked parts cannot be edited"
 msgstr "无法编辑锁定的零件"
 
-#: part/models.py:1294
+#: part/models.py:1318
 msgid "Is this a virtual part, such as a software product or license?"
 msgstr "这是一个虚拟零件，例如一个软件产品或许可证吗？"
 
-#: part/models.py:1299
+#: part/models.py:1323
 msgid "BOM Validated"
 msgstr "物料清单已验证"
 
-#: part/models.py:1300
+#: part/models.py:1324
 msgid "Is the BOM for this part valid?"
 msgstr "该零件的物料清单是否通过验证？"
 
-#: part/models.py:1306
+#: part/models.py:1330
 msgid "BOM checksum"
 msgstr "物料清单校验和"
 
-#: part/models.py:1307
+#: part/models.py:1331
 msgid "Stored BOM checksum"
 msgstr "保存的物料清单校验和"
 
-#: part/models.py:1315
+#: part/models.py:1339
 msgid "BOM checked by"
 msgstr "物料清单检查人"
 
-#: part/models.py:1320
+#: part/models.py:1344
 msgid "BOM checked date"
 msgstr "物料清单检查日期"
 
-#: part/models.py:1336
+#: part/models.py:1360
 msgid "Creation User"
 msgstr "新建用户"
 
-#: part/models.py:1346
+#: part/models.py:1370
 msgid "Owner responsible for this part"
 msgstr "此零件的负责人"
 
-#: part/models.py:2303
+#: part/models.py:2327
 msgid "Sell multiple"
 msgstr "出售多个"
 
-#: part/models.py:3308
+#: part/models.py:3331
 msgid "Currency used to cache pricing calculations"
 msgstr "用于缓存定价计算的货币"
 
-#: part/models.py:3324
+#: part/models.py:3347
 msgid "Minimum BOM Cost"
 msgstr "最低物料清单成本"
 
-#: part/models.py:3325
+#: part/models.py:3348
 msgid "Minimum cost of component parts"
 msgstr "元件的最低成本"
 
-#: part/models.py:3331
+#: part/models.py:3354
 msgid "Maximum BOM Cost"
 msgstr "物料清单的最高成本"
 
-#: part/models.py:3332
+#: part/models.py:3355
 msgid "Maximum cost of component parts"
 msgstr "元件的最高成本"
 
-#: part/models.py:3338
+#: part/models.py:3361
 msgid "Minimum Purchase Cost"
 msgstr "最低购买成本"
 
-#: part/models.py:3339
+#: part/models.py:3362
 msgid "Minimum historical purchase cost"
 msgstr "最高历史购买成本"
 
-#: part/models.py:3345
+#: part/models.py:3368
 msgid "Maximum Purchase Cost"
 msgstr "最大购买成本"
 
-#: part/models.py:3346
+#: part/models.py:3369
 msgid "Maximum historical purchase cost"
 msgstr "最高历史购买成本"
 
-#: part/models.py:3352
+#: part/models.py:3375
 msgid "Minimum Internal Price"
 msgstr "最低内部价格"
 
-#: part/models.py:3353
+#: part/models.py:3376
 msgid "Minimum cost based on internal price breaks"
 msgstr "基于内部批发价的最低成本"
 
-#: part/models.py:3359
+#: part/models.py:3382
 msgid "Maximum Internal Price"
 msgstr "最大内部价格"
 
-#: part/models.py:3360
+#: part/models.py:3383
 msgid "Maximum cost based on internal price breaks"
 msgstr "基于内部批发价的最高成本"
 
-#: part/models.py:3366
+#: part/models.py:3389
 msgid "Minimum Supplier Price"
 msgstr "供应商最低价格"
 
-#: part/models.py:3367
+#: part/models.py:3390
 msgid "Minimum price of part from external suppliers"
 msgstr "外部供应商零件的最低价格"
 
-#: part/models.py:3373
+#: part/models.py:3396
 msgid "Maximum Supplier Price"
 msgstr "供应商最高价格"
 
-#: part/models.py:3374
+#: part/models.py:3397
 msgid "Maximum price of part from external suppliers"
 msgstr "来自外部供应商的商零件的最高价格"
 
-#: part/models.py:3380
+#: part/models.py:3403
 msgid "Minimum Variant Cost"
 msgstr "最小变体成本"
 
-#: part/models.py:3381
+#: part/models.py:3404
 msgid "Calculated minimum cost of variant parts"
 msgstr "计算出的变体零件的最低成本"
 
-#: part/models.py:3387
+#: part/models.py:3410
 msgid "Maximum Variant Cost"
 msgstr "最大变体成本"
 
-#: part/models.py:3388
+#: part/models.py:3411
 msgid "Calculated maximum cost of variant parts"
 msgstr "计算出的变体零件的最大成本"
 
-#: part/models.py:3394 part/models.py:3408
+#: part/models.py:3417 part/models.py:3431
 msgid "Minimum Cost"
 msgstr "最低成本"
 
-#: part/models.py:3395
+#: part/models.py:3418
 msgid "Override minimum cost"
 msgstr "覆盖最低成本"
 
-#: part/models.py:3401 part/models.py:3415
+#: part/models.py:3424 part/models.py:3438
 msgid "Maximum Cost"
 msgstr "最高成本"
 
-#: part/models.py:3402
+#: part/models.py:3425
 msgid "Override maximum cost"
 msgstr "覆盖最大成本"
 
-#: part/models.py:3409
+#: part/models.py:3432
 msgid "Calculated overall minimum cost"
 msgstr "计算总最低成本"
 
-#: part/models.py:3416
+#: part/models.py:3439
 msgid "Calculated overall maximum cost"
 msgstr "计算总最大成本"
 
-#: part/models.py:3422
+#: part/models.py:3445
 msgid "Minimum Sale Price"
 msgstr "最低售出价格"
 
-#: part/models.py:3423
+#: part/models.py:3446
 msgid "Minimum sale price based on price breaks"
 msgstr "基于批发价的最低售出价格"
 
-#: part/models.py:3429
+#: part/models.py:3452
 msgid "Maximum Sale Price"
 msgstr "最高售出价格"
 
-#: part/models.py:3430
+#: part/models.py:3453
 msgid "Maximum sale price based on price breaks"
 msgstr "基于批发价的最大售出价格"
 
-#: part/models.py:3436
+#: part/models.py:3459
 msgid "Minimum Sale Cost"
 msgstr "最低销售成本"
 
-#: part/models.py:3437
+#: part/models.py:3460
 msgid "Minimum historical sale price"
 msgstr "历史最低售出价格"
 
-#: part/models.py:3443
+#: part/models.py:3466
 msgid "Maximum Sale Cost"
 msgstr "最高销售成本"
 
-#: part/models.py:3444
+#: part/models.py:3467
 msgid "Maximum historical sale price"
 msgstr "历史最高售出价格"
 
-#: part/models.py:3462
+#: part/models.py:3485
 msgid "Part for stocktake"
 msgstr "用于盘点的零件"
 
-#: part/models.py:3467
+#: part/models.py:3490
 msgid "Item Count"
 msgstr "物品数量"
 
-#: part/models.py:3468
+#: part/models.py:3491
 msgid "Number of individual stock entries at time of stocktake"
 msgstr "盘点时的个别库存条目数"
 
-#: part/models.py:3476
+#: part/models.py:3499
 msgid "Total available stock at time of stocktake"
 msgstr "盘点时可用库存总额"
 
-#: part/models.py:3480 report/templates/report/inventree_test_report.html:106
-#: stock/models.py:3105
+#: part/models.py:3503 report/templates/report/inventree_test_report.html:106
 msgid "Date"
 msgstr "日期"
 
-#: part/models.py:3481
+#: part/models.py:3504
 msgid "Date stocktake was performed"
 msgstr "进行盘点的日期"
 
-#: part/models.py:3488
+#: part/models.py:3511
 msgid "Minimum Stock Cost"
 msgstr "最低库存成本"
 
-#: part/models.py:3489
+#: part/models.py:3512
 msgid "Estimated minimum cost of stock on hand"
 msgstr "现有存库存最低成本估算"
 
-#: part/models.py:3495
+#: part/models.py:3518
 msgid "Maximum Stock Cost"
 msgstr "最高库存成本"
 
-#: part/models.py:3496
+#: part/models.py:3519
 msgid "Estimated maximum cost of stock on hand"
 msgstr "目前库存最高成本估算"
 
-#: part/models.py:3506
+#: part/models.py:3529
 msgid "Part Sale Price Break"
 msgstr "零件售出价格折扣"
 
-#: part/models.py:3620
+#: part/models.py:3641
 msgid "Part Test Template"
 msgstr "零件测试模板"
 
-#: part/models.py:3646
+#: part/models.py:3667
 msgid "Invalid template name - must include at least one alphanumeric character"
 msgstr "模板名称无效 - 必须包含至少一个字母或者数字"
 
-#: part/models.py:3678
+#: part/models.py:3699
 msgid "Test templates can only be created for testable parts"
 msgstr "测试模板只能为可拆分的部件创建"
 
-#: part/models.py:3692
+#: part/models.py:3713
 msgid "Test template with the same key already exists for part"
 msgstr "零件已存在具有相同主键的测试模板"
 
-#: part/models.py:3709
+#: part/models.py:3730
 msgid "Test Name"
 msgstr "测试名"
 
-#: part/models.py:3710
+#: part/models.py:3731
 msgid "Enter a name for the test"
 msgstr "输入测试的名称"
 
-#: part/models.py:3716
+#: part/models.py:3737
 msgid "Test Key"
 msgstr "测试主键"
 
-#: part/models.py:3717
+#: part/models.py:3738
 msgid "Simplified key for the test"
 msgstr "简化测试主键"
 
-#: part/models.py:3724
+#: part/models.py:3745
 msgid "Test Description"
 msgstr "测试说明"
 
-#: part/models.py:3725
+#: part/models.py:3746
 msgid "Enter description for this test"
 msgstr "输入测试的描述"
 
-#: part/models.py:3729
+#: part/models.py:3750
 msgid "Is this test enabled?"
 msgstr "此测试是否已启用？"
 
-#: part/models.py:3734
+#: part/models.py:3755
 msgid "Required"
 msgstr "必须的"
 
-#: part/models.py:3735
+#: part/models.py:3756
 msgid "Is this test required to pass?"
 msgstr "需要此测试才能通过吗？"
 
-#: part/models.py:3740
+#: part/models.py:3761
 msgid "Requires Value"
 msgstr "需要值"
 
-#: part/models.py:3741
+#: part/models.py:3762
 msgid "Does this test require a value when adding a test result?"
 msgstr "添加测试结果时是否需要一个值？"
 
-#: part/models.py:3746
+#: part/models.py:3767
 msgid "Requires Attachment"
 msgstr "需要附件"
 
-#: part/models.py:3748
+#: part/models.py:3769
 msgid "Does this test require a file attachment when adding a test result?"
 msgstr "添加测试结果时是否需要文件附件？"
 
-#: part/models.py:3755
+#: part/models.py:3776
 msgid "Valid choices for this test (comma-separated)"
 msgstr "此测试的有效选择 (逗号分隔)"
 
-#: part/models.py:3949
+#: part/models.py:3970
 msgid "BOM item cannot be modified - assembly is locked"
 msgstr "物料清单项目不能被修改 - 装配已锁定"
 
-#: part/models.py:3956
+#: part/models.py:3977
 msgid "BOM item cannot be modified - variant assembly is locked"
 msgstr "物料清单项目不能修改 - 变体装配已锁定"
 
-#: part/models.py:3966
+#: part/models.py:3987
 msgid "Select parent part"
 msgstr "选择父零件"
 
-#: part/models.py:3976
+#: part/models.py:3997
 msgid "Sub part"
 msgstr "子零件"
 
-#: part/models.py:3977
+#: part/models.py:3998
 msgid "Select part to be used in BOM"
 msgstr "选择要用于物料清单的零件"
 
-#: part/models.py:3988
+#: part/models.py:4009
 msgid "BOM quantity for this BOM item"
 msgstr "此物料清单项目的数量"
 
-#: part/models.py:3994
+#: part/models.py:4015
 msgid "This BOM item is optional"
 msgstr "此物料清单项目是可选的"
 
-#: part/models.py:4000
+#: part/models.py:4021
 msgid "This BOM item is consumable (it is not tracked in build orders)"
 msgstr "这个物料清单项目是耗材 (它没有在生产订单中被追踪)"
 
-#: part/models.py:4008
+#: part/models.py:4029
 msgid "Setup Quantity"
 msgstr "设置数量"
 
-#: part/models.py:4009
+#: part/models.py:4030
 msgid "Extra required quantity for a build, to account for setup losses"
 msgstr "为补偿生产准备损耗所需的额外数量"
 
-#: part/models.py:4017
+#: part/models.py:4038
 msgid "Attrition"
 msgstr "损耗"
 
-#: part/models.py:4019
+#: part/models.py:4040
 msgid "Estimated attrition for a build, expressed as a percentage (0-100)"
 msgstr "生产预估损耗率（百分比，0-100）"
 
-#: part/models.py:4030
+#: part/models.py:4051
 msgid "Rounding Multiple"
 msgstr "舍入倍数"
 
-#: part/models.py:4032
+#: part/models.py:4053
 msgid "Round up required production quantity to nearest multiple of this value"
 msgstr "将所需生产数量向上舍入至该值的最接近倍数"
 
-#: part/models.py:4040
+#: part/models.py:4061
 msgid "BOM item reference"
 msgstr "物料清单项目引用"
 
-#: part/models.py:4048
+#: part/models.py:4069
 msgid "BOM item notes"
 msgstr "物料清单项目注释"
 
-#: part/models.py:4054
+#: part/models.py:4075
 msgid "Checksum"
 msgstr "校验和"
 
-#: part/models.py:4055
+#: part/models.py:4076
 msgid "BOM line checksum"
 msgstr "物料清单行校验和"
 
-#: part/models.py:4060
+#: part/models.py:4081
 msgid "Validated"
 msgstr "已验证"
 
-#: part/models.py:4061
+#: part/models.py:4082
 msgid "This BOM item has been validated"
 msgstr "此物料清单项目已验证"
 
-#: part/models.py:4066
+#: part/models.py:4087
 msgid "Gets inherited"
 msgstr "获取继承的"
 
-#: part/models.py:4067
+#: part/models.py:4088
 msgid "This BOM item is inherited by BOMs for variant parts"
 msgstr "此物料清单项目是由物料清单继承的变体零件"
 
-#: part/models.py:4073
+#: part/models.py:4094
 msgid "Stock items for variant parts can be used for this BOM item"
 msgstr "变体零件的库存项可以用于此物料清单项目"
 
-#: part/models.py:4180 stock/models.py:932
+#: part/models.py:4201 stock/models.py:927
 msgid "Quantity must be integer value for trackable parts"
 msgstr "可追踪零件的数量必须是整数"
 
-#: part/models.py:4190 part/models.py:4192
+#: part/models.py:4211 part/models.py:4213
 msgid "Sub part must be specified"
 msgstr "必须指定子零件"
 
-#: part/models.py:4343
+#: part/models.py:4364
 msgid "BOM Item Substitute"
 msgstr "物料清单项目替代品"
 
-#: part/models.py:4364
+#: part/models.py:4385
 msgid "Substitute part cannot be the same as the master part"
 msgstr "替代品零件不能与主零件相同"
 
-#: part/models.py:4377
+#: part/models.py:4398
 msgid "Parent BOM item"
 msgstr "上级物料清单项目"
 
-#: part/models.py:4385
+#: part/models.py:4406
 msgid "Substitute part"
 msgstr "替代品零件"
 
-#: part/models.py:4401
+#: part/models.py:4422
 msgid "Part 1"
 msgstr "零件 1"
 
-#: part/models.py:4409
+#: part/models.py:4430
 msgid "Part 2"
 msgstr "零件2"
 
-#: part/models.py:4410
+#: part/models.py:4431
 msgid "Select Related Part"
 msgstr "选择相关的零件"
 
-#: part/models.py:4417
+#: part/models.py:4438
 msgid "Note for this relationship"
 msgstr "此关系的注释"
 
-#: part/models.py:4436
+#: part/models.py:4457
 msgid "Part relationship cannot be created between a part and itself"
 msgstr "零件关系不能在零件和自身之间创建"
 
-#: part/models.py:4441
+#: part/models.py:4462
 msgid "Duplicate relationship already exists"
 msgstr "复制关系已经存在"
 
-#: part/serializers.py:115
+#: part/serializers.py:113
 msgid "Parent Category"
 msgstr "上级类别"
 
-#: part/serializers.py:116
+#: part/serializers.py:114
 msgid "Parent part category"
 msgstr "上级零件类别"
 
-#: part/serializers.py:124 part/serializers.py:174
+#: part/serializers.py:122 part/serializers.py:163
 msgid "Subcategories"
 msgstr "子类别"
 
-#: part/serializers.py:213
+#: part/serializers.py:202
 msgid "Results"
 msgstr "结果"
 
-#: part/serializers.py:214
+#: part/serializers.py:203
 msgid "Number of results recorded against this template"
 msgstr "根据该模板记录的结果数量"
 
-#: part/serializers.py:245 part/serializers.py:263 stock/serializers.py:658
+#: part/serializers.py:234 part/serializers.py:252 stock/serializers.py:647
 msgid "Purchase currency of this stock item"
 msgstr "购买此库存项的货币"
 
-#: part/serializers.py:290
+#: part/serializers.py:279
 msgid "File is not an image"
 msgstr "文件不是一个图片"
 
-#: part/serializers.py:393
+#: part/serializers.py:382
 msgid "Original Part"
 msgstr "原始零件"
 
-#: part/serializers.py:394
+#: part/serializers.py:383
 msgid "Select original part to duplicate"
 msgstr "选择要复制的原始零件"
 
-#: part/serializers.py:399
+#: part/serializers.py:388
 msgid "Copy Image"
 msgstr "复制图片"
 
-#: part/serializers.py:400
+#: part/serializers.py:389
 msgid "Copy image from original part"
 msgstr "从原零件复制图片"
 
-#: part/serializers.py:406
+#: part/serializers.py:395
 msgid "Copy BOM"
 msgstr "复制物料清单"
 
-#: part/serializers.py:407
+#: part/serializers.py:396
 msgid "Copy bill of materials from original part"
 msgstr "从原始零件复制材料清单"
 
-#: part/serializers.py:414
+#: part/serializers.py:402
+msgid "Copy Parameters"
+msgstr "复制参数"
+
+#: part/serializers.py:403
 msgid "Copy parameter data from original part"
 msgstr "从原始零件复制参数数据"
 
-#: part/serializers.py:420
+#: part/serializers.py:409
 msgid "Copy Notes"
 msgstr "复制备注"
 
-#: part/serializers.py:421
+#: part/serializers.py:410
 msgid "Copy notes from original part"
 msgstr "从原始零件复制备注"
 
-#: part/serializers.py:427
+#: part/serializers.py:416
 msgid "Copy Tests"
 msgstr "复制测试"
 
-#: part/serializers.py:428
+#: part/serializers.py:417
 msgid "Copy test templates from original part"
 msgstr "从原始零件复制测试模板"
 
-#: part/serializers.py:446
+#: part/serializers.py:435
 msgid "Initial Stock Quantity"
 msgstr "初始化库存数量"
 
-#: part/serializers.py:448
+#: part/serializers.py:437
 msgid "Specify initial stock quantity for this Part. If quantity is zero, no stock is added."
 msgstr "指定此零件的初始库存数量。如果数量为零，则不添加任何库存。"
 
-#: part/serializers.py:455
+#: part/serializers.py:444
 msgid "Initial Stock Location"
 msgstr "初始化库存地点"
 
-#: part/serializers.py:456
+#: part/serializers.py:445
 msgid "Specify initial stock location for this Part"
 msgstr "初始化指定此零件的库存地点"
 
-#: part/serializers.py:473
+#: part/serializers.py:462
 msgid "Select supplier (or leave blank to skip)"
 msgstr "选择供应商(或为空以跳过)"
 
-#: part/serializers.py:489
+#: part/serializers.py:478
 msgid "Select manufacturer (or leave blank to skip)"
 msgstr "选择制造商(或为空)"
 
-#: part/serializers.py:499
+#: part/serializers.py:488
 msgid "Manufacturer part number"
 msgstr "制造商零件号"
 
-#: part/serializers.py:506
+#: part/serializers.py:495
 msgid "Selected company is not a valid supplier"
 msgstr "所选公司不是一个有效的供应商"
 
-#: part/serializers.py:515
+#: part/serializers.py:504
 msgid "Selected company is not a valid manufacturer"
 msgstr "所选公司不是一个有效的制造商"
 
-#: part/serializers.py:526
+#: part/serializers.py:515
 msgid "Manufacturer part matching this MPN already exists"
 msgstr "与此制造商零件编号 (MPN) 的相匹配的制造商零件已存在"
 
-#: part/serializers.py:533
+#: part/serializers.py:522
 msgid "Supplier part matching this SKU already exists"
 msgstr "匹配此库存单位 (SKU) 的供应商零件已存在"
 
-#: part/serializers.py:804
+#: part/serializers.py:786
 msgid "Category Name"
 msgstr "类别名称"
 
-#: part/serializers.py:833
+#: part/serializers.py:815
 msgid "Building"
 msgstr "正在生产"
 
-#: part/serializers.py:834
+#: part/serializers.py:816
 msgid "Quantity of this part currently being in production"
 msgstr "目前正在生产的零件数量"
 
-#: part/serializers.py:841
+#: part/serializers.py:823
 msgid "Outstanding quantity of this part scheduled to be built"
 msgstr "此零件计划待产数量"
 
-#: part/serializers.py:861 stock/serializers.py:1034 stock/serializers.py:1217
+#: part/serializers.py:843 stock/serializers.py:1023 stock/serializers.py:1206
 #: users/ruleset.py:30
 msgid "Stock Items"
 msgstr "库存项"
 
-#: part/serializers.py:865
+#: part/serializers.py:847
 msgid "Revisions"
 msgstr "修订"
 
-#: part/serializers.py:869 part/serializers.py:1161
+#: part/serializers.py:851 part/serializers.py:1143
 #: templates/email/low_stock_notification.html:16
 #: templates/email/part_event_notification.html:17
 msgid "Total Stock"
 msgstr "库存总量"
 
-#: part/serializers.py:877
+#: part/serializers.py:859
 msgid "Unallocated Stock"
 msgstr "未分配的库存"
 
-#: part/serializers.py:885
+#: part/serializers.py:867
 msgid "Variant Stock"
 msgstr "变体库存"
 
-#: part/serializers.py:941
+#: part/serializers.py:923
 msgid "Duplicate Part"
 msgstr "重复零件"
 
-#: part/serializers.py:942
+#: part/serializers.py:924
 msgid "Copy initial data from another Part"
 msgstr "从另一个零件复制初始数据"
 
-#: part/serializers.py:948
+#: part/serializers.py:930
 msgid "Initial Stock"
 msgstr "初始库存"
 
-#: part/serializers.py:949
+#: part/serializers.py:931
 msgid "Create Part with initial stock quantity"
 msgstr "创建具有初始库存数量的零件"
 
-#: part/serializers.py:955
+#: part/serializers.py:937
 msgid "Supplier Information"
 msgstr "供应商信息"
 
-#: part/serializers.py:956
+#: part/serializers.py:938
 msgid "Add initial supplier information for this part"
 msgstr "添加此零件的初始供应商信息"
 
-#: part/serializers.py:965
+#: part/serializers.py:947
 msgid "Copy Category Parameters"
 msgstr "复制类别参数"
 
-#: part/serializers.py:966
+#: part/serializers.py:948
 msgid "Copy parameter templates from selected part category"
 msgstr "从选择的零件复制参数模版"
 
-#: part/serializers.py:971
+#: part/serializers.py:953
 msgid "Existing Image"
 msgstr "现有的图片"
 
-#: part/serializers.py:972
+#: part/serializers.py:954
 msgid "Filename of an existing part image"
 msgstr "现有零件图片的文件名"
 
-#: part/serializers.py:989
+#: part/serializers.py:971
 msgid "Image file does not exist"
 msgstr "图片不存在"
 
-#: part/serializers.py:1133
+#: part/serializers.py:1115
 msgid "Validate entire Bill of Materials"
 msgstr "验证整个物料清单"
 
-#: part/serializers.py:1167 part/serializers.py:1759
+#: part/serializers.py:1149 part/serializers.py:1623
 msgid "Can Build"
 msgstr "可以创建"
 
-#: part/serializers.py:1184
+#: part/serializers.py:1166
 msgid "Required for Build Orders"
 msgstr "生产订单必填项"
 
-#: part/serializers.py:1189
+#: part/serializers.py:1171
 msgid "Allocated to Build Orders"
 msgstr "分配到生产订单"
 
-#: part/serializers.py:1196
+#: part/serializers.py:1178
 msgid "Required for Sales Orders"
 msgstr "销售订单必填项"
 
-#: part/serializers.py:1200
+#: part/serializers.py:1182
 msgid "Allocated to Sales Orders"
 msgstr "分配到销售订单"
 
-#: part/serializers.py:1260
-msgid "Part IPN"
-msgstr "内部零件号"
-
-#: part/serializers.py:1267
-msgid "Part Description"
-msgstr "零件描述"
-
-#: part/serializers.py:1306
-msgid "Select a part to generate stocktake information for that part (and any variant parts)"
-msgstr "选择一个物料，以生成该物料（及其所有变型物料）的盘点信息"
-
-#: part/serializers.py:1316
-msgid "Select a category to include all parts within that category (and subcategories)"
-msgstr "选择一个分类，以包含该分类（及其子分类）下的所有物料"
-
-#: part/serializers.py:1326
-msgid "Select a location to include all parts with stock in that location (including sub-locations)"
-msgstr "选择一个库位，以包含该库位（含子库位）中有库存的所有物料"
-
-#: part/serializers.py:1333
-msgid "Generate Stocktake Entries"
-msgstr "生成盘点条目"
-
-#: part/serializers.py:1334
-msgid "Save stocktake entries for the selected parts"
-msgstr "保存所选物料的盘点条目"
-
-#: part/serializers.py:1341
-msgid "Generate Report"
-msgstr "生成报告"
-
-#: part/serializers.py:1342
-msgid "Generate a stocktake report for the selected parts"
-msgstr "为所选物料生成盘点报告"
-
-#: part/serializers.py:1445
+#: part/serializers.py:1321
 msgid "Minimum Price"
 msgstr "最低价格"
 
-#: part/serializers.py:1446
+#: part/serializers.py:1322
 msgid "Override calculated value for minimum price"
 msgstr "覆盖已计算的最低价格值"
 
-#: part/serializers.py:1453
+#: part/serializers.py:1329
 msgid "Minimum price currency"
 msgstr "最低价格货币"
 
-#: part/serializers.py:1460
+#: part/serializers.py:1336
 msgid "Maximum Price"
 msgstr "最高价格"
 
-#: part/serializers.py:1461
+#: part/serializers.py:1337
 msgid "Override calculated value for maximum price"
 msgstr "覆盖已计算的最高价格值"
 
-#: part/serializers.py:1468
+#: part/serializers.py:1344
 msgid "Maximum price currency"
 msgstr "最高价格货币"
 
-#: part/serializers.py:1497
+#: part/serializers.py:1373
 msgid "Update"
 msgstr "更新"
 
-#: part/serializers.py:1498
+#: part/serializers.py:1374
 msgid "Update pricing for this part"
 msgstr "更新这个零件的价格"
 
-#: part/serializers.py:1521
+#: part/serializers.py:1397
 #, python-brace-format
 msgid "Could not convert from provided currencies to {default_currency}"
 msgstr "无法将所提供的货币转换为 {default_currency}"
 
-#: part/serializers.py:1528
+#: part/serializers.py:1404
 msgid "Minimum price must not be greater than maximum price"
 msgstr "最低价格不能高于最高价格。"
 
-#: part/serializers.py:1531
+#: part/serializers.py:1407
 msgid "Maximum price must not be less than minimum price"
 msgstr "最高价格不能低于最低价格"
 
-#: part/serializers.py:1684
-msgid "Quantity must be greater than or equal to zero"
-msgstr "数量必须大于或等于零"
-
-#: part/serializers.py:1697
+#: part/serializers.py:1561
 msgid "Select the parent assembly"
 msgstr "选择父装配"
 
-#: part/serializers.py:1725
+#: part/serializers.py:1589
 msgid "Select the component part"
 msgstr "选择零部件"
 
-#: part/serializers.py:1927
+#: part/serializers.py:1791
 msgid "Select part to copy BOM from"
 msgstr "选择要复制物料清单的零件"
 
-#: part/serializers.py:1935
+#: part/serializers.py:1799
 msgid "Remove Existing Data"
 msgstr "移除现有数据"
 
-#: part/serializers.py:1936
+#: part/serializers.py:1800
 msgid "Remove existing BOM items before copying"
 msgstr "复制前删除现有的物料清单项目"
 
-#: part/serializers.py:1941
+#: part/serializers.py:1805
 msgid "Include Inherited"
 msgstr "包含继承的"
 
-#: part/serializers.py:1942
+#: part/serializers.py:1806
 msgid "Include BOM items which are inherited from templated parts"
 msgstr "包含从模板零件继承的物料清单项目"
 
-#: part/serializers.py:1947
+#: part/serializers.py:1811
 msgid "Skip Invalid Rows"
 msgstr "跳过无效行"
 
-#: part/serializers.py:1948
+#: part/serializers.py:1812
 msgid "Enable this option to skip invalid rows"
 msgstr "启用此选项以跳过无效行"
 
-#: part/serializers.py:1953
+#: part/serializers.py:1817
 msgid "Copy Substitute Parts"
 msgstr "复制替代品零件"
 
-#: part/serializers.py:1954
+#: part/serializers.py:1818
 msgid "Copy substitute parts when duplicate BOM items"
 msgstr "复制物料清单项目时复制替代品零件"
 
-#: part/tasks.py:42
+#: part/tasks.py:41
 msgid "Low stock notification"
 msgstr "低库存通知"
 
-#: part/tasks.py:44
+#: part/tasks.py:43
 #, python-brace-format
 msgid "The available stock for {part.name} has fallen below the configured minimum level"
 msgstr "可用的 {part.name}库存已经跌到设置的最低值"
 
-#: part/tasks.py:74
+#: part/tasks.py:73
 msgid "Stale stock notification"
 msgstr "到期库存通知"
 
-#: part/tasks.py:78
+#: part/tasks.py:77
 msgid "You have 1 stock item approaching its expiry date"
 msgstr "您有1个库存项即将到期"
 
-#: part/tasks.py:80
+#: part/tasks.py:79
 #, python-brace-format
 msgid "You have {item_count} stock items approaching their expiry dates"
 msgstr "您有{item_count}个库存项即将到期"
 
-#: part/tasks.py:89
+#: part/tasks.py:88
 msgid "No expiry date"
 msgstr "永久有效"
 
-#: part/tasks.py:96
+#: part/tasks.py:95
 msgid "Expired {abs(days_diff)} days ago"
 msgstr "已过期 {abs(days_diff)} 天"
 
-#: part/tasks.py:99
+#: part/tasks.py:98
 msgid "Expires today"
 msgstr "今天到期"
 
-#: part/tasks.py:102
+#: part/tasks.py:101
 #, python-brace-format
 msgid "{days_until_expiry} days"
 msgstr "{days_until_expiry}天"
@@ -7622,77 +7496,64 @@ msgstr "为扫描 TME 条形码提供支持"
 msgid "The Supplier which acts as 'TME'"
 msgstr "作为‘TME’的供应商"
 
-#: plugin/installer.py:240 plugin/installer.py:344 plugin/serializers.py:169
-#: plugin/serializers.py:275
-msgid "Only superuser accounts can administer plugins"
-msgstr "只有超级用户账户才能管理插件"
+#: plugin/installer.py:240 plugin/installer.py:320
+msgid "Only staff users can administer plugins"
+msgstr "只有员工用户可以管理插件"
 
 #: plugin/installer.py:243
 msgid "Plugin installation is disabled"
 msgstr "插件安装已禁用"
 
-#: plugin/installer.py:273
-msgid "No package name or URL provided for installation"
-msgstr "未提供安装所需的包名或 URL"
-
-#: plugin/installer.py:277
-msgid "Invalid characters in package name or URL"
-msgstr "包名或 URL 中存在无效字符"
-
-#: plugin/installer.py:287
+#: plugin/installer.py:280
 msgid "Installed plugin successfully"
 msgstr "插件安装成功"
 
-#: plugin/installer.py:292
+#: plugin/installer.py:285
 #, python-brace-format
 msgid "Installed plugin into {path}"
 msgstr "插件安装到 {path}"
 
-#: plugin/installer.py:318
+#: plugin/installer.py:311
 msgid "Plugin was not found in registry"
 msgstr "在插件仓库中找不到插件"
 
-#: plugin/installer.py:321
+#: plugin/installer.py:314
 msgid "Plugin is not a packaged plugin"
 msgstr "插件不是一个打包的插件"
 
-#: plugin/installer.py:324
+#: plugin/installer.py:317
 msgid "Plugin package name not found"
 msgstr "找不到插件包名称"
 
-#: plugin/installer.py:327
-msgid "Only staff users can administer plugins"
-msgstr "只有员工用户可以管理插件"
-
-#: plugin/installer.py:347
+#: plugin/installer.py:337
 msgid "Plugin uninstalling is disabled"
 msgstr "插件卸载已禁用"
 
-#: plugin/installer.py:351
+#: plugin/installer.py:341
 msgid "Plugin cannot be uninstalled as it is currently active"
 msgstr "插件无法卸载，因为它目前处于激活状态"
 
-#: plugin/installer.py:357
+#: plugin/installer.py:347
 msgid "Plugin cannot be uninstalled as it is mandatory"
 msgstr "该插件为系统必需组件，无法卸载"
 
-#: plugin/installer.py:362
+#: plugin/installer.py:352
 msgid "Plugin cannot be uninstalled as it is a sample plugin"
 msgstr "该插件为示例插件，无法卸载"
 
-#: plugin/installer.py:367
+#: plugin/installer.py:357
 msgid "Plugin cannot be uninstalled as it is a built-in plugin"
 msgstr "该插件为系统内置组件，无法卸载"
 
-#: plugin/installer.py:371
+#: plugin/installer.py:361
 msgid "Plugin is not installed"
 msgstr "插件未安装"
 
-#: plugin/installer.py:389
+#: plugin/installer.py:379
 msgid "Plugin installation not found"
 msgstr "未找到插件安装记录"
 
-#: plugin/installer.py:405
+#: plugin/installer.py:395
 msgid "Uninstalled plugin successfully"
 msgstr "插件卸载成功"
 
@@ -7744,21 +7605,21 @@ msgstr "软件包插件"
 msgid "Plugin"
 msgstr "插件"
 
-#: plugin/plugin.py:389
+#: plugin/plugin.py:386
 msgid "No author found"
 msgstr "未找到作者"
 
-#: plugin/registry.py:786
+#: plugin/registry.py:774
 #, python-brace-format
 msgid "Plugin '{p}' is not compatible with the current InvenTree version {v}"
 msgstr "插件 '{p}' 与当前 InvenTree 版本{v} 不兼容"
 
-#: plugin/registry.py:789
+#: plugin/registry.py:777
 #, python-brace-format
 msgid "Plugin requires at least version {v}"
 msgstr "插件所需最低版本 {v}"
 
-#: plugin/registry.py:791
+#: plugin/registry.py:779
 #, python-brace-format
 msgid "Plugin requires at most version {v}"
 msgstr "插件所需最高版本 {v}"
@@ -7939,51 +7800,51 @@ msgstr "安装尚未确认"
 msgid "Either packagename or URL must be provided"
 msgstr "必须提供软件包名称或者URL"
 
-#: plugin/serializers.py:191
+#: plugin/serializers.py:188
 msgid "Full reload"
 msgstr "完全重载"
 
-#: plugin/serializers.py:192
+#: plugin/serializers.py:189
 msgid "Perform a full reload of the plugin registry"
 msgstr "执行插件库的完整重载"
 
-#: plugin/serializers.py:198
+#: plugin/serializers.py:195
 msgid "Force reload"
 msgstr "强制重载"
 
-#: plugin/serializers.py:200
+#: plugin/serializers.py:197
 msgid "Force a reload of the plugin registry, even if it is already loaded"
 msgstr "强制重载插件库，即使已经加载"
 
-#: plugin/serializers.py:207
+#: plugin/serializers.py:204
 msgid "Collect plugins"
 msgstr "收集插件"
 
-#: plugin/serializers.py:208
+#: plugin/serializers.py:205
 msgid "Collect plugins and add them to the registry"
 msgstr "收集插件并添加到注册表中"
 
-#: plugin/serializers.py:236
+#: plugin/serializers.py:233
 msgid "Activate Plugin"
 msgstr "激活插件"
 
-#: plugin/serializers.py:237
+#: plugin/serializers.py:234
 msgid "Activate this plugin"
 msgstr "激活此插件"
 
-#: plugin/serializers.py:246
+#: plugin/serializers.py:243
 msgid "Mandatory plugin cannot be deactivated"
 msgstr "强制插件不可停用"
 
-#: plugin/serializers.py:264
+#: plugin/serializers.py:261
 msgid "Delete configuration"
 msgstr "删除配置"
 
-#: plugin/serializers.py:265
+#: plugin/serializers.py:262
 msgid "Delete the plugin configuration from the database"
 msgstr "从数据库中删除插件配置"
 
-#: plugin/serializers.py:299
+#: plugin/serializers.py:293
 msgid "The user for which this setting applies"
 msgstr "该设置项适用的目标用户"
 
@@ -8245,7 +8106,7 @@ msgstr "总计"
 #: report/templates/report/inventree_return_order_report.html:25
 #: report/templates/report/inventree_sales_order_shipment_report.html:45
 #: report/templates/report/inventree_stock_report_merge.html:88
-#: report/templates/report/inventree_test_report.html:88 stock/models.py:1090
+#: report/templates/report/inventree_test_report.html:88 stock/models.py:1085
 #: stock/serializers.py:164 templates/email/stale_stock_notification.html:21
 msgid "Serial Number"
 msgstr "序列号"
@@ -8270,7 +8131,7 @@ msgstr "库存项测试报告"
 
 #: report/templates/report/inventree_stock_report_merge.html:97
 #: report/templates/report/inventree_test_report.html:153
-#: stock/serializers.py:641
+#: stock/serializers.py:630
 msgid "Installed Items"
 msgstr "已安装的项目"
 
@@ -8303,519 +8164,495 @@ msgstr "无结果 (必填)"
 msgid "No result"
 msgstr "没有结果"
 
-#: report/templatetags/report.py:166
-msgid "Invalid media file path"
-msgstr "无效的媒体文件路径"
+#: report/templatetags/report.py:169
+msgid "Asset file does not exist"
+msgstr "资产文件不存在"
 
-#: report/templatetags/report.py:185
-msgid "Invalid static file path"
-msgstr "无效的静态文件路径"
-
-#: report/templatetags/report.py:287
-msgid "Asset file not found"
-msgstr "未找到资源文件"
-
-#: report/templatetags/report.py:345 report/templatetags/report.py:461
+#: report/templatetags/report.py:226 report/templatetags/report.py:302
 msgid "Image file not found"
 msgstr "找不到图片文件"
 
-#: report/templatetags/report.py:430
-msgid "No image file specified"
-msgstr "未指定图片文件"
-
-#: report/templatetags/report.py:455
+#: report/templatetags/report.py:327
 msgid "part_image tag requires a Part instance"
 msgstr "parpart_image 标签需要一个零件实例"
 
-#: report/templatetags/report.py:553
+#: report/templatetags/report.py:384
 msgid "company_image tag requires a Company instance"
 msgstr "公司_图片标签需要一个公司实例"
 
-#: stock/api.py:287
+#: stock/api.py:288
 msgid "Filter by location depth"
 msgstr "按位置深度筛选"
 
-#: stock/api.py:307
+#: stock/api.py:308
 msgid "Filter by top-level locations"
 msgstr "按顶级位置筛选"
 
-#: stock/api.py:322
+#: stock/api.py:323
 msgid "Include sub-locations in filtered results"
 msgstr "在筛选结果中包含子地点"
 
-#: stock/api.py:343 stock/serializers.py:1213
+#: stock/api.py:344 stock/serializers.py:1202
 msgid "Parent Location"
 msgstr "上级地点"
 
-#: stock/api.py:344
+#: stock/api.py:345
 msgid "Filter by parent location"
 msgstr "按上级位置筛选"
 
-#: stock/api.py:604
+#: stock/api.py:605
 msgid "Part name (case insensitive)"
 msgstr "零件名称 (不区分大小写)"
 
-#: stock/api.py:610
+#: stock/api.py:611
 msgid "Part name contains (case insensitive)"
 msgstr "零件名称包含 (不区分大小写)"
 
-#: stock/api.py:616
+#: stock/api.py:617
 msgid "Part name (regex)"
 msgstr "零件名称 (正则表达式)"
 
-#: stock/api.py:621
+#: stock/api.py:622
 msgid "Part IPN (case insensitive)"
 msgstr "内部零件号 (不区分大小写)"
 
-#: stock/api.py:627
+#: stock/api.py:628
 msgid "Part IPN contains (case insensitive)"
 msgstr "内部零件号 (不区分大小写)"
 
-#: stock/api.py:633
+#: stock/api.py:634
 msgid "Part IPN (regex)"
 msgstr "内部零件号 (正则表达式)"
 
-#: stock/api.py:645
+#: stock/api.py:646
 msgid "Minimum stock"
 msgstr "最低库存"
 
-#: stock/api.py:649
+#: stock/api.py:650
 msgid "Maximum stock"
 msgstr "最大库存"
 
-#: stock/api.py:652
+#: stock/api.py:653
 msgid "Status Code"
 msgstr "状态代码"
 
-#: stock/api.py:692
+#: stock/api.py:693
 msgid "External Location"
 msgstr "外部地点"
 
-#: stock/api.py:791
+#: stock/api.py:792
 msgid "Consumed by Build Order"
 msgstr "被生产订单消耗"
 
-#: stock/api.py:801
+#: stock/api.py:802
 msgid "Installed in other stock item"
 msgstr "安装于其他库存项中"
 
-#: stock/api.py:890
+#: stock/api.py:891
 msgid "Part Tree"
 msgstr "零件树"
 
-#: stock/api.py:912
+#: stock/api.py:913
 msgid "Updated before"
 msgstr "更新时间早于"
 
-#: stock/api.py:916
+#: stock/api.py:917
 msgid "Updated after"
 msgstr "更新时间晚于"
 
-#: stock/api.py:920
+#: stock/api.py:921
 msgid "Stocktake Before"
 msgstr "盘点时间早于"
 
-#: stock/api.py:924
+#: stock/api.py:925
 msgid "Stocktake After"
 msgstr "盘点时间晚于"
 
-#: stock/api.py:929
+#: stock/api.py:930
 msgid "Expiry date before"
 msgstr "过期日期前"
 
-#: stock/api.py:933
+#: stock/api.py:934
 msgid "Expiry date after"
 msgstr "过期日期后"
 
-#: stock/api.py:936 stock/serializers.py:646
+#: stock/api.py:937 stock/serializers.py:635
 msgid "Stale"
 msgstr "过期"
 
-#: stock/api.py:962
+#: stock/api.py:963
 msgid "Provide a StockItem PK to exclude that item and all its descendants"
 msgstr "提供库存项的主键(PK)以排除该项及其所有子项"
 
-#: stock/api.py:980
+#: stock/api.py:981
 msgid "Cascade Locations"
 msgstr "级联位置"
 
-#: stock/api.py:981
+#: stock/api.py:982
 msgid "If true, include items in child locations of the given location"
 msgstr "若为真，则包含给定位置的所有子位置中的项目"
 
-#: stock/api.py:987
+#: stock/api.py:988
 msgid "Filter by numeric Location ID or the literal 'null'"
 msgstr "按数字位置ID或字母“null”筛选"
 
-#: stock/api.py:1087
+#: stock/api.py:1084
 msgid "Quantity is required"
 msgstr "请先输入数量"
 
-#: stock/api.py:1092
+#: stock/api.py:1089
 msgid "Valid part must be supplied"
 msgstr "必须提供有效的零件"
 
-#: stock/api.py:1123
+#: stock/api.py:1120
 msgid "The given supplier part does not exist"
 msgstr "给定的供应商零件不存在"
 
-#: stock/api.py:1133
+#: stock/api.py:1130
 msgid "The supplier part has a pack size defined, but flag use_pack_size not set"
 msgstr "供应商零件有定义的包装大小，但 use_pack_size 标志未设置"
 
-#: stock/api.py:1165
+#: stock/api.py:1162
 msgid "Serial numbers cannot be supplied for a non-trackable part"
 msgstr "不能为不可跟踪的零件提供序列号"
 
-#: stock/api.py:1409
+#: stock/api.py:1396
 msgid "Include Installed"
 msgstr "包含已安装项"
 
-#: stock/api.py:1411
+#: stock/api.py:1398
 msgid "If true, include test results for items installed underneath the given stock item"
 msgstr "如果为真，则包含给定库存项下已安装组件的测试结果"
 
-#: stock/api.py:1418
+#: stock/api.py:1405
 msgid "Filter by numeric Stock Item ID"
 msgstr "按数字库存项ID进行筛选"
 
-#: stock/api.py:1439
+#: stock/api.py:1426
 #, python-brace-format
 msgid "Stock item with ID {id} does not exist"
 msgstr "ID 为 {id} 的库存项不存在"
 
-#: stock/api.py:1516
-msgid "Include Part Variants"
-msgstr "包含零件变体"
-
-#: stock/api.py:1546
-msgid "Date after"
-msgstr "日期晚于"
-
-#: stock/api.py:1550
-msgid "Date before"
-msgstr "日期早于"
-
-#: stock/models.py:73
+#: stock/models.py:71
 msgid "Stock Location type"
 msgstr "库存地点类型"
 
-#: stock/models.py:74
+#: stock/models.py:72
 msgid "Stock Location types"
 msgstr "库存地点类型"
 
-#: stock/models.py:100
+#: stock/models.py:98
 msgid "Default icon for all locations that have no icon set (optional)"
 msgstr "为所有没有图标的位置设置默认图标(可选)"
 
-#: stock/models.py:147 stock/models.py:1052
+#: stock/models.py:145 stock/models.py:1047
 msgid "Stock Location"
 msgstr "库存地点"
 
-#: stock/models.py:148 users/ruleset.py:29
+#: stock/models.py:146 users/ruleset.py:29
 msgid "Stock Locations"
 msgstr "库存地点"
 
-#: stock/models.py:197 stock/models.py:1217
+#: stock/models.py:195 stock/models.py:1212
 msgid "Owner"
 msgstr "所有者"
 
-#: stock/models.py:198 stock/models.py:1218
+#: stock/models.py:196 stock/models.py:1213
 msgid "Select Owner"
 msgstr "选择所有者"
 
-#: stock/models.py:206
+#: stock/models.py:204
 msgid "Stock items may not be directly located into a structural stock locations, but may be located to child locations."
 msgstr "库存项可能不直接位于结构库存地点，但可能位于其子地点。"
 
-#: stock/models.py:213 users/models.py:497
+#: stock/models.py:211 users/models.py:497
 msgid "External"
 msgstr "外部"
 
-#: stock/models.py:214
+#: stock/models.py:212
 msgid "This is an external stock location"
 msgstr "这是一个外部库存地点"
 
-#: stock/models.py:220
+#: stock/models.py:218
 msgid "Location type"
 msgstr "位置类型"
 
-#: stock/models.py:224
+#: stock/models.py:222
 msgid "Stock location type of this location"
 msgstr "该位置的库存地点类型"
 
-#: stock/models.py:296
+#: stock/models.py:294
 msgid "You cannot make this stock location structural because some stock items are already located into it!"
 msgstr "您不能将此库存地点设置为结构性，因为某些库存项已经位于它！"
 
-#: stock/models.py:585
+#: stock/models.py:580
 #, python-brace-format
 msgid "{field} does not exist"
 msgstr "{field} 不存在"
 
-#: stock/models.py:598
+#: stock/models.py:593
 msgid "Part must be specified"
 msgstr "必须指定零件"
 
-#: stock/models.py:911
+#: stock/models.py:906
 msgid "Stock items cannot be located into structural stock locations!"
 msgstr "库存项不能存放在结构性库存地点！"
 
-#: stock/models.py:938 stock/serializers.py:466
+#: stock/models.py:933 stock/serializers.py:455
 msgid "Stock item cannot be created for virtual parts"
 msgstr "无法为虚拟零件创建库存项"
 
-#: stock/models.py:955
+#: stock/models.py:950
 #, python-brace-format
 msgid "Part type ('{self.supplier_part.part}') must be {self.part}"
 msgstr "零件类型 ('{self.supplier_part.part}') 必须为 {self.part}"
 
-#: stock/models.py:965 stock/models.py:978
+#: stock/models.py:960 stock/models.py:973
 msgid "Quantity must be 1 for item with a serial number"
 msgstr "有序列号的项目的数量必须是1"
 
-#: stock/models.py:968
+#: stock/models.py:963
 msgid "Serial number cannot be set if quantity greater than 1"
 msgstr "如果数量大于1，则不能设置序列号"
 
-#: stock/models.py:990
+#: stock/models.py:985
 msgid "Item cannot belong to itself"
 msgstr "项目不能属于其自身"
 
-#: stock/models.py:995
+#: stock/models.py:990
 msgid "Item must have a build reference if is_building=True"
 msgstr "如果is_building=True，则项必须具有构建引用"
 
-#: stock/models.py:1008
+#: stock/models.py:1003
 msgid "Build reference does not point to the same part object"
 msgstr "构建引用未指向同一零件对象"
 
-#: stock/models.py:1022
+#: stock/models.py:1017
 msgid "Parent Stock Item"
 msgstr "父级库存项"
 
-#: stock/models.py:1034
+#: stock/models.py:1029
 msgid "Base part"
 msgstr "基础零件"
 
-#: stock/models.py:1044
+#: stock/models.py:1039
 msgid "Select a matching supplier part for this stock item"
 msgstr "为此库存项目选择匹配的供应商零件"
 
-#: stock/models.py:1056
+#: stock/models.py:1051
 msgid "Where is this stock item located?"
 msgstr "这个库存物品在哪里？"
 
-#: stock/models.py:1064 stock/serializers.py:1649
+#: stock/models.py:1059 stock/serializers.py:1628
 msgid "Packaging this stock item is stored in"
 msgstr "包装此库存物品存储在"
 
-#: stock/models.py:1070
+#: stock/models.py:1065
 msgid "Installed In"
 msgstr "安装于"
 
-#: stock/models.py:1075
+#: stock/models.py:1070
 msgid "Is this item installed in another item?"
 msgstr "此项目是否安装在另一个项目中？"
 
-#: stock/models.py:1094
+#: stock/models.py:1089
 msgid "Serial number for this item"
 msgstr "此项目的序列号"
 
-#: stock/models.py:1111 stock/serializers.py:1634
+#: stock/models.py:1106 stock/serializers.py:1613
 msgid "Batch code for this stock item"
 msgstr "此库存项的批号"
 
-#: stock/models.py:1116
+#: stock/models.py:1111
 msgid "Stock Quantity"
 msgstr "库存数量"
 
-#: stock/models.py:1126
+#: stock/models.py:1121
 msgid "Source Build"
 msgstr "源代码构建"
 
-#: stock/models.py:1129
+#: stock/models.py:1124
 msgid "Build for this stock item"
 msgstr "为此库存项目构建"
 
-#: stock/models.py:1136
+#: stock/models.py:1131
 msgid "Consumed By"
 msgstr "消费者"
 
-#: stock/models.py:1139
+#: stock/models.py:1134
 msgid "Build order which consumed this stock item"
 msgstr "构建消耗此库存项的生产订单"
 
-#: stock/models.py:1148
+#: stock/models.py:1143
 msgid "Source Purchase Order"
 msgstr "采购订单来源"
 
-#: stock/models.py:1152
+#: stock/models.py:1147
 msgid "Purchase order for this stock item"
 msgstr "此库存商品的采购订单"
 
-#: stock/models.py:1158
+#: stock/models.py:1153
 msgid "Destination Sales Order"
 msgstr "目的地销售订单"
 
-#: stock/models.py:1169
+#: stock/models.py:1164
 msgid "Expiry date for stock item. Stock will be considered expired after this date"
 msgstr "库存物品的到期日。在此日期之后，库存将被视为过期"
 
-#: stock/models.py:1187
+#: stock/models.py:1182
 msgid "Delete on deplete"
 msgstr "耗尽时删除"
 
-#: stock/models.py:1188
+#: stock/models.py:1183
 msgid "Delete this Stock Item when stock is depleted"
 msgstr "当库存耗尽时删除此库存项"
 
-#: stock/models.py:1209
+#: stock/models.py:1204
 msgid "Single unit purchase price at time of purchase"
 msgstr "购买时一个单位的价格"
 
-#: stock/models.py:1240
+#: stock/models.py:1235
 msgid "Converted to part"
 msgstr "转换为零件"
 
-#: stock/models.py:1442
+#: stock/models.py:1437
 msgid "Quantity exceeds available stock"
 msgstr "数量超过可用库存"
 
-#: stock/models.py:1893
+#: stock/models.py:1880
 msgid "Part is not set as trackable"
 msgstr "零件未设置为可跟踪"
 
-#: stock/models.py:1899
+#: stock/models.py:1886
 msgid "Quantity must be integer"
 msgstr "数量必须是整数"
 
-#: stock/models.py:1907
+#: stock/models.py:1894
 #, python-brace-format
 msgid "Quantity must not exceed available stock quantity ({self.quantity})"
 msgstr "数量不得超过现有库存量 ({self.quantity})"
 
-#: stock/models.py:1913
+#: stock/models.py:1900
 msgid "Serial numbers must be provided as a list"
 msgstr "必须以列表形式提供序列号"
 
-#: stock/models.py:1918
+#: stock/models.py:1905
 msgid "Quantity does not match serial numbers"
 msgstr "数量不匹配序列号"
 
-#: stock/models.py:1936
+#: stock/models.py:1923
 msgid "Cannot assign stock to structural location"
 msgstr "无法将库存分配到结构位置"
 
-#: stock/models.py:2053 stock/models.py:3023
+#: stock/models.py:2040 stock/models.py:2991
 msgid "Test template does not exist"
 msgstr "测试模板不存在"
 
-#: stock/models.py:2071
+#: stock/models.py:2058
 msgid "Stock item has been assigned to a sales order"
 msgstr "库存项已分配到销售订单"
 
-#: stock/models.py:2075
+#: stock/models.py:2062
 msgid "Stock item is installed in another item"
 msgstr "库存项已安装在另一个项目中"
 
-#: stock/models.py:2078
+#: stock/models.py:2065
 msgid "Stock item contains other items"
 msgstr "库存项包含其他项目"
 
-#: stock/models.py:2081
+#: stock/models.py:2068
 msgid "Stock item has been assigned to a customer"
 msgstr "库存项已分配给客户"
 
-#: stock/models.py:2084 stock/models.py:2270
+#: stock/models.py:2071 stock/models.py:2254
 msgid "Stock item is currently in production"
 msgstr "库存项目前正在生产"
 
-#: stock/models.py:2087
+#: stock/models.py:2074
 msgid "Serialized stock cannot be merged"
 msgstr "序列化的库存不能合并"
 
-#: stock/models.py:2094 stock/serializers.py:1504
+#: stock/models.py:2081 stock/serializers.py:1483
 msgid "Duplicate stock items"
 msgstr "复制库存项"
 
-#: stock/models.py:2098
+#: stock/models.py:2085
 msgid "Stock items must refer to the same part"
 msgstr "库存项必须指相同零件"
 
-#: stock/models.py:2106
+#: stock/models.py:2093
 msgid "Stock items must refer to the same supplier part"
 msgstr "库存项必须是同一供应商的零件"
 
-#: stock/models.py:2111
+#: stock/models.py:2098
 msgid "Stock status codes must match"
 msgstr "库存状态码必须匹配"
 
-#: stock/models.py:2411
+#: stock/models.py:2395
 msgid "StockItem cannot be moved as it is not in stock"
 msgstr "库存项不能移动，因为它没有库存"
 
-#: stock/models.py:2905
+#: stock/models.py:2892
 msgid "Stock Item Tracking"
 msgstr "库存项跟踪"
 
-#: stock/models.py:2955
+#: stock/models.py:2923
 msgid "Entry notes"
 msgstr "条目注释"
 
-#: stock/models.py:2995
+#: stock/models.py:2963
 msgid "Stock Item Test Result"
 msgstr "库存项测试结果"
 
-#: stock/models.py:3026
+#: stock/models.py:2994
 msgid "Value must be provided for this test"
 msgstr "必须为此测试提供值"
 
-#: stock/models.py:3030
+#: stock/models.py:2998
 msgid "Attachment must be uploaded for this test"
 msgstr "测试附件必须上传"
 
-#: stock/models.py:3035
+#: stock/models.py:3003
 msgid "Invalid value for this test"
 msgstr "此测试的值无效"
 
-#: stock/models.py:3059
+#: stock/models.py:3027
 msgid "Test result"
 msgstr "测试结果"
 
-#: stock/models.py:3066
+#: stock/models.py:3034
 msgid "Test output value"
 msgstr "测试输出值"
 
-#: stock/models.py:3074 stock/serializers.py:259
+#: stock/models.py:3042 stock/serializers.py:250
 msgid "Test result attachment"
 msgstr "测验结果附件"
 
-#: stock/models.py:3078
+#: stock/models.py:3046
 msgid "Test notes"
 msgstr "测试备注"
 
-#: stock/models.py:3086
+#: stock/models.py:3054
 msgid "Test station"
 msgstr "测试站"
 
-#: stock/models.py:3087
+#: stock/models.py:3055
 msgid "The identifier of the test station where the test was performed"
 msgstr "进行测试的测试站的标识符"
 
-#: stock/models.py:3093
+#: stock/models.py:3061
 msgid "Started"
 msgstr "已开始"
 
-#: stock/models.py:3094
+#: stock/models.py:3062
 msgid "The timestamp of the test start"
 msgstr "测试开始的时间戳"
 
-#: stock/models.py:3100
+#: stock/models.py:3068
 msgid "Finished"
 msgstr "已完成"
 
-#: stock/models.py:3101
+#: stock/models.py:3069
 msgid "The timestamp of the test finish"
 msgstr "测试结束的时间戳"
 
@@ -8859,246 +8696,246 @@ msgstr "选择要生成序列号的零件"
 msgid "Quantity of serial numbers to generate"
 msgstr "要生成的序列号的数量"
 
-#: stock/serializers.py:245
+#: stock/serializers.py:236
 msgid "Test template for this result"
 msgstr "此结果的测试模板"
 
-#: stock/serializers.py:289
+#: stock/serializers.py:280
 msgid "No matching test found for this part"
 msgstr "未找到适用于此零件的匹配测试"
 
-#: stock/serializers.py:293
+#: stock/serializers.py:284
 msgid "Template ID or test name must be provided"
 msgstr "必须提供模板 ID 或测试名称"
 
-#: stock/serializers.py:303
+#: stock/serializers.py:294
 msgid "The test finished time cannot be earlier than the test started time"
 msgstr "测试完成时间不能早于测试开始时间"
 
-#: stock/serializers.py:427
+#: stock/serializers.py:416
 msgid "Parent Item"
 msgstr "父项"
 
-#: stock/serializers.py:428
+#: stock/serializers.py:417
 msgid "Parent stock item"
 msgstr "父库存项"
 
-#: stock/serializers.py:451
+#: stock/serializers.py:440
 msgid "Use pack size when adding: the quantity defined is the number of packs"
 msgstr "添加时使用包装尺寸：定义的数量是包装的数量"
 
-#: stock/serializers.py:453
+#: stock/serializers.py:442
 msgid "Use pack size"
 msgstr "包装规格"
 
-#: stock/serializers.py:460 stock/serializers.py:715
+#: stock/serializers.py:449 stock/serializers.py:704
 msgid "Enter serial numbers for new items"
 msgstr "输入新项目的序列号"
 
-#: stock/serializers.py:568
+#: stock/serializers.py:557
 msgid "Supplier Part Number"
 msgstr "供应商零件编号"
 
-#: stock/serializers.py:638 users/models.py:187
+#: stock/serializers.py:627 users/models.py:187
 msgid "Expired"
 msgstr "已过期"
 
-#: stock/serializers.py:644
+#: stock/serializers.py:633
 msgid "Child Items"
 msgstr "子项目"
 
-#: stock/serializers.py:648
+#: stock/serializers.py:637
 msgid "Tracking Items"
 msgstr "跟踪项目"
 
-#: stock/serializers.py:654
+#: stock/serializers.py:643
 msgid "Purchase price of this stock item, per unit or pack"
 msgstr "此库存商品的购买价格，单位或包装"
 
-#: stock/serializers.py:692
+#: stock/serializers.py:681
 msgid "Enter number of stock items to serialize"
 msgstr "输入要序列化的库存项目数量"
 
-#: stock/serializers.py:700 stock/serializers.py:743 stock/serializers.py:781
-#: stock/serializers.py:919
+#: stock/serializers.py:689 stock/serializers.py:732 stock/serializers.py:770
+#: stock/serializers.py:908
 msgid "No stock item provided"
 msgstr "未提供库存项"
 
-#: stock/serializers.py:708
+#: stock/serializers.py:697
 #, python-brace-format
 msgid "Quantity must not exceed available stock quantity ({q})"
 msgstr "数量不得超过现有库存量 ({q})"
 
-#: stock/serializers.py:726 stock/serializers.py:1461 stock/serializers.py:1782
-#: stock/serializers.py:1831
+#: stock/serializers.py:715 stock/serializers.py:1440 stock/serializers.py:1761
+#: stock/serializers.py:1810
 msgid "Destination stock location"
 msgstr "目标库存位置"
 
-#: stock/serializers.py:746
+#: stock/serializers.py:735
 msgid "Serial numbers cannot be assigned to this part"
 msgstr "此零件不能分配序列号"
 
-#: stock/serializers.py:766
+#: stock/serializers.py:755
 msgid "Serial numbers already exist"
 msgstr "序列号已存在"
 
-#: stock/serializers.py:816
+#: stock/serializers.py:805
 msgid "Select stock item to install"
 msgstr "选择要安装的库存项目"
 
-#: stock/serializers.py:823
+#: stock/serializers.py:812
 msgid "Quantity to Install"
 msgstr "安装数量"
 
-#: stock/serializers.py:824
+#: stock/serializers.py:813
 msgid "Enter the quantity of items to install"
 msgstr "输入要安装的项目数量"
 
-#: stock/serializers.py:829 stock/serializers.py:909 stock/serializers.py:1051
+#: stock/serializers.py:818 stock/serializers.py:898 stock/serializers.py:1040
 msgid "Add transaction note (optional)"
 msgstr "添加交易记录 (可选)"
 
-#: stock/serializers.py:837
+#: stock/serializers.py:826
 msgid "Quantity to install must be at least 1"
 msgstr "安装数量必须至少为1"
 
-#: stock/serializers.py:845
+#: stock/serializers.py:834
 msgid "Stock item is unavailable"
 msgstr "库存项不可用"
 
-#: stock/serializers.py:856
+#: stock/serializers.py:845
 msgid "Selected part is not in the Bill of Materials"
 msgstr "所选零件不在物料清单中"
 
-#: stock/serializers.py:869
+#: stock/serializers.py:858
 msgid "Quantity to install must not exceed available quantity"
 msgstr "安装数量不得超过可用数量"
 
-#: stock/serializers.py:904
+#: stock/serializers.py:893
 msgid "Destination location for uninstalled item"
 msgstr "已卸载项目的目标位置"
 
-#: stock/serializers.py:942
+#: stock/serializers.py:931
 msgid "Select part to convert stock item into"
 msgstr "选择要将库存项目转换为的零件"
 
-#: stock/serializers.py:955
+#: stock/serializers.py:944
 msgid "Selected part is not a valid option for conversion"
 msgstr "所选零件不是有效的转换选项"
 
-#: stock/serializers.py:972
+#: stock/serializers.py:961
 msgid "Cannot convert stock item with assigned SupplierPart"
 msgstr "无法转换已分配供应商零件的库存项"
 
-#: stock/serializers.py:1006
+#: stock/serializers.py:995
 msgid "Stock item status code"
 msgstr "库存项状态代码"
 
-#: stock/serializers.py:1035
+#: stock/serializers.py:1024
 msgid "Select stock items to change status"
 msgstr "选择要更改状态的库存项目"
 
-#: stock/serializers.py:1041
+#: stock/serializers.py:1030
 msgid "No stock items selected"
 msgstr "未选择库存商品"
 
-#: stock/serializers.py:1148 stock/serializers.py:1219
+#: stock/serializers.py:1137 stock/serializers.py:1208
 msgid "Sublocations"
 msgstr "子位置"
 
-#: stock/serializers.py:1214
+#: stock/serializers.py:1203
 msgid "Parent stock location"
 msgstr "上级库存地点"
 
-#: stock/serializers.py:1333
+#: stock/serializers.py:1312
 msgid "Part must be salable"
 msgstr "零件必须可销售"
 
-#: stock/serializers.py:1337
+#: stock/serializers.py:1316
 msgid "Item is allocated to a sales order"
 msgstr "物料已分配到销售订单"
 
-#: stock/serializers.py:1341
+#: stock/serializers.py:1320
 msgid "Item is allocated to a build order"
 msgstr "项目被分配到生产订单中"
 
-#: stock/serializers.py:1365
+#: stock/serializers.py:1344
 msgid "Customer to assign stock items"
 msgstr "客户分配库存项目"
 
-#: stock/serializers.py:1371
+#: stock/serializers.py:1350
 msgid "Selected company is not a customer"
 msgstr "所选公司不是客户"
 
-#: stock/serializers.py:1379
+#: stock/serializers.py:1358
 msgid "Stock assignment notes"
 msgstr "库存分配说明"
 
-#: stock/serializers.py:1389 stock/serializers.py:1677
+#: stock/serializers.py:1368 stock/serializers.py:1656
 msgid "A list of stock items must be provided"
 msgstr "必须提供库存物品清单"
 
-#: stock/serializers.py:1468
+#: stock/serializers.py:1447
 msgid "Stock merging notes"
 msgstr "库存合并说明"
 
-#: stock/serializers.py:1473
+#: stock/serializers.py:1452
 msgid "Allow mismatched suppliers"
 msgstr "允许不匹配的供应商"
 
-#: stock/serializers.py:1474
+#: stock/serializers.py:1453
 msgid "Allow stock items with different supplier parts to be merged"
 msgstr "允许合并具有不同供应商零件的库存项目"
 
-#: stock/serializers.py:1479
+#: stock/serializers.py:1458
 msgid "Allow mismatched status"
 msgstr "允许不匹配的状态"
 
-#: stock/serializers.py:1480
+#: stock/serializers.py:1459
 msgid "Allow stock items with different status codes to be merged"
 msgstr "允许合并具有不同状态代码的库存项目"
 
-#: stock/serializers.py:1490
+#: stock/serializers.py:1469
 msgid "At least two stock items must be provided"
 msgstr "必须提供至少两件库存物品"
 
-#: stock/serializers.py:1557
+#: stock/serializers.py:1536
 msgid "No Change"
 msgstr "无更改"
 
-#: stock/serializers.py:1595
+#: stock/serializers.py:1574
 msgid "StockItem primary key value"
 msgstr "库存项主键值"
 
-#: stock/serializers.py:1608
+#: stock/serializers.py:1587
 msgid "Stock item is not in stock"
 msgstr "库存项无现货"
 
-#: stock/serializers.py:1611
+#: stock/serializers.py:1590
 msgid "Stock item is already in stock"
 msgstr "库存项已有现货"
 
-#: stock/serializers.py:1625
+#: stock/serializers.py:1604
 msgid "Quantity must not be negative"
 msgstr "数量不得为负"
 
-#: stock/serializers.py:1667
+#: stock/serializers.py:1646
 msgid "Stock transaction notes"
 msgstr "库存交易记录"
 
-#: stock/serializers.py:1837
+#: stock/serializers.py:1816
 msgid "Merge into existing stock"
 msgstr "合并至现有库存"
 
-#: stock/serializers.py:1838
+#: stock/serializers.py:1817
 msgid "Merge returned items into existing stock items if possible"
 msgstr "若可行，将退回项目合并至现有库存项"
 
-#: stock/serializers.py:1881
+#: stock/serializers.py:1860
 msgid "Next Serial Number"
 msgstr "下一个序列号"
 
-#: stock/serializers.py:1887
+#: stock/serializers.py:1866
 msgid "Previous Serial Number"
 msgstr "上一个序列号"
 
@@ -9604,75 +9441,59 @@ msgstr "用户的姓氏"
 msgid "Email address of the user"
 msgstr "用户的电子邮件地址"
 
-#: users/serializers.py:244
-msgid "User must be authenticated"
-msgstr "用户必须经过身份验证"
-
-#: users/serializers.py:253
-msgid "Only a superuser can create a token for another user"
-msgstr "只有超级用户才能为其他用户创建令牌"
-
-#: users/serializers.py:322
-msgid "Administrator"
-msgstr "管理员"
-
-#: users/serializers.py:323
-msgid "Does this user have administrative permissions"
-msgstr "该用户是否拥有管理员权限"
-
-#: users/serializers.py:328 users/serializers.py:417
-msgid "Superuser"
-msgstr "超级用户"
-
-#: users/serializers.py:328 users/serializers.py:418
-msgid "Is this user a superuser"
-msgstr "此用户是否为超级用户"
-
-#: users/serializers.py:332 users/serializers.py:425
-msgid "Is this user account active"
-msgstr "此用户帐户是否已激活"
-
-#: users/serializers.py:344
-msgid "Only a superuser can adjust this field"
-msgstr "只有超级用户可以调整此字段"
-
-#: users/serializers.py:372
-msgid "Password"
-msgstr "密码"
-
-#: users/serializers.py:373
-msgid "Password for the user"
-msgstr "用户密码"
-
-#: users/serializers.py:379
-msgid "Override warning"
-msgstr "覆盖警告"
-
-#: users/serializers.py:380
-msgid "Override the warning about password rules"
-msgstr "覆盖有关密码规则的警告"
-
-#: users/serializers.py:410
+#: users/serializers.py:309
 msgid "Staff"
 msgstr "职员"
 
-#: users/serializers.py:411
+#: users/serializers.py:310
 msgid "Does this user have staff permissions"
-msgstr "此用户是否具有职员权限"
+msgstr "此用户是否拥有员工权限"
 
-#: users/serializers.py:461
+#: users/serializers.py:315
+msgid "Superuser"
+msgstr "超级用户"
+
+#: users/serializers.py:315
+msgid "Is this user a superuser"
+msgstr "此用户是否为超级用户"
+
+#: users/serializers.py:319
+msgid "Is this user account active"
+msgstr "此用户帐户是否已激活"
+
+#: users/serializers.py:331
+msgid "Only a superuser can adjust this field"
+msgstr "只有超级用户可以调整此字段"
+
+#: users/serializers.py:359
+msgid "Password"
+msgstr "密码"
+
+#: users/serializers.py:360
+msgid "Password for the user"
+msgstr "用户密码"
+
+#: users/serializers.py:366
+msgid "Override warning"
+msgstr "覆盖警告"
+
+#: users/serializers.py:367
+msgid "Override the warning about password rules"
+msgstr "覆盖有关密码规则的警告"
+
+#: users/serializers.py:423
 msgid "You do not have permission to create users"
 msgstr "你没有权限创建用户"
 
-#: users/serializers.py:482
+#: users/serializers.py:444
 msgid "Your account has been created."
 msgstr "您的账户已创建。"
 
-#: users/serializers.py:484
+#: users/serializers.py:446
 msgid "Please use the password reset function to login"
 msgstr "请使用密码重置功能登录"
 
-#: users/serializers.py:490
+#: users/serializers.py:452
 msgid "Welcome to InvenTree"
 msgstr "欢迎使用 InvenTree"
 

--- a/src/frontend/src/locales/zh_Hans/messages.po
+++ b/src/frontend/src/locales/zh_Hans/messages.po
@@ -1,5 +1,5 @@
 msgid ""
-msgstr "空字符串"
+msgstr ""
 "POT-Creation-Date: 2023-06-09 22:10+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -8,7 +8,7 @@ msgstr "空字符串"
 "Language: zh\n"
 "Project-Id-Version: inventree\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2026-04-08 05:40\n"
+"PO-Revision-Date: 2026-02-02 23:26\n"
 "Last-Translator: \n"
 "Language-Team: Chinese Simplified\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
@@ -30,12 +30,12 @@ msgid "Edit"
 msgstr "编辑"
 
 #: lib/components/RowActions.tsx:56
-#: src/components/forms/ApiForm.tsx:770
+#: src/components/forms/ApiForm.tsx:754
 #: src/components/items/ActionDropdown.tsx:257
 #: src/components/items/RoleTable.tsx:155
-#: src/hooks/UseForm.tsx:170
+#: src/hooks/UseForm.tsx:164
 #: src/pages/Notifications.tsx:109
-#: src/tables/plugin/PluginListTable.tsx:247
+#: src/tables/plugin/PluginListTable.tsx:243
 msgid "Delete"
 msgstr "删除"
 
@@ -44,36 +44,36 @@ msgstr "删除"
 #: src/components/editors/TemplateEditor/TemplateEditor.tsx:188
 #: src/components/items/ActionDropdown.tsx:277
 #: src/components/items/ActionDropdown.tsx:278
-#: src/contexts/ThemeContext.tsx:57
-#: src/hooks/UseForm.tsx:39
+#: src/contexts/ThemeContext.tsx:45
+#: src/hooks/UseForm.tsx:33
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:148
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:323
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:414
-#: src/tables/FilterSelectDrawer.tsx:382
-#: src/tables/build/BuildOutputTable.tsx:610
+#: src/tables/FilterSelectDrawer.tsx:336
+#: src/tables/build/BuildOutputTable.tsx:560
 msgid "Cancel"
 msgstr "取消"
 
 #: lib/components/RowActions.tsx:136
 #: src/components/nav/NavigationDrawer.tsx:190
-#: src/forms/PurchaseOrderForms.tsx:891
-#: src/forms/StockForms.tsx:805
-#: src/forms/StockForms.tsx:852
-#: src/forms/StockForms.tsx:905
-#: src/forms/StockForms.tsx:951
-#: src/forms/StockForms.tsx:989
-#: src/forms/StockForms.tsx:1099
+#: src/forms/PurchaseOrderForms.tsx:862
+#: src/forms/StockForms.tsx:803
+#: src/forms/StockForms.tsx:850
+#: src/forms/StockForms.tsx:903
+#: src/forms/StockForms.tsx:949
+#: src/forms/StockForms.tsx:987
+#: src/forms/StockForms.tsx:1097
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:976
 msgid "Actions"
 msgstr "操作"
 
 #: lib/components/SearchInput.tsx:34
-#: src/components/forms/fields/RelatedModelField.tsx:480
-#: src/components/nav/Header.tsx:179
+#: src/components/forms/fields/RelatedModelField.tsx:479
+#: src/components/nav/Header.tsx:169
 #: src/components/wizards/ImportPartWizard.tsx:200
 #: src/components/wizards/ImportPartWizard.tsx:233
 #: src/pages/Index/Settings/UserSettings.tsx:75
-#: src/pages/part/PartDetail.tsx:1168
+#: src/pages/part/PartDetail.tsx:1183
 msgid "Search"
 msgstr "搜索"
 
@@ -86,46 +86,43 @@ msgid "Fail"
 msgstr "失效"
 
 #: lib/components/YesNoButton.tsx:43
-#: src/tables/Filter.tsx:41
-#: src/tables/Filter.tsx:77
+#: src/tables/Filter.tsx:35
 msgid "Yes"
 msgstr "是"
 
 #: lib/components/YesNoButton.tsx:44
-#: src/tables/Filter.tsx:41
-#: src/tables/Filter.tsx:78
+#: src/tables/Filter.tsx:36
 msgid "No"
 msgstr "否"
 
 #: lib/enums/ModelInformation.tsx:29
 #: src/components/wizards/OrderPartsWizard.tsx:279
-#: src/forms/BuildForms.tsx:364
-#: src/forms/BuildForms.tsx:441
-#: src/forms/BuildForms.tsx:511
-#: src/forms/BuildForms.tsx:669
-#: src/forms/BuildForms.tsx:833
-#: src/forms/BuildForms.tsx:936
-#: src/forms/PurchaseOrderForms.tsx:887
-#: src/forms/ReturnOrderForms.tsx:244
-#: src/forms/SalesOrderForms.tsx:429
-#: src/forms/StockForms.tsx:368
-#: src/forms/StockForms.tsx:800
-#: src/forms/StockForms.tsx:847
-#: src/forms/StockForms.tsx:900
-#: src/forms/StockForms.tsx:946
-#: src/forms/StockForms.tsx:984
-#: src/forms/StockForms.tsx:1027
-#: src/forms/StockForms.tsx:1095
-#: src/forms/StockForms.tsx:1143
-#: src/forms/StockForms.tsx:1187
-#: src/pages/build/BuildDetail.tsx:219
-#: src/pages/part/PartDetail.tsx:1220
+#: src/forms/BuildForms.tsx:337
+#: src/forms/BuildForms.tsx:412
+#: src/forms/BuildForms.tsx:482
+#: src/forms/BuildForms.tsx:640
+#: src/forms/BuildForms.tsx:803
+#: src/forms/BuildForms.tsx:906
+#: src/forms/PurchaseOrderForms.tsx:858
+#: src/forms/ReturnOrderForms.tsx:242
+#: src/forms/SalesOrderForms.tsx:384
+#: src/forms/StockForms.tsx:366
+#: src/forms/StockForms.tsx:798
+#: src/forms/StockForms.tsx:845
+#: src/forms/StockForms.tsx:898
+#: src/forms/StockForms.tsx:944
+#: src/forms/StockForms.tsx:982
+#: src/forms/StockForms.tsx:1025
+#: src/forms/StockForms.tsx:1093
+#: src/forms/StockForms.tsx:1141
+#: src/forms/StockForms.tsx:1185
+#: src/pages/build/BuildDetail.tsx:201
+#: src/pages/part/PartDetail.tsx:1235
 #: src/tables/ColumnRenderers.tsx:91
 #: src/tables/build/BuildOrderParametricTable.tsx:26
 #: src/tables/part/PartTestResultTable.tsx:247
 #: src/tables/part/RelatedPartTable.tsx:53
-#: src/tables/stock/StockTrackingTable.tsx:119
-#: src/tables/stock/StockTrackingTable.tsx:237
+#: src/tables/stock/StockTrackingTable.tsx:102
 msgid "Part"
 msgstr "零件"
 
@@ -138,7 +135,7 @@ msgstr "零件"
 #: src/pages/part/CategoryDetail.tsx:285
 #: src/pages/part/CategoryDetail.tsx:340
 #: src/pages/part/CategoryDetail.tsx:371
-#: src/pages/part/PartDetail.tsx:956
+#: src/pages/part/PartDetail.tsx:982
 msgid "Parts"
 msgstr "零件"
 
@@ -160,7 +157,7 @@ msgstr "参数"
 #: src/components/wizards/ImportPartWizard.tsx:807
 #: src/pages/Index/Settings/AdminCenter/Index.tsx:195
 #: src/pages/Index/Settings/SystemSettings.tsx:191
-#: src/pages/part/PartDetail.tsx:920
+#: src/pages/part/PartDetail.tsx:946
 msgid "Parameters"
 msgstr "参数"
 
@@ -189,13 +186,13 @@ msgstr "零件测试模板"
 #: src/tables/build/BuildAllocatedStockTable.tsx:152
 #: src/tables/part/PartPurchaseOrdersTable.tsx:50
 #: src/tables/purchasing/SupplierPartParametricTable.tsx:29
-#: src/tables/purchasing/SupplierPartTable.tsx:106
-#: src/tables/stock/StockItemTable.tsx:99
+#: src/tables/purchasing/SupplierPartTable.tsx:83
+#: src/tables/stock/StockItemTable.tsx:247
 msgid "Supplier Part"
 msgstr "供应商零件"
 
 #: lib/enums/ModelInformation.tsx:60
-#: src/pages/purchasing/PurchasingIndex.tsx:129
+#: src/pages/purchasing/PurchasingIndex.tsx:128
 msgid "Supplier Parts"
 msgstr "供应商零件"
 
@@ -203,18 +200,18 @@ msgstr "供应商零件"
 #: src/pages/company/ManufacturerPartDetail.tsx:289
 #: src/pages/company/SupplierPartDetail.tsx:162
 #: src/tables/part/PartPurchaseOrdersTable.tsx:56
-#: src/tables/stock/StockItemTable.tsx:106
+#: src/tables/stock/StockItemTable.tsx:253
 msgid "Manufacturer Part"
 msgstr "制造商零件"
 
 #: lib/enums/ModelInformation.tsx:70
-#: src/pages/purchasing/PurchasingIndex.tsx:179
+#: src/pages/purchasing/PurchasingIndex.tsx:177
 msgid "Manufacturer Parts"
 msgstr "制造商零件"
 
 #: lib/enums/ModelInformation.tsx:79
 #: src/pages/part/CategoryDetail.tsx:371
-#: src/tables/Filter.tsx:449
+#: src/tables/Filter.tsx:389
 msgid "Part Category"
 msgstr "零件类别"
 
@@ -222,22 +219,19 @@ msgstr "零件类别"
 #: lib/enums/Roles.tsx:37
 #: src/pages/part/CategoryDetail.tsx:279
 #: src/pages/part/CategoryDetail.tsx:362
-#: src/pages/part/PartDetail.tsx:1209
+#: src/pages/part/PartDetail.tsx:1224
 msgid "Part Categories"
 msgstr "零件类别"
 
 #: lib/enums/ModelInformation.tsx:88
-#: src/forms/BuildForms.tsx:512
-#: src/forms/BuildForms.tsx:672
-#: src/forms/BuildForms.tsx:834
-#: src/forms/SalesOrderForms.tsx:431
-#: src/pages/stock/StockDetail.tsx:1008
-#: src/tables/ColumnRenderers.tsx:129
+#: src/forms/BuildForms.tsx:483
+#: src/forms/BuildForms.tsx:643
+#: src/forms/BuildForms.tsx:804
+#: src/forms/SalesOrderForms.tsx:386
+#: src/pages/stock/StockDetail.tsx:1007
 #: src/tables/part/PartTestResultTable.tsx:256
-#: src/tables/stock/InstalledItemsTable.tsx:66
-#: src/tables/stock/StockTrackingTable.tsx:65
-#: src/tables/stock/StockTrackingTable.tsx:72
-#: src/tables/stock/StockTrackingTable.tsx:247
+#: src/tables/stock/StockTrackingTable.tsx:48
+#: src/tables/stock/StockTrackingTable.tsx:55
 msgid "Stock Item"
 msgstr "库存项"
 
@@ -245,7 +239,7 @@ msgstr "库存项"
 #: lib/enums/Roles.tsx:45
 #: src/pages/company/CompanyDetail.tsx:211
 #: src/pages/part/CategoryDetail.tsx:314
-#: src/pages/part/PartStockHistoryDetail.tsx:117
+#: src/pages/part/PartStockHistoryDetail.tsx:101
 #: src/pages/stock/LocationDetail.tsx:130
 #: src/pages/stock/LocationDetail.tsx:211
 msgid "Stock Items"
@@ -253,14 +247,14 @@ msgstr "库存项"
 
 #: lib/enums/ModelInformation.tsx:98
 #: lib/enums/Roles.tsx:47
-#: src/pages/stock/LocationDetail.tsx:457
+#: src/pages/stock/LocationDetail.tsx:456
 msgid "Stock Location"
 msgstr "库存地点"
 
 #: lib/enums/ModelInformation.tsx:99
 #: src/pages/stock/LocationDetail.tsx:185
-#: src/pages/stock/LocationDetail.tsx:449
-#: src/pages/stock/StockDetail.tsx:999
+#: src/pages/stock/LocationDetail.tsx:448
+#: src/pages/stock/StockDetail.tsx:998
 msgid "Stock Locations"
 msgstr "库存地点"
 
@@ -273,8 +267,8 @@ msgid "Stock Location Types"
 msgstr "库存地点类型"
 
 #: lib/enums/ModelInformation.tsx:114
-#: src/pages/Index/Settings/SystemSettings.tsx:255
-#: src/pages/part/PartDetail.tsx:877
+#: src/pages/Index/Settings/SystemSettings.tsx:254
+#: src/pages/part/PartDetail.tsx:903
 msgid "Stock History"
 msgstr "库存历史记录"
 
@@ -307,8 +301,8 @@ msgid "Build Items"
 msgstr "构建多个项目"
 
 #: lib/enums/ModelInformation.tsx:144
-#: src/pages/company/CompanyDetail.tsx:347
-#: src/tables/company/CompanyTable.tsx:56
+#: src/pages/company/CompanyDetail.tsx:346
+#: src/tables/company/CompanyTable.tsx:47
 #: src/tables/company/ContactTable.tsx:67
 #: src/tables/company/ParametricCompanyTable.tsx:18
 msgid "Company"
@@ -319,12 +313,12 @@ msgid "Companies"
 msgstr "公司"
 
 #: lib/enums/ModelInformation.tsx:152
-#: src/pages/build/BuildDetail.tsx:335
+#: src/pages/build/BuildDetail.tsx:317
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:254
 #: src/pages/sales/ReturnOrderDetail.tsx:232
 #: src/pages/sales/SalesOrderDetail.tsx:225
-#: src/tables/ColumnRenderers.tsx:566
-#: src/tables/Filter.tsx:346
+#: src/tables/ColumnRenderers.tsx:381
+#: src/tables/Filter.tsx:286
 #: src/tables/TableHoverCard.tsx:101
 msgid "Project Code"
 msgstr "项目编码"
@@ -337,21 +331,21 @@ msgstr "项目编码"
 #: lib/enums/ModelInformation.tsx:159
 #: src/components/wizards/OrderPartsWizard.tsx:338
 #: src/pages/part/pricing/PurchaseHistoryPanel.tsx:33
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:565
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:556
 #: src/pages/stock/StockDetail.tsx:352
 #: src/tables/part/PartPurchaseOrdersTable.tsx:32
-#: src/tables/stock/StockItemTable.tsx:91
-#: src/tables/stock/StockTrackingTable.tsx:152
+#: src/tables/stock/StockItemTable.tsx:239
+#: src/tables/stock/StockTrackingTable.tsx:135
 msgid "Purchase Order"
 msgstr "采购订单"
 
 #: lib/enums/ModelInformation.tsx:160
 #: lib/enums/Roles.tsx:39
-#: src/defaults/actions.tsx:106
-#: src/pages/Index/Settings/SystemSettings.tsx:301
+#: src/defaults/actions.tsx:105
+#: src/pages/Index/Settings/SystemSettings.tsx:289
 #: src/pages/company/CompanyDetail.tsx:204
 #: src/pages/company/SupplierPartDetail.tsx:267
-#: src/pages/part/PartDetail.tsx:841
+#: src/pages/part/PartDetail.tsx:867
 #: src/pages/purchasing/PurchasingIndex.tsx:66
 msgid "Purchase Orders"
 msgstr "采购订单"
@@ -365,31 +359,31 @@ msgid "Purchase Order Lines"
 msgstr "采购订单行"
 
 #: lib/enums/ModelInformation.tsx:175
-#: src/pages/build/BuildDetail.tsx:308
+#: src/pages/build/BuildDetail.tsx:290
 #: src/pages/part/pricing/SaleHistoryPanel.tsx:24
-#: src/pages/sales/SalesOrderDetail.tsx:629
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:102
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:440
+#: src/pages/sales/SalesOrderDetail.tsx:620
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:103
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:447
 #: src/pages/stock/StockDetail.tsx:361
-#: src/tables/part/PartSalesAllocationsTable.tsx:42
-#: src/tables/sales/SalesOrderAllocationTable.tsx:111
-#: src/tables/sales/SalesOrderShipmentTable.tsx:136
-#: src/tables/stock/StockTrackingTable.tsx:163
+#: src/tables/part/PartSalesAllocationsTable.tsx:41
+#: src/tables/sales/SalesOrderAllocationTable.tsx:110
+#: src/tables/sales/SalesOrderShipmentTable.tsx:143
+#: src/tables/stock/StockTrackingTable.tsx:146
 msgid "Sales Order"
 msgstr "销售订单"
 
 #: lib/enums/ModelInformation.tsx:176
 #: lib/enums/Roles.tsx:43
-#: src/defaults/actions.tsx:116
-#: src/pages/Index/Settings/SystemSettings.tsx:317
+#: src/defaults/actions.tsx:115
+#: src/pages/Index/Settings/SystemSettings.tsx:305
 #: src/pages/company/CompanyDetail.tsx:224
-#: src/pages/part/PartDetail.tsx:853
+#: src/pages/part/PartDetail.tsx:879
 #: src/pages/sales/SalesIndex.tsx:53
 msgid "Sales Orders"
 msgstr "销售订单"
 
 #: lib/enums/ModelInformation.tsx:185
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:439
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:446
 msgid "Sales Order Shipment"
 msgstr "销售订单配送"
 
@@ -398,17 +392,17 @@ msgid "Sales Order Shipments"
 msgstr "销售订单配送"
 
 #: lib/enums/ModelInformation.tsx:194
-#: src/pages/sales/ReturnOrderDetail.tsx:564
-#: src/tables/stock/StockTrackingTable.tsx:174
+#: src/pages/sales/ReturnOrderDetail.tsx:555
+#: src/tables/stock/StockTrackingTable.tsx:157
 msgid "Return Order"
 msgstr "退货订单"
 
 #: lib/enums/ModelInformation.tsx:195
 #: lib/enums/Roles.tsx:41
-#: src/defaults/actions.tsx:127
-#: src/pages/Index/Settings/SystemSettings.tsx:334
+#: src/defaults/actions.tsx:126
+#: src/pages/Index/Settings/SystemSettings.tsx:322
 #: src/pages/company/CompanyDetail.tsx:231
-#: src/pages/part/PartDetail.tsx:860
+#: src/pages/part/PartDetail.tsx:886
 #: src/pages/sales/SalesIndex.tsx:99
 msgid "Return Orders"
 msgstr "退货订单"
@@ -427,7 +421,7 @@ msgid "Address"
 msgstr "地址"
 
 #: lib/enums/ModelInformation.tsx:211
-#: src/pages/company/CompanyDetail.tsx:266
+#: src/pages/company/CompanyDetail.tsx:265
 msgid "Addresses"
 msgstr "地址"
 
@@ -441,13 +435,13 @@ msgid "Contact"
 msgstr "联系人"
 
 #: lib/enums/ModelInformation.tsx:218
-#: src/pages/company/CompanyDetail.tsx:260
+#: src/pages/company/CompanyDetail.tsx:259
 #: src/pages/core/CoreIndex.tsx:33
 msgid "Contacts"
 msgstr "联系人"
 
 #: lib/enums/ModelInformation.tsx:224
-#: src/tables/ColumnRenderers.tsx:648
+#: src/tables/ColumnRenderers.tsx:463
 msgid "Owner"
 msgstr "所有者"
 
@@ -458,15 +452,15 @@ msgstr "所有者"
 #: lib/enums/ModelInformation.tsx:231
 #: src/pages/Auth/ChangePassword.tsx:36
 #: src/pages/core/UserDetail.tsx:220
-#: src/tables/ColumnRenderers.tsx:599
-#: src/tables/Filter.tsx:395
-#: src/tables/settings/ApiTokenTable.tsx:107
-#: src/tables/settings/ApiTokenTable.tsx:127
+#: src/tables/ColumnRenderers.tsx:414
+#: src/tables/Filter.tsx:335
+#: src/tables/settings/ApiTokenTable.tsx:106
+#: src/tables/settings/ApiTokenTable.tsx:126
 #: src/tables/settings/BarcodeScanHistoryTable.tsx:79
 #: src/tables/settings/ExportSessionTable.tsx:44
-#: src/tables/settings/ImportSessionTable.tsx:78
-#: src/tables/stock/StockTrackingTable.tsx:225
-#: src/tables/stock/StockTrackingTable.tsx:273
+#: src/tables/settings/ImportSessionTable.tsx:77
+#: src/tables/stock/StockTrackingTable.tsx:205
+#: src/tables/stock/StockTrackingTable.tsx:233
 msgid "User"
 msgstr "用户"
 
@@ -520,7 +514,7 @@ msgid "Report Templates"
 msgstr "报告模板"
 
 #: lib/enums/ModelInformation.tsx:270
-#: src/components/plugins/PluginDrawer.tsx:153
+#: src/components/plugins/PluginDrawer.tsx:145
 msgid "Plugin Configuration"
 msgstr "插件配置"
 
@@ -547,11 +541,10 @@ msgstr "选择列表"
 
 #: lib/enums/ModelInformation.tsx:291
 #: src/components/barcodes/BarcodeInput.tsx:114
-#: src/components/buttons/StarredToggleButton.tsx:46
 #: src/components/dashboard/DashboardLayout.tsx:281
 #: src/components/editors/NotesEditor.tsx:74
 #: src/components/editors/TemplateEditor/TemplateEditor.tsx:158
-#: src/components/forms/fields/ApiFormField.tsx:251
+#: src/components/forms/fields/ApiFormField.tsx:241
 #: src/components/forms/fields/TableField.tsx:45
 #: src/components/importer/ImportDataSelector.tsx:192
 #: src/components/importer/ImporterColumnSelector.tsx:261
@@ -560,10 +553,10 @@ msgstr "选择列表"
 #: src/components/nav/NavigationTree.tsx:211
 #: src/components/nav/NotificationDrawer.tsx:235
 #: src/components/nav/SearchDrawer.tsx:572
-#: src/components/settings/SettingList.tsx:145
+#: src/components/settings/SettingList.tsx:143
 #: src/components/wizards/ImportPartWizard.tsx:574
 #: src/components/wizards/ImportPartWizard.tsx:719
-#: src/forms/BomForms.tsx:74
+#: src/forms/BomForms.tsx:69
 #: src/functions/auth.tsx:687
 #: src/pages/ErrorPage.tsx:11
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:317
@@ -574,8 +567,8 @@ msgstr "选择列表"
 #: src/pages/part/PartPricingPanel.tsx:71
 #: src/states/IconState.tsx:46
 #: src/states/IconState.tsx:76
-#: src/tables/InvenTreeTableHeader.tsx:124
-#: src/tables/bom/BomTable.tsx:557
+#: src/tables/InvenTreeTableHeader.tsx:125
+#: src/tables/bom/BomTable.tsx:563
 #: src/tables/settings/EmailTable.tsx:109
 #: src/tables/stock/StockItemTestResultTable.tsx:338
 msgid "Error"
@@ -592,22 +585,18 @@ msgid "Admin"
 msgstr "管理员"
 
 #: lib/enums/Roles.tsx:33
-#: src/defaults/actions.tsx:146
-#: src/pages/Index/Settings/SystemSettings.tsx:282
+#: src/defaults/actions.tsx:136
+#: src/pages/Index/Settings/SystemSettings.tsx:270
 #: src/pages/build/BuildIndex.tsx:67
-#: src/pages/part/PartDetail.tsx:870
-#: src/pages/sales/SalesOrderDetail.tsx:431
+#: src/pages/part/PartDetail.tsx:896
+#: src/pages/sales/SalesOrderDetail.tsx:422
 msgid "Build Orders"
 msgstr "生产订单"
 
-#: lib/hooks/MonitorDataOutput.tsx:57
-#: lib/hooks/MonitorDataOutput.tsx:116
-msgid "Process failed"
-msgstr "处理失败"
-
-#: lib/hooks/MonitorDataOutput.tsx:75
-msgid "Process completed successfully"
-msgstr "处理成功"
+#: lib/enums/Roles.tsx:50
+#: src/pages/Index/Settings/AdminCenter/Index.tsx:202
+#~ msgid "Stocktake"
+#~ msgstr "Stocktake"
 
 #: src/components/Boundary.tsx:14
 msgid "Error rendering component"
@@ -649,7 +638,7 @@ msgstr "条形码"
 
 #: src/components/barcodes/BarcodeInput.tsx:35
 #: src/components/barcodes/BarcodeKeyboardInput.tsx:18
-#: src/defaults/actions.tsx:137
+#: src/defaults/actions.tsx:86
 msgid "Scan"
 msgstr "扫描"
 
@@ -680,8 +669,8 @@ msgstr "输入条形码数据"
 #: src/components/barcodes/BarcodeScanDialog.tsx:56
 #: src/components/buttons/ScanButton.tsx:27
 #: src/components/nav/NavigationDrawer.tsx:122
-#: src/forms/PurchaseOrderForms.tsx:507
-#: src/forms/PurchaseOrderForms.tsx:648
+#: src/forms/PurchaseOrderForms.tsx:503
+#: src/forms/PurchaseOrderForms.tsx:620
 msgid "Scan Barcode"
 msgstr "扫描条形码"
 
@@ -696,11 +685,11 @@ msgstr "条形码与预期型号不匹配"
 #: src/components/barcodes/BarcodeScanDialog.tsx:161
 #: src/components/editors/NotesEditor.tsx:84
 #: src/components/editors/NotesEditor.tsx:118
-#: src/components/forms/ApiForm.tsx:496
+#: src/components/forms/ApiForm.tsx:484
 #: src/components/wizards/ImportPartWizard.tsx:566
 #: src/components/wizards/ImportPartWizard.tsx:691
 #: src/pages/Index/Settings/AdminCenter/CurrencyManagementPanel.tsx:45
-#: src/tables/bom/BomTable.tsx:548
+#: src/tables/bom/BomTable.tsx:554
 #: src/tables/settings/PendingTasksTable.tsx:68
 msgid "Success"
 msgstr "操作成功"
@@ -751,11 +740,11 @@ msgid "Failed to link barcode"
 msgstr "链接条形码失败"
 
 #: src/components/barcodes/QRCode.tsx:179
-#: src/pages/part/PartDetail.tsx:498
+#: src/pages/part/PartDetail.tsx:521
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:223
 #: src/pages/sales/ReturnOrderDetail.tsx:189
 #: src/pages/sales/SalesOrderDetail.tsx:182
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:119
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:120
 #: src/pages/stock/StockDetail.tsx:186
 msgid "Link"
 msgstr "链接"
@@ -766,7 +755,7 @@ msgstr "这将删除关联条形码的链接"
 
 #: src/components/barcodes/QRCode.tsx:205
 #: src/components/items/ActionDropdown.tsx:192
-#: src/forms/PurchaseOrderForms.tsx:638
+#: src/forms/PurchaseOrderForms.tsx:611
 msgid "Unlink Barcode"
 msgstr "解绑条形码"
 
@@ -778,11 +767,11 @@ msgstr "在管理员界面打开"
 #~ msgid "Copy to clipboard"
 #~ msgstr "Copy to clipboard"
 
-#: src/components/buttons/CopyButton.tsx:50
+#: src/components/buttons/CopyButton.tsx:42
 msgid "Copied"
 msgstr "已复制"
 
-#: src/components/buttons/CopyButton.tsx:50
+#: src/components/buttons/CopyButton.tsx:42
 msgid "Copy"
 msgstr "复制"
 
@@ -818,6 +807,10 @@ msgstr "打印标签"
 #: src/components/buttons/PrintingActions.tsx:172
 msgid "Print"
 msgstr "打印"
+
+#: src/components/buttons/PrintingActions.tsx:152
+#~ msgid "Generate"
+#~ msgstr "Generate"
 
 #: src/components/buttons/PrintingActions.tsx:153
 #~ msgid "Report printing completed successfully"
@@ -879,14 +872,6 @@ msgstr "打开聚焦"
 msgid "Subscription Updated"
 msgstr "订阅已更新"
 
-#: src/components/buttons/StarredToggleButton.tsx:38
-msgid "Subscription removed"
-msgstr "订阅已移除"
-
-#: src/components/buttons/StarredToggleButton.tsx:38
-msgid "Subscription added"
-msgstr "订阅已添加"
-
 #: src/components/buttons/StarredToggleButton.tsx:57
 #~ msgid "Unsubscribe from part"
 #~ msgstr "Unsubscribe from part"
@@ -899,32 +884,27 @@ msgstr "取消订阅通知"
 msgid "Subscribe to notifications"
 msgstr "订阅通知"
 
-#: src/components/calendar/Calendar.tsx:118
-#: src/components/calendar/Calendar.tsx:181
+#: src/components/calendar/Calendar.tsx:102
+#: src/components/calendar/Calendar.tsx:165
 msgid "Calendar Filters"
 msgstr "日历筛选器"
 
-#: src/components/calendar/Calendar.tsx:133
+#: src/components/calendar/Calendar.tsx:117
 msgid "Previous month"
 msgstr "上个月"
 
-#: src/components/calendar/Calendar.tsx:142
+#: src/components/calendar/Calendar.tsx:126
 msgid "Select month"
 msgstr "选择月份"
 
-#: src/components/calendar/Calendar.tsx:163
+#: src/components/calendar/Calendar.tsx:147
 msgid "Next month"
 msgstr "下个月"
 
 #: src/components/calendar/Calendar.tsx:178
 #: src/tables/InvenTreeTableHeader.tsx:294
-#~ msgid "Download data"
-#~ msgstr "Download data"
-
-#: src/components/calendar/Calendar.tsx:194
-#: src/tables/InvenTreeTableHeader.tsx:288
-msgid "Export data"
-msgstr "出口数据"
+msgid "Download data"
+msgstr "下载数据"
 
 #: src/components/calendar/OrderCalendar.tsx:132
 msgid "Order Updated"
@@ -935,7 +915,7 @@ msgid "Error updating order"
 msgstr "更新订单时出错"
 
 #: src/components/calendar/OrderCalendar.tsx:178
-#: src/tables/Filter.tsx:194
+#: src/tables/Filter.tsx:152
 msgid "Overdue"
 msgstr "逾期"
 
@@ -1000,185 +980,185 @@ msgstr "没有可用组件"
 msgid "There are no more widgets available for the dashboard"
 msgstr "面板没有更多的组件"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:25
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:24
 msgid "Subscribed Parts"
 msgstr "已订购零件"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:26
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:25
 msgid "Show the number of parts which you have subscribed to"
 msgstr "显示订阅的零件数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:32
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:31
 msgid "Subscribed Categories"
 msgstr "已订阅类别"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:33
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:32
 msgid "Show the number of part categories which you have subscribed to"
 msgstr "显示订阅的零件类别数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:42
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:41
 msgid "Invalid BOMs"
 msgstr "无效物料清单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:43
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:42
 msgid "Assemblies requiring bill of materials validation"
 msgstr "需要物料清单验证的装配件"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:54
-#: src/tables/part/PartTable.tsx:264
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:53
+#: src/tables/part/PartTable.tsx:263
 msgid "Low Stock"
 msgstr "低库存"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:56
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:55
 msgid "Show the number of parts which are low on stock"
 msgstr "显示低库存的零件数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:65
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:64
 msgid "Required for Build Orders"
 msgstr "生产订单所需的"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:67
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:66
 msgid "Show parts which are required for active build orders"
 msgstr "显示当前生产订单所需的零件"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:72
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:71
 msgid "Expired Stock Items"
 msgstr "已过期库存项"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:74
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:73
 msgid "Show the number of stock items which have expired"
 msgstr "显示已过期的库存项"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:80
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:79
 msgid "Stale Stock Items"
 msgstr "过期库存项"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:82
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:81
 msgid "Show the number of stock items which are stale"
 msgstr "显示过期库存项"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:88
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:87
 msgid "Active Build Orders"
 msgstr "激活的生产订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:90
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:89
 msgid "Show the number of build orders which are currently active"
 msgstr "显示当前激活的生产订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:95
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:94
 msgid "Overdue Build Orders"
 msgstr "逾期的生产订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:97
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:96
 msgid "Show the number of build orders which are overdue"
 msgstr "显示逾期的生产订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:102
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:101
 msgid "Assigned Build Orders"
 msgstr "已分配的生产订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:104
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:103
 msgid "Show the number of build orders which are assigned to you"
 msgstr "显示分配给您的生产订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:109
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:108
 msgid "Active Sales Orders"
 msgstr "活动的销售订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:111
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:110
 msgid "Show the number of sales orders which are currently active"
 msgstr "显示当前活动的销售订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:116
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:115
 msgid "Overdue Sales Orders"
 msgstr "逾期的销售订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:118
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:117
 msgid "Show the number of sales orders which are overdue"
 msgstr "显示逾期的销售订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:123
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:122
 msgid "Assigned Sales Orders"
 msgstr "已分配的销售订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:125
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:124
 msgid "Show the number of sales orders which are assigned to you"
 msgstr "显示分配给您的销售订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:130
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:129
 #: src/pages/sales/SalesIndex.tsx:87
 msgid "Pending Shipments"
 msgstr "待处理货件"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:132
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:131
 msgid "Show the number of pending sales order shipments"
 msgstr "显示待处理销售订单的发货数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:137
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:136
 msgid "Active Purchase Orders"
 msgstr "活跃的采购订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:139
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:138
 msgid "Show the number of purchase orders which are currently active"
 msgstr "显示当前活跃的采购订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:144
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:143
 msgid "Overdue Purchase Orders"
 msgstr "逾期的采购订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:146
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:145
 msgid "Show the number of purchase orders which are overdue"
 msgstr "显示逾期的采购订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:151
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:150
 msgid "Assigned Purchase Orders"
 msgstr "已分配的采购订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:153
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:152
 msgid "Show the number of purchase orders which are assigned to you"
 msgstr "显示分配给您的采购订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:158
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:157
 msgid "Active Return Orders"
 msgstr "活跃的退货订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:160
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:159
 msgid "Show the number of return orders which are currently active"
 msgstr "显示当前活跃的退货订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:165
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:164
 msgid "Overdue Return Orders"
 msgstr "逾期退货订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:167
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:166
 msgid "Show the number of return orders which are overdue"
 msgstr "显示逾期的退货订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:172
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:171
 msgid "Assigned Return Orders"
 msgstr "已分配的退货订单"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:174
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:173
 msgid "Show the number of return orders which are assigned to you"
 msgstr "显示分配给您的退货订单数量"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:194
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:193
 #: src/components/dashboard/widgets/GetStartedWidget.tsx:15
 #: src/defaults/links.tsx:86
 msgid "Getting Started"
 msgstr "快速上手"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:195
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:194
 #: src/defaults/links.tsx:89
 msgid "Getting started with InvenTree"
 msgstr "开始使用 InvenTree"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:202
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:201
 #: src/components/dashboard/widgets/NewsWidget.tsx:123
 msgid "News Updates"
 msgstr "最新消息"
 
-#: src/components/dashboard/DashboardWidgetLibrary.tsx:203
+#: src/components/dashboard/DashboardWidgetLibrary.tsx:202
 msgid "The latest news from InvenTree"
 msgstr "来自 InvenTree 的最新消息"
 
@@ -1221,62 +1201,30 @@ msgstr "沒有消息"
 msgid "There are no unread news items"
 msgstr "没有未读新闻项目"
 
-#: src/components/dashboard/widgets/StocktakeDashboardWidget.tsx:15
-msgid "Generating Stocktake Report"
-msgstr "正在生成盘点报告"
-
-#: src/components/dashboard/widgets/StocktakeDashboardWidget.tsx:20
-#: src/components/dashboard/widgets/StocktakeDashboardWidget.tsx:53
-#: src/pages/part/PartStockHistoryDetail.tsx:96
-msgid "Generate Stocktake Report"
-msgstr "生成盘点报告"
-
-#: src/components/dashboard/widgets/StocktakeDashboardWidget.tsx:37
-#: src/pages/part/PartStockHistoryDetail.tsx:108
-msgid "Generate"
-msgstr "生成"
-
-#: src/components/dashboard/widgets/StocktakeDashboardWidget.tsx:64
-msgid "Stocktake"
-msgstr "库存盘点"
-
-#: src/components/dashboard/widgets/StocktakeDashboardWidget.tsx:65
-msgid "Generate a new stocktake report"
-msgstr "生成新的盘点报告"
-
 #: src/components/details/Details.tsx:117
 #~ msgid "Email:"
 #~ msgstr "Email:"
 
-#: src/components/details/Details.tsx:129
+#: src/components/details/Details.tsx:123
 #: src/pages/Index/Settings/AccountSettings/AccountDetailPanel.tsx:76
 #: src/pages/core/UserDetail.tsx:93
 #: src/pages/core/UserDetail.tsx:203
-#: src/tables/settings/UserTable.tsx:411
+#: src/tables/settings/UserTable.tsx:410
 msgid "Superuser"
 msgstr "超级用户"
 
-#: src/components/details/Details.tsx:130
-#: src/pages/Index/Settings/AccountSettings/AccountDetailPanel.tsx:72
-#: src/pages/core/UserDetail.tsx:87
-#: src/pages/core/UserDetail.tsx:200
-#: src/tables/settings/UserTable.tsx:285
-#: src/tables/settings/UserTable.tsx:406
-msgid "Administrator"
-msgstr "管理员"
-
-#: src/components/details/Details.tsx:130
+#: src/components/details/Details.tsx:124
 #: src/pages/core/UserDetail.tsx:87
 #: src/pages/core/UserDetail.tsx:200
 #: src/tables/settings/UserTable.tsx:405
-#~ msgid "Staff"
-#~ msgstr "Staff"
+msgid "Staff"
+msgstr "工作人员"
 
-#: src/components/details/Details.tsx:131
+#: src/components/details/Details.tsx:125
 msgid "Email: "
 msgstr "邮箱: "
 
-#: src/components/details/Details.tsx:423
+#: src/components/details/Details.tsx:411
 msgid "No name defined"
 msgstr "未定义名称"
 
@@ -1289,96 +1237,84 @@ msgid "Remove the associated image from this item?"
 msgstr "删除与此项关联的图片？"
 
 #: src/components/details/DetailsImage.tsx:83
-#: src/forms/StockForms.tsx:904
+#: src/forms/StockForms.tsx:902
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:326
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:417
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:898
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:917
 #: src/pages/Index/Settings/AccountSettings/SecurityContent.tsx:268
-#: src/tables/build/BuildAllocatedStockTable.tsx:180
-#: src/tables/build/BuildAllocatedStockTable.tsx:276
-#: src/tables/build/BuildLineTable.tsx:116
-#: src/tables/build/BuildLineTable.tsx:671
-#: src/tables/sales/SalesOrderAllocationTable.tsx:223
-#: src/tables/sales/SalesOrderAllocationTable.tsx:246
+#: src/tables/build/BuildAllocatedStockTable.tsx:178
+#: src/tables/build/BuildAllocatedStockTable.tsx:258
+#: src/tables/build/BuildLineTable.tsx:111
+#: src/tables/build/BuildLineTable.tsx:666
+#: src/tables/sales/SalesOrderAllocationTable.tsx:224
+#: src/tables/sales/SalesOrderAllocationTable.tsx:247
 msgid "Remove"
 msgstr "移除"
 
-#: src/components/details/DetailsImage.tsx:88
-msgid "Image removed"
-msgstr "图像已移除"
+#: src/components/details/DetailsImage.tsx:109
+msgid "Drag and drop to upload"
+msgstr "拖拽上传"
 
-#: src/components/details/DetailsImage.tsx:89
-msgid "The image has been removed successfully"
-msgstr "图片已成功删除"
-
-#: src/components/details/DetailsImage.tsx:115
-#~ msgid "Drag and drop to upload"
-#~ msgstr "Drag and drop to upload"
-
-#: src/components/details/DetailsImage.tsx:157
-msgid "Drag and drop to upload, or paste an image from the clipboard"
-msgstr "拖放上传，或从剪贴板粘贴图片"
-
-#: src/components/details/DetailsImage.tsx:162
+#: src/components/details/DetailsImage.tsx:112
 msgid "Click to select file(s)"
 msgstr "点击选择文件"
 
-#: src/components/details/DetailsImage.tsx:222
+#: src/components/details/DetailsImage.tsx:172
 msgid "Image uploaded"
 msgstr "图片已上传"
 
-#: src/components/details/DetailsImage.tsx:223
+#: src/components/details/DetailsImage.tsx:173
 msgid "Image has been uploaded successfully"
 msgstr "图片已经上传成功"
 
-#: src/components/details/DetailsImage.tsx:230
+#: src/components/details/DetailsImage.tsx:180
 #: src/tables/general/AttachmentTable.tsx:201
 msgid "Upload Error"
 msgstr "上传错误"
 
-#: src/components/details/DetailsImage.tsx:300
+#: src/components/details/DetailsImage.tsx:250
 #: src/components/forms/fields/AutoFillRightSection.tsx:34
 msgid "Clear"
 msgstr "清除"
 
-#: src/components/details/DetailsImage.tsx:306
-#: src/components/forms/ApiForm.tsx:712
-#: src/contexts/ThemeContext.tsx:56
+#: src/components/details/DetailsImage.tsx:256
+#: src/components/forms/ApiForm.tsx:696
+#: src/contexts/ThemeContext.tsx:44
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:151
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:570
 msgid "Submit"
 msgstr "提交"
 
-#: src/components/details/DetailsImage.tsx:350
+#: src/components/details/DetailsImage.tsx:300
 msgid "Select from existing images"
 msgstr "从现有图片中选择"
 
-#: src/components/details/DetailsImage.tsx:358
+#: src/components/details/DetailsImage.tsx:308
 msgid "Select Image"
 msgstr "选择图片"
 
-#: src/components/details/DetailsImage.tsx:374
+#: src/components/details/DetailsImage.tsx:324
 msgid "Download remote image"
 msgstr "下载远程图片"
 
-#: src/components/details/DetailsImage.tsx:389
+#: src/components/details/DetailsImage.tsx:339
 msgid "Upload new image"
 msgstr "上传新图片"
 
-#: src/components/details/DetailsImage.tsx:396
+#: src/components/details/DetailsImage.tsx:346
 msgid "Upload Image"
 msgstr "上传图片"
 
-#: src/components/details/DetailsImage.tsx:409
+#: src/components/details/DetailsImage.tsx:359
 msgid "Delete image"
 msgstr "删除图片"
 
-#: src/components/details/DetailsImage.tsx:443
+#: src/components/details/DetailsImage.tsx:393
 msgid "Download Image"
 msgstr "下载图片"
 
-#: src/components/details/DetailsImage.tsx:448
+#: src/components/details/DetailsImage.tsx:398
 msgid "Image downloaded successfully"
 msgstr "图片下载成功"
 
@@ -1596,8 +1532,8 @@ msgstr "服务器错误"
 msgid "A server error occurred"
 msgstr "服务器出错。"
 
-#: src/components/forms/ApiForm.tsx:108
-#: src/components/forms/ApiForm.tsx:624
+#: src/components/forms/ApiForm.tsx:107
+#: src/components/forms/ApiForm.tsx:613
 msgid "Form Error"
 msgstr "表单错误"
 
@@ -1605,13 +1541,13 @@ msgstr "表单错误"
 #~ msgid "Form Errors Exist"
 #~ msgstr "Form Errors Exist"
 
-#: src/components/forms/ApiForm.tsx:634
+#: src/components/forms/ApiForm.tsx:623
 msgid "Errors exist for one or more form fields"
 msgstr "一个或多个表单字段存在错误"
 
-#: src/components/forms/ApiForm.tsx:750
-#: src/hooks/UseForm.tsx:139
-#: src/tables/plugin/PluginListTable.tsx:210
+#: src/components/forms/ApiForm.tsx:734
+#: src/hooks/UseForm.tsx:133
+#: src/tables/plugin/PluginListTable.tsx:204
 msgid "Update"
 msgstr "更新"
 
@@ -1768,7 +1704,7 @@ msgid "Repeat password"
 msgstr "再次输入密码"
 
 #: src/components/forms/AuthenticationForm.tsx:332
-#: src/pages/Auth/Login.tsx:128
+#: src/pages/Auth/Login.tsx:121
 #: src/pages/Auth/Register.tsx:13
 msgid "Register"
 msgstr "注册"
@@ -1796,18 +1732,18 @@ msgstr "主机"
 
 #: src/components/forms/HostOptionsForm.tsx:42
 #: src/components/forms/HostOptionsForm.tsx:70
-#: src/components/forms/InstanceOptions.tsx:125
+#: src/components/forms/InstanceOptions.tsx:124
 #: src/components/plugins/PluginDrawer.tsx:68
 #: src/pages/Index/Settings/AdminCenter/UnitManagementPanel.tsx:19
 #: src/pages/part/CategoryDetail.tsx:91
-#: src/pages/part/PartDetail.tsx:421
+#: src/pages/part/PartDetail.tsx:446
 #: src/pages/stock/LocationDetail.tsx:91
 #: src/tables/machine/MachineTypeTable.tsx:67
 #: src/tables/machine/MachineTypeTable.tsx:149
 #: src/tables/machine/MachineTypeTable.tsx:252
 #: src/tables/machine/MachineTypeTable.tsx:355
-#: src/tables/plugin/PluginErrorTable.tsx:35
-#: src/tables/settings/ApiTokenTable.tsx:58
+#: src/tables/plugin/PluginErrorTable.tsx:33
+#: src/tables/settings/ApiTokenTable.tsx:57
 #: src/tables/settings/GroupTable.tsx:95
 #: src/tables/settings/GroupTable.tsx:148
 #: src/tables/settings/GroupTable.tsx:256
@@ -1835,12 +1771,12 @@ msgstr "保存"
 #~ msgid "Select destination instance"
 #~ msgstr "Select destination instance"
 
-#: src/components/forms/InstanceOptions.tsx:59
+#: src/components/forms/InstanceOptions.tsx:58
 msgid "Select Server"
 msgstr "选择服务器"
 
-#: src/components/forms/InstanceOptions.tsx:69
-#: src/components/forms/InstanceOptions.tsx:93
+#: src/components/forms/InstanceOptions.tsx:68
+#: src/components/forms/InstanceOptions.tsx:92
 msgid "Edit host options"
 msgstr "编辑主机选项"
 
@@ -1848,7 +1784,7 @@ msgstr "编辑主机选项"
 #~ msgid "Edit possible host options"
 #~ msgstr "Edit possible host options"
 
-#: src/components/forms/InstanceOptions.tsx:77
+#: src/components/forms/InstanceOptions.tsx:76
 msgid "Save host selection"
 msgstr "保存主机选择"
 
@@ -1868,32 +1804,32 @@ msgstr "保存主机选择"
 #~ msgid "State: <0>worker</0> ({0}), <1>plugins</1>{1}"
 #~ msgstr "State: <0>worker</0> ({0}), <1>plugins</1>{1}"
 
-#: src/components/forms/InstanceOptions.tsx:119
+#: src/components/forms/InstanceOptions.tsx:118
 #: src/pages/Index/Settings/SystemSettings.tsx:46
 msgid "Server"
 msgstr "服务器"
 
-#: src/components/forms/InstanceOptions.tsx:131
+#: src/components/forms/InstanceOptions.tsx:130
 #: src/components/plugins/PluginDrawer.tsx:88
 #: src/tables/plugin/PluginListTable.tsx:127
 msgid "Version"
 msgstr "版本"
 
-#: src/components/forms/InstanceOptions.tsx:137
-#: src/components/modals/AboutInvenTreeModal.tsx:119
+#: src/components/forms/InstanceOptions.tsx:136
+#: src/components/modals/AboutInvenTreeModal.tsx:124
 #: src/components/modals/ServerInfoModal.tsx:34
 msgid "API Version"
 msgstr "API 版本"
 
-#: src/components/forms/InstanceOptions.tsx:143
+#: src/components/forms/InstanceOptions.tsx:142
 #: src/components/nav/NavigationDrawer.tsx:197
-#: src/defaults/actions.tsx:173
+#: src/defaults/actions.tsx:163
 #: src/pages/Index/Settings/AdminCenter/Index.tsx:228
 #: src/pages/Index/Settings/AdminCenter/PluginManagementPanel.tsx:46
 msgid "Plugins"
 msgstr "插件"
 
-#: src/components/forms/InstanceOptions.tsx:144
+#: src/components/forms/InstanceOptions.tsx:143
 #: src/tables/general/ParameterTemplateTable.tsx:153
 #: src/tables/general/ParameterTemplateTable.tsx:188
 #: src/tables/part/PartTestTemplateTable.tsx:117
@@ -1903,24 +1839,24 @@ msgstr "插件"
 msgid "Enabled"
 msgstr "已启用"
 
-#: src/components/forms/InstanceOptions.tsx:144
+#: src/components/forms/InstanceOptions.tsx:143
 msgid "Disabled"
 msgstr "已禁用"
 
-#: src/components/forms/InstanceOptions.tsx:150
+#: src/components/forms/InstanceOptions.tsx:149
 msgid "Worker"
 msgstr "工作人员"
 
-#: src/components/forms/InstanceOptions.tsx:151
+#: src/components/forms/InstanceOptions.tsx:150
 #: src/tables/settings/FailedTasksTable.tsx:48
 msgid "Stopped"
 msgstr "已停止"
 
-#: src/components/forms/InstanceOptions.tsx:151
+#: src/components/forms/InstanceOptions.tsx:150
 msgid "Running"
 msgstr "运行中"
 
-#: src/components/forms/fields/ApiFormField.tsx:206
+#: src/components/forms/fields/ApiFormField.tsx:201
 msgid "Select file to upload"
 msgstr "选择要上传的文件"
 
@@ -1941,8 +1877,8 @@ msgid "Uncategorized"
 msgstr "未分类"
 
 #: src/components/forms/fields/IconField.tsx:211
-#: src/components/nav/Layout.tsx:141
-#: src/tables/part/PartThumbTable.tsx:209
+#: src/components/nav/Layout.tsx:138
+#: src/tables/part/PartThumbTable.tsx:199
 msgid "Search..."
 msgstr "搜索..."
 
@@ -1960,13 +1896,13 @@ msgstr "选择包"
 msgid "{0} icons"
 msgstr "{0} 个图标"
 
-#: src/components/forms/fields/RelatedModelField.tsx:481
-#: src/components/modals/AboutInvenTreeModal.tsx:91
+#: src/components/forms/fields/RelatedModelField.tsx:480
+#: src/components/modals/AboutInvenTreeModal.tsx:96
 #: src/pages/Index/Settings/AccountSettings/SecurityContent.tsx:397
 msgid "Loading"
 msgstr "正在加载"
 
-#: src/components/forms/fields/RelatedModelField.tsx:483
+#: src/components/forms/fields/RelatedModelField.tsx:482
 msgid "No results found"
 msgstr "未找到结果"
 
@@ -2010,41 +1946,41 @@ msgstr "编辑数据"
 msgid "Delete Row"
 msgstr "删除行"
 
-#: src/components/importer/ImportDataSelector.tsx:280
+#: src/components/importer/ImportDataSelector.tsx:276
 msgid "Row"
 msgstr "行"
 
-#: src/components/importer/ImportDataSelector.tsx:298
+#: src/components/importer/ImportDataSelector.tsx:294
 msgid "Row contains errors"
 msgstr "行包含错误"
 
-#: src/components/importer/ImportDataSelector.tsx:339
+#: src/components/importer/ImportDataSelector.tsx:335
 msgid "Accept"
 msgstr "同意"
 
-#: src/components/importer/ImportDataSelector.tsx:372
+#: src/components/importer/ImportDataSelector.tsx:368
 msgid "Valid"
 msgstr "有效"
 
-#: src/components/importer/ImportDataSelector.tsx:373
+#: src/components/importer/ImportDataSelector.tsx:369
 msgid "Filter by row validation status"
 msgstr "按行验证状态筛选"
 
-#: src/components/importer/ImportDataSelector.tsx:378
+#: src/components/importer/ImportDataSelector.tsx:374
 #: src/components/wizards/WizardDrawer.tsx:113
-#: src/tables/build/BuildOutputTable.tsx:582
+#: src/tables/build/BuildOutputTable.tsx:533
 msgid "Complete"
 msgstr "完成"
 
-#: src/components/importer/ImportDataSelector.tsx:379
+#: src/components/importer/ImportDataSelector.tsx:375
 msgid "Filter by row completion status"
 msgstr "按行完成状态筛选"
 
-#: src/components/importer/ImportDataSelector.tsx:397
+#: src/components/importer/ImportDataSelector.tsx:393
 msgid "Import selected rows"
 msgstr "导入选定的行"
 
-#: src/components/importer/ImportDataSelector.tsx:412
+#: src/components/importer/ImportDataSelector.tsx:408
 msgid "Processing Data"
 msgstr "处理数据中"
 
@@ -2112,6 +2048,10 @@ msgstr "映射列"
 msgid "Import Rows"
 msgstr "导入行"
 
+#: src/components/importer/ImporterDrawer.tsx:45
+#~ msgid "Import Data"
+#~ msgstr "Import Data"
+
 #: src/components/importer/ImporterDrawer.tsx:46
 msgid "Process Data"
 msgstr "处理数据"
@@ -2137,10 +2077,10 @@ msgid "Data has been imported successfully"
 msgstr "数据已成功导入"
 
 #: src/components/importer/ImporterDrawer.tsx:109
-#: src/components/modals/AboutInvenTreeModal.tsx:200
+#: src/components/modals/AboutInvenTreeModal.tsx:205
 #: src/components/modals/ServerInfoModal.tsx:134
 #: src/components/wizards/ImportPartWizard.tsx:773
-#: src/forms/BomForms.tsx:137
+#: src/forms/BomForms.tsx:132
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:687
 msgid "Close"
 msgstr "关闭"
@@ -2174,8 +2114,8 @@ msgstr "选项"
 #~ msgstr "Link custom barcode"
 
 #: src/components/items/ActionDropdown.tsx:171
-#: src/tables/InvenTreeTableHeader.tsx:192
 #: src/tables/InvenTreeTableHeader.tsx:193
+#: src/tables/InvenTreeTableHeader.tsx:194
 msgid "Barcode Actions"
 msgstr "条形码操作"
 
@@ -2247,28 +2187,18 @@ msgstr "未知错误"
 msgid "None"
 msgstr "无"
 
-#: src/components/items/InvenTreeLogo.tsx:36
-#: src/components/items/InvenTreeLogo.tsx:40
+#: src/components/items/InvenTreeLogo.tsx:23
 msgid "InvenTree Logo"
 msgstr "InvenTree Logo"
 
-#: src/components/items/LanguageSelect.tsx:44
-msgid "Default Language"
-msgstr "默认语言"
-
-#: src/components/items/LanguageSelect.tsx:52
 #: src/components/items/LanguageToggle.tsx:21
 msgid "Select language"
 msgstr "选择语言"
 
 #: src/components/items/OnlyStaff.tsx:10
 #: src/components/modals/AboutInvenTreeModal.tsx:50
-#~ msgid "This information is only available for staff users"
-#~ msgstr "This information is only available for staff users"
-
-#: src/components/items/OnlyStaff.tsx:11
-msgid "This information is only available for administrative users"
-msgstr "此信息仅对管理员用户开放"
+msgid "This information is only available for staff users"
+msgstr "此信息仅供员工使用"
 
 #: src/components/items/Placeholder.tsx:14
 #~ msgid "This feature/button/site is a placeholder for a feature that is not implemented, only partial or intended for testing."
@@ -2290,8 +2220,7 @@ msgstr "正在更新组角色"
 #: src/components/settings/ConfigValueList.tsx:42
 #: src/pages/part/pricing/BomPricingPanel.tsx:151
 #: src/pages/part/pricing/VariantPricingPanel.tsx:51
-#: src/tables/ColumnRenderers.tsx:731
-#: src/tables/purchasing/SupplierPartTable.tsx:186
+#: src/tables/purchasing/SupplierPartTable.tsx:155
 msgid "Updated"
 msgstr "已更新"
 
@@ -2313,7 +2242,7 @@ msgid "Change"
 msgstr "更改"
 
 #: src/components/items/RoleTable.tsx:150
-#: src/forms/StockForms.tsx:950
+#: src/forms/StockForms.tsx:948
 #: src/tables/stock/StockItemTestResultTable.tsx:368
 msgid "Add"
 msgstr "添加"
@@ -2336,14 +2265,14 @@ msgstr "没有项目"
 
 #: src/components/items/TransferList.tsx:161
 #: src/components/render/Stock.tsx:102
-#: src/pages/part/PartDetail.tsx:991
+#: src/pages/part/PartDetail.tsx:1013
 #: src/pages/stock/StockDetail.tsx:265
-#: src/pages/stock/StockDetail.tsx:944
-#: src/tables/ColumnRenderers.tsx:243
+#: src/pages/stock/StockDetail.tsx:943
 #: src/tables/build/BuildAllocatedStockTable.tsx:125
-#: src/tables/build/BuildLineTable.tsx:198
-#: src/tables/part/PartTable.tsx:138
-#: src/tables/stock/StockItemTable.tsx:197
+#: src/tables/build/BuildLineTable.tsx:193
+#: src/tables/part/PartTable.tsx:137
+#: src/tables/stock/StockItemTable.tsx:182
+#: src/tables/stock/StockItemTable.tsx:343
 msgid "Available"
 msgstr "可用的"
 
@@ -2355,31 +2284,31 @@ msgstr "已选"
 #~ msgid "Your InvenTree version status is"
 #~ msgstr "Your InvenTree version status is"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:113
+#: src/components/modals/AboutInvenTreeModal.tsx:118
 msgid "InvenTree Version"
 msgstr "InvenTree 版本"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:125
+#: src/components/modals/AboutInvenTreeModal.tsx:130
 msgid "Python Version"
 msgstr "Python 版本"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:130
+#: src/components/modals/AboutInvenTreeModal.tsx:135
 msgid "Django Version"
 msgstr "Django版本"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:139
+#: src/components/modals/AboutInvenTreeModal.tsx:144
 msgid "Commit Hash"
 msgstr "提交哈希值"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:144
+#: src/components/modals/AboutInvenTreeModal.tsx:149
 msgid "Commit Date"
 msgstr "提交日期"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:149
+#: src/components/modals/AboutInvenTreeModal.tsx:154
 msgid "Commit Branch"
 msgstr "提交分支"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:160
+#: src/components/modals/AboutInvenTreeModal.tsx:165
 msgid "Version Information"
 msgstr "版本信息"
 
@@ -2392,28 +2321,28 @@ msgstr "版本信息"
 #~ msgstr "InvenTree Documentation"
 
 #: src/components/modals/AboutInvenTreeModal.tsx:169
-msgid "Links"
-msgstr "链接"
-
-#: src/components/modals/AboutInvenTreeModal.tsx:169
 #~ msgid "View Code on GitHub"
 #~ msgstr "View Code on GitHub"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:175
+#: src/components/modals/AboutInvenTreeModal.tsx:174
+msgid "Links"
+msgstr "链接"
+
+#: src/components/modals/AboutInvenTreeModal.tsx:180
 #: src/components/nav/NavigationDrawer.tsx:208
 #: src/defaults/actions.tsx:49
 msgid "Documentation"
 msgstr "文档"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:176
+#: src/components/modals/AboutInvenTreeModal.tsx:181
 msgid "Source Code"
 msgstr "源代码"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:177
+#: src/components/modals/AboutInvenTreeModal.tsx:182
 msgid "Mobile App"
 msgstr "手机 App"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:178
+#: src/components/modals/AboutInvenTreeModal.tsx:183
 msgid "Submit Bug Report"
 msgstr "提交问题报告"
 
@@ -2422,19 +2351,19 @@ msgstr "提交问题报告"
 #~ msgid "Dismiss"
 #~ msgstr "Dismiss"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:190
+#: src/components/modals/AboutInvenTreeModal.tsx:195
 msgid "Copy version information"
 msgstr "复制版本信息"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:210
+#: src/components/modals/AboutInvenTreeModal.tsx:215
 msgid "Development Version"
 msgstr "开发版"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:212
+#: src/components/modals/AboutInvenTreeModal.tsx:217
 msgid "Up to Date"
 msgstr "已是最新版本"
 
-#: src/components/modals/AboutInvenTreeModal.tsx:214
+#: src/components/modals/AboutInvenTreeModal.tsx:219
 msgid "Update Available"
 msgstr "有可用更新"
 
@@ -2594,7 +2523,7 @@ msgstr "存在待处理的数据库迁移。"
 msgid "Learn more about {code}"
 msgstr "了解更多关于{code}的信息"
 
-#: src/components/nav/Header.tsx:198
+#: src/components/nav/Header.tsx:188
 #: src/components/nav/NavigationDrawer.tsx:134
 #: src/components/nav/NotificationDrawer.tsx:181
 #: src/pages/Index/Settings/SystemSettings.tsx:122
@@ -2604,19 +2533,7 @@ msgstr "了解更多关于{code}的信息"
 msgid "Notifications"
 msgstr "通知"
 
-#: src/components/nav/Header.tsx:216
-msgid "Superuser Mode"
-msgstr "超级用户模式"
-
-#: src/components/nav/Header.tsx:216
-msgid "Administrator Mode"
-msgstr "管理员模式"
-
-#: src/components/nav/Header.tsx:221
-msgid "The current user has elevated privileges and should not be used for regular usage."
-msgstr "当前用户拥有提升权限，不应用于日常常规操作。"
-
-#: src/components/nav/Layout.tsx:144
+#: src/components/nav/Layout.tsx:141
 msgid "Nothing found..."
 msgstr "无结果..."
 
@@ -2640,7 +2557,7 @@ msgstr "设置"
 #: src/components/nav/MainMenu.tsx:61
 #: src/components/nav/NavigationDrawer.tsx:140
 #: src/components/nav/SettingsHeader.tsx:40
-#: src/defaults/actions.tsx:86
+#: src/defaults/actions.tsx:93
 #: src/pages/Index/Settings/UserSettings.tsx:142
 #: src/pages/Index/Settings/UserSettings.tsx:146
 msgid "User Settings"
@@ -2658,9 +2575,9 @@ msgstr "用户设置"
 #: src/components/nav/MainMenu.tsx:69
 #: src/components/nav/NavigationDrawer.tsx:146
 #: src/components/nav/SettingsHeader.tsx:41
-#: src/defaults/actions.tsx:155
-#: src/pages/Index/Settings/SystemSettings.tsx:366
-#: src/pages/Index/Settings/SystemSettings.tsx:371
+#: src/defaults/actions.tsx:145
+#: src/pages/Index/Settings/SystemSettings.tsx:354
+#: src/pages/Index/Settings/SystemSettings.tsx:359
 msgid "System Settings"
 msgstr "系统设置"
 
@@ -2671,7 +2588,7 @@ msgstr "系统设置"
 #: src/components/nav/MainMenu.tsx:78
 #: src/components/nav/NavigationDrawer.tsx:153
 #: src/components/nav/SettingsHeader.tsx:42
-#: src/defaults/actions.tsx:164
+#: src/defaults/actions.tsx:154
 #: src/pages/Index/Settings/AdminCenter/Index.tsx:293
 #: src/pages/Index/Settings/AdminCenter/Index.tsx:298
 msgid "Admin Center"
@@ -2709,19 +2626,19 @@ msgstr "登出"
 #: src/components/render/Part.tsx:36
 #: src/components/wizards/ImportPartWizard.tsx:808
 #: src/defaults/links.tsx:42
-#: src/forms/StockForms.tsx:803
-#: src/pages/Index/Settings/SystemSettings.tsx:231
-#: src/pages/part/PartDetail.tsx:770
-#: src/pages/stock/LocationDetail.tsx:427
-#: src/pages/stock/LocationDetail.tsx:457
+#: src/forms/StockForms.tsx:801
+#: src/pages/Index/Settings/SystemSettings.tsx:230
+#: src/pages/part/PartDetail.tsx:796
+#: src/pages/stock/LocationDetail.tsx:426
+#: src/pages/stock/LocationDetail.tsx:456
 #: src/pages/stock/StockDetail.tsx:643
-#: src/tables/stock/StockItemTable.tsx:75
+#: src/tables/stock/StockItemTable.tsx:85
 msgid "Stock"
 msgstr "库存"
 
 #: src/components/nav/NavigationDrawer.tsx:84
 #: src/defaults/links.tsx:48
-#: src/pages/build/BuildDetail.tsx:775
+#: src/pages/build/BuildDetail.tsx:754
 #: src/pages/build/BuildIndex.tsx:101
 msgid "Manufacturing"
 msgstr "生产"
@@ -2732,18 +2649,18 @@ msgstr "生产"
 #: src/pages/company/ManufacturerPartDetail.tsx:268
 #: src/pages/company/SupplierDetail.tsx:9
 #: src/pages/company/SupplierPartDetail.tsx:366
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:568
-#: src/pages/purchasing/PurchasingIndex.tsx:214
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:559
+#: src/pages/purchasing/PurchasingIndex.tsx:212
 msgid "Purchasing"
 msgstr "采购"
 
 #: src/components/nav/NavigationDrawer.tsx:98
 #: src/defaults/links.tsx:60
 #: src/pages/company/CustomerDetail.tsx:9
-#: src/pages/sales/ReturnOrderDetail.tsx:569
-#: src/pages/sales/SalesIndex.tsx:169
-#: src/pages/sales/SalesOrderDetail.tsx:634
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:442
+#: src/pages/sales/ReturnOrderDetail.tsx:560
+#: src/pages/sales/SalesIndex.tsx:168
+#: src/pages/sales/SalesOrderDetail.tsx:625
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:449
 msgid "Sales"
 msgstr "销售"
 
@@ -2798,7 +2715,7 @@ msgstr "移除搜索组"
 
 #: src/components/nav/SearchDrawer.tsx:288
 #: src/pages/company/ManufacturerPartDetail.tsx:179
-#: src/pages/part/PartDetail.tsx:828
+#: src/pages/part/PartDetail.tsx:854
 #: src/pages/part/PartSupplierDetail.tsx:15
 #: src/pages/purchasing/PurchasingIndex.tsx:100
 msgid "Suppliers"
@@ -2806,7 +2723,7 @@ msgstr "供应商"
 
 #: src/components/nav/SearchDrawer.tsx:298
 #: src/pages/part/PartSupplierDetail.tsx:23
-#: src/pages/purchasing/PurchasingIndex.tsx:150
+#: src/pages/purchasing/PurchasingIndex.tsx:149
 msgid "Manufacturers"
 msgstr "制造商"
 
@@ -2863,7 +2780,7 @@ msgstr "附件"
 
 #: src/components/panels/NotesPanel.tsx:25
 #: src/tables/part/PartTestResultTable.tsx:214
-#: src/tables/stock/StockTrackingTable.tsx:267
+#: src/tables/stock/StockTrackingTable.tsx:227
 msgid "Notes"
 msgstr "备注"
 
@@ -2902,19 +2819,19 @@ msgstr "插件信息"
 
 #: src/components/plugins/PluginDrawer.tsx:73
 #: src/forms/selectionListFields.tsx:102
-#: src/pages/build/BuildDetail.tsx:269
+#: src/pages/build/BuildDetail.tsx:251
 #: src/pages/company/CompanyDetail.tsx:94
 #: src/pages/company/ManufacturerPartDetail.tsx:92
 #: src/pages/company/ManufacturerPartDetail.tsx:119
 #: src/pages/company/SupplierPartDetail.tsx:146
 #: src/pages/part/CategoryDetail.tsx:111
-#: src/pages/part/PartDetail.tsx:435
+#: src/pages/part/PartDetail.tsx:460
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:163
 #: src/pages/sales/ReturnOrderDetail.tsx:130
 #: src/pages/sales/SalesOrderDetail.tsx:120
 #: src/pages/stock/LocationDetail.tsx:111
-#: src/tables/ColumnRenderers.tsx:459
-#: src/tables/build/BuildAllocatedStockTable.tsx:91
+#: src/tables/ColumnRenderers.tsx:278
+#: src/tables/build/BuildAllocatedStockTable.tsx:88
 #: src/tables/machine/MachineTypeTable.tsx:159
 #: src/tables/machine/MachineTypeTable.tsx:255
 #: src/tables/plugin/PluginListTable.tsx:110
@@ -2928,7 +2845,7 @@ msgstr "作者"
 #: src/components/plugins/PluginDrawer.tsx:83
 #: src/pages/part/pricing/PurchaseHistoryPanel.tsx:41
 #: src/pages/part/pricing/SaleHistoryPanel.tsx:38
-#: src/tables/ColumnRenderers.tsx:677
+#: src/tables/ColumnRenderers.tsx:492
 #: src/tables/part/PartTestResultTable.tsx:222
 msgid "Date"
 msgstr "日期"
@@ -2938,54 +2855,48 @@ msgstr "日期"
 #: src/pages/Index/Settings/AccountSettings/AccountDetailPanel.tsx:68
 #: src/pages/core/UserDetail.tsx:81
 #: src/pages/core/UserDetail.tsx:209
-#: src/pages/part/PartDetail.tsx:592
-#: src/tables/bom/UsedInTable.tsx:95
-#: src/tables/company/CompanyTable.tsx:66
-#: src/tables/company/CompanyTable.tsx:101
+#: src/pages/part/PartDetail.tsx:615
+#: src/tables/bom/UsedInTable.tsx:90
+#: src/tables/company/CompanyTable.tsx:57
+#: src/tables/company/CompanyTable.tsx:91
 #: src/tables/machine/MachineListTable.tsx:384
 #: src/tables/machine/MachineListTable.tsx:799
 #: src/tables/part/ParametricPartTable.tsx:19
-#: src/tables/part/PartTable.tsx:198
+#: src/tables/part/PartTable.tsx:197
 #: src/tables/part/PartVariantTable.tsx:15
 #: src/tables/plugin/PluginListTable.tsx:96
-#: src/tables/plugin/PluginListTable.tsx:420
-#: src/tables/purchasing/SupplierPartTable.tsx:135
-#: src/tables/purchasing/SupplierPartTable.tsx:249
-#: src/tables/settings/ApiTokenTable.tsx:63
-#: src/tables/settings/UserTable.tsx:401
-#: src/tables/stock/StockItemTable.tsx:176
+#: src/tables/plugin/PluginListTable.tsx:412
+#: src/tables/purchasing/SupplierPartTable.tsx:104
+#: src/tables/purchasing/SupplierPartTable.tsx:215
+#: src/tables/settings/ApiTokenTable.tsx:62
+#: src/tables/settings/UserTable.tsx:400
+#: src/tables/stock/StockItemTable.tsx:322
 msgid "Active"
 msgstr "激活"
 
-#: src/components/plugins/PluginDrawer.tsx:99
-#: src/pages/company/CompanyDetail.tsx:100
-#: src/tables/plugin/PluginListTable.tsx:140
-msgid "Website"
-msgstr "网站"
-
-#: src/components/plugins/PluginDrawer.tsx:113
+#: src/components/plugins/PluginDrawer.tsx:105
 msgid "Package Name"
 msgstr "软件包名"
 
-#: src/components/plugins/PluginDrawer.tsx:119
+#: src/components/plugins/PluginDrawer.tsx:111
 msgid "Installation Path"
 msgstr "安装路径"
 
-#: src/components/plugins/PluginDrawer.tsx:124
+#: src/components/plugins/PluginDrawer.tsx:116
 #: src/tables/machine/MachineTypeTable.tsx:182
 #: src/tables/machine/MachineTypeTable.tsx:291
 #: src/tables/plugin/PluginListTable.tsx:101
-#: src/tables/plugin/PluginListTable.tsx:425
+#: src/tables/plugin/PluginListTable.tsx:417
 msgid "Builtin"
 msgstr "内置"
 
-#: src/components/plugins/PluginDrawer.tsx:129
+#: src/components/plugins/PluginDrawer.tsx:121
 msgid "Package"
 msgstr "软件包"
 
-#: src/components/plugins/PluginDrawer.tsx:141
+#: src/components/plugins/PluginDrawer.tsx:133
 #: src/pages/Index/Settings/AdminCenter/PluginManagementPanel.tsx:55
-#: src/pages/Index/Settings/SystemSettings.tsx:349
+#: src/pages/Index/Settings/SystemSettings.tsx:337
 #: src/pages/Index/Settings/UserSettings.tsx:129
 msgid "Plugin Settings"
 msgstr "插件设置"
@@ -3068,30 +2979,31 @@ msgstr "未知模型: {model_name}"
 #~ msgstr "Unknown Models"
 
 #: src/components/render/Order.tsx:122
-#: src/tables/sales/SalesOrderAllocationTable.tsx:172
+#: src/tables/sales/SalesOrderAllocationTable.tsx:173
 msgid "Shipment"
 msgstr "配送"
 
 #: src/components/render/Part.tsx:28
 #: src/components/render/Plugin.tsx:17
 #: src/components/render/User.tsx:37
-#: src/pages/company/CompanyDetail.tsx:330
+#: src/pages/company/CompanyDetail.tsx:329
 #: src/pages/company/SupplierPartDetail.tsx:379
 #: src/pages/core/UserDetail.tsx:211
-#: src/pages/part/PartDetail.tsx:1036
-#: src/tables/ColumnRenderers.tsx:614
+#: src/pages/part/PartDetail.tsx:1052
+#: src/tables/ColumnRenderers.tsx:429
 msgid "Inactive"
 msgstr "未激活"
 
 #: src/components/render/Part.tsx:31
-#: src/tables/part/PartTable.tsx:282
+#: src/tables/part/PartTable.tsx:281
+#: src/tables/part/PartTable.tsx:285
 #: src/tables/part/PartVariantTable.tsx:25
 msgid "Virtual"
 msgstr "虚拟"
 
 #: src/components/render/Part.tsx:34
-#: src/tables/bom/BomTable.tsx:301
-#: src/tables/part/PartTable.tsx:153
+#: src/tables/bom/BomTable.tsx:308
+#: src/tables/part/PartTable.tsx:152
 msgid "No stock"
 msgstr "无库存"
 
@@ -3099,33 +3011,33 @@ msgstr "无库存"
 #: src/components/wizards/OrderPartsWizard.tsx:135
 #: src/pages/company/SupplierPartDetail.tsx:198
 #: src/pages/company/SupplierPartDetail.tsx:400
-#: src/pages/part/PartDetail.tsx:1018
-#: src/tables/bom/BomTable.tsx:443
-#: src/tables/build/BuildLineTable.tsx:228
-#: src/tables/part/PartTable.tsx:109
+#: src/pages/part/PartDetail.tsx:1034
+#: src/tables/bom/BomTable.tsx:450
+#: src/tables/build/BuildLineTable.tsx:223
+#: src/tables/part/PartTable.tsx:108
 msgid "On Order"
 msgstr "订购中"
 
 #: src/components/render/Part.tsx:55
 #: src/components/wizards/OrderPartsWizard.tsx:141
-#: src/pages/part/PartDetail.tsx:564
-#: src/pages/part/PartDetail.tsx:1024
-#: src/pages/stock/StockDetail.tsx:927
-#: src/tables/part/PartTestResultTable.tsx:306
-#: src/tables/stock/StockItemTable.tsx:213
+#: src/pages/part/PartDetail.tsx:587
+#: src/pages/part/PartDetail.tsx:1040
+#: src/pages/stock/StockDetail.tsx:926
+#: src/tables/part/PartTestResultTable.tsx:305
+#: src/tables/stock/StockItemTable.tsx:359
 msgid "In Production"
 msgstr "生产中"
 
 #: src/components/render/Part.tsx:74
-#: src/tables/stock/StockTrackingTable.tsx:261
+#: src/tables/stock/StockTrackingTable.tsx:221
 msgid "Details"
 msgstr "详情"
 
 #: src/components/render/Part.tsx:112
 #: src/components/wizards/ImportPartWizard.tsx:807
-#: src/pages/part/PartDetail.tsx:464
-#: src/tables/ColumnRenderers.tsx:414
-#: src/tables/ColumnRenderers.tsx:423
+#: src/pages/part/PartDetail.tsx:487
+#: src/tables/ColumnRenderers.tsx:233
+#: src/tables/ColumnRenderers.tsx:242
 #: src/tables/notifications/NotificationTable.tsx:32
 #: src/tables/part/PartCategoryTemplateTable.tsx:78
 msgid "Category"
@@ -3134,76 +3046,77 @@ msgstr "类别"
 #: src/components/render/Stock.tsx:36
 #: src/components/render/Stock.tsx:114
 #: src/components/render/Stock.tsx:132
-#: src/forms/BuildForms.tsx:835
-#: src/forms/PurchaseOrderForms.tsx:681
-#: src/forms/StockForms.tsx:801
-#: src/forms/StockForms.tsx:848
-#: src/forms/StockForms.tsx:901
-#: src/forms/StockForms.tsx:947
-#: src/forms/StockForms.tsx:985
-#: src/forms/StockForms.tsx:1028
-#: src/forms/StockForms.tsx:1096
-#: src/forms/StockForms.tsx:1144
-#: src/forms/StockForms.tsx:1188
+#: src/forms/BuildForms.tsx:805
+#: src/forms/PurchaseOrderForms.tsx:652
+#: src/forms/StockForms.tsx:799
+#: src/forms/StockForms.tsx:846
+#: src/forms/StockForms.tsx:899
+#: src/forms/StockForms.tsx:945
+#: src/forms/StockForms.tsx:983
+#: src/forms/StockForms.tsx:1026
+#: src/forms/StockForms.tsx:1094
+#: src/forms/StockForms.tsx:1142
+#: src/forms/StockForms.tsx:1186
 #: src/pages/Index/Settings/AccountSettings/AccountDetailPanel.tsx:88
 #: src/pages/core/UserDetail.tsx:158
 #: src/pages/stock/StockDetail.tsx:298
-#: src/tables/ColumnRenderers.tsx:366
-#: src/tables/ColumnRenderers.tsx:375
-#: src/tables/Filter.tsx:460
-#: src/tables/stock/StockTrackingTable.tsx:130
+#: src/tables/ColumnRenderers.tsx:185
+#: src/tables/ColumnRenderers.tsx:194
+#: src/tables/Filter.tsx:400
+#: src/tables/stock/StockTrackingTable.tsx:113
 msgid "Location"
 msgstr "位置"
 
 #: src/components/render/Stock.tsx:99
 #: src/pages/stock/StockDetail.tsx:198
-#: src/pages/stock/StockDetail.tsx:932
-#: src/tables/build/BuildOutputTable.tsx:109
-#: src/tables/sales/SalesOrderAllocationTable.tsx:139
+#: src/pages/stock/StockDetail.tsx:931
+#: src/tables/build/BuildOutputTable.tsx:106
+#: src/tables/sales/SalesOrderAllocationTable.tsx:142
 msgid "Serial Number"
 msgstr "序列号"
 
 #: src/components/render/Stock.tsx:104
 #: src/components/wizards/OrderPartsWizard.tsx:377
-#: src/forms/BuildForms.tsx:267
-#: src/forms/BuildForms.tsx:673
-#: src/forms/BuildForms.tsx:837
-#: src/forms/PurchaseOrderForms.tsx:890
-#: src/forms/ReturnOrderForms.tsx:245
-#: src/forms/SalesOrderForms.tsx:432
-#: src/forms/StockForms.tsx:850
-#: src/pages/part/PartStockHistoryDetail.tsx:61
-#: src/pages/part/PartStockHistoryDetail.tsx:241
-#: src/pages/part/PartStockHistoryDetail.tsx:265
+#: src/forms/BuildForms.tsx:242
+#: src/forms/BuildForms.tsx:644
+#: src/forms/BuildForms.tsx:807
+#: src/forms/PurchaseOrderForms.tsx:861
+#: src/forms/ReturnOrderForms.tsx:243
+#: src/forms/SalesOrderForms.tsx:387
+#: src/forms/StockForms.tsx:848
+#: src/pages/part/PartStockHistoryDetail.tsx:56
+#: src/pages/part/PartStockHistoryDetail.tsx:210
+#: src/pages/part/PartStockHistoryDetail.tsx:234
 #: src/pages/part/pricing/BomPricingPanel.tsx:106
 #: src/pages/part/pricing/PriceBreakPanel.tsx:89
 #: src/pages/part/pricing/PriceBreakPanel.tsx:172
 #: src/pages/stock/StockDetail.tsx:258
-#: src/pages/stock/StockDetail.tsx:938
-#: src/tables/build/BuildLineTable.tsx:86
+#: src/pages/stock/StockDetail.tsx:937
+#: src/tables/build/BuildLineTable.tsx:83
 #: src/tables/part/PartPurchaseOrdersTable.tsx:94
 #: src/tables/part/PartTestResultTable.tsx:277
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:171
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:202
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:175
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:206
 #: src/tables/purchasing/SupplierPriceBreakTable.tsx:69
-#: src/tables/stock/StockTrackingTable.tsx:104
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:124
+#: src/tables/stock/StockTrackingTable.tsx:87
 msgid "Quantity"
 msgstr "数量"
 
 #: src/components/render/Stock.tsx:117
-#: src/forms/BuildForms.tsx:367
-#: src/forms/BuildForms.tsx:444
-#: src/forms/BuildForms.tsx:513
-#: src/forms/StockForms.tsx:802
-#: src/forms/StockForms.tsx:849
-#: src/forms/StockForms.tsx:902
-#: src/forms/StockForms.tsx:948
-#: src/forms/StockForms.tsx:986
-#: src/forms/StockForms.tsx:1029
-#: src/forms/StockForms.tsx:1097
-#: src/forms/StockForms.tsx:1145
-#: src/forms/StockForms.tsx:1189
-#: src/tables/build/BuildLineTable.tsx:96
+#: src/forms/BuildForms.tsx:340
+#: src/forms/BuildForms.tsx:415
+#: src/forms/BuildForms.tsx:484
+#: src/forms/StockForms.tsx:800
+#: src/forms/StockForms.tsx:847
+#: src/forms/StockForms.tsx:900
+#: src/forms/StockForms.tsx:946
+#: src/forms/StockForms.tsx:984
+#: src/forms/StockForms.tsx:1027
+#: src/forms/StockForms.tsx:1095
+#: src/forms/StockForms.tsx:1143
+#: src/forms/StockForms.tsx:1187
+#: src/tables/build/BuildLineTable.tsx:93
 msgid "Batch"
 msgstr "批次"
 
@@ -3302,40 +3215,40 @@ msgstr "您想继续更改此设置吗？"
 msgid "This setting requires confirmation"
 msgstr "此设置需要确认"
 
-#: src/components/settings/SettingList.tsx:74
+#: src/components/settings/SettingList.tsx:72
 msgid "Edit Setting"
 msgstr "编辑设置"
 
-#: src/components/settings/SettingList.tsx:87
+#: src/components/settings/SettingList.tsx:85
 msgid "Setting {key} updated successfully"
 msgstr "设置{key}更新成功"
 
-#: src/components/settings/SettingList.tsx:120
+#: src/components/settings/SettingList.tsx:118
 msgid "Setting updated"
 msgstr "设置已更新"
 
 #. placeholder {0}: setting.key
-#: src/components/settings/SettingList.tsx:121
+#: src/components/settings/SettingList.tsx:119
 msgid "Setting {0} updated successfully"
 msgstr "成功更新设置{0}"
 
-#: src/components/settings/SettingList.tsx:130
+#: src/components/settings/SettingList.tsx:128
 msgid "Error editing setting"
 msgstr "编辑设置时出错"
 
-#: src/components/settings/SettingList.tsx:146
+#: src/components/settings/SettingList.tsx:144
 msgid "Error loading settings"
 msgstr "设置加载错误"
 
-#: src/components/settings/SettingList.tsx:157
+#: src/components/settings/SettingList.tsx:155
 msgid "No Settings"
 msgstr "无设置项"
 
-#: src/components/settings/SettingList.tsx:158
+#: src/components/settings/SettingList.tsx:156
 msgid "There are no configurable settings available"
 msgstr "当前无可配置设置"
 
-#: src/components/settings/SettingList.tsx:197
+#: src/components/settings/SettingList.tsx:193
 msgid "No settings specified"
 msgstr "未指定设置"
 
@@ -3714,17 +3627,17 @@ msgstr "已经载入"
 #: src/pages/company/SupplierPartDetail.tsx:236
 #: src/pages/company/SupplierPartDetail.tsx:370
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:157
-#: src/tables/Filter.tsx:420
-#: src/tables/company/CompanyTable.tsx:106
+#: src/tables/Filter.tsx:360
+#: src/tables/company/CompanyTable.tsx:96
 #: src/tables/part/PartPurchaseOrdersTable.tsx:43
 #: src/tables/purchasing/PurchaseOrderParametricTable.tsx:34
-#: src/tables/purchasing/PurchaseOrderTable.tsx:122
+#: src/tables/purchasing/PurchaseOrderTable.tsx:109
 #: src/tables/purchasing/SupplierPriceBreakTable.tsx:40
 msgid "Supplier"
 msgstr "供应商"
 
 #: src/components/wizards/ImportPartWizard.tsx:221
-#: src/forms/StockForms.tsx:622
+#: src/forms/StockForms.tsx:620
 msgid "Loading..."
 msgstr "正在加载..."
 
@@ -3786,8 +3699,8 @@ msgid "Next"
 msgstr "下一个"
 
 #: src/components/wizards/ImportPartWizard.tsx:540
-#: src/pages/part/PartDetail.tsx:1058
-#: src/tables/part/PartTable.tsx:411
+#: src/pages/part/PartDetail.tsx:1074
+#: src/tables/part/PartTable.tsx:408
 msgid "Edit Part"
 msgstr "编辑零件"
 
@@ -3870,19 +3783,19 @@ msgid "Sales Requirements"
 msgstr "销售需求"
 
 #: src/components/wizards/OrderPartsWizard.tsx:129
-#: src/forms/StockForms.tsx:903
-#: src/forms/StockForms.tsx:949
-#: src/forms/StockForms.tsx:987
-#: src/forms/StockForms.tsx:1030
-#: src/forms/StockForms.tsx:1098
-#: src/forms/StockForms.tsx:1146
-#: src/forms/StockForms.tsx:1190
+#: src/forms/StockForms.tsx:901
+#: src/forms/StockForms.tsx:947
+#: src/forms/StockForms.tsx:985
+#: src/forms/StockForms.tsx:1028
+#: src/forms/StockForms.tsx:1096
+#: src/forms/StockForms.tsx:1144
+#: src/forms/StockForms.tsx:1188
 #: src/pages/company/SupplierPartDetail.tsx:191
 #: src/pages/company/SupplierPartDetail.tsx:384
-#: src/pages/part/PartDetail.tsx:511
-#: src/pages/part/PartDetail.tsx:981
-#: src/tables/Filter.tsx:134
-#: src/tables/purchasing/SupplierPartTable.tsx:269
+#: src/pages/part/PartDetail.tsx:534
+#: src/pages/part/PartDetail.tsx:1003
+#: src/tables/Filter.tsx:92
+#: src/tables/purchasing/SupplierPartTable.tsx:230
 msgid "In Stock"
 msgstr "入库"
 
@@ -3904,8 +3817,8 @@ msgid "New Supplier Part"
 msgstr "新增供应商零件"
 
 #: src/components/wizards/OrderPartsWizard.tsx:219
-#: src/tables/purchasing/SupplierPartTable.tsx:213
-#: src/tables/purchasing/SupplierPartTable.tsx:302
+#: src/tables/purchasing/SupplierPartTable.tsx:180
+#: src/tables/purchasing/SupplierPartTable.tsx:258
 msgid "Supplier part created"
 msgstr "供应商零件已更新"
 
@@ -3979,9 +3892,9 @@ msgid "Please correct the errors in the selected parts"
 msgstr "请修正所选零件中的错误"
 
 #: src/components/wizards/OrderPartsWizard.tsx:587
-#: src/tables/build/BuildLineTable.tsx:844
-#: src/tables/part/PartTable.tsx:525
-#: src/tables/sales/SalesOrderLineItemTable.tsx:368
+#: src/tables/build/BuildLineTable.tsx:823
+#: src/tables/part/PartTable.tsx:522
+#: src/tables/sales/SalesOrderLineItemTable.tsx:370
 msgid "Order Parts"
 msgstr "订购零件"
 
@@ -4182,46 +4095,38 @@ msgid "Open the main navigation menu"
 msgstr "打开主导航菜单"
 
 #: src/defaults/actions.tsx:87
-msgid "Go to your user settings"
-msgstr "前往您的用户设置"
-
-#: src/defaults/actions.tsx:96
-msgid "Import Data"
-msgstr "导入数据"
-
-#: src/defaults/actions.tsx:97
-msgid "Import data from a file"
-msgstr "从文件导入数据"
-
-#: src/defaults/actions.tsx:107
-msgid "Go to Purchase Orders"
-msgstr "跳转到采购订单"
-
-#: src/defaults/actions.tsx:117
-msgid "Go to Sales Orders"
-msgstr "转到销售订单"
-
-#: src/defaults/actions.tsx:128
-msgid "Go to Return Orders"
-msgstr "跳转到退货订单"
-
-#: src/defaults/actions.tsx:138
 msgid "Scan a barcode or QR code"
 msgstr "扫描条形码或二维码"
 
-#: src/defaults/actions.tsx:147
+#: src/defaults/actions.tsx:95
+msgid "Go to your user settings"
+msgstr "前往您的用户设置"
+
+#: src/defaults/actions.tsx:106
+msgid "Go to Purchase Orders"
+msgstr "跳转到采购订单"
+
+#: src/defaults/actions.tsx:116
+msgid "Go to Sales Orders"
+msgstr "转到销售订单"
+
+#: src/defaults/actions.tsx:127
+msgid "Go to Return Orders"
+msgstr "跳转到退货订单"
+
+#: src/defaults/actions.tsx:137
 msgid "Go to Build Orders"
 msgstr "前往生产订单"
 
-#: src/defaults/actions.tsx:156
+#: src/defaults/actions.tsx:146
 msgid "Go to System Settings"
 msgstr "跳转到系统设置"
 
-#: src/defaults/actions.tsx:165
+#: src/defaults/actions.tsx:155
 msgid "Go to the Admin Center"
 msgstr "转到管理中心"
 
-#: src/defaults/actions.tsx:174
+#: src/defaults/actions.tsx:164
 msgid "Manage InvenTree plugins"
 msgstr "管理InvenTree插件"
 
@@ -4265,17 +4170,13 @@ msgstr "管理InvenTree插件"
 #~ msgid "Current News"
 #~ msgstr "Current News"
 
-#: src/defaults/defaultHostList.tsx:10
-msgid "Local Server"
-msgstr "本地服务器"
+#: src/defaults/defaultHostList.tsx:8
+#~ msgid "InvenTree Demo"
+#~ msgstr "InvenTree Demo"
 
-#: src/defaults/defaultHostList.tsx:12
-msgid "InvenTree Demo"
-msgstr "InvenTree 演示版"
-
-#: src/defaults/defaultHostList.tsx:14
-msgid "Current Server"
-msgstr "当前服务器"
+#: src/defaults/defaultHostList.tsx:16
+#~ msgid "Local Server"
+#~ msgstr "Local Server"
 
 #: src/defaults/links.tsx:17
 #~ msgid "GitHub"
@@ -4468,19 +4369,19 @@ msgstr "关于InvenTree项目"
 #~ msgid "Are you sure you want to delete this attachment?"
 #~ msgstr "Are you sure you want to delete this attachment?"
 
-#: src/forms/BomForms.tsx:114
+#: src/forms/BomForms.tsx:109
 msgid "Substitute Part"
 msgstr "替代零件"
 
-#: src/forms/BomForms.tsx:131
+#: src/forms/BomForms.tsx:126
 msgid "Edit BOM Substitutes"
 msgstr "编辑物料清单替代项"
 
-#: src/forms/BomForms.tsx:138
+#: src/forms/BomForms.tsx:133
 msgid "Add Substitute"
 msgstr "添加替代项"
 
-#: src/forms/BomForms.tsx:139
+#: src/forms/BomForms.tsx:134
 msgid "Substitute added"
 msgstr "替代项已添加"
 
@@ -4494,53 +4395,53 @@ msgstr "替代项已添加"
 #~ msgid "Remove output"
 #~ msgstr "Remove output"
 
-#: src/forms/BuildForms.tsx:365
-#: src/forms/BuildForms.tsx:442
-#: src/forms/BuildForms.tsx:724
+#: src/forms/BuildForms.tsx:338
+#: src/forms/BuildForms.tsx:413
+#: src/forms/BuildForms.tsx:695
 #: src/tables/build/BuildAllocatedStockTable.tsx:147
-#: src/tables/build/BuildOutputTable.tsx:632
+#: src/tables/build/BuildOutputTable.tsx:582
 #: src/tables/part/PartTestResultTable.tsx:280
 msgid "Build Output"
 msgstr "生产产出"
 
-#: src/forms/BuildForms.tsx:366
+#: src/forms/BuildForms.tsx:339
 msgid "Quantity to Complete"
 msgstr "待完成数量"
 
-#: src/forms/BuildForms.tsx:368
-#: src/forms/BuildForms.tsx:445
-#: src/forms/BuildForms.tsx:514
-#: src/forms/PurchaseOrderForms.tsx:806
-#: src/forms/ReturnOrderForms.tsx:199
-#: src/forms/ReturnOrderForms.tsx:246
-#: src/forms/StockForms.tsx:721
+#: src/forms/BuildForms.tsx:341
+#: src/forms/BuildForms.tsx:416
+#: src/forms/BuildForms.tsx:485
+#: src/forms/PurchaseOrderForms.tsx:777
+#: src/forms/ReturnOrderForms.tsx:197
+#: src/forms/ReturnOrderForms.tsx:244
+#: src/forms/StockForms.tsx:719
 #: src/pages/Index/Settings/AccountSettings/AccountDetailPanel.tsx:87
-#: src/pages/build/BuildDetail.tsx:241
+#: src/pages/build/BuildDetail.tsx:223
 #: src/pages/core/UserDetail.tsx:151
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:169
 #: src/pages/sales/ReturnOrderDetail.tsx:136
 #: src/pages/sales/SalesOrderDetail.tsx:126
 #: src/pages/stock/StockDetail.tsx:170
-#: src/tables/Filter.tsx:334
-#: src/tables/build/BuildOutputTable.tsx:442
+#: src/tables/Filter.tsx:274
+#: src/tables/build/BuildOutputTable.tsx:404
 #: src/tables/machine/MachineListTable.tsx:387
 #: src/tables/part/PartPurchaseOrdersTable.tsx:38
-#: src/tables/part/PartTestResultTable.tsx:318
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:137
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:175
+#: src/tables/part/PartTestResultTable.tsx:317
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:138
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:176
 #: src/tables/settings/CustomStateTable.tsx:79
 #: src/tables/settings/EmailTable.tsx:95
-#: src/tables/settings/ImportSessionTable.tsx:118
-#: src/tables/stock/StockItemTable.tsx:181
-#: src/tables/stock/StockTrackingTable.tsx:82
+#: src/tables/settings/ImportSessionTable.tsx:117
+#: src/tables/stock/StockItemTable.tsx:327
+#: src/tables/stock/StockTrackingTable.tsx:65
 msgid "Status"
 msgstr "状态"
 
-#: src/forms/BuildForms.tsx:392
+#: src/forms/BuildForms.tsx:363
 msgid "Complete Build Outputs"
 msgstr "完成生产输出"
 
-#: src/forms/BuildForms.tsx:395
+#: src/forms/BuildForms.tsx:366
 msgid "Build outputs have been completed"
 msgstr "生产已完成"
 
@@ -4548,96 +4449,105 @@ msgstr "生产已完成"
 #~ msgid "Selected build outputs will be deleted"
 #~ msgstr "Selected build outputs will be deleted"
 
-#: src/forms/BuildForms.tsx:443
+#: src/forms/BuildForms.tsx:414
 msgid "Quantity to Scrap"
 msgstr "待报废数量"
 
-#: src/forms/BuildForms.tsx:463
-#: src/forms/BuildForms.tsx:465
+#: src/forms/BuildForms.tsx:434
+#: src/forms/BuildForms.tsx:436
 msgid "Scrap Build Outputs"
 msgstr "报废生产输出"
 
-#: src/forms/BuildForms.tsx:468
+#: src/forms/BuildForms.tsx:439
 msgid "Selected build outputs will be completed, but marked as scrapped"
 msgstr "选定的生产产出将被完成，但标记为报废"
 
-#: src/forms/BuildForms.tsx:470
+#: src/forms/BuildForms.tsx:441
 msgid "Allocated stock items will be consumed"
 msgstr "已分配的库存物料将被消耗"
+
+#: src/forms/BuildForms.tsx:447
+msgid "Build outputs have been scrapped"
+msgstr "生产已完成"
 
 #: src/forms/BuildForms.tsx:470
 #~ msgid "Remove line"
 #~ msgstr "Remove line"
 
-#: src/forms/BuildForms.tsx:476
-msgid "Build outputs have been scrapped"
-msgstr "生产已完成"
-
-#: src/forms/BuildForms.tsx:524
-#: src/forms/BuildForms.tsx:526
+#: src/forms/BuildForms.tsx:495
+#: src/forms/BuildForms.tsx:497
 msgid "Cancel Build Outputs"
 msgstr "取消生产输出"
 
-#: src/forms/BuildForms.tsx:528
+#: src/forms/BuildForms.tsx:499
 msgid "Selected build outputs will be removed"
 msgstr "选定的生产产出将被移除"
 
-#: src/forms/BuildForms.tsx:530
+#: src/forms/BuildForms.tsx:501
 msgid "Allocated stock items will be returned to stock"
 msgstr "已分配的库存物料将退回可用库存"
 
-#: src/forms/BuildForms.tsx:537
+#: src/forms/BuildForms.tsx:508
 msgid "Build outputs have been cancelled"
 msgstr "生产已完成"
 
-#: src/forms/BuildForms.tsx:670
-#: src/pages/build/BuildDetail.tsx:226
+#: src/forms/BuildForms.tsx:641
+#: src/pages/build/BuildDetail.tsx:208
 #: src/pages/company/ManufacturerPartDetail.tsx:84
 #: src/pages/company/SupplierPartDetail.tsx:97
-#: src/pages/part/PartDetail.tsx:428
+#: src/pages/part/PartDetail.tsx:453
 #: src/pages/stock/StockDetail.tsx:153
-#: src/tables/ColumnRenderers.tsx:116
+#: src/tables/bom/BomTable.tsx:134
+#: src/tables/bom/UsedInTable.tsx:40
+#: src/tables/build/BuildAllocatedStockTable.tsx:105
+#: src/tables/build/BuildLineTable.tsx:338
+#: src/tables/build/BuildOrderTable.tsx:79
+#: src/tables/part/PartSalesAllocationsTable.tsx:61
 #: src/tables/part/RelatedPartTable.tsx:73
+#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:21
+#: src/tables/purchasing/ManufacturerPartTable.tsx:69
+#: src/tables/purchasing/SupplierPartTable.tsx:70
+#: src/tables/sales/SalesOrderAllocationTable.tsx:135
+#: src/tables/sales/SalesOrderLineItemTable.tsx:99
+#: src/tables/stock/StockItemTable.tsx:69
 msgid "IPN"
 msgstr "内部零件编码 IPN"
 
-#: src/forms/BuildForms.tsx:671
-#: src/forms/BuildForms.tsx:836
-#: src/forms/BuildForms.tsx:937
-#: src/forms/SalesOrderForms.tsx:430
-#: src/pages/part/PartDetail.tsx:1006
+#: src/forms/BuildForms.tsx:642
+#: src/forms/BuildForms.tsx:806
+#: src/forms/BuildForms.tsx:907
+#: src/forms/SalesOrderForms.tsx:385
 #: src/tables/build/BuildAllocatedStockTable.tsx:129
-#: src/tables/build/BuildLineTable.tsx:188
-#: src/tables/sales/SalesOrderLineItemTable.tsx:340
-#: src/tables/stock/StockItemTable.tsx:192
+#: src/tables/build/BuildLineTable.tsx:183
+#: src/tables/sales/SalesOrderLineItemTable.tsx:342
+#: src/tables/stock/StockItemTable.tsx:338
 msgid "Allocated"
 msgstr "已分配"
 
-#: src/forms/BuildForms.tsx:706
-#: src/forms/SalesOrderForms.tsx:419
+#: src/forms/BuildForms.tsx:677
+#: src/forms/SalesOrderForms.tsx:374
 #: src/pages/build/BuildDetail.tsx:109
-#: src/pages/build/BuildDetail.tsx:345
+#: src/pages/build/BuildDetail.tsx:327
 msgid "Source Location"
 msgstr "来源地点"
 
-#: src/forms/BuildForms.tsx:707
-#: src/forms/SalesOrderForms.tsx:420
+#: src/forms/BuildForms.tsx:678
+#: src/forms/SalesOrderForms.tsx:375
 msgid "Select the source location for the stock allocation"
 msgstr "选择分配库存的源位置"
 
-#: src/forms/BuildForms.tsx:739
-#: src/forms/SalesOrderForms.tsx:461
-#: src/tables/build/BuildLineTable.tsx:587
-#: src/tables/build/BuildLineTable.tsx:760
-#: src/tables/build/BuildLineTable.tsx:859
-#: src/tables/build/BuildOutputTable.tsx:233
-#: src/tables/sales/SalesOrderLineItemTable.tsx:378
-#: src/tables/sales/SalesOrderLineItemTable.tsx:404
+#: src/forms/BuildForms.tsx:710
+#: src/forms/SalesOrderForms.tsx:415
+#: src/tables/build/BuildLineTable.tsx:576
+#: src/tables/build/BuildLineTable.tsx:739
+#: src/tables/build/BuildLineTable.tsx:838
+#: src/tables/sales/SalesOrderLineItemTable.tsx:380
+#: src/tables/sales/SalesOrderLineItemTable.tsx:406
 msgid "Allocate Stock"
 msgstr "分配库存"
 
-#: src/forms/BuildForms.tsx:742
-#: src/forms/SalesOrderForms.tsx:466
+#: src/forms/BuildForms.tsx:713
+#: src/forms/SalesOrderForms.tsx:420
 msgid "Stock items allocated"
 msgstr "分配的库存项目"
 
@@ -4646,36 +4556,36 @@ msgstr "分配的库存项目"
 #~ msgid "Stock items consumed"
 #~ msgstr "Stock items consumed"
 
-#: src/forms/BuildForms.tsx:856
-#: src/forms/BuildForms.tsx:957
-#: src/tables/build/BuildAllocatedStockTable.tsx:261
-#: src/tables/build/BuildAllocatedStockTable.tsx:297
-#: src/tables/build/BuildLineTable.tsx:770
-#: src/tables/build/BuildLineTable.tsx:893
+#: src/forms/BuildForms.tsx:826
+#: src/forms/BuildForms.tsx:927
+#: src/tables/build/BuildAllocatedStockTable.tsx:243
+#: src/tables/build/BuildAllocatedStockTable.tsx:279
+#: src/tables/build/BuildLineTable.tsx:749
+#: src/tables/build/BuildLineTable.tsx:872
 msgid "Consume Stock"
 msgstr "消耗库存"
 
-#: src/forms/BuildForms.tsx:856
-#: src/forms/BuildForms.tsx:957
-#~ msgid "Stock items scheduled to be consumed"
-#~ msgstr "Stock items scheduled to be consumed"
+#: src/forms/BuildForms.tsx:827
+#: src/forms/BuildForms.tsx:928
+msgid "Stock items scheduled to be consumed"
+msgstr "计划消耗的库存物品"
 
-#: src/forms/BuildForms.tsx:893
+#: src/forms/BuildForms.tsx:863
 #: src/tables/build/BuildLineTable.tsx:516
 #: src/tables/part/PartBuildAllocationsTable.tsx:101
 msgid "Fully consumed"
 msgstr "已全部消耗"
 
-#: src/forms/BuildForms.tsx:938
-#: src/tables/build/BuildLineTable.tsx:193
-#: src/tables/stock/StockItemTable.tsx:221
+#: src/forms/BuildForms.tsx:908
+#: src/tables/build/BuildLineTable.tsx:188
+#: src/tables/stock/StockItemTable.tsx:367
 msgid "Consumed"
 msgstr "已消耗"
 
-#: src/forms/CommonForms.tsx:93
-#: src/forms/PurchaseOrderForms.tsx:173
-#: src/forms/ReturnOrderForms.tsx:140
-#: src/forms/SalesOrderForms.tsx:191
+#: src/forms/CommonForms.tsx:92
+#: src/forms/PurchaseOrderForms.tsx:176
+#: src/forms/ReturnOrderForms.tsx:138
+#: src/forms/SalesOrderForms.tsx:185
 msgid "Select project code for this line item"
 msgstr "请为此行项目选择项目编码"
 
@@ -4683,32 +4593,32 @@ msgstr "请为此行项目选择项目编码"
 #~ msgid "Company updated"
 #~ msgstr "Company updated"
 
-#: src/forms/PartForms.tsx:101
-#: src/forms/PartForms.tsx:230
-#: src/pages/part/CategoryDetail.tsx:127
-#: src/pages/part/PartDetail.tsx:645
-#: src/tables/part/PartCategoryTable.tsx:96
-#: src/tables/part/PartTable.tsx:322
-msgid "Subscribed"
-msgstr "已订阅"
-
-#: src/forms/PartForms.tsx:102
-msgid "Subscribe to notifications for this part"
-msgstr "订阅此零件的通知"
-
 #: src/forms/PartForms.tsx:108
 #~ msgid "Part created"
 #~ msgstr "Part created"
+
+#: src/forms/PartForms.tsx:109
+#: src/forms/PartForms.tsx:239
+#: src/pages/part/CategoryDetail.tsx:127
+#: src/pages/part/PartDetail.tsx:668
+#: src/tables/part/PartCategoryTable.tsx:94
+#: src/tables/part/PartTable.tsx:325
+msgid "Subscribed"
+msgstr "已订阅"
+
+#: src/forms/PartForms.tsx:110
+msgid "Subscribe to notifications for this part"
+msgstr "订阅此零件的通知"
 
 #: src/forms/PartForms.tsx:129
 #~ msgid "Part updated"
 #~ msgstr "Part updated"
 
-#: src/forms/PartForms.tsx:216
+#: src/forms/PartForms.tsx:225
 msgid "Parent part category"
 msgstr "上级零件类别"
 
-#: src/forms/PartForms.tsx:231
+#: src/forms/PartForms.tsx:240
 msgid "Subscribe to notifications for this category"
 msgstr "订阅此类别的通知"
 
@@ -4725,74 +4635,62 @@ msgstr "订阅此类别的通知"
 #~ msgid "Remove item from list"
 #~ msgstr "Remove item from list"
 
-#: src/forms/PurchaseOrderForms.tsx:454
+#: src/forms/PurchaseOrderForms.tsx:456
 msgid "Choose Location"
 msgstr "选择位置"
 
-#: src/forms/PurchaseOrderForms.tsx:462
+#: src/forms/PurchaseOrderForms.tsx:464
 msgid "Item Destination selected"
 msgstr "已选择项目目的地"
 
-#: src/forms/PurchaseOrderForms.tsx:472
+#: src/forms/PurchaseOrderForms.tsx:474
 msgid "Part category default location selected"
 msgstr "已选择零件类别默认位置"
 
-#: src/forms/PurchaseOrderForms.tsx:482
+#: src/forms/PurchaseOrderForms.tsx:484
 msgid "Received stock location selected"
 msgstr "已选择接收库存位置"
 
-#: src/forms/PurchaseOrderForms.tsx:490
+#: src/forms/PurchaseOrderForms.tsx:492
 msgid "Default location selected"
 msgstr "已选择默认位置"
 
-#: src/forms/PurchaseOrderForms.tsx:537
-#: src/pages/part/PartDetail.tsx:640
-#: src/pages/part/PartDetail.tsx:1042
-#: src/tables/bom/BomTable.tsx:144
-#: src/tables/bom/BomTable.tsx:433
-msgid "Virtual Part"
-msgstr "虚拟零件"
+#: src/forms/PurchaseOrderForms.tsx:553
+msgid "Set Location"
+msgstr "设置位置"
 
-#: src/forms/PurchaseOrderForms.tsx:538
-msgid "This part is virtual, no physical stock will be received."
-msgstr "该零件为虚拟件，不会接收实物库存。"
+#: src/forms/PurchaseOrderForms.tsx:561
+msgid "Assign Batch Code"
+msgstr "分配批号"
 
 #: src/forms/PurchaseOrderForms.tsx:566
 #~ msgid "Serial numbers"
 #~ msgstr "Serial numbers"
 
-#: src/forms/PurchaseOrderForms.tsx:573
-msgid "Set Location"
-msgstr "设置位置"
+#: src/forms/PurchaseOrderForms.tsx:570
+msgid "Assign Serial Numbers"
+msgstr "分配序列号"
 
-#: src/forms/PurchaseOrderForms.tsx:582
-msgid "Assign Batch Code"
-msgstr "分配批号"
+#: src/forms/PurchaseOrderForms.tsx:581
+msgid "Set Expiry Date"
+msgstr "设置到期日期"
 
 #: src/forms/PurchaseOrderForms.tsx:582
 #~ msgid "Store at line item destination"
 #~ msgstr "Store at line item destination"
 
-#: src/forms/PurchaseOrderForms.tsx:592
-msgid "Assign Serial Numbers"
-msgstr "分配序列号"
-
-#: src/forms/PurchaseOrderForms.tsx:604
-msgid "Set Expiry Date"
-msgstr "设置到期日期"
-
-#: src/forms/PurchaseOrderForms.tsx:613
-#: src/forms/StockForms.tsx:702
+#: src/forms/PurchaseOrderForms.tsx:589
+#: src/forms/StockForms.tsx:700
 msgid "Adjust Packaging"
 msgstr "调整封包"
 
-#: src/forms/PurchaseOrderForms.tsx:622
-#: src/forms/StockForms.tsx:693
-#: src/hooks/UseStockAdjustActions.tsx:152
+#: src/forms/PurchaseOrderForms.tsx:597
+#: src/forms/StockForms.tsx:691
+#: src/hooks/UseStockAdjustActions.tsx:148
 msgid "Change Status"
 msgstr "更改状态"
 
-#: src/forms/PurchaseOrderForms.tsx:629
+#: src/forms/PurchaseOrderForms.tsx:603
 msgid "Add Note"
 msgstr "添加备注"
 
@@ -4800,146 +4698,128 @@ msgstr "添加备注"
 #~ msgid "Receive line items"
 #~ msgstr "Receive line items"
 
-#: src/forms/PurchaseOrderForms.tsx:696
+#: src/forms/PurchaseOrderForms.tsx:667
 msgid "Store at default location"
 msgstr "存储在默认位置"
 
-#: src/forms/PurchaseOrderForms.tsx:711
+#: src/forms/PurchaseOrderForms.tsx:682
 msgid "Store at line item destination "
 msgstr "存储至行项目指定位置 "
 
-#: src/forms/PurchaseOrderForms.tsx:723
+#: src/forms/PurchaseOrderForms.tsx:694
 msgid "Store with already received stock"
 msgstr "存储已收到的库存"
 
-#: src/forms/PurchaseOrderForms.tsx:747
-#: src/pages/build/BuildDetail.tsx:359
+#: src/forms/PurchaseOrderForms.tsx:718
+#: src/pages/build/BuildDetail.tsx:341
 #: src/pages/stock/StockDetail.tsx:280
-#: src/pages/stock/StockDetail.tsx:954
-#: src/tables/Filter.tsx:125
-#: src/tables/build/BuildAllocatedStockTable.tsx:116
-#: src/tables/build/BuildOutputTable.tsx:114
+#: src/pages/stock/StockDetail.tsx:953
+#: src/tables/Filter.tsx:83
+#: src/tables/build/BuildAllocatedStockTable.tsx:118
+#: src/tables/build/BuildOutputTable.tsx:111
 #: src/tables/part/PartTestResultTable.tsx:268
 #: src/tables/part/PartTestResultTable.tsx:289
-#: src/tables/sales/SalesOrderAllocationTable.tsx:146
+#: src/tables/sales/SalesOrderAllocationTable.tsx:149
 msgid "Batch Code"
 msgstr "批号"
 
-#: src/forms/PurchaseOrderForms.tsx:748
+#: src/forms/PurchaseOrderForms.tsx:719
 msgid "Enter batch code for received items"
 msgstr "输入接收项目的批号"
 
-#: src/forms/PurchaseOrderForms.tsx:761
-#: src/forms/StockForms.tsx:224
+#: src/forms/PurchaseOrderForms.tsx:732
+#: src/forms/StockForms.tsx:223
 msgid "Serial Numbers"
 msgstr "序列号"
 
-#: src/forms/PurchaseOrderForms.tsx:762
+#: src/forms/PurchaseOrderForms.tsx:733
 msgid "Enter serial numbers for received items"
 msgstr "输入接收项目的序列号"
 
-#: src/forms/PurchaseOrderForms.tsx:779
+#: src/forms/PurchaseOrderForms.tsx:750
 #: src/pages/stock/StockDetail.tsx:382
-#: src/tables/stock/StockItemTable.tsx:148
+#: src/tables/stock/StockItemTable.tsx:294
 msgid "Expiry Date"
 msgstr "有效期至"
 
-#: src/forms/PurchaseOrderForms.tsx:780
+#: src/forms/PurchaseOrderForms.tsx:751
 msgid "Enter an expiry date for received items"
 msgstr "输入接收项目的到期日期"
 
-#: src/forms/PurchaseOrderForms.tsx:792
-#: src/forms/StockForms.tsx:737
+#: src/forms/PurchaseOrderForms.tsx:763
+#: src/forms/StockForms.tsx:735
 #: src/pages/company/SupplierPartDetail.tsx:173
 #: src/pages/company/SupplierPartDetail.tsx:237
 #: src/pages/stock/StockDetail.tsx:419
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:223
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:227
 msgid "Packaging"
 msgstr "包装"
 
-#: src/forms/PurchaseOrderForms.tsx:816
+#: src/forms/PurchaseOrderForms.tsx:787
 #: src/pages/company/SupplierPartDetail.tsx:121
-#: src/tables/ColumnRenderers.tsx:517
+#: src/tables/ColumnRenderers.tsx:332
 msgid "Note"
 msgstr "备注"
 
-#: src/forms/PurchaseOrderForms.tsx:888
+#: src/forms/PurchaseOrderForms.tsx:859
 #: src/pages/company/SupplierPartDetail.tsx:139
 #: src/tables/purchasing/SupplierPriceBreakTable.tsx:49
 msgid "SKU"
 msgstr "库存单位  (SKU)"
 
-#: src/forms/PurchaseOrderForms.tsx:889
+#: src/forms/PurchaseOrderForms.tsx:860
 #: src/tables/part/PartPurchaseOrdersTable.tsx:127
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:209
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:281
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:170
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:213
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:283
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:171
 msgid "Received"
 msgstr "已接收"
 
-#: src/forms/PurchaseOrderForms.tsx:906
+#: src/forms/PurchaseOrderForms.tsx:877
 msgid "Receive Line Items"
 msgstr "接收行项目"
 
-#: src/forms/PurchaseOrderForms.tsx:912
+#: src/forms/PurchaseOrderForms.tsx:883
 msgid "Items received"
 msgstr "物料已收货"
 
-#: src/forms/ReturnOrderForms.tsx:259
+#: src/forms/ReturnOrderForms.tsx:257
 msgid "Receive Items"
 msgstr "接收物品"
 
-#: src/forms/ReturnOrderForms.tsx:266
+#: src/forms/ReturnOrderForms.tsx:264
 msgid "Item received into stock"
 msgstr "已收到库存物品"
 
-#. placeholder {0}: salePrice ? `; suggested: (${salePrice})` : '.'
-#: src/forms/SalesOrderForms.tsx:183
-msgid "Price based on part and quantity differs{0}"
-msgstr "根据零件和数量计算的价格不一致 {0}"
-
-#: src/forms/SalesOrderForms.tsx:214
-#: src/forms/SalesOrderForms.tsx:216
-#: src/tables/sales/SalesOrderShipmentTable.tsx:210
+#: src/forms/SalesOrderForms.tsx:208
+#: src/forms/SalesOrderForms.tsx:210
+#: src/tables/sales/SalesOrderShipmentTable.tsx:215
 msgid "Check Shipment"
 msgstr "检查发货"
 
-#: src/forms/SalesOrderForms.tsx:217
+#: src/forms/SalesOrderForms.tsx:211
 msgid "Marking the shipment as checked indicates that you have verified that all items included in this shipment are correct"
 msgstr "将装运标记为已检查的货物，表明您已经验证这批装运的所有物品都是正确的"
 
-#: src/forms/SalesOrderForms.tsx:227
+#: src/forms/SalesOrderForms.tsx:221
 msgid "Shipment marked as checked"
-msgstr "发货单已标记为已核对"
+msgstr "发货单已标记为已检查"
 
-#: src/forms/SalesOrderForms.tsx:242
-#: src/forms/SalesOrderForms.tsx:244
-#: src/tables/sales/SalesOrderShipmentTable.tsx:223
+#: src/forms/SalesOrderForms.tsx:236
+#: src/forms/SalesOrderForms.tsx:238
+#: src/tables/sales/SalesOrderShipmentTable.tsx:228
 msgid "Uncheck Shipment"
-msgstr "取消核对发货单"
+msgstr "取消发货检查"
 
-#: src/forms/SalesOrderForms.tsx:245
+#: src/forms/SalesOrderForms.tsx:239
 msgid "Marking the shipment as unchecked indicates that the shipment requires further verification"
-msgstr "将发货单标记为未核对，表示该发货单需要进一步核查"
+msgstr "将发货单标记为未检查，表示该发货单需要进一步验证"
 
-#: src/forms/SalesOrderForms.tsx:255
+#: src/forms/SalesOrderForms.tsx:249
 msgid "Shipment marked as unchecked"
-msgstr "发货单已标记为未核对"
+msgstr "发货单已标记为未检查"
 
-#: src/forms/SalesOrderForms.tsx:273
-msgid "Completing shipment"
-msgstr "正在完成发货"
-
-#: src/forms/SalesOrderForms.tsx:274
-msgid "Shipment completed successfully"
-msgstr "发货已成功完成"
-
-#: src/forms/SalesOrderForms.tsx:281
-#: src/tables/sales/SalesOrderShipmentTable.tsx:233
-msgid "Complete Shipment"
-msgstr "完成配送"
-
-#: src/forms/SalesOrderForms.tsx:527
+#: src/forms/SalesOrderForms.tsx:480
 msgid "Leave blank to use the order address"
 msgstr "留空则使用订单地址"
 
@@ -4951,202 +4831,193 @@ msgstr "留空则使用订单地址"
 #~ msgid "Stock item updated"
 #~ msgstr "Stock item updated"
 
-#: src/forms/StockForms.tsx:202
+#: src/forms/StockForms.tsx:201
 msgid "Add given quantity as packs instead of individual items"
 msgstr "将给定的数量添加为包，而不是单个项目"
 
-#: src/forms/StockForms.tsx:216
+#: src/forms/StockForms.tsx:215
 msgid "Enter initial quantity for this stock item"
 msgstr "输入此库存项的初始数量"
 
-#: src/forms/StockForms.tsx:226
+#: src/forms/StockForms.tsx:225
 msgid "Enter serial numbers for new stock (or leave blank)"
 msgstr "输入新库存的序列号(或留空)"
 
-#: src/forms/StockForms.tsx:246
+#: src/forms/StockForms.tsx:245
 msgid "Stock Status"
 msgstr "库存状态"
 
-#: src/forms/StockForms.tsx:324
+#: src/forms/StockForms.tsx:323
 #: src/pages/stock/StockDetail.tsx:687
-#: src/tables/stock/StockItemTable.tsx:406
-#: src/tables/stock/StockItemTable.tsx:455
+#: src/tables/stock/StockItemTable.tsx:525
+#: src/tables/stock/StockItemTable.tsx:572
 msgid "Add Stock Item"
 msgstr "编辑库存项"
 
-#: src/forms/StockForms.tsx:369
+#: src/forms/StockForms.tsx:367
 msgid "Select the part to install"
 msgstr "选择要安装的零件"
 
-#: src/forms/StockForms.tsx:495
+#: src/forms/StockForms.tsx:493
 msgid "Confirm Stock Transfer"
 msgstr "确认库存转移"
 
-#: src/forms/StockForms.tsx:681
+#: src/forms/StockForms.tsx:679
 msgid "Move to default location"
 msgstr "移动到默认位置"
 
-#: src/forms/StockForms.tsx:804
+#: src/forms/StockForms.tsx:802
 msgid "Move"
 msgstr "移动"
 
-#: src/forms/StockForms.tsx:851
+#: src/forms/StockForms.tsx:849
 msgid "Return"
 msgstr "退货"
 
-#: src/forms/StockForms.tsx:988
+#: src/forms/StockForms.tsx:986
 #: src/pages/Index/Scan.tsx:182
 msgid "Count"
 msgstr "总计"
 
-#: src/forms/StockForms.tsx:1295
-#: src/hooks/UseStockAdjustActions.tsx:112
+#: src/forms/StockForms.tsx:1293
+#: src/hooks/UseStockAdjustActions.tsx:108
 msgid "Add Stock"
 msgstr "添加库存"
 
-#: src/forms/StockForms.tsx:1296
+#: src/forms/StockForms.tsx:1294
 msgid "Stock added"
 msgstr "库存已添加"
 
-#: src/forms/StockForms.tsx:1299
+#: src/forms/StockForms.tsx:1297
 msgid "Increase the quantity of the selected stock items by a given amount."
 msgstr "按指定数量增加选定库存物料的存量。"
 
-#: src/forms/StockForms.tsx:1310
-#: src/hooks/UseStockAdjustActions.tsx:122
+#: src/forms/StockForms.tsx:1308
+#: src/hooks/UseStockAdjustActions.tsx:118
 msgid "Remove Stock"
 msgstr "移除库存"
 
-#: src/forms/StockForms.tsx:1311
+#: src/forms/StockForms.tsx:1309
 msgid "Stock removed"
 msgstr "库存已移除"
 
-#: src/forms/StockForms.tsx:1314
+#: src/forms/StockForms.tsx:1312
 msgid "Decrease the quantity of the selected stock items by a given amount."
 msgstr "按指定数量减少选定库存物料的存量。"
 
-#: src/forms/StockForms.tsx:1325
-#: src/hooks/UseStockAdjustActions.tsx:132
+#: src/forms/StockForms.tsx:1323
+#: src/hooks/UseStockAdjustActions.tsx:128
 msgid "Transfer Stock"
 msgstr "转移库存"
 
-#: src/forms/StockForms.tsx:1326
+#: src/forms/StockForms.tsx:1324
 msgid "Stock transferred"
 msgstr "库存已转移"
 
-#: src/forms/StockForms.tsx:1329
+#: src/forms/StockForms.tsx:1327
 msgid "Transfer selected items to the specified location."
 msgstr "将选定物料转移至指定位置。"
 
-#: src/forms/StockForms.tsx:1340
-#: src/hooks/UseStockAdjustActions.tsx:182
+#: src/forms/StockForms.tsx:1338
+#: src/hooks/UseStockAdjustActions.tsx:168
 msgid "Return Stock"
 msgstr "退回库存"
 
-#: src/forms/StockForms.tsx:1341
+#: src/forms/StockForms.tsx:1339
 msgid "Stock returned"
 msgstr "库存已退回"
 
-#: src/forms/StockForms.tsx:1344
+#: src/forms/StockForms.tsx:1342
 msgid "Return selected items into stock, to the specified location."
 msgstr "将选定物料退回库存至指定位置。"
 
-#: src/forms/StockForms.tsx:1355
-#: src/hooks/UseStockAdjustActions.tsx:102
+#: src/forms/StockForms.tsx:1353
+#: src/hooks/UseStockAdjustActions.tsx:98
 msgid "Count Stock"
 msgstr "库存数量"
 
-#: src/forms/StockForms.tsx:1356
+#: src/forms/StockForms.tsx:1354
 msgid "Stock counted"
 msgstr "库存计数"
 
-#: src/forms/StockForms.tsx:1359
+#: src/forms/StockForms.tsx:1357
 msgid "Count the selected stock items, and adjust the quantity accordingly."
 msgstr "统计选定库存物料数量并按需调整。"
 
-#: src/forms/StockForms.tsx:1370
+#: src/forms/StockForms.tsx:1368
 msgid "Change Stock Status"
 msgstr "更改库存状态"
 
-#: src/forms/StockForms.tsx:1371
+#: src/forms/StockForms.tsx:1369
 msgid "Stock status changed"
 msgstr "库存状态已改变"
 
-#: src/forms/StockForms.tsx:1374
+#: src/forms/StockForms.tsx:1372
 msgid "Change the status of the selected stock items."
 msgstr "变更选定库存物料的状态。"
 
-#: src/forms/StockForms.tsx:1397
-#: src/hooks/UseStockAdjustActions.tsx:162
-msgid "Change Batch Code"
-msgstr "修改批号"
-
-#: src/forms/StockForms.tsx:1400
-msgid "Change batch code for the selected stock items"
-msgstr "变更选定库存物料的批号"
-
-#: src/forms/StockForms.tsx:1417
-#: src/hooks/UseStockAdjustActions.tsx:142
+#: src/forms/StockForms.tsx:1383
+#: src/hooks/UseStockAdjustActions.tsx:138
 msgid "Merge Stock"
 msgstr "合并库存"
 
-#: src/forms/StockForms.tsx:1418
+#: src/forms/StockForms.tsx:1384
 msgid "Stock merged"
 msgstr "库存已合并"
 
-#: src/forms/StockForms.tsx:1420
+#: src/forms/StockForms.tsx:1386
 msgid "Merge Stock Items"
 msgstr "合并库存物料"
 
-#: src/forms/StockForms.tsx:1422
+#: src/forms/StockForms.tsx:1388
 msgid "Merge operation cannot be reversed"
 msgstr "合并操作不可逆"
 
-#: src/forms/StockForms.tsx:1423
+#: src/forms/StockForms.tsx:1389
 msgid "Tracking information may be lost when merging items"
 msgstr "合并操作可能导致追溯信息丢失"
 
-#: src/forms/StockForms.tsx:1424
+#: src/forms/StockForms.tsx:1390
 msgid "Supplier information may be lost when merging items"
 msgstr "合并操作可能导致供应商信息丢失"
 
-#: src/forms/StockForms.tsx:1442
+#: src/forms/StockForms.tsx:1408
 msgid "Assign Stock to Customer"
 msgstr "将库存分配给客户"
 
-#: src/forms/StockForms.tsx:1443
+#: src/forms/StockForms.tsx:1409
 msgid "Stock assigned to customer"
 msgstr "库存已分配给客户"
 
-#: src/forms/StockForms.tsx:1453
+#: src/forms/StockForms.tsx:1419
 msgid "Delete Stock Items"
 msgstr "删除库存项"
 
-#: src/forms/StockForms.tsx:1454
+#: src/forms/StockForms.tsx:1420
 msgid "Stock deleted"
 msgstr "库存已删除"
 
-#: src/forms/StockForms.tsx:1457
+#: src/forms/StockForms.tsx:1423
 msgid "This operation will permanently delete the selected stock items."
 msgstr "此操作将永久删除选定的库存物料。"
 
-#: src/forms/StockForms.tsx:1466
+#: src/forms/StockForms.tsx:1432
 msgid "Parent stock location"
 msgstr "上级库存地点"
 
-#: src/forms/StockForms.tsx:1597
+#: src/forms/StockForms.tsx:1563
 msgid "Find Serial Number"
 msgstr "查找序列号"
 
-#: src/forms/StockForms.tsx:1608
+#: src/forms/StockForms.tsx:1574
 msgid "No matching items"
 msgstr "未找到匹配项"
 
-#: src/forms/StockForms.tsx:1614
+#: src/forms/StockForms.tsx:1580
 msgid "Multiple matching items"
 msgstr "存在多个匹配项"
 
-#: src/forms/StockForms.tsx:1623
+#: src/forms/StockForms.tsx:1589
 msgid "Invalid response from server"
 msgstr "服务器返回无效响应"
 
@@ -5159,10 +5030,10 @@ msgid "List of entries to choose from"
 msgstr "要选择的条目列表"
 
 #: src/forms/selectionListFields.tsx:100
-#: src/pages/part/PartStockHistoryDetail.tsx:64
-#: src/tables/FilterSelectDrawer.tsx:155
-#: src/tables/FilterSelectDrawer.tsx:178
-#: src/tables/FilterSelectDrawer.tsx:190
+#: src/pages/part/PartStockHistoryDetail.tsx:59
+#: src/tables/FilterSelectDrawer.tsx:114
+#: src/tables/FilterSelectDrawer.tsx:137
+#: src/tables/FilterSelectDrawer.tsx:149
 #: src/tables/part/PartTestResultTable.tsx:206
 #: src/tables/stock/StockItemTestResultTable.tsx:207
 msgid "Value"
@@ -5223,7 +5094,7 @@ msgstr "已登出"
 
 #: src/functions/auth.tsx:125
 msgid "There was a conflicting session for this browser, which has been logged out."
-msgstr "此浏览器存在冲突会话，已被登出。"
+msgstr "此浏览器存在冲突的会话，已被登出"
 
 #: src/functions/auth.tsx:142
 #~ msgid "Found an existing login - using it to log you in."
@@ -5300,7 +5171,7 @@ msgstr "MFA 设置成功"
 
 #: src/functions/auth.tsx:588
 msgid "MFA via TOTP has been set up successfully; you will need to login again."
-msgstr "基于 TOTP 的多因素认证（MFA）设置成功；您需要重新登录。"
+msgstr "TOTP MFA 已成功设置，需要重新登录"
 
 #: src/functions/auth.tsx:603
 msgid "Password set"
@@ -5383,27 +5254,36 @@ msgstr "导出数据"
 msgid "Export"
 msgstr "导出"
 
-#: src/hooks/UseForm.tsx:102
+#: src/hooks/UseDataOutput.tsx:57
+#: src/hooks/UseDataOutput.tsx:111
+msgid "Process failed"
+msgstr "处理失败"
+
+#: src/hooks/UseDataOutput.tsx:75
+msgid "Process completed successfully"
+msgstr "处理成功"
+
+#: src/hooks/UseForm.tsx:96
 msgid "Item Created"
 msgstr "项目已创建"
 
-#: src/hooks/UseForm.tsx:122
+#: src/hooks/UseForm.tsx:116
 msgid "Item Updated"
 msgstr "项目已更新"
 
-#: src/hooks/UseForm.tsx:143
+#: src/hooks/UseForm.tsx:137
 msgid "Items Updated"
 msgstr "项目已更新"
 
-#: src/hooks/UseForm.tsx:145
+#: src/hooks/UseForm.tsx:139
 msgid "Update multiple items"
 msgstr "更新多个项目"
 
-#: src/hooks/UseForm.tsx:175
+#: src/hooks/UseForm.tsx:169
 msgid "Item Deleted"
 msgstr "项目已删除"
 
-#: src/hooks/UseForm.tsx:179
+#: src/hooks/UseForm.tsx:173
 msgid "Are you sure you want to delete this item?"
 msgstr "确实要删除此项目吗?"
 
@@ -5411,56 +5291,52 @@ msgstr "确实要删除此项目吗?"
 #~ msgid "Latest serial number"
 #~ msgstr "Latest serial number"
 
-#: src/hooks/UseStockAdjustActions.tsx:104
+#: src/hooks/UseStockAdjustActions.tsx:100
 msgid "Count selected stock items"
 msgstr "统计选中的库存物料数量"
 
-#: src/hooks/UseStockAdjustActions.tsx:114
+#: src/hooks/UseStockAdjustActions.tsx:110
 msgid "Add to selected stock items"
 msgstr "添加到选中库存物料"
 
-#: src/hooks/UseStockAdjustActions.tsx:124
+#: src/hooks/UseStockAdjustActions.tsx:120
 msgid "Remove from selected stock items"
 msgstr "从选中库存物料中移除"
 
-#: src/hooks/UseStockAdjustActions.tsx:134
+#: src/hooks/UseStockAdjustActions.tsx:130
 msgid "Transfer selected stock items"
 msgstr "转移选中库存物料"
 
-#: src/hooks/UseStockAdjustActions.tsx:144
+#: src/hooks/UseStockAdjustActions.tsx:140
 msgid "Merge selected stock items"
 msgstr "合并选中库存物料"
 
-#: src/hooks/UseStockAdjustActions.tsx:154
+#: src/hooks/UseStockAdjustActions.tsx:150
 msgid "Change status of selected stock items"
 msgstr "修改选中库存物料状态"
 
-#: src/hooks/UseStockAdjustActions.tsx:164
-msgid "Change batch code of selected stock items"
-msgstr "修改选中库存项的批次代码"
-
-#: src/hooks/UseStockAdjustActions.tsx:172
+#: src/hooks/UseStockAdjustActions.tsx:158
 msgid "Assign Stock"
 msgstr "分配库存"
 
-#: src/hooks/UseStockAdjustActions.tsx:174
+#: src/hooks/UseStockAdjustActions.tsx:160
 msgid "Assign selected stock items to a customer"
 msgstr "将选中的库存物料分配给客户"
 
-#: src/hooks/UseStockAdjustActions.tsx:184
+#: src/hooks/UseStockAdjustActions.tsx:170
 msgid "Return selected items into stock"
 msgstr "将选中物料退回库存"
 
-#: src/hooks/UseStockAdjustActions.tsx:192
+#: src/hooks/UseStockAdjustActions.tsx:178
 msgid "Delete Stock"
 msgstr "删除库存"
 
-#: src/hooks/UseStockAdjustActions.tsx:194
+#: src/hooks/UseStockAdjustActions.tsx:180
 msgid "Delete selected stock items"
 msgstr "删除选中的库存物料"
 
-#: src/hooks/UseStockAdjustActions.tsx:219
-#: src/pages/part/PartDetail.tsx:1150
+#: src/hooks/UseStockAdjustActions.tsx:205
+#: src/pages/part/PartDetail.tsx:1165
 msgid "Stock Actions"
 msgstr "库存操作"
 
@@ -5505,7 +5381,7 @@ msgstr "注销登录"
 msgid "Checking if you are already logged in"
 msgstr "检查您是否已经登录"
 
-#: src/pages/Auth/Login.tsx:36
+#: src/pages/Auth/Login.tsx:32
 msgid "No selection"
 msgstr "未选择"
 
@@ -5517,15 +5393,15 @@ msgstr "未选择"
 #~ msgid "Register below"
 #~ msgstr "Register below"
 
-#: src/pages/Auth/Login.tsx:107
+#: src/pages/Auth/Login.tsx:100
 msgid "Login"
 msgstr "登录"
 
-#: src/pages/Auth/Login.tsx:113
+#: src/pages/Auth/Login.tsx:106
 msgid "Logging you in"
 msgstr "正在登录"
 
-#: src/pages/Auth/Login.tsx:120
+#: src/pages/Auth/Login.tsx:113
 msgid "Don't have an account?"
 msgstr "没有帐户？"
 
@@ -5554,7 +5430,7 @@ msgstr "TOTP 代码"
 
 #: src/pages/Auth/MFA.tsx:35
 msgid "Enter one of your codes: {mfa_types}"
-msgstr "输入您的其中一个验证码：{mfa_types}"
+msgstr "输入你的验证码之一：{mfa_types}"
 
 #: src/pages/Auth/MFA.tsx:42
 msgid "Remember this device"
@@ -6031,8 +5907,8 @@ msgstr "姓"
 #~ msgstr "Last name:"
 
 #: src/pages/Index/Settings/AccountSettings/AccountDetailPanel.tsx:72
-#~ msgid "Staff Access"
-#~ msgstr "Staff Access"
+msgid "Staff Access"
+msgstr "工作人员访问"
 
 #: src/pages/Index/Settings/AccountSettings/AccountDetailPanel.tsx:85
 #: src/pages/core/UserDetail.tsx:119
@@ -6072,7 +5948,7 @@ msgid "Edit Account"
 msgstr "编辑账户"
 
 #: src/pages/Index/Settings/AccountSettings/AccountDetailPanel.tsx:117
-#: src/tables/settings/UserTable.tsx:323
+#: src/tables/settings/UserTable.tsx:322
 msgid "Change Password"
 msgstr "更改密码"
 
@@ -6103,7 +5979,7 @@ msgstr "您已成功重新验证。"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:114
 msgid "Error during reauthentication"
-msgstr "变更选定库存物料的批号"
+msgstr "重新认证时出错"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:117
 msgid "Reauthentication Failed"
@@ -6128,35 +6004,35 @@ msgstr "输入您的密码"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:221
 msgid "Enter one of your TOTP codes"
-msgstr "输入您的 TOTP 代码"
+msgstr "输入你的 TOTP 验证码"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:273
 msgid "WebAuthn Credential Removed"
-msgstr "WebAuthn 凭据已移除"
+msgstr "WebAuthn 凭证已移除"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:274
 msgid "WebAuthn credential removed successfully."
-msgstr "WebAuthn 凭据删除成功。"
+msgstr "WebAuthn 凭证移除成功"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:283
 msgid "Error removing WebAuthn credential"
-msgstr "删除 WebAuthn 凭证出错"
+msgstr "移除 WebAuthn 凭证时出错"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:304
 msgid "Remove WebAuthn Credential"
-msgstr "移除 WebAuthn 凭据"
+msgstr "移除 WebAuthn 凭证"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:312
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:403
-#: src/tables/build/BuildAllocatedStockTable.tsx:183
-#: src/tables/build/BuildLineTable.tsx:674
-#: src/tables/sales/SalesOrderAllocationTable.tsx:219
+#: src/tables/build/BuildAllocatedStockTable.tsx:181
+#: src/tables/build/BuildLineTable.tsx:669
+#: src/tables/sales/SalesOrderAllocationTable.tsx:220
 msgid "Confirm Removal"
 msgstr "确认移除"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:314
 msgid "Confirm removal of webauth credential"
-msgstr "确认移除 webauth 凭据"
+msgstr "确认移除 WebAuthn 凭证"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:366
 msgid "TOTP Removed"
@@ -6164,7 +6040,7 @@ msgstr "TOTP 已移除"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:367
 msgid "TOTP token removed successfully."
-msgstr "TOTP 令牌删除成功。"
+msgstr "TOTP 令牌移除成功"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:377
 msgid "Error removing TOTP token"
@@ -6176,31 +6052,31 @@ msgstr "移除 TOTP 令牌"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:405
 msgid "Confirm removal of TOTP code"
-msgstr "确认移除 TOTP 代码"
+msgstr "确认移除 TOTP 验证码"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:465
 msgid "TOTP Already Registered"
-msgstr "已经注册了 TOTP"
+msgstr "TOTP 已注册"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:466
 msgid "A TOTP token is already registered for this account."
-msgstr "此账户已经注册了TOTP 令牌。"
+msgstr "此账户已注册 TOTP 令牌"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:481
 msgid "Error Fetching TOTP Registration"
-msgstr "获取TOTP注册时出错"
+msgstr "获取 TOTP 注册信息出错"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:482
 msgid "An unexpected error occurred while fetching TOTP registration data."
-msgstr "获取TOTP 注册数据时发生异常错误。"
+msgstr "获取 TOTP 注册数据时发生意外错误"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:524
 msgid "TOTP Registered"
-msgstr "TOTP 注册成功"
+msgstr "TOTP 已注册"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:525
 msgid "TOTP token registered successfully."
-msgstr "TOTP 令牌注册成功。"
+msgstr "TOTP 令牌注册成功"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:534
 msgid "Error registering TOTP token"
@@ -6212,7 +6088,7 @@ msgstr "注册TOTP 令牌"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:598
 msgid "Error fetching recovery codes"
-msgstr "获取恢复码时出错"
+msgstr "获取恢复码出错"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:634
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:650
@@ -6222,7 +6098,7 @@ msgstr "恢复代码"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:652
 msgid "The following one time recovery codes are available for use"
-msgstr "以下一次性恢复码可供使用"
+msgstr "以下是一次性恢复码，可供使用"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:669
 msgid "Copy recovery codes to clipboard"
@@ -6230,7 +6106,7 @@ msgstr "复制恢复码到剪贴板"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:679
 msgid "No Unused Codes"
-msgstr "没有未使用的代码"
+msgstr "无剩余验证码"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:681
 msgid "There are no available recovery codes"
@@ -6238,15 +6114,15 @@ msgstr "没有可用的恢复码"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:782
 msgid "WebAuthn Registered"
-msgstr "WebAuthn 注册成功"
+msgstr "WebAuthn 已注册"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:783
 msgid "WebAuthn credential registered successfully"
-msgstr "WebAuthn 凭据注册成功"
+msgstr "WebAuthn 凭证注册成功"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:792
 msgid "Error registering WebAuthn credential"
-msgstr "注册 WebAuthn 凭据时出错"
+msgstr "注册 WebAuthn 凭证时出错"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:795
 msgid "WebAuthn Registration Failed"
@@ -6254,11 +6130,11 @@ msgstr "WebAuthn 注册失败"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:796
 msgid "Failed to register WebAuthn credential"
-msgstr "注册 WebAuthn 凭证失败"
+msgstr "WebAuthn 凭证注册失败"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:819
 msgid "Error fetching WebAuthn registration"
-msgstr "获取 WebAuthn 注册出错"
+msgstr "获取 WebAuthn 注册信息出错"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:859
 msgid "TOTP"
@@ -6278,7 +6154,7 @@ msgstr "WebAuthn"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:874
 msgid "Web Authentication (WebAuthn) is a web standard for secure authentication"
-msgstr "Web 身份验证 (WebAuthn) 是一个安全身份验证的网络标准"
+msgstr "WebAuthn（网页认证）是一种网页安全认证标准"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:970
 msgid "Last used at"
@@ -6304,11 +6180,11 @@ msgstr "注册认证方式"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:1009
 msgid "No MFA Methods Available"
-msgstr "无可用的 MFA 方法"
+msgstr "无可用的 MFA 认证方式"
 
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:1013
 msgid "There are no MFA methods available for configuration"
-msgstr "没有可供配置的 MFA 方法"
+msgstr "没有可用的 MFA 认证方式可供配置"
 
 #: src/pages/Index/Settings/AccountSettings/QrRegistrationForm.tsx:27
 msgid "Secret"
@@ -6387,7 +6263,6 @@ msgid "The following email addresses are associated with your account:"
 msgstr "以下电子邮件地址与您的账户相关联："
 
 #: src/pages/Index/Settings/AccountSettings/SecurityContent.tsx:228
-#: src/tables/purchasing/SupplierPartTable.tsx:254
 msgid "Primary"
 msgstr "主要的"
 
@@ -6581,7 +6456,7 @@ msgstr "点"
 #~ msgstr "Advanced Amininistrative Options for InvenTree"
 
 #: src/pages/Index/Settings/AdminCenter/CurrencyManagementPanel.tsx:28
-#: src/tables/ColumnRenderers.tsx:753
+#: src/tables/ColumnRenderers.tsx:557
 msgid "Currency"
 msgstr "货币"
 
@@ -6631,15 +6506,15 @@ msgstr "管理中心信息"
 
 #: src/pages/Index/Settings/AdminCenter/HomePanel.tsx:53
 msgid "The home panel (and the whole Admin Center) is a new feature starting with the new UI and was previously (before 1.0) not available."
-msgstr "主面板（以及整个管理中心）是新界面推出后的一项新功能，在 1.0 版本之前是没有的。"
+msgstr "主页面板（及整个管理中心）是自新 UI 界面开始的新功能，在 1.0 版本之前不可用"
 
 #: src/pages/Index/Settings/AdminCenter/HomePanel.tsx:60
 msgid "The admin center provides a centralized location for all administration functionality and is meant to replace all interaction with the (django) backend admin interface."
-msgstr "管理中心提供了所有管理功能的统一入口，旨在完全替代对（Django）后端管理界面的操作。"
+msgstr "管理中心为所有管理功能提供了集中的位置，旨在取代所有与 Django 后台管理界面的交互操作"
 
 #: src/pages/Index/Settings/AdminCenter/HomePanel.tsx:67
 msgid "Please open feature requests (after checking the tracker) for any existing backend admin functionality you are missing in this UI. The backend admin interface should be used carefully and seldom."
-msgstr "如果你在当前界面中缺少任何原后端管理后台的功能，请先查看任务追踪器，再提交功能需求。后端管理界面应谨慎使用，且尽量少用。"
+msgstr "对于你在本 UI 中缺失的任何现有后台管理功能，请（在查看追踪器后）提交功能请求。后台管理界面应谨慎使用"
 
 #: src/pages/Index/Settings/AdminCenter/HomePanel.tsx:85
 msgid "Quick Actions"
@@ -6846,34 +6721,30 @@ msgstr "附加到模型"
 #~ msgid "Stocktake Reports"
 #~ msgstr "Stocktake Reports"
 
-#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:32
-msgid "Background worker running"
-msgstr "后台程序正在运行"
+#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:30
+msgid "Background worker not running"
+msgstr "后台worker未运行"
+
+#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:31
+msgid "The background task manager service is not running. Contact your system administrator."
+msgstr "后台任务管理器服务未运行。请联系系统管理员。"
 
 #: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:35
 #~ msgid "Background Worker Not Running"
 #~ msgstr "Background Worker Not Running"
 
 #: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:38
-msgid "Background worker not running"
-msgstr "后台worker未运行"
-
-#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:42
-msgid "The background task manager service is not running. Contact your system administrator."
-msgstr "后台任务管理器服务未运行。请联系系统管理员。"
-
-#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:49
-#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:58
+#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:47
 msgid "Pending Tasks"
 msgstr "待完成任务"
 
-#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:50
-#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:66
+#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:39
+#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:55
 msgid "Scheduled Tasks"
 msgstr "计划任务"
 
-#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:51
-#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:74
+#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:40
+#: src/pages/Index/Settings/AdminCenter/TaskManagementPanel.tsx:63
 msgid "Failed Tasks"
 msgstr "失败任务"
 
@@ -6970,16 +6841,6 @@ msgstr "定价"
 msgid "Labels"
 msgstr "标签"
 
-#: src/pages/Index/Settings/SystemSettings.tsx:260
-msgid "Part Stocktake"
-msgstr "零件盘点"
-
-#: src/pages/Index/Settings/SystemSettings.tsx:271
-#: src/pages/part/PartStockHistoryDetail.tsx:296
-#: src/pages/stock/StockDetail.tsx:532
-msgid "Stock Tracking"
-msgstr "库存跟踪"
-
 #: src/pages/Index/Settings/SystemSettings.tsx:317
 #~ msgid "Switch to User Setting"
 #~ msgstr "Switch to User Setting"
@@ -7064,6 +6925,15 @@ msgstr "该装配件可能未定义物料清单（BOM），或BOM为空。"
 #~ msgid "Build Order updated"
 #~ msgstr "Build Order updated"
 
+#: src/pages/build/BuildDetail.tsx:216
+#: src/pages/part/PartDetail.tsx:480
+#: src/pages/stock/StockDetail.tsx:161
+#: src/tables/bom/UsedInTable.tsx:44
+#: src/tables/build/BuildOrderTable.tsx:83
+#: src/tables/stock/StockItemTable.tsx:74
+msgid "Revision"
+msgstr "版本"
+
 #: src/pages/build/BuildDetail.tsx:221
 #~ msgid "Edit build order"
 #~ msgstr "Edit build order"
@@ -7072,20 +6942,7 @@ msgstr "该装配件可能未定义物料清单（BOM），或BOM为空。"
 #~ msgid "Duplicate build order"
 #~ msgstr "Duplicate build order"
 
-#: src/pages/build/BuildDetail.tsx:231
-#~ msgid "Delete build order"
-#~ msgstr "Delete build order"
-
-#: src/pages/build/BuildDetail.tsx:234
-#: src/pages/part/PartDetail.tsx:457
-#: src/pages/stock/StockDetail.tsx:161
-#: src/tables/bom/UsedInTable.tsx:49
-#: src/tables/build/BuildOrderTable.tsx:87
-#: src/tables/stock/StockItemTable.tsx:66
-msgid "Revision"
-msgstr "版本"
-
-#: src/pages/build/BuildDetail.tsx:247
+#: src/pages/build/BuildDetail.tsx:229
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:175
 #: src/pages/sales/ReturnOrderDetail.tsx:142
 #: src/pages/sales/SalesOrderDetail.tsx:132
@@ -7093,287 +6950,291 @@ msgstr "版本"
 msgid "Custom Status"
 msgstr "自定义状态"
 
-#: src/pages/build/BuildDetail.tsx:256
-#: src/pages/build/BuildDetail.tsx:750
+#: src/pages/build/BuildDetail.tsx:231
+#~ msgid "Delete build order"
+#~ msgstr "Delete build order"
+
+#: src/pages/build/BuildDetail.tsx:238
+#: src/pages/build/BuildDetail.tsx:729
 #: src/pages/build/BuildIndex.tsx:34
 #: src/pages/stock/LocationDetail.tsx:149
-#: src/tables/build/BuildOrderTable.tsx:127
-#: src/tables/build/BuildOrderTable.tsx:188
+#: src/tables/build/BuildOrderTable.tsx:123
+#: src/tables/build/BuildOrderTable.tsx:183
 #: src/tables/stock/StockLocationTable.tsx:48
 msgid "External"
 msgstr "外部"
 
-#: src/pages/build/BuildDetail.tsx:263
+#: src/pages/build/BuildDetail.tsx:245
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:142
 #: src/pages/sales/ReturnOrderDetail.tsx:109
 #: src/pages/sales/SalesOrderDetail.tsx:99
-#: src/tables/ColumnRenderers.tsx:505
-#: src/tables/build/BuildAllocatedStockTable.tsx:110
+#: src/tables/ColumnRenderers.tsx:321
+#: src/tables/build/BuildAllocatedStockTable.tsx:112
 #: src/tables/build/BuildLineTable.tsx:354
 msgid "Reference"
 msgstr "参考"
 
-#: src/pages/build/BuildDetail.tsx:277
+#: src/pages/build/BuildDetail.tsx:259
 msgid "Parent Build"
 msgstr "上级生产"
 
-#: src/pages/build/BuildDetail.tsx:288
+#: src/pages/build/BuildDetail.tsx:270
 msgid "Build Quantity"
 msgstr "生产数量"
 
-#: src/pages/build/BuildDetail.tsx:294
-#: src/pages/part/PartDetail.tsx:575
-#: src/tables/bom/BomTable.tsx:359
-#: src/tables/bom/BomTable.tsx:401
+#: src/pages/build/BuildDetail.tsx:276
+#: src/pages/part/PartDetail.tsx:598
+#: src/tables/bom/BomTable.tsx:366
+#: src/tables/bom/BomTable.tsx:408
 msgid "Can Build"
 msgstr "可以创建"
 
-#: src/pages/build/BuildDetail.tsx:303
-#: src/pages/build/BuildDetail.tsx:494
+#: src/pages/build/BuildDetail.tsx:285
+#: src/pages/build/BuildDetail.tsx:475
 msgid "Completed Outputs"
 msgstr "已出产"
 
-#: src/pages/build/BuildDetail.tsx:320
-#: src/tables/Filter.tsx:441
-#: src/tables/build/BuildOrderTable.tsx:147
+#: src/pages/build/BuildDetail.tsx:302
+#: src/tables/Filter.tsx:381
+#: src/tables/build/BuildOrderTable.tsx:143
 msgid "Issued By"
 msgstr "发布人"
 
-#: src/pages/build/BuildDetail.tsx:328
-#: src/pages/part/PartDetail.tsx:668
+#: src/pages/build/BuildDetail.tsx:310
+#: src/pages/part/PartDetail.tsx:691
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:262
 #: src/pages/sales/ReturnOrderDetail.tsx:240
 #: src/pages/sales/SalesOrderDetail.tsx:233
-#: src/tables/ColumnRenderers.tsx:668
-#: src/tables/Filter.tsx:379
+#: src/tables/ColumnRenderers.tsx:483
+#: src/tables/Filter.tsx:319
 msgid "Responsible"
 msgstr "责任人"
 
-#: src/pages/build/BuildDetail.tsx:346
+#: src/pages/build/BuildDetail.tsx:328
 msgid "Any location"
 msgstr "任意地点"
+
+#: src/pages/build/BuildDetail.tsx:335
+msgid "Destination Location"
+msgstr "目标地点"
 
 #: src/pages/build/BuildDetail.tsx:347
 #: src/pages/part/PartDetail.tsx:727
 #~ msgid "Test Statistics"
 #~ msgstr "Test Statistics"
 
-#: src/pages/build/BuildDetail.tsx:353
-msgid "Destination Location"
-msgstr "目标地点"
+#: src/pages/build/BuildDetail.tsx:351
+#: src/tables/settings/ApiTokenTable.tsx:97
+#: src/tables/settings/PendingTasksTable.tsx:41
+msgid "Created"
+msgstr "已创建"
+
+#: src/pages/build/BuildDetail.tsx:359
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:287
+#: src/pages/sales/ReturnOrderDetail.tsx:266
+#: src/pages/sales/SalesOrderDetail.tsx:258
+#: src/tables/ColumnRenderers.tsx:505
+msgid "Start Date"
+msgstr "开始日期"
+
+#: src/pages/build/BuildDetail.tsx:367
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:295
+#: src/pages/sales/ReturnOrderDetail.tsx:274
+#: src/pages/sales/SalesOrderDetail.tsx:266
+#: src/tables/ColumnRenderers.tsx:513
+#: src/tables/part/PartPurchaseOrdersTable.tsx:101
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:154
+#: src/tables/sales/SalesOrderLineItemTable.tsx:134
+msgid "Target Date"
+msgstr "预计日期"
 
 #: src/pages/build/BuildDetail.tsx:368
 #~ msgid "Reporting Actions"
 #~ msgstr "Reporting Actions"
 
-#: src/pages/build/BuildDetail.tsx:369
-#: src/tables/settings/ApiTokenTable.tsx:98
-#: src/tables/settings/PendingTasksTable.tsx:41
-msgid "Created"
-msgstr "已创建"
-
 #: src/pages/build/BuildDetail.tsx:374
 #~ msgid "Print build report"
 #~ msgstr "Print build report"
 
-#: src/pages/build/BuildDetail.tsx:377
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:287
-#: src/pages/sales/ReturnOrderDetail.tsx:266
-#: src/pages/sales/SalesOrderDetail.tsx:258
-#: src/tables/ColumnRenderers.tsx:691
-msgid "Start Date"
-msgstr "开始日期"
-
-#: src/pages/build/BuildDetail.tsx:385
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:295
-#: src/pages/sales/ReturnOrderDetail.tsx:274
-#: src/pages/sales/SalesOrderDetail.tsx:266
-#: src/tables/ColumnRenderers.tsx:699
-#: src/tables/part/PartPurchaseOrdersTable.tsx:101
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:153
-#: src/tables/sales/SalesOrderLineItemTable.tsx:130
-msgid "Target Date"
-msgstr "预计日期"
-
-#: src/pages/build/BuildDetail.tsx:393
-#: src/tables/build/BuildOrderTable.tsx:97
-#: src/tables/sales/SalesOrderLineItemTable.tsx:345
+#: src/pages/build/BuildDetail.tsx:375
+#: src/tables/build/BuildOrderTable.tsx:93
+#: src/tables/sales/SalesOrderLineItemTable.tsx:347
 msgid "Completed"
 msgstr "已完成"
 
-#: src/pages/build/BuildDetail.tsx:429
+#: src/pages/build/BuildDetail.tsx:411
 msgid "Build Details"
 msgstr "生产详情"
 
-#: src/pages/build/BuildDetail.tsx:435
+#: src/pages/build/BuildDetail.tsx:417
 msgid "Required Parts"
 msgstr "所需零件"
 
-#: src/pages/build/BuildDetail.tsx:447
-#: src/pages/sales/SalesOrderDetail.tsx:417
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:258
-#: src/tables/part/PartSalesAllocationsTable.tsx:71
+#: src/pages/build/BuildDetail.tsx:429
+#: src/pages/sales/SalesOrderDetail.tsx:408
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:259
+#: src/tables/part/PartSalesAllocationsTable.tsx:73
 msgid "Allocated Stock"
 msgstr "已分配的库存"
 
-#: src/pages/build/BuildDetail.tsx:463
+#: src/pages/build/BuildDetail.tsx:445
 msgid "Consumed Stock"
 msgstr "已消耗库存"
 
-#: src/pages/build/BuildDetail.tsx:481
+#: src/pages/build/BuildDetail.tsx:462
 msgid "Incomplete Outputs"
 msgstr "未出产"
 
-#: src/pages/build/BuildDetail.tsx:509
+#: src/pages/build/BuildDetail.tsx:490
 msgid "External Orders"
 msgstr "外部订单"
 
-#: src/pages/build/BuildDetail.tsx:523
+#: src/pages/build/BuildDetail.tsx:504
 msgid "Child Build Orders"
 msgstr "子生产订单"
 
-#: src/pages/build/BuildDetail.tsx:534
-#: src/pages/part/PartDetail.tsx:903
+#: src/pages/build/BuildDetail.tsx:514
+#: src/pages/part/PartDetail.tsx:929
 #: src/pages/stock/StockDetail.tsx:587
-#: src/tables/build/BuildOutputTable.tsx:704
+#: src/tables/build/BuildOutputTable.tsx:654
 #: src/tables/stock/StockItemTestResultTable.tsx:173
 msgid "Test Results"
 msgstr "测试结果"
 
-#: src/pages/build/BuildDetail.tsx:577
+#: src/pages/build/BuildDetail.tsx:556
 msgid "Edit Build Order"
 msgstr "编辑生产订单"
 
-#: src/pages/build/BuildDetail.tsx:599
-#: src/tables/build/BuildOrderTable.tsx:212
-#: src/tables/build/BuildOrderTable.tsx:229
+#: src/pages/build/BuildDetail.tsx:578
+#: src/tables/build/BuildOrderTable.tsx:207
+#: src/tables/build/BuildOrderTable.tsx:223
 msgid "Add Build Order"
 msgstr "添加生产订单"
 
-#: src/pages/build/BuildDetail.tsx:609
+#: src/pages/build/BuildDetail.tsx:588
 msgid "Cancel Build Order"
 msgstr "取消生产订单"
 
-#: src/pages/build/BuildDetail.tsx:611
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:431
-#: src/pages/sales/ReturnOrderDetail.tsx:442
-#: src/pages/sales/SalesOrderDetail.tsx:469
-msgid "Order cancelled"
-msgstr "订单已取消"
-
-#: src/pages/build/BuildDetail.tsx:612
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:430
-#: src/pages/sales/ReturnOrderDetail.tsx:441
-#: src/pages/sales/SalesOrderDetail.tsx:468
-msgid "Cancel this order"
-msgstr "取消此订单"
-
-#: src/pages/build/BuildDetail.tsx:621
-msgid "Hold Build Order"
-msgstr "挂起生产订单"
-
-#: src/pages/build/BuildDetail.tsx:623
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:438
-#: src/pages/sales/ReturnOrderDetail.tsx:449
-#: src/pages/sales/SalesOrderDetail.tsx:476
-msgid "Place this order on hold"
-msgstr "将此订单挂起"
-
-#: src/pages/build/BuildDetail.tsx:624
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:439
-#: src/pages/sales/ReturnOrderDetail.tsx:450
-#: src/pages/sales/SalesOrderDetail.tsx:477
-msgid "Order placed on hold"
-msgstr "挂起订单"
-
-#: src/pages/build/BuildDetail.tsx:629
-msgid "Issue Build Order"
-msgstr "发出生产订单"
-
-#: src/pages/build/BuildDetail.tsx:631
+#: src/pages/build/BuildDetail.tsx:590
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:422
 #: src/pages/sales/ReturnOrderDetail.tsx:433
 #: src/pages/sales/SalesOrderDetail.tsx:460
+msgid "Order cancelled"
+msgstr "订单已取消"
+
+#: src/pages/build/BuildDetail.tsx:591
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:421
+#: src/pages/sales/ReturnOrderDetail.tsx:432
+#: src/pages/sales/SalesOrderDetail.tsx:459
+msgid "Cancel this order"
+msgstr "取消此订单"
+
+#: src/pages/build/BuildDetail.tsx:600
+msgid "Hold Build Order"
+msgstr "挂起生产订单"
+
+#: src/pages/build/BuildDetail.tsx:602
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:429
+#: src/pages/sales/ReturnOrderDetail.tsx:440
+#: src/pages/sales/SalesOrderDetail.tsx:467
+msgid "Place this order on hold"
+msgstr "将此订单挂起"
+
+#: src/pages/build/BuildDetail.tsx:603
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:430
+#: src/pages/sales/ReturnOrderDetail.tsx:441
+#: src/pages/sales/SalesOrderDetail.tsx:468
+msgid "Order placed on hold"
+msgstr "挂起订单"
+
+#: src/pages/build/BuildDetail.tsx:608
+msgid "Issue Build Order"
+msgstr "发出生产订单"
+
+#: src/pages/build/BuildDetail.tsx:610
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:413
+#: src/pages/sales/ReturnOrderDetail.tsx:424
+#: src/pages/sales/SalesOrderDetail.tsx:451
 msgid "Issue this order"
 msgstr "发出这个订单"
 
-#: src/pages/build/BuildDetail.tsx:632
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:423
-#: src/pages/sales/ReturnOrderDetail.tsx:434
-#: src/pages/sales/SalesOrderDetail.tsx:461
+#: src/pages/build/BuildDetail.tsx:611
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:414
+#: src/pages/sales/ReturnOrderDetail.tsx:425
+#: src/pages/sales/SalesOrderDetail.tsx:452
 msgid "Order issued"
 msgstr "订单发起"
 
-#: src/pages/build/BuildDetail.tsx:651
+#: src/pages/build/BuildDetail.tsx:630
 msgid "Complete Build Order"
 msgstr "完成生产订单"
 
-#: src/pages/build/BuildDetail.tsx:657
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:451
-#: src/pages/sales/ReturnOrderDetail.tsx:457
-#: src/pages/sales/SalesOrderDetail.tsx:495
+#: src/pages/build/BuildDetail.tsx:636
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:442
+#: src/pages/sales/ReturnOrderDetail.tsx:448
+#: src/pages/sales/SalesOrderDetail.tsx:486
 msgid "Mark this order as complete"
 msgstr "标记该订单为已完成"
 
-#: src/pages/build/BuildDetail.tsx:660
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:445
-#: src/pages/sales/ReturnOrderDetail.tsx:458
-#: src/pages/sales/SalesOrderDetail.tsx:496
+#: src/pages/build/BuildDetail.tsx:639
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:436
+#: src/pages/sales/ReturnOrderDetail.tsx:449
+#: src/pages/sales/SalesOrderDetail.tsx:487
 msgid "Order completed"
 msgstr "订单已完成"
 
-#: src/pages/build/BuildDetail.tsx:687
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:474
-#: src/pages/sales/ReturnOrderDetail.tsx:485
-#: src/pages/sales/SalesOrderDetail.tsx:531
+#: src/pages/build/BuildDetail.tsx:666
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:465
+#: src/pages/sales/ReturnOrderDetail.tsx:476
+#: src/pages/sales/SalesOrderDetail.tsx:522
 msgid "Issue Order"
 msgstr "发布订单"
 
-#: src/pages/build/BuildDetail.tsx:694
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:481
-#: src/pages/sales/ReturnOrderDetail.tsx:492
-#: src/pages/sales/SalesOrderDetail.tsx:545
+#: src/pages/build/BuildDetail.tsx:673
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:472
+#: src/pages/sales/ReturnOrderDetail.tsx:483
+#: src/pages/sales/SalesOrderDetail.tsx:536
 msgid "Complete Order"
 msgstr "完成订单"
 
-#: src/pages/build/BuildDetail.tsx:713
+#: src/pages/build/BuildDetail.tsx:692
 msgid "Build Order Actions"
 msgstr "生产订单操作"
 
-#: src/pages/build/BuildDetail.tsx:718
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:504
-#: src/pages/sales/ReturnOrderDetail.tsx:515
-#: src/pages/sales/SalesOrderDetail.tsx:569
+#: src/pages/build/BuildDetail.tsx:697
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:495
+#: src/pages/sales/ReturnOrderDetail.tsx:506
+#: src/pages/sales/SalesOrderDetail.tsx:560
 msgid "Edit order"
 msgstr "编辑订单"
 
-#: src/pages/build/BuildDetail.tsx:722
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:512
-#: src/pages/sales/ReturnOrderDetail.tsx:521
-#: src/pages/sales/SalesOrderDetail.tsx:574
+#: src/pages/build/BuildDetail.tsx:701
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:503
+#: src/pages/sales/ReturnOrderDetail.tsx:512
+#: src/pages/sales/SalesOrderDetail.tsx:565
 msgid "Duplicate order"
 msgstr "复制订单"
 
-#: src/pages/build/BuildDetail.tsx:726
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:515
-#: src/pages/sales/ReturnOrderDetail.tsx:526
-#: src/pages/sales/SalesOrderDetail.tsx:577
+#: src/pages/build/BuildDetail.tsx:705
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:506
+#: src/pages/sales/ReturnOrderDetail.tsx:517
+#: src/pages/sales/SalesOrderDetail.tsx:568
 msgid "Hold order"
 msgstr "挂起订单"
 
-#: src/pages/build/BuildDetail.tsx:731
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:520
-#: src/pages/sales/ReturnOrderDetail.tsx:531
-#: src/pages/sales/SalesOrderDetail.tsx:582
+#: src/pages/build/BuildDetail.tsx:710
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:511
+#: src/pages/sales/ReturnOrderDetail.tsx:522
+#: src/pages/sales/SalesOrderDetail.tsx:573
 msgid "Cancel order"
 msgstr "取消订单"
 
-#: src/pages/build/BuildDetail.tsx:769
+#: src/pages/build/BuildDetail.tsx:748
 #: src/pages/stock/StockDetail.tsx:344
-#: src/tables/build/BuildAllocatedStockTable.tsx:85
+#: src/tables/build/BuildAllocatedStockTable.tsx:82
 #: src/tables/part/PartBuildAllocationsTable.tsx:45
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:153
-#: src/tables/stock/StockTrackingTable.tsx:141
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:157
+#: src/tables/stock/StockTrackingTable.tsx:124
 msgid "Build Order"
 msgstr "生产订单"
 
@@ -7382,7 +7243,7 @@ msgstr "生产订单"
 #~ msgstr "Build order created"
 
 #: src/pages/build/BuildIndex.tsx:35
-#: src/tables/build/BuildOrderTable.tsx:189
+#: src/tables/build/BuildOrderTable.tsx:184
 msgid "Show external build orders"
 msgstr "显示外部生产订单"
 
@@ -7394,9 +7255,9 @@ msgstr "显示外部生产订单"
 #: src/pages/part/CategoryDetail.tsx:292
 #: src/pages/purchasing/PurchasingIndex.tsx:74
 #: src/pages/purchasing/PurchasingIndex.tsx:107
-#: src/pages/purchasing/PurchasingIndex.tsx:136
-#: src/pages/purchasing/PurchasingIndex.tsx:157
-#: src/pages/purchasing/PurchasingIndex.tsx:186
+#: src/pages/purchasing/PurchasingIndex.tsx:135
+#: src/pages/purchasing/PurchasingIndex.tsx:156
+#: src/pages/purchasing/PurchasingIndex.tsx:184
 #: src/pages/sales/SalesIndex.tsx:61
 #: src/pages/sales/SalesIndex.tsx:107
 #: src/pages/sales/SalesIndex.tsx:140
@@ -7414,16 +7275,20 @@ msgstr "日历视图"
 #: src/pages/build/BuildIndex.tsx:86
 #: src/pages/part/CategoryDetail.tsx:306
 #: src/pages/purchasing/PurchasingIndex.tsx:92
-#: src/pages/purchasing/PurchasingIndex.tsx:119
-#: src/pages/purchasing/PurchasingIndex.tsx:142
-#: src/pages/purchasing/PurchasingIndex.tsx:169
-#: src/pages/purchasing/PurchasingIndex.tsx:192
+#: src/pages/purchasing/PurchasingIndex.tsx:118
+#: src/pages/purchasing/PurchasingIndex.tsx:141
+#: src/pages/purchasing/PurchasingIndex.tsx:167
+#: src/pages/purchasing/PurchasingIndex.tsx:190
 #: src/pages/sales/SalesIndex.tsx:79
 #: src/pages/sales/SalesIndex.tsx:125
-#: src/pages/sales/SalesIndex.tsx:152
+#: src/pages/sales/SalesIndex.tsx:151
 #: src/pages/stock/LocationDetail.tsx:199
 msgid "Parametric View"
 msgstr "参数视图"
+
+#: src/pages/company/CompanyDetail.tsx:100
+msgid "Website"
+msgstr "网站"
 
 #: src/pages/company/CompanyDetail.tsx:108
 msgid "Phone Number"
@@ -7446,9 +7311,9 @@ msgstr "默认货币单位"
 #: src/pages/company/ManufacturerPartDetail.tsx:103
 #: src/pages/company/ManufacturerPartDetail.tsx:272
 #: src/pages/company/SupplierPartDetail.tsx:153
-#: src/tables/Filter.tsx:407
-#: src/tables/company/CompanyTable.tsx:111
-#: src/tables/purchasing/SupplierPartTable.tsx:113
+#: src/tables/Filter.tsx:347
+#: src/tables/company/CompanyTable.tsx:101
+#: src/tables/purchasing/SupplierPartTable.tsx:89
 msgid "Manufacturer"
 msgstr "制造商"
 
@@ -7457,15 +7322,15 @@ msgstr "制造商"
 #: src/pages/part/pricing/SaleHistoryPanel.tsx:31
 #: src/pages/sales/ReturnOrderDetail.tsx:124
 #: src/pages/sales/SalesOrderDetail.tsx:114
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:110
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:111
 #: src/pages/stock/StockDetail.tsx:370
-#: src/tables/company/CompanyTable.tsx:116
+#: src/tables/company/CompanyTable.tsx:106
 #: src/tables/sales/ReturnOrderParametricTable.tsx:32
-#: src/tables/sales/ReturnOrderTable.tsx:125
+#: src/tables/sales/ReturnOrderTable.tsx:108
 #: src/tables/sales/SalesOrderParametricTable.tsx:32
-#: src/tables/sales/SalesOrderShipmentTable.tsx:125
-#: src/tables/sales/SalesOrderTable.tsx:148
-#: src/tables/stock/StockTrackingTable.tsx:185
+#: src/tables/sales/SalesOrderShipmentTable.tsx:132
+#: src/tables/sales/SalesOrderTable.tsx:134
+#: src/tables/stock/StockTrackingTable.tsx:168
 msgid "Customer"
 msgstr "客户"
 
@@ -7493,16 +7358,16 @@ msgstr "制成零件"
 msgid "Assigned Stock"
 msgstr "已分配的库存"
 
-#: src/pages/company/CompanyDetail.tsx:289
-#: src/tables/company/CompanyTable.tsx:92
+#: src/pages/company/CompanyDetail.tsx:288
+#: src/tables/company/CompanyTable.tsx:82
 msgid "Edit Company"
 msgstr "编辑公司"
 
-#: src/pages/company/CompanyDetail.tsx:297
+#: src/pages/company/CompanyDetail.tsx:296
 msgid "Delete Company"
 msgstr "删除该公司"
 
-#: src/pages/company/CompanyDetail.tsx:312
+#: src/pages/company/CompanyDetail.tsx:311
 msgid "Company Actions"
 msgstr "公司操作"
 
@@ -7522,7 +7387,7 @@ msgstr "外部链接"
 
 #: src/pages/company/ManufacturerPartDetail.tsx:147
 #: src/pages/company/SupplierPartDetail.tsx:233
-#: src/pages/part/PartDetail.tsx:764
+#: src/pages/part/PartDetail.tsx:790
 msgid "Part Details"
 msgstr "零件详情"
 
@@ -7536,24 +7401,24 @@ msgstr "制造商零件详情"
 
 #: src/pages/company/ManufacturerPartDetail.tsx:165
 #: src/pages/company/SupplierPartDetail.tsx:253
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:391
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:382
 msgid "Received Stock"
 msgstr "接收库存"
 
 #: src/pages/company/ManufacturerPartDetail.tsx:212
-#: src/tables/purchasing/ManufacturerPartTable.tsx:128
+#: src/tables/purchasing/ManufacturerPartTable.tsx:108
 msgid "Edit Manufacturer Part"
 msgstr "编辑制造商零件"
 
 #: src/pages/company/ManufacturerPartDetail.tsx:219
+#: src/tables/purchasing/ManufacturerPartTable.tsx:96
 #: src/tables/purchasing/ManufacturerPartTable.tsx:115
-#: src/tables/purchasing/ManufacturerPartTable.tsx:135
-#: src/tables/purchasing/ManufacturerPartTable.tsx:176
+#: src/tables/purchasing/ManufacturerPartTable.tsx:156
 msgid "Add Manufacturer Part"
 msgstr "添加制造商零件"
 
 #: src/pages/company/ManufacturerPartDetail.tsx:231
-#: src/tables/purchasing/ManufacturerPartTable.tsx:146
+#: src/tables/purchasing/ManufacturerPartTable.tsx:126
 msgid "Delete Manufacturer Part"
 msgstr "删除制造商零件"
 
@@ -7566,15 +7431,15 @@ msgstr "制造商零件操作"
 #~ msgstr "ManufacturerPart"
 
 #: src/pages/company/SupplierPartDetail.tsx:105
-#: src/tables/part/RelatedPartTable.tsx:83
+#: src/tables/part/RelatedPartTable.tsx:82
 msgid "Part Description"
 msgstr "零件描述"
 
 #: src/pages/company/SupplierPartDetail.tsx:180
 #: src/tables/part/PartPurchaseOrdersTable.tsx:73
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:187
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:229
-#: src/tables/purchasing/SupplierPartTable.tsx:169
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:191
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:233
+#: src/tables/purchasing/SupplierPartTable.tsx:138
 msgid "Pack Quantity"
 msgstr "包装数量"
 
@@ -7605,23 +7470,23 @@ msgid "Supplier Part Actions"
 msgstr "供应商零件操作"
 
 #: src/pages/company/SupplierPartDetail.tsx:338
-#: src/tables/purchasing/SupplierPartTable.tsx:283
+#: src/tables/purchasing/SupplierPartTable.tsx:244
 msgid "Edit Supplier Part"
 msgstr "编辑供应商零件"
 
 #: src/pages/company/SupplierPartDetail.tsx:346
-#: src/tables/purchasing/SupplierPartTable.tsx:308
+#: src/tables/purchasing/SupplierPartTable.tsx:264
 msgid "Delete Supplier Part"
 msgstr "删除供应商零件"
 
 #: src/pages/company/SupplierPartDetail.tsx:354
-#: src/tables/purchasing/SupplierPartTable.tsx:203
-#: src/tables/purchasing/SupplierPartTable.tsx:292
+#: src/tables/purchasing/SupplierPartTable.tsx:172
+#: src/tables/purchasing/SupplierPartTable.tsx:251
 msgid "Add Supplier Part"
 msgstr "添加供应商零件"
 
 #: src/pages/company/SupplierPartDetail.tsx:394
-#: src/pages/part/PartDetail.tsx:1000
+#: src/pages/part/PartDetail.tsx:1022
 msgid "No Stock"
 msgstr "无库存"
 
@@ -7647,7 +7512,7 @@ msgid "Group Roles"
 msgstr "分组角色"
 
 #: src/pages/core/UserDetail.tsx:175
-#: src/tables/ColumnRenderers.tsx:622
+#: src/tables/ColumnRenderers.tsx:437
 msgid "User Information"
 msgstr "用户信息"
 
@@ -7665,12 +7530,8 @@ msgid "User Details"
 msgstr "用户详情"
 
 #: src/pages/core/UserDetail.tsx:206
-msgid "Normal user"
-msgstr "普通用户"
-
-#: src/pages/core/UserDetail.tsx:206
-#~ msgid "Basic user"
-#~ msgstr "Basic user"
+msgid "Basic user"
+msgstr "基本用户"
 
 #: src/pages/part/CategoryDetail.tsx:103
 #: src/pages/stock/LocationDetail.tsx:103
@@ -7690,7 +7551,7 @@ msgstr "子类别"
 
 #: src/pages/part/CategoryDetail.tsx:149
 #: src/pages/stock/LocationDetail.tsx:143
-#: src/tables/part/PartCategoryTable.tsx:91
+#: src/tables/part/PartCategoryTable.tsx:89
 #: src/tables/stock/StockLocationTable.tsx:43
 msgid "Structural"
 msgstr "结构性"
@@ -7709,7 +7570,7 @@ msgstr "最高级零件类别"
 
 #: src/pages/part/CategoryDetail.tsx:183
 #: src/pages/part/CategoryDetail.tsx:251
-#: src/tables/part/PartCategoryTable.tsx:125
+#: src/tables/part/PartCategoryTable.tsx:122
 msgid "Edit Part Category"
 msgstr "编辑零件类别"
 
@@ -7744,7 +7605,7 @@ msgid "Action for child categories in this category"
 msgstr "对此类别中零件的操作"
 
 #: src/pages/part/CategoryDetail.tsx:247
-#: src/tables/part/PartCategoryTable.tsx:146
+#: src/tables/part/PartCategoryTable.tsx:143
 msgid "Category Actions"
 msgstr "类别操作"
 
@@ -7754,64 +7615,60 @@ msgstr "类别详情"
 
 #: src/pages/part/PartAllocationPanel.tsx:21
 #: src/pages/stock/StockDetail.tsx:555
-#: src/tables/part/PartTable.tsx:122
+#: src/tables/part/PartTable.tsx:121
 msgid "Build Order Allocations"
 msgstr "分配生产订单"
 
 #: src/pages/part/PartAllocationPanel.tsx:31
 #: src/pages/stock/StockDetail.tsx:570
-#: src/tables/part/PartTable.tsx:130
+#: src/tables/part/PartTable.tsx:129
 msgid "Sales Order Allocations"
 msgstr "分配销售订单"
 
-#: src/pages/part/PartDetail.tsx:177
-msgid "Validating BOM"
-msgstr "正在验证 BOM"
-
-#: src/pages/part/PartDetail.tsx:178
-msgid "BOM validated"
-msgstr "BOM 已验证"
-
-#: src/pages/part/PartDetail.tsx:187
-#~ msgid "Bill of materials scheduled for validation"
-#~ msgstr "Bill of materials scheduled for validation"
-
-#: src/pages/part/PartDetail.tsx:193
-#: src/pages/part/PartDetail.tsx:196
-#: src/pages/part/PartDetail.tsx:245
+#: src/pages/part/PartDetail.tsx:180
+#: src/pages/part/PartDetail.tsx:183
+#: src/pages/part/PartDetail.tsx:227
 msgid "Validate BOM"
 msgstr "验证物料清单"
 
-#: src/pages/part/PartDetail.tsx:197
+#: src/pages/part/PartDetail.tsx:184
 msgid "Do you want to validate the bill of materials for this assembly?"
 msgstr "您想要验证此装配的材料清单吗？"
 
-#: src/pages/part/PartDetail.tsx:223
+#: src/pages/part/PartDetail.tsx:187
+msgid "Bill of materials scheduled for validation"
+msgstr "待验证的物料清单"
+
+#: src/pages/part/PartDetail.tsx:187
+#~ msgid "BOM validated"
+#~ msgstr "BOM validated"
+
+#: src/pages/part/PartDetail.tsx:205
 msgid "BOM Validated"
 msgstr "物料清单已验证"
 
-#: src/pages/part/PartDetail.tsx:224
+#: src/pages/part/PartDetail.tsx:206
 msgid "The Bill of Materials for this part has been validated"
 msgstr "该零件的物料清单已完成验证"
 
-#: src/pages/part/PartDetail.tsx:228
-#: src/pages/part/PartDetail.tsx:233
+#: src/pages/part/PartDetail.tsx:210
+#: src/pages/part/PartDetail.tsx:215
 msgid "BOM Not Validated"
 msgstr "物料清单未验证"
 
-#: src/pages/part/PartDetail.tsx:229
+#: src/pages/part/PartDetail.tsx:211
 msgid "The Bill of Materials for this part has previously been checked, but requires revalidation"
 msgstr "该零件的物料清单已通过历史检验，但需重新验证"
 
-#: src/pages/part/PartDetail.tsx:234
+#: src/pages/part/PartDetail.tsx:216
 msgid "The Bill of Materials for this part has not yet been validated"
 msgstr "该零件的物料清单尚未完成验证"
 
-#: src/pages/part/PartDetail.tsx:265
+#: src/pages/part/PartDetail.tsx:247
 msgid "Validated On"
 msgstr "验证通过日期"
 
-#: src/pages/part/PartDetail.tsx:270
+#: src/pages/part/PartDetail.tsx:252
 msgid "Validated By"
 msgstr "验证人"
 
@@ -7831,239 +7688,246 @@ msgstr "验证人"
 #~ msgid "Delete part"
 #~ msgstr "Delete part"
 
-#: src/pages/part/PartDetail.tsx:441
+#: src/pages/part/PartDetail.tsx:466
 msgid "Variant of"
 msgstr "变体于"
 
-#: src/pages/part/PartDetail.tsx:449
+#: src/pages/part/PartDetail.tsx:473
 msgid "Revision of"
 msgstr "修订"
 
-#: src/pages/part/PartDetail.tsx:470
-#: src/tables/ColumnRenderers.tsx:390
-#: src/tables/ColumnRenderers.tsx:399
+#: src/pages/part/PartDetail.tsx:493
+#: src/tables/ColumnRenderers.tsx:209
+#: src/tables/ColumnRenderers.tsx:218
 msgid "Default Location"
 msgstr "默认位置"
 
-#: src/pages/part/PartDetail.tsx:477
+#: src/pages/part/PartDetail.tsx:500
 msgid "Category Default Location"
 msgstr "类别默认位置"
 
-#: src/pages/part/PartDetail.tsx:484
+#: src/pages/part/PartDetail.tsx:507
 msgid "Units"
 msgstr "单位"
-
-#: src/pages/part/PartDetail.tsx:491
-#: src/tables/settings/PendingTasksTable.tsx:51
-msgid "Keywords"
-msgstr "关键词"
 
 #: src/pages/part/PartDetail.tsx:510
 #~ msgid "Stocktake By"
 #~ msgstr "Stocktake By"
 
-#: src/pages/part/PartDetail.tsx:519
-#: src/tables/bom/BomTable.tsx:438
-#: src/tables/build/BuildLineTable.tsx:311
-#: src/tables/part/PartTable.tsx:316
-#: src/tables/sales/SalesOrderLineItemTable.tsx:134
+#: src/pages/part/PartDetail.tsx:514
+#: src/tables/settings/PendingTasksTable.tsx:51
+msgid "Keywords"
+msgstr "关键词"
+
+#: src/pages/part/PartDetail.tsx:542
+#: src/tables/bom/BomTable.tsx:445
+#: src/tables/build/BuildLineTable.tsx:306
+#: src/tables/part/PartTable.tsx:319
+#: src/tables/sales/SalesOrderLineItemTable.tsx:138
 msgid "Available Stock"
 msgstr "可用库存"
 
-#: src/pages/part/PartDetail.tsx:525
-#: src/tables/bom/BomTable.tsx:335
-#: src/tables/build/BuildLineTable.tsx:273
-#: src/tables/sales/SalesOrderLineItemTable.tsx:176
+#: src/pages/part/PartDetail.tsx:548
+#: src/tables/bom/BomTable.tsx:342
+#: src/tables/build/BuildLineTable.tsx:268
+#: src/tables/sales/SalesOrderLineItemTable.tsx:180
 msgid "On order"
 msgstr "订购中"
 
-#: src/pages/part/PartDetail.tsx:532
+#: src/pages/part/PartDetail.tsx:555
 msgid "Required for Orders"
 msgstr "订单必填项"
 
-#: src/pages/part/PartDetail.tsx:543
+#: src/pages/part/PartDetail.tsx:566
 msgid "Allocated to Build Orders"
 msgstr "分配生产订单"
 
-#: src/pages/part/PartDetail.tsx:555
+#: src/pages/part/PartDetail.tsx:578
 msgid "Allocated to Sales Orders"
 msgstr "分配销售订单"
 
-#: src/pages/part/PartDetail.tsx:582
+#: src/pages/part/PartDetail.tsx:605
 msgid "Minimum Stock"
 msgstr "最低库存"
-
-#: src/pages/part/PartDetail.tsx:597
-#: src/tables/part/ParametricPartTable.tsx:24
-#: src/tables/part/PartTable.tsx:204
-msgid "Locked"
-msgstr "已锁定"
-
-#: src/pages/part/PartDetail.tsx:603
-msgid "Template Part"
-msgstr "模板零件"
-
-#: src/pages/part/PartDetail.tsx:608
-#: src/tables/bom/BomTable.tsx:428
-msgid "Assembled Part"
-msgstr "组装零件"
-
-#: src/pages/part/PartDetail.tsx:613
-msgid "Component Part"
-msgstr "组件零件"
 
 #: src/pages/part/PartDetail.tsx:613
 #~ msgid "Scheduling"
 #~ msgstr "Scheduling"
 
-#: src/pages/part/PartDetail.tsx:618
-#: src/tables/bom/BomTable.tsx:413
+#: src/pages/part/PartDetail.tsx:620
+#: src/tables/part/ParametricPartTable.tsx:24
+#: src/tables/part/PartTable.tsx:203
+msgid "Locked"
+msgstr "已锁定"
+
+#: src/pages/part/PartDetail.tsx:626
+msgid "Template Part"
+msgstr "模板零件"
+
+#: src/pages/part/PartDetail.tsx:631
+#: src/tables/bom/BomTable.tsx:435
+msgid "Assembled Part"
+msgstr "组装零件"
+
+#: src/pages/part/PartDetail.tsx:636
+msgid "Component Part"
+msgstr "组件零件"
+
+#: src/pages/part/PartDetail.tsx:641
+#: src/tables/bom/BomTable.tsx:420
 msgid "Testable Part"
 msgstr "可测试零件"
 
-#: src/pages/part/PartDetail.tsx:624
-#: src/tables/bom/BomTable.tsx:418
+#: src/pages/part/PartDetail.tsx:647
+#: src/tables/bom/BomTable.tsx:425
 msgid "Trackable Part"
 msgstr "可追溯零件"
 
-#: src/pages/part/PartDetail.tsx:629
+#: src/pages/part/PartDetail.tsx:652
 msgid "Purchaseable Part"
 msgstr "可购买零件"
 
-#: src/pages/part/PartDetail.tsx:635
+#: src/pages/part/PartDetail.tsx:658
 msgid "Saleable Part"
 msgstr "可销售零件"
 
-#: src/pages/part/PartDetail.tsx:655
+#: src/pages/part/PartDetail.tsx:663
+#: src/pages/part/PartDetail.tsx:1058
+#: src/tables/bom/BomTable.tsx:151
+#: src/tables/bom/BomTable.tsx:440
+msgid "Virtual Part"
+msgstr "虚拟零件"
+
+#: src/pages/part/PartDetail.tsx:678
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:272
 #: src/pages/sales/ReturnOrderDetail.tsx:250
 #: src/pages/sales/SalesOrderDetail.tsx:243
-#: src/tables/ColumnRenderers.tsx:707
+#: src/tables/ColumnRenderers.tsx:521
 msgid "Creation Date"
 msgstr "创建日期"
 
-#: src/pages/part/PartDetail.tsx:660
-#: src/tables/ColumnRenderers.tsx:639
-#: src/tables/Filter.tsx:433
+#: src/pages/part/PartDetail.tsx:683
+#: src/tables/ColumnRenderers.tsx:454
+#: src/tables/Filter.tsx:373
 msgid "Created By"
 msgstr "创建人"
 
-#: src/pages/part/PartDetail.tsx:674
+#: src/pages/part/PartDetail.tsx:698
+msgid "Default Supplier"
+msgstr "默认供应商"
+
+#: src/pages/part/PartDetail.tsx:707
 msgid "Default Expiry"
 msgstr "默认有效期"
 
-#: src/pages/part/PartDetail.tsx:679
+#: src/pages/part/PartDetail.tsx:712
 msgid "days"
 msgstr "天"
 
-#: src/pages/part/PartDetail.tsx:689
+#: src/pages/part/PartDetail.tsx:722
 #: src/pages/part/pricing/BomPricingPanel.tsx:78
 #: src/pages/part/pricing/VariantPricingPanel.tsx:95
-#: src/tables/part/PartTable.tsx:180
+#: src/tables/part/PartTable.tsx:179
 msgid "Price Range"
 msgstr "价格范围"
 
-#: src/pages/part/PartDetail.tsx:698
-#~ msgid "Default Supplier"
-#~ msgstr "Default Supplier"
-
-#: src/pages/part/PartDetail.tsx:699
+#: src/pages/part/PartDetail.tsx:732
 msgid "Latest Serial Number"
 msgstr "最新序列号"
 
-#: src/pages/part/PartDetail.tsx:732
+#: src/pages/part/PartDetail.tsx:760
 msgid "Select Part Revision"
 msgstr "选择零件版本"
 
-#: src/pages/part/PartDetail.tsx:789
+#: src/pages/part/PartDetail.tsx:815
 msgid "Variants"
 msgstr "变体"
 
-#: src/pages/part/PartDetail.tsx:796
+#: src/pages/part/PartDetail.tsx:822
 #: src/pages/stock/StockDetail.tsx:542
 msgid "Allocations"
 msgstr "分配"
 
-#: src/pages/part/PartDetail.tsx:803
+#: src/pages/part/PartDetail.tsx:829
 msgid "Bill of Materials"
 msgstr "物料清单"
 
-#: src/pages/part/PartDetail.tsx:815
+#: src/pages/part/PartDetail.tsx:841
 msgid "Used In"
 msgstr "用于"
 
-#: src/pages/part/PartDetail.tsx:822
+#: src/pages/part/PartDetail.tsx:848
 msgid "Part Pricing"
 msgstr "零件价格"
 
-#: src/pages/part/PartDetail.tsx:892
+#: src/pages/part/PartDetail.tsx:918
 msgid "Test Templates"
 msgstr "测试模板"
 
-#: src/pages/part/PartDetail.tsx:914
+#: src/pages/part/PartDetail.tsx:940
 msgid "Related Parts"
 msgstr "关联零件"
 
-#: src/pages/part/PartDetail.tsx:926
+#: src/pages/part/PartDetail.tsx:952
 #: src/tables/ColumnRenderers.tsx:73
-#: src/tables/bom/BomTable.tsx:657
+#: src/tables/bom/BomTable.tsx:663
 #: src/tables/part/PartTestTemplateTable.tsx:258
 msgid "Part is Locked"
 msgstr "零件已锁定"
-
-#: src/pages/part/PartDetail.tsx:931
-msgid "Part parameters cannot be edited, as the part is locked"
-msgstr "零件参数无法编辑，因为零件已锁定"
 
 #: src/pages/part/PartDetail.tsx:956
 #~ msgid "Count part stock"
 #~ msgstr "Count part stock"
 
+#: src/pages/part/PartDetail.tsx:957
+msgid "Part parameters cannot be edited, as the part is locked"
+msgstr "零件参数无法编辑，因为零件已锁定"
+
 #: src/pages/part/PartDetail.tsx:967
 #~ msgid "Transfer part stock"
 #~ msgstr "Transfer part stock"
 
-#: src/pages/part/PartDetail.tsx:1012
+#: src/pages/part/PartDetail.tsx:1028
 #: src/tables/part/PartTestTemplateTable.tsx:112
 #: src/tables/stock/StockItemTestResultTable.tsx:405
 msgid "Required"
 msgstr "必填"
 
-#: src/pages/part/PartDetail.tsx:1030
+#: src/pages/part/PartDetail.tsx:1046
 msgid "Deficit"
-msgstr "不足"
+msgstr "短缺"
 
-#: src/pages/part/PartDetail.tsx:1070
-#: src/tables/part/PartTable.tsx:398
-#: src/tables/part/PartTable.tsx:452
+#: src/pages/part/PartDetail.tsx:1086
+#: src/tables/part/PartTable.tsx:396
+#: src/tables/part/PartTable.tsx:449
 msgid "Add Part"
 msgstr "添加零件"
 
-#: src/pages/part/PartDetail.tsx:1084
+#: src/pages/part/PartDetail.tsx:1100
 msgid "Delete Part"
 msgstr "删除零件"
 
-#: src/pages/part/PartDetail.tsx:1093
+#: src/pages/part/PartDetail.tsx:1109
 msgid "Deleting this part cannot be reversed"
 msgstr "删除此零件无法撤销"
 
-#: src/pages/part/PartDetail.tsx:1156
-#: src/pages/stock/StockDetail.tsx:885
+#: src/pages/part/PartDetail.tsx:1171
+#: src/pages/stock/StockDetail.tsx:884
 msgid "Order"
 msgstr "订单"
 
-#: src/pages/part/PartDetail.tsx:1157
-#: src/pages/stock/StockDetail.tsx:886
-#: src/tables/build/BuildLineTable.tsx:790
+#: src/pages/part/PartDetail.tsx:1172
+#: src/pages/stock/StockDetail.tsx:885
+#: src/tables/build/BuildLineTable.tsx:769
 msgid "Order Stock"
 msgstr "订单库存"
 
-#: src/pages/part/PartDetail.tsx:1169
+#: src/pages/part/PartDetail.tsx:1184
 msgid "Search by serial number"
 msgstr "按序列号搜索"
 
-#: src/pages/part/PartDetail.tsx:1177
-#: src/tables/part/PartTable.tsx:509
+#: src/pages/part/PartDetail.tsx:1192
+#: src/tables/part/PartTable.tsx:506
 msgid "Part Actions"
 msgstr "零件选项"
 
@@ -8142,46 +8006,35 @@ msgstr "销售记录"
 #~ msgid "Expected Quantity"
 #~ msgstr "Expected Quantity"
 
-#: src/pages/part/PartStockHistoryDetail.tsx:83
+#: src/pages/part/PartStockHistoryDetail.tsx:80
 msgid "Edit Stocktake Entry"
 msgstr "编辑盘点条目"
 
-#: src/pages/part/PartStockHistoryDetail.tsx:91
+#: src/pages/part/PartStockHistoryDetail.tsx:88
 msgid "Delete Stocktake Entry"
 msgstr "删除盘点条目"
 
-#: src/pages/part/PartStockHistoryDetail.tsx:109
-msgid "Stocktake report scheduled for generation"
-msgstr "计划生成的盘点报告"
-
-#: src/pages/part/PartStockHistoryDetail.tsx:123
-msgid "Stock Quantity"
-msgstr "库存数量"
-
-#: src/pages/part/PartStockHistoryDetail.tsx:129
-#: src/pages/part/PartStockHistoryDetail.tsx:242
+#: src/pages/part/PartStockHistoryDetail.tsx:107
+#: src/pages/part/PartStockHistoryDetail.tsx:211
 #: src/pages/stock/StockDetail.tsx:402
-#: src/tables/stock/StockItemTable.tsx:125
+#: src/tables/stock/StockItemTable.tsx:271
 msgid "Stock Value"
 msgstr "库存价值"
 
-#: src/pages/part/PartStockHistoryDetail.tsx:201
-msgid "Generate Stocktake Entry"
-msgstr "生成盘点条目"
-
-#: src/pages/part/PartStockHistoryDetail.tsx:271
+#: src/pages/part/PartStockHistoryDetail.tsx:240
 #: src/pages/part/pricing/PricingOverviewPanel.tsx:334
 msgid "Minimum Value"
 msgstr "最小值"
 
-#: src/pages/part/PartStockHistoryDetail.tsx:277
+#: src/pages/part/PartStockHistoryDetail.tsx:246
 #: src/pages/part/pricing/PricingOverviewPanel.tsx:335
 msgid "Maximum Value"
 msgstr "最大值"
 
-#: src/pages/part/PartStockHistoryDetail.tsx:304
-msgid "Stocktake Entries"
-msgstr "盘点录入"
+#: src/pages/part/PartStocktakeDetail.tsx:99
+#: src/tables/settings/StocktakeReportTable.tsx:70
+#~ msgid "Generate Stocktake Report"
+#~ msgstr "Generate Stocktake Report"
 
 #: src/pages/part/PartStocktakeDetail.tsx:104
 #: src/tables/settings/StocktakeReportTable.tsx:72
@@ -8195,21 +8048,21 @@ msgstr "盘点录入"
 
 #: src/pages/part/pricing/BomPricingPanel.tsx:57
 #: src/pages/part/pricing/BomPricingPanel.tsx:135
-#: src/tables/ColumnRenderers.tsx:767
-#: src/tables/bom/BomTable.tsx:276
-#: src/tables/general/ExtraLineItemTable.tsx:74
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:259
-#: src/tables/purchasing/PurchaseOrderTable.tsx:155
-#: src/tables/sales/ReturnOrderTable.tsx:160
-#: src/tables/sales/SalesOrderLineItemTable.tsx:120
-#: src/tables/sales/SalesOrderTable.tsx:197
+#: src/tables/ColumnRenderers.tsx:571
+#: src/tables/bom/BomTable.tsx:283
+#: src/tables/general/ExtraLineItemTable.tsx:72
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:261
+#: src/tables/purchasing/PurchaseOrderTable.tsx:138
+#: src/tables/sales/ReturnOrderTable.tsx:139
+#: src/tables/sales/SalesOrderLineItemTable.tsx:124
+#: src/tables/sales/SalesOrderTable.tsx:179
 msgid "Total Price"
 msgstr "总价"
 
 #: src/pages/part/pricing/BomPricingPanel.tsx:77
 #: src/pages/part/pricing/BomPricingPanel.tsx:101
-#: src/tables/bom/UsedInTable.tsx:59
-#: src/tables/part/PartTable.tsx:228
+#: src/tables/bom/UsedInTable.tsx:54
+#: src/tables/part/PartTable.tsx:227
 msgid "Component"
 msgstr "组件"
 
@@ -8239,11 +8092,11 @@ msgstr "最高价格"
 #: src/pages/part/pricing/PurchaseHistoryPanel.tsx:126
 #: src/pages/part/pricing/SupplierPricingPanel.tsx:66
 #: src/pages/stock/StockDetail.tsx:390
-#: src/tables/bom/BomTable.tsx:266
-#: src/tables/general/ExtraLineItemTable.tsx:66
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:255
+#: src/tables/bom/BomTable.tsx:273
+#: src/tables/general/ExtraLineItemTable.tsx:64
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:257
 #: src/tables/purchasing/SupplierPriceBreakTable.tsx:84
-#: src/tables/stock/StockItemTable.tsx:113
+#: src/tables/stock/StockItemTable.tsx:259
 msgid "Unit Price"
 msgstr "单价"
 
@@ -8321,12 +8174,9 @@ msgid "Purchase Pricing"
 msgstr "采购价格"
 
 #: src/pages/part/pricing/PricingOverviewPanel.tsx:288
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:311
-#: src/pages/sales/ReturnOrderDetail.tsx:289
-#: src/pages/sales/SalesOrderDetail.tsx:280
 #: src/pages/stock/StockDetail.tsx:426
 #: src/tables/general/ParameterTable.tsx:101
-#: src/tables/stock/StockItemTable.tsx:154
+#: src/tables/stock/StockItemTable.tsx:300
 msgid "Last Updated"
 msgstr "最近更新"
 
@@ -8398,8 +8248,8 @@ msgid "Edit Purchase Order"
 msgstr "编辑采购订单"
 
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:126
-#: src/tables/purchasing/PurchaseOrderTable.tsx:172
-#: src/tables/purchasing/PurchaseOrderTable.tsx:186
+#: src/tables/purchasing/PurchaseOrderTable.tsx:154
+#: src/tables/purchasing/PurchaseOrderTable.tsx:167
 msgid "Add Purchase Order"
 msgstr "添加采购订单"
 
@@ -8420,7 +8270,7 @@ msgid "Completed Line Items"
 msgstr "已完成行项目"
 
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:197
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:270
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:272
 msgid "Destination"
 msgstr "目的地"
 
@@ -8463,60 +8313,60 @@ msgstr "签发日期"
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:304
 #: src/pages/sales/ReturnOrderDetail.tsx:282
 #: src/pages/sales/SalesOrderDetail.tsx:273
-#: src/tables/ColumnRenderers.tsx:715
-#: src/tables/build/BuildOrderTable.tsx:141
+#: src/tables/ColumnRenderers.tsx:529
+#: src/tables/build/BuildOrderTable.tsx:137
 #: src/tables/part/PartPurchaseOrdersTable.tsx:106
 msgid "Completion Date"
 msgstr "完成日期"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:343
-#: src/pages/sales/ReturnOrderDetail.tsx:321
-#: src/pages/sales/SalesOrderDetail.tsx:359
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:334
+#: src/pages/sales/ReturnOrderDetail.tsx:312
+#: src/pages/sales/SalesOrderDetail.tsx:350
 msgid "Order Details"
 msgstr "订单细节"
 
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:340
 #: src/pages/purchasing/PurchaseOrderDetail.tsx:349
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:358
 #: src/pages/sales/ReturnOrderDetail.tsx:154
+#: src/pages/sales/ReturnOrderDetail.tsx:318
 #: src/pages/sales/ReturnOrderDetail.tsx:327
-#: src/pages/sales/ReturnOrderDetail.tsx:336
+#: src/pages/sales/SalesOrderDetail.tsx:356
 #: src/pages/sales/SalesOrderDetail.tsx:365
-#: src/pages/sales/SalesOrderDetail.tsx:374
 msgid "Line Items"
 msgstr "行项目"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:373
-#: src/pages/sales/ReturnOrderDetail.tsx:351
-#: src/pages/sales/SalesOrderDetail.tsx:388
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:364
+#: src/pages/sales/ReturnOrderDetail.tsx:342
+#: src/pages/sales/SalesOrderDetail.tsx:379
 msgid "Extra Line Items"
 msgstr "额外行项目"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:420
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:411
 msgid "Issue Purchase Order"
 msgstr "发布采购订单"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:428
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:419
 msgid "Cancel Purchase Order"
 msgstr "取消采购订单"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:436
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:427
 msgid "Hold Purchase Order"
 msgstr "挂起采购订单"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:444
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:435
 msgid "Complete Purchase Order"
 msgstr "完成采购订单"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:500
-#: src/pages/sales/ReturnOrderDetail.tsx:511
-#: src/pages/sales/SalesOrderDetail.tsx:564
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:491
+#: src/pages/sales/ReturnOrderDetail.tsx:502
+#: src/pages/sales/SalesOrderDetail.tsx:555
 msgid "Order Actions"
 msgstr "订单操作"
 
 #: src/pages/sales/ReturnOrderDetail.tsx:115
 #: src/pages/sales/SalesOrderDetail.tsx:105
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:131
-#: src/tables/sales/SalesOrderTable.tsx:156
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:132
+#: src/tables/sales/SalesOrderTable.tsx:142
 msgid "Customer Reference"
 msgstr "客户参考"
 
@@ -8526,7 +8376,7 @@ msgstr "退货地址"
 
 #: src/pages/sales/ReturnOrderDetail.tsx:202
 #: src/pages/sales/SalesOrderDetail.tsx:195
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:178
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:179
 msgid "Not specified"
 msgstr "未指定"
 
@@ -8534,29 +8384,29 @@ msgstr "未指定"
 #~ msgid "Order canceled"
 #~ msgstr "Order canceled"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:404
+#: src/pages/sales/ReturnOrderDetail.tsx:395
 msgid "Edit Return Order"
 msgstr "编辑退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:422
-#: src/tables/sales/ReturnOrderTable.tsx:176
-#: src/tables/sales/ReturnOrderTable.tsx:190
+#: src/pages/sales/ReturnOrderDetail.tsx:413
+#: src/tables/sales/ReturnOrderTable.tsx:154
+#: src/tables/sales/ReturnOrderTable.tsx:167
 msgid "Add Return Order"
 msgstr "添加退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:431
+#: src/pages/sales/ReturnOrderDetail.tsx:422
 msgid "Issue Return Order"
 msgstr "发布退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:439
+#: src/pages/sales/ReturnOrderDetail.tsx:430
 msgid "Cancel Return Order"
 msgstr "取消退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:447
+#: src/pages/sales/ReturnOrderDetail.tsx:438
 msgid "Hold Return Order"
 msgstr "挂起退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:455
+#: src/pages/sales/ReturnOrderDetail.tsx:446
 msgid "Complete Return Order"
 msgstr "完成退货订单"
 
@@ -8565,86 +8415,86 @@ msgid "Completed Shipments"
 msgstr "完成配送"
 
 #: src/pages/sales/SalesOrderDetail.tsx:189
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:167
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:168
 msgid "Shipping Address"
 msgstr "收货地址"
 
-#: src/pages/sales/SalesOrderDetail.tsx:326
+#: src/pages/sales/SalesOrderDetail.tsx:317
 msgid "Edit Sales Order"
 msgstr "编辑销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:348
+#: src/pages/sales/SalesOrderDetail.tsx:339
+#: src/tables/sales/SalesOrderTable.tsx:109
 #: src/tables/sales/SalesOrderTable.tsx:122
-#: src/tables/sales/SalesOrderTable.tsx:136
 msgid "Add Sales Order"
 msgstr "添加销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:406
-#: src/tables/sales/SalesOrderTable.tsx:166
+#: src/pages/sales/SalesOrderDetail.tsx:397
+#: src/tables/sales/SalesOrderTable.tsx:151
 msgid "Shipments"
 msgstr "配送"
 
-#: src/pages/sales/SalesOrderDetail.tsx:458
+#: src/pages/sales/SalesOrderDetail.tsx:449
 msgid "Issue Sales Order"
 msgstr "发布销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:466
+#: src/pages/sales/SalesOrderDetail.tsx:457
 msgid "Cancel Sales Order"
 msgstr "取消销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:474
+#: src/pages/sales/SalesOrderDetail.tsx:465
 msgid "Hold Sales Order"
 msgstr "挂起销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:482
+#: src/pages/sales/SalesOrderDetail.tsx:473
 msgid "Ship Sales Order"
 msgstr "销售订单发货"
 
-#: src/pages/sales/SalesOrderDetail.tsx:484
+#: src/pages/sales/SalesOrderDetail.tsx:475
 msgid "Ship this order?"
 msgstr "确认发货此订单？"
 
-#: src/pages/sales/SalesOrderDetail.tsx:485
+#: src/pages/sales/SalesOrderDetail.tsx:476
 msgid "Order shipped"
 msgstr "订单已发货"
 
-#: src/pages/sales/SalesOrderDetail.tsx:493
+#: src/pages/sales/SalesOrderDetail.tsx:484
 msgid "Complete Sales Order"
 msgstr "完成销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:538
+#: src/pages/sales/SalesOrderDetail.tsx:529
 msgid "Ship Order"
 msgstr "装货单"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:139
-#: src/tables/sales/SalesOrderShipmentTable.tsx:150
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:140
+#: src/tables/sales/SalesOrderShipmentTable.tsx:156
 msgid "Shipment Reference"
 msgstr "配送参考"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:145
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:146
 msgid "Tracking Number"
 msgstr "跟踪单号"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:153
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:154
 msgid "Invoice Number"
 msgstr "发票号码"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:188
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:189
 msgid "Allocated Items"
 msgstr "已分配的项"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:193
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:194
 msgid "Checked By"
-msgstr "审核人"
+msgstr "检查人"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:199
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:200
 msgid "Not checked"
-msgstr "未审查"
+msgstr "未检查"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:205
-#: src/tables/ColumnRenderers.tsx:723
-#: src/tables/sales/SalesOrderAllocationTable.tsx:181
-#: src/tables/sales/SalesOrderShipmentTable.tsx:184
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:206
+#: src/tables/ColumnRenderers.tsx:537
+#: src/tables/sales/SalesOrderAllocationTable.tsx:182
+#: src/tables/sales/SalesOrderShipmentTable.tsx:189
 msgid "Shipment Date"
 msgstr "发货日期"
 
@@ -8652,78 +8502,84 @@ msgstr "发货日期"
 #~ msgid "Assigned Items"
 #~ msgstr "Assigned Items"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:213
-#: src/tables/sales/SalesOrderShipmentTable.tsx:188
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:214
+#: src/tables/sales/SalesOrderShipmentTable.tsx:193
 msgid "Delivery Date"
 msgstr "送达日期"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:252
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:253
 msgid "Shipment Details"
 msgstr "发货详情"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:296
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:400
-#: src/tables/sales/SalesOrderShipmentTable.tsx:98
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:293
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:407
+#: src/tables/sales/SalesOrderShipmentTable.tsx:97
 msgid "Edit Shipment"
 msgstr "编辑配送"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:303
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:419
-#: src/tables/sales/SalesOrderShipmentTable.tsx:90
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:300
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:426
+#: src/tables/sales/SalesOrderShipmentTable.tsx:89
 msgid "Cancel Shipment"
 msgstr "取消发货"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:333
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:313
+#: src/tables/sales/SalesOrderShipmentTable.tsx:119
+#: src/tables/sales/SalesOrderShipmentTable.tsx:238
+msgid "Complete Shipment"
+msgstr "完成配送"
+
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:340
 #: src/tables/part/PartPurchaseOrdersTable.tsx:122
 msgid "Pending"
 msgstr "待定"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:339
-#: src/tables/sales/SalesOrderShipmentTable.tsx:163
-#: src/tables/sales/SalesOrderShipmentTable.tsx:294
-msgid "Checked"
-msgstr "已核对"
-
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:345
-msgid "Not Checked"
-msgstr "未核对"
-
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:351
-#: src/tables/sales/SalesOrderShipmentTable.tsx:170
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:346
+#: src/tables/sales/SalesOrderShipmentTable.tsx:168
 #: src/tables/sales/SalesOrderShipmentTable.tsx:299
+msgid "Checked"
+msgstr "已检查"
+
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:352
+msgid "Not Checked"
+msgstr "未检查"
+
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:358
+#: src/tables/sales/SalesOrderShipmentTable.tsx:175
+#: src/tables/sales/SalesOrderShipmentTable.tsx:304
 msgid "Shipped"
 msgstr "已配送"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:357
-#: src/tables/sales/SalesOrderShipmentTable.tsx:177
-#: src/tables/sales/SalesOrderShipmentTable.tsx:304
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:364
+#: src/tables/sales/SalesOrderShipmentTable.tsx:182
+#: src/tables/sales/SalesOrderShipmentTable.tsx:309
 #: src/tables/settings/EmailTable.tsx:31
 msgid "Delivered"
 msgstr "已送达"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:372
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:379
 msgid "Send Shipment"
 msgstr "发送货物"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:395
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:402
 msgid "Shipment Actions"
 msgstr "货运操作"
 
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:404
-msgid "Check"
-msgstr "已核对"
-
-#: src/pages/sales/SalesOrderShipmentDetail.tsx:405
-msgid "Mark shipment as checked"
-msgstr "标记为已核对"
-
 #: src/pages/sales/SalesOrderShipmentDetail.tsx:411
-msgid "Uncheck"
-msgstr "未核对"
+msgid "Check"
+msgstr "检查"
 
 #: src/pages/sales/SalesOrderShipmentDetail.tsx:412
+msgid "Mark shipment as checked"
+msgstr "标记发货单为已检查"
+
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:418
+msgid "Uncheck"
+msgstr "取消检查"
+
+#: src/pages/sales/SalesOrderShipmentDetail.tsx:419
 msgid "Mark shipment as unchecked"
-msgstr "标记为未核对"
+msgstr "标记发货单为未检查"
 
 #: src/pages/stock/LocationDetail.tsx:119
 msgid "Parent Location"
@@ -8756,8 +8612,8 @@ msgstr "默认零件"
 #~ msgstr "Child Locations Action"
 
 #: src/pages/stock/LocationDetail.tsx:249
-#: src/pages/stock/LocationDetail.tsx:411
-#: src/tables/stock/StockLocationTable.tsx:124
+#: src/pages/stock/LocationDetail.tsx:410
+#: src/tables/stock/StockLocationTable.tsx:121
 msgid "Edit Stock Location"
 msgstr "编辑库存地点"
 
@@ -8766,7 +8622,7 @@ msgid "Move items to parent location"
 msgstr "移动项目到父位置"
 
 #: src/pages/stock/LocationDetail.tsx:270
-#: src/pages/stock/LocationDetail.tsx:416
+#: src/pages/stock/LocationDetail.tsx:415
 msgid "Delete Stock Location"
 msgstr "删除库存地点"
 
@@ -8779,60 +8635,43 @@ msgid "Action for stock items in this location"
 msgstr "对此位置中的库存物品执行的操作"
 
 #: src/pages/stock/LocationDetail.tsx:280
-#: src/pages/stock/LocationDetail.tsx:407
-#: src/tables/stock/StockLocationTable.tsx:145
-msgid "Location Actions"
+msgid "Locations Action"
 msgstr "位置操作"
-
-#: src/pages/stock/LocationDetail.tsx:280
-#~ msgid "Locations Action"
-#~ msgstr "Locations Action"
 
 #: src/pages/stock/LocationDetail.tsx:282
 msgid "Action for child locations in this location"
 msgstr "对此位置中的子位置执行的操作"
 
-#: src/pages/stock/LocationDetail.tsx:317
+#: src/pages/stock/LocationDetail.tsx:316
 msgid "Scan Stock Item"
 msgstr "扫描库存物料"
 
-#: src/pages/stock/LocationDetail.tsx:335
-#: src/pages/stock/StockDetail.tsx:814
+#: src/pages/stock/LocationDetail.tsx:334
+#: src/pages/stock/StockDetail.tsx:813
 msgid "Scanned stock item into location"
 msgstr "库存物料已扫描入库"
 
-#: src/pages/stock/LocationDetail.tsx:341
-#: src/pages/stock/StockDetail.tsx:820
+#: src/pages/stock/LocationDetail.tsx:340
+#: src/pages/stock/StockDetail.tsx:819
 msgid "Error scanning stock item"
 msgstr "库存物料扫描错误"
 
-#: src/pages/stock/LocationDetail.tsx:348
+#: src/pages/stock/LocationDetail.tsx:347
 msgid "Scan Stock Location"
 msgstr "扫描库存地点"
 
-#: src/pages/stock/LocationDetail.tsx:360
+#: src/pages/stock/LocationDetail.tsx:359
 msgid "Scanned stock location into location"
 msgstr "库存地点绑定完成"
 
-#: src/pages/stock/LocationDetail.tsx:366
+#: src/pages/stock/LocationDetail.tsx:365
 msgid "Error scanning stock location"
 msgstr "库存地点扫描错误"
 
-#: src/pages/stock/LocationDetail.tsx:384
-msgid "Scan in stock items"
-msgstr "扫描入库库存项"
-
-#: src/pages/stock/LocationDetail.tsx:386
-msgid "Scan item into this location"
-msgstr "扫描物料至该库位"
-
-#: src/pages/stock/LocationDetail.tsx:390
-msgid "Scan in container"
-msgstr "扫描入库容器"
-
-#: src/pages/stock/LocationDetail.tsx:392
-msgid "Scan container into this location"
-msgstr "扫描容器至该库位"
+#: src/pages/stock/LocationDetail.tsx:406
+#: src/tables/stock/StockLocationTable.tsx:142
+msgid "Location Actions"
+msgstr "位置操作"
 
 #: src/pages/stock/StockDetail.tsx:147
 msgid "Base Part"
@@ -8902,6 +8741,10 @@ msgstr "最近库存盘点"
 msgid "Stock Details"
 msgstr "库存详情"
 
+#: src/pages/stock/StockDetail.tsx:532
+msgid "Stock Tracking"
+msgstr "库存跟踪"
+
 #: src/pages/stock/StockDetail.tsx:571
 #~ msgid "Test Data"
 #~ msgstr "Test Data"
@@ -8953,7 +8796,7 @@ msgstr "删除库存项"
 #~ msgid "Return this item into stock. This will remove the customer assignment."
 #~ msgstr "Return this item into stock. This will remove the customer assignment."
 
-#: src/pages/stock/StockDetail.tsx:772
+#: src/pages/stock/StockDetail.tsx:771
 msgid "Serialize Stock Item"
 msgstr "序列化库存"
 
@@ -8961,23 +8804,24 @@ msgstr "序列化库存"
 #~ msgid "Item returned to stock"
 #~ msgstr "Item returned to stock"
 
-#: src/pages/stock/StockDetail.tsx:788
+#: src/pages/stock/StockDetail.tsx:787
+#: src/tables/stock/StockItemTable.tsx:539
 msgid "Stock item serialized"
 msgstr "库存项已创建"
 
-#: src/pages/stock/StockDetail.tsx:796
+#: src/pages/stock/StockDetail.tsx:795
 msgid "Scan Into Location"
 msgstr "扫码入库至指定位置"
 
-#: src/pages/stock/StockDetail.tsx:854
+#: src/pages/stock/StockDetail.tsx:853
 msgid "Scan into location"
 msgstr "扫码入库"
 
-#: src/pages/stock/StockDetail.tsx:856
+#: src/pages/stock/StockDetail.tsx:855
 msgid "Scan this item into a location"
 msgstr "将此物料扫码入库至指定库位"
 
-#: src/pages/stock/StockDetail.tsx:868
+#: src/pages/stock/StockDetail.tsx:867
 msgid "Stock Operations"
 msgstr "库存操作"
 
@@ -8985,12 +8829,12 @@ msgstr "库存操作"
 #~ msgid "Count stock"
 #~ msgstr "Count stock"
 
-#: src/pages/stock/StockDetail.tsx:873
-#: src/tables/build/BuildOutputTable.tsx:571
+#: src/pages/stock/StockDetail.tsx:872
+#: src/tables/build/BuildOutputTable.tsx:522
 msgid "Serialize"
 msgstr "序列化"
 
-#: src/pages/stock/StockDetail.tsx:874
+#: src/pages/stock/StockDetail.tsx:873
 msgid "Serialize stock"
 msgstr "序列化库存"
 
@@ -8998,7 +8842,7 @@ msgstr "序列化库存"
 #~ msgid "Return from customer"
 #~ msgstr "Return from customer"
 
-#: src/pages/stock/StockDetail.tsx:899
+#: src/pages/stock/StockDetail.tsx:898
 msgid "Stock Item Actions"
 msgstr "库存项操作"
 
@@ -9014,17 +8858,17 @@ msgstr "库存项操作"
 #~ msgid "Assign to a customer"
 #~ msgstr "Assign to a customer"
 
-#: src/pages/stock/StockDetail.tsx:969
-#: src/tables/stock/StockItemTable.tsx:258
+#: src/pages/stock/StockDetail.tsx:968
+#: src/tables/stock/StockItemTable.tsx:404
 msgid "Stale"
 msgstr "呆滞"
 
-#: src/pages/stock/StockDetail.tsx:975
-#: src/tables/stock/StockItemTable.tsx:252
+#: src/pages/stock/StockDetail.tsx:974
+#: src/tables/stock/StockItemTable.tsx:398
 msgid "Expired"
 msgstr "已过期"
 
-#: src/pages/stock/StockDetail.tsx:981
+#: src/pages/stock/StockDetail.tsx:980
 msgid "Unavailable"
 msgstr "不可用"
 
@@ -9049,75 +8893,10 @@ msgstr "您已订阅此零件的通知"
 #~ msgid "No location set"
 #~ msgstr "No location set"
 
-#: src/tables/ColumnRenderers.tsx:162
-msgid "This stock item is in production"
-msgstr "该库存项正在生产"
-
-#: src/tables/ColumnRenderers.tsx:169
-msgid "This stock item has been assigned to a sales order"
-msgstr "库存项已分配到销售订单"
-
-#: src/tables/ColumnRenderers.tsx:176
-msgid "This stock item has been assigned to a customer"
-msgstr "库存项已分配给客户"
-
-#: src/tables/ColumnRenderers.tsx:183
-msgid "This stock item is installed in another stock item"
-msgstr "此库存项已安装在另一个库存项中"
-
-#: src/tables/ColumnRenderers.tsx:190
-msgid "This stock item has been consumed by a build order"
-msgstr "此库存项已被生产订单消耗"
-
-#: src/tables/ColumnRenderers.tsx:197
-msgid "This stock item is unavailable"
-msgstr "此库存项不可用"
-
-#: src/tables/ColumnRenderers.tsx:203
-msgid "This stock item has expired"
-msgstr "此库存项已过期"
-
-#: src/tables/ColumnRenderers.tsx:207
-msgid "This stock item is stale"
-msgstr "此库存项是过期项"
-
-#: src/tables/ColumnRenderers.tsx:219
-msgid "This stock item is over-allocated"
-msgstr "此库存项已超额分配"
-
-#: src/tables/ColumnRenderers.tsx:227
-msgid "This stock item is fully allocated"
-msgstr "此库存项已完全分配"
-
-#: src/tables/ColumnRenderers.tsx:234
-msgid "This stock item is partially allocated"
-msgstr "此库存项已被部分分配"
-
-#: src/tables/ColumnRenderers.tsx:252
-#: src/tables/build/BuildLineTable.tsx:308
-#: src/tables/sales/SalesOrderLineItemTable.tsx:156
-msgid "No stock available"
-msgstr "无可用库存"
-
-#: src/tables/ColumnRenderers.tsx:262
-msgid "This stock item has been depleted"
-msgstr "库存项已耗尽"
-
-#: src/tables/ColumnRenderers.tsx:283
-#: src/tables/bom/BomTable.tsx:352
-#: src/tables/part/PartTable.tsx:172
-#: src/tables/sales/SalesOrderLineItemTable.tsx:185
-msgid "Stock Information"
-msgstr "库存信息"
-
-#: src/tables/ColumnRenderers.tsx:545
-#: src/tables/build/BuildOutputTable.tsx:660
+#: src/tables/ColumnRenderers.tsx:360
+#: src/tables/build/BuildOutputTable.tsx:610
 msgid "Allocated Lines"
 msgstr "已分配的项目"
-
-#: src/tables/ColumnRenderers.tsx:774
-msgid "Line Item"
-msgstr "明细项"
 
 #: src/tables/ColumnSelect.tsx:16
 #: src/tables/ColumnSelect.tsx:23
@@ -9152,282 +8931,264 @@ msgstr "选择列"
 #~ msgid "Download Data"
 #~ msgstr "Download Data"
 
+#: src/tables/Filter.tsx:75
+msgid "Has Batch Code"
+msgstr "有批号"
+
+#: src/tables/Filter.tsx:76
+msgid "Show items which have a batch code"
+msgstr "显示有批号的项目"
+
+#: src/tables/Filter.tsx:84
+msgid "Filter items by batch code"
+msgstr "按批号筛选项目"
+
+#: src/tables/Filter.tsx:93
+msgid "Show items which are in stock"
+msgstr "显示库存中的项目"
+
+#: src/tables/Filter.tsx:100
+msgid "Is Serialized"
+msgstr "已序列化"
+
+#: src/tables/Filter.tsx:101
+msgid "Show items which have a serial number"
+msgstr "显示带有序列号的项目"
+
 #: src/tables/Filter.tsx:106
 #~ msgid "Show overdue orders"
 #~ msgstr "Show overdue orders"
 
-#: src/tables/Filter.tsx:117
-msgid "Has Batch Code"
-msgstr "有批号"
-
-#: src/tables/Filter.tsx:118
-msgid "Show items which have a batch code"
-msgstr "显示有批号的项目"
-
-#: src/tables/Filter.tsx:126
-msgid "Filter items by batch code"
-msgstr "按批号筛选项目"
-
-#: src/tables/Filter.tsx:135
-msgid "Show items which are in stock"
-msgstr "显示库存中的项目"
-
-#: src/tables/Filter.tsx:142
-msgid "Is Serialized"
-msgstr "已序列化"
-
-#: src/tables/Filter.tsx:143
-msgid "Show items which have a serial number"
-msgstr "显示带有序列号的项目"
-
-#: src/tables/Filter.tsx:150
+#: src/tables/Filter.tsx:108
 #: src/tables/build/BuildAllocatedStockTable.tsx:134
 msgid "Serial"
 msgstr "序列号"
 
-#: src/tables/Filter.tsx:151
+#: src/tables/Filter.tsx:109
 msgid "Filter items by serial number"
 msgstr "按序列号筛选项目"
 
-#: src/tables/Filter.tsx:159
+#: src/tables/Filter.tsx:117
 msgid "Serial Below"
 msgstr "序列号下方"
 
-#: src/tables/Filter.tsx:160
+#: src/tables/Filter.tsx:118
 msgid "Show items with serial numbers less than or equal to a given value"
 msgstr "显示序列号小于或等于给定值的项目"
 
-#: src/tables/Filter.tsx:168
+#: src/tables/Filter.tsx:126
 msgid "Serial Above"
 msgstr "序列号上方"
 
-#: src/tables/Filter.tsx:169
+#: src/tables/Filter.tsx:127
 msgid "Show items with serial numbers greater than or equal to a given value"
 msgstr "显示序列号大于或等于给定值的项目"
 
-#: src/tables/Filter.tsx:178
+#: src/tables/Filter.tsx:136
 msgid "Assigned to me"
 msgstr "已分派给我的"
 
-#: src/tables/Filter.tsx:179
+#: src/tables/Filter.tsx:137
 msgid "Show orders assigned to me"
 msgstr "显示分配给我的订单"
 
-#: src/tables/Filter.tsx:186
-#: src/tables/sales/SalesOrderAllocationTable.tsx:89
+#: src/tables/Filter.tsx:144
+#: src/tables/sales/SalesOrderAllocationTable.tsx:88
 msgid "Outstanding"
 msgstr "未完成"
 
-#: src/tables/Filter.tsx:187
+#: src/tables/Filter.tsx:145
 msgid "Show outstanding items"
 msgstr "显示未完成项"
 
-#: src/tables/Filter.tsx:195
+#: src/tables/Filter.tsx:153
 msgid "Show overdue items"
 msgstr "显示逾期项"
 
-#: src/tables/Filter.tsx:202
+#: src/tables/Filter.tsx:160
 msgid "Minimum Date"
 msgstr "最早日期"
 
-#: src/tables/Filter.tsx:203
+#: src/tables/Filter.tsx:161
 msgid "Show items after this date"
 msgstr "显示此日期之后的项目"
 
-#: src/tables/Filter.tsx:211
+#: src/tables/Filter.tsx:169
 msgid "Maximum Date"
 msgstr "最晚日期"
 
-#: src/tables/Filter.tsx:212
+#: src/tables/Filter.tsx:170
 msgid "Show items before this date"
 msgstr "显示此日期之前的项目"
 
-#: src/tables/Filter.tsx:220
+#: src/tables/Filter.tsx:178
 msgid "Created Before"
 msgstr "创建时间早于"
 
-#: src/tables/Filter.tsx:221
+#: src/tables/Filter.tsx:179
 msgid "Show items created before this date"
 msgstr "显示早于此日期创建的项目"
 
-#: src/tables/Filter.tsx:229
+#: src/tables/Filter.tsx:187
 msgid "Created After"
 msgstr "创建时间晚于"
 
-#: src/tables/Filter.tsx:230
+#: src/tables/Filter.tsx:188
 msgid "Show items created after this date"
 msgstr "显示此日期之后创建的项目"
 
-#: src/tables/Filter.tsx:238
+#: src/tables/Filter.tsx:196
 msgid "Start Date Before"
 msgstr "开始日期早于"
 
-#: src/tables/Filter.tsx:239
+#: src/tables/Filter.tsx:197
 msgid "Show items with a start date before this date"
 msgstr "显示开始日期早于此日期的项目"
 
-#: src/tables/Filter.tsx:247
+#: src/tables/Filter.tsx:205
 msgid "Start Date After"
 msgstr "开始日期晚于"
 
-#: src/tables/Filter.tsx:248
+#: src/tables/Filter.tsx:206
 msgid "Show items with a start date after this date"
 msgstr "显示开始日期晚于此日期的项目"
 
-#: src/tables/Filter.tsx:256
+#: src/tables/Filter.tsx:214
 msgid "Target Date Before"
 msgstr "目标日期早于"
 
-#: src/tables/Filter.tsx:257
+#: src/tables/Filter.tsx:215
 msgid "Show items with a target date before this date"
 msgstr "显示目标日期早于此日期的项目"
 
-#: src/tables/Filter.tsx:265
+#: src/tables/Filter.tsx:223
 msgid "Target Date After"
 msgstr "目标日期晚于"
 
-#: src/tables/Filter.tsx:266
+#: src/tables/Filter.tsx:224
 msgid "Show items with a target date after this date"
 msgstr "显示目标日期晚于此日期的项目"
 
-#: src/tables/Filter.tsx:274
+#: src/tables/Filter.tsx:232
 msgid "Completed Before"
 msgstr "完成时间早于"
 
-#: src/tables/Filter.tsx:275
+#: src/tables/Filter.tsx:233
 msgid "Show items completed before this date"
 msgstr "显示在此日期之前完成的项目"
 
-#: src/tables/Filter.tsx:283
+#: src/tables/Filter.tsx:241
 msgid "Completed After"
 msgstr "完成时间晚于"
 
-#: src/tables/Filter.tsx:284
+#: src/tables/Filter.tsx:242
 msgid "Show items completed after this date"
 msgstr "显示在此日期之后完成的项目"
 
-#: src/tables/Filter.tsx:292
-#: src/tables/stock/StockItemTable.tsx:284
-msgid "Updated After"
-msgstr "在此之后更新"
-
-#: src/tables/Filter.tsx:293
-msgid "Show orders updated after this date"
-msgstr "显示此日期后更新的订单"
-
-#: src/tables/Filter.tsx:301
-#: src/tables/stock/StockItemTable.tsx:278
-msgid "Updated Before"
-msgstr "在此之前更新"
-
-#: src/tables/Filter.tsx:302
-msgid "Show orders updated before this date"
-msgstr "显示在此日期之前更新的订单"
-
-#: src/tables/Filter.tsx:314
+#: src/tables/Filter.tsx:254
 msgid "Has Project Code"
 msgstr "有项目编码"
 
-#: src/tables/Filter.tsx:315
+#: src/tables/Filter.tsx:255
 msgid "Show orders with an assigned project code"
 msgstr "显示已分配项目编码的订单"
 
-#: src/tables/Filter.tsx:324
+#: src/tables/Filter.tsx:264
 msgid "Include Variants"
 msgstr "包含变体"
 
-#: src/tables/Filter.tsx:325
+#: src/tables/Filter.tsx:265
 msgid "Include results for part variants"
 msgstr "包含零件变体结果"
 
-#: src/tables/Filter.tsx:335
+#: src/tables/Filter.tsx:275
 #: src/tables/part/PartPurchaseOrdersTable.tsx:133
 msgid "Filter by order status"
 msgstr "按订单状态筛选"
 
-#: src/tables/Filter.tsx:347
+#: src/tables/Filter.tsx:287
 msgid "Filter by project code"
 msgstr "按项目编码筛选"
 
-#: src/tables/Filter.tsx:380
+#: src/tables/Filter.tsx:320
 msgid "Filter by responsible owner"
 msgstr "根据负责人进行筛选"
 
-#: src/tables/Filter.tsx:396
-#: src/tables/settings/ApiTokenTable.tsx:128
-#: src/tables/stock/StockTrackingTable.tsx:226
+#: src/tables/Filter.tsx:336
+#: src/tables/settings/ApiTokenTable.tsx:127
+#: src/tables/stock/StockTrackingTable.tsx:206
 msgid "Filter by user"
 msgstr "按用户筛选"
 
-#: src/tables/Filter.tsx:408
+#: src/tables/Filter.tsx:348
 msgid "Filter by manufacturer"
 msgstr "按制造商筛选"
 
-#: src/tables/Filter.tsx:421
+#: src/tables/Filter.tsx:361
 msgid "Filter by supplier"
 msgstr "按供应商筛选"
 
-#: src/tables/Filter.tsx:434
+#: src/tables/Filter.tsx:374
 msgid "Filter by user who created the order"
 msgstr "按订单创建人筛选"
 
-#: src/tables/Filter.tsx:442
+#: src/tables/Filter.tsx:382
 msgid "Filter by user who issued the order"
 msgstr "按订单签发人筛选"
 
-#: src/tables/Filter.tsx:450
+#: src/tables/Filter.tsx:390
 msgid "Filter by part category"
 msgstr "按零件类别筛选"
 
-#: src/tables/Filter.tsx:461
+#: src/tables/Filter.tsx:401
 msgid "Filter by stock location"
 msgstr "按库存库位筛选"
 
-#: src/tables/FilterSelectDrawer.tsx:97
+#: src/tables/FilterSelectDrawer.tsx:59
 msgid "Remove filter"
 msgstr "移除过滤器"
 
-#: src/tables/FilterSelectDrawer.tsx:143
-#: src/tables/FilterSelectDrawer.tsx:145
-#: src/tables/FilterSelectDrawer.tsx:192
+#: src/tables/FilterSelectDrawer.tsx:102
+#: src/tables/FilterSelectDrawer.tsx:104
+#: src/tables/FilterSelectDrawer.tsx:151
 msgid "Select filter value"
 msgstr "选择过滤器值"
 
-#: src/tables/FilterSelectDrawer.tsx:157
+#: src/tables/FilterSelectDrawer.tsx:116
 msgid "Enter filter value"
 msgstr "输入筛选值"
 
-#: src/tables/FilterSelectDrawer.tsx:179
+#: src/tables/FilterSelectDrawer.tsx:138
 msgid "Select date value"
 msgstr "选择日期值"
 
-#: src/tables/FilterSelectDrawer.tsx:301
+#: src/tables/FilterSelectDrawer.tsx:260
 msgid "Select filter"
 msgstr "选择过滤器"
 
-#: src/tables/FilterSelectDrawer.tsx:302
+#: src/tables/FilterSelectDrawer.tsx:261
 msgid "Filter"
 msgstr "过滤器"
 
-#: src/tables/FilterSelectDrawer.tsx:354
-#: src/tables/InvenTreeTableHeader.tsx:259
+#: src/tables/FilterSelectDrawer.tsx:313
+#: src/tables/InvenTreeTableHeader.tsx:260
 msgid "Table Filters"
 msgstr "表格筛选"
 
-#: src/tables/FilterSelectDrawer.tsx:392
+#: src/tables/FilterSelectDrawer.tsx:346
 msgid "Add Filter"
 msgstr "添加过滤条件"
 
-#: src/tables/FilterSelectDrawer.tsx:401
+#: src/tables/FilterSelectDrawer.tsx:355
 msgid "Clear Filters"
 msgstr "清除筛选"
 
-#: src/tables/InvenTreeTable.tsx:47
-#: src/tables/InvenTreeTable.tsx:522
+#: src/tables/InvenTreeTable.tsx:46
+#: src/tables/InvenTreeTable.tsx:481
 msgid "No records found"
 msgstr "没有找到记录"
 
-#: src/tables/InvenTreeTable.tsx:154
+#: src/tables/InvenTreeTable.tsx:153
 msgid "Error loading table options"
 msgstr "表格选项加载错误"
 
@@ -9438,6 +9199,10 @@ msgstr "表格选项加载错误"
 #: src/tables/InvenTreeTable.tsx:510
 #~ msgid "Are you sure you want to delete the selected records?"
 #~ msgstr "Are you sure you want to delete the selected records?"
+
+#: src/tables/InvenTreeTable.tsx:522
+msgid "Server returned incorrect data type"
+msgstr "服务器返回了错误的数据类型"
 
 #: src/tables/InvenTreeTable.tsx:535
 #~ msgid "Deleted records"
@@ -9455,23 +9220,27 @@ msgstr "表格选项加载错误"
 #~ msgid "This action cannot be undone!"
 #~ msgstr "This action cannot be undone!"
 
-#: src/tables/InvenTreeTable.tsx:567
-msgid "Server returned incorrect data type"
-msgstr "服务器返回了错误的数据类型"
+#: src/tables/InvenTreeTable.tsx:555
+msgid "Error loading table data"
+msgstr "表格数据加载错误"
 
 #: src/tables/InvenTreeTable.tsx:594
 #: src/tables/InvenTreeTable.tsx:595
 #~ msgid "Print actions"
 #~ msgstr "Print actions"
 
-#: src/tables/InvenTreeTable.tsx:600
-msgid "Error loading table data"
-msgstr "表格数据加载错误"
-
 #: src/tables/InvenTreeTable.tsx:655
 #: src/tables/InvenTreeTable.tsx:656
 #~ msgid "Barcode actions"
 #~ msgstr "Barcode actions"
+
+#: src/tables/InvenTreeTable.tsx:684
+msgid "View details"
+msgstr "查看详情"
+
+#: src/tables/InvenTreeTable.tsx:687
+msgid "View {model}"
+msgstr "查看 {model}"
 
 #: src/tables/InvenTreeTable.tsx:712
 #~ msgid "Table filters"
@@ -9481,49 +9250,41 @@ msgstr "表格数据加载错误"
 #~ msgid "Clear custom query filters"
 #~ msgstr "Clear custom query filters"
 
-#: src/tables/InvenTreeTable.tsx:729
-msgid "View details"
-msgstr "查看详情"
-
-#: src/tables/InvenTreeTable.tsx:732
-msgid "View {model}"
-msgstr "{model} 视图"
-
-#: src/tables/InvenTreeTableHeader.tsx:103
+#: src/tables/InvenTreeTableHeader.tsx:104
 msgid "Delete Selected Items"
 msgstr "删除所选项目"
 
-#: src/tables/InvenTreeTableHeader.tsx:107
+#: src/tables/InvenTreeTableHeader.tsx:108
 msgid "Are you sure you want to delete the selected items?"
 msgstr "确定要删除所选的项目吗?"
 
-#: src/tables/InvenTreeTableHeader.tsx:109
-#: src/tables/plugin/PluginListTable.tsx:320
+#: src/tables/InvenTreeTableHeader.tsx:110
+#: src/tables/plugin/PluginListTable.tsx:316
 msgid "This action cannot be undone"
 msgstr "该操作无法撤销"
 
-#: src/tables/InvenTreeTableHeader.tsx:120
+#: src/tables/InvenTreeTableHeader.tsx:121
 msgid "Items deleted"
 msgstr "物料已删除"
 
-#: src/tables/InvenTreeTableHeader.tsx:125
+#: src/tables/InvenTreeTableHeader.tsx:126
 msgid "Failed to delete items"
 msgstr "删除物料失败"
 
-#: src/tables/InvenTreeTableHeader.tsx:176
+#: src/tables/InvenTreeTableHeader.tsx:177
 msgid "Custom table filters are active"
 msgstr "当前启用了自定义表格筛选器"
 
-#: src/tables/InvenTreeTableHeader.tsx:202
+#: src/tables/InvenTreeTableHeader.tsx:203
 #: src/tables/general/BarcodeScanTable.tsx:93
 msgid "Delete selected records"
 msgstr "删除选中的记录"
 
-#: src/tables/InvenTreeTableHeader.tsx:222
+#: src/tables/InvenTreeTableHeader.tsx:223
 msgid "Refresh data"
 msgstr "刷新数据"
 
-#: src/tables/InvenTreeTableHeader.tsx:271
+#: src/tables/InvenTreeTableHeader.tsx:272
 msgid "Active Filters"
 msgstr "当前生效的筛选条件"
 
@@ -9535,66 +9296,61 @@ msgstr "当前生效的筛选条件"
 #~ msgid "Upload Data"
 #~ msgstr "Upload Data"
 
-#: src/tables/bom/BomTable.tsx:98
+#: src/tables/bom/BomTable.tsx:102
 msgid "This BOM item is defined for a different parent"
 msgstr "此物料清单项目是为另一个上级定义的"
 
-#: src/tables/bom/BomTable.tsx:114
+#: src/tables/bom/BomTable.tsx:118
 msgid "Part Information"
 msgstr "零件信息"
 
-#: src/tables/bom/BomTable.tsx:117
+#: src/tables/bom/BomTable.tsx:121
 msgid "This BOM item has not been validated"
 msgstr "该物料清单物料未经验证"
 
-#: src/tables/bom/BomTable.tsx:234
+#: src/tables/bom/BomTable.tsx:241
 msgid "Substitutes"
 msgstr "替代料"
-
-#: src/tables/bom/BomTable.tsx:296
-#: src/tables/sales/SalesOrderLineItemTable.tsx:137
-#: src/tables/sales/SalesOrderLineItemTable.tsx:195
-#: src/tables/sales/SalesOrderLineItemTable.tsx:212
-msgid "Virtual part"
-msgstr "虚拟零件"
 
 #: src/tables/bom/BomTable.tsx:301
 #~ msgid "Create BOM Item"
 #~ msgstr "Create BOM Item"
 
-#: src/tables/bom/BomTable.tsx:309
-#: src/tables/build/BuildLineTable.tsx:282
-#: src/tables/part/PartTable.tsx:146
-msgid "External stock"
-msgstr "外部库存"
+#: src/tables/bom/BomTable.tsx:303
+#: src/tables/sales/SalesOrderLineItemTable.tsx:141
+#: src/tables/sales/SalesOrderLineItemTable.tsx:199
+#: src/tables/sales/SalesOrderLineItemTable.tsx:216
+msgid "Virtual part"
+msgstr "虚拟零件"
 
 #: src/tables/bom/BomTable.tsx:310
 #~ msgid "Show asssmbled items"
 #~ msgstr "Show asssmbled items"
 
-#: src/tables/bom/BomTable.tsx:317
-#: src/tables/build/BuildLineTable.tsx:245
+#: src/tables/bom/BomTable.tsx:316
+#: src/tables/build/BuildLineTable.tsx:277
+#: src/tables/part/PartTable.tsx:145
+msgid "External stock"
+msgstr "外部库存"
+
+#: src/tables/bom/BomTable.tsx:324
+#: src/tables/build/BuildLineTable.tsx:240
 msgid "Includes substitute stock"
 msgstr "包括替代库存"
-
-#: src/tables/bom/BomTable.tsx:326
-#: src/tables/build/BuildLineTable.tsx:255
-#: src/tables/sales/SalesOrderLineItemTable.tsx:162
-msgid "Includes variant stock"
-msgstr "包括变体库存"
 
 #: src/tables/bom/BomTable.tsx:331
 #~ msgid "Edit Bom Item"
 #~ msgstr "Edit Bom Item"
 
 #: src/tables/bom/BomTable.tsx:333
+#: src/tables/build/BuildLineTable.tsx:250
+#: src/tables/sales/SalesOrderLineItemTable.tsx:166
+msgid "Includes variant stock"
+msgstr "包括变体库存"
+
+#: src/tables/bom/BomTable.tsx:333
 #~ msgid "Bom item updated"
 #~ msgstr "Bom item updated"
-
-#: src/tables/bom/BomTable.tsx:343
-#: src/tables/part/PartTable.tsx:115
-msgid "Building"
-msgstr "正在生产"
 
 #: src/tables/bom/BomTable.tsx:348
 #~ msgid "Delete Bom Item"
@@ -9604,6 +9360,11 @@ msgstr "正在生产"
 #~ msgid "Bom item deleted"
 #~ msgstr "Bom item deleted"
 
+#: src/tables/bom/BomTable.tsx:350
+#: src/tables/part/PartTable.tsx:114
+msgid "Building"
+msgstr "正在生产"
+
 #: src/tables/bom/BomTable.tsx:351
 #~ msgid "Are you sure you want to remove this BOM item?"
 #~ msgstr "Are you sure you want to remove this BOM item?"
@@ -9612,209 +9373,214 @@ msgstr "正在生产"
 #~ msgid "Validate BOM line"
 #~ msgstr "Validate BOM line"
 
-#: src/tables/bom/BomTable.tsx:393
+#: src/tables/bom/BomTable.tsx:359
+#: src/tables/part/PartTable.tsx:171
+#: src/tables/sales/SalesOrderLineItemTable.tsx:189
+#: src/tables/stock/StockItemTable.tsx:222
+msgid "Stock Information"
+msgstr "库存信息"
+
+#: src/tables/bom/BomTable.tsx:400
 #: src/tables/build/BuildLineTable.tsx:498
 #: src/tables/build/BuildLineTable.tsx:539
 msgid "Consumable item"
 msgstr "可耗物品"
 
-#: src/tables/bom/BomTable.tsx:396
+#: src/tables/bom/BomTable.tsx:403
 msgid "No available stock"
 msgstr "无可用库存"
 
-#: src/tables/bom/BomTable.tsx:414
-#: src/tables/build/BuildLineTable.tsx:219
+#: src/tables/bom/BomTable.tsx:421
+#: src/tables/build/BuildLineTable.tsx:214
 msgid "Show testable items"
 msgstr "显示可跟踪项目"
 
-#: src/tables/bom/BomTable.tsx:419
+#: src/tables/bom/BomTable.tsx:426
 msgid "Show trackable items"
 msgstr "显示可跟踪项目"
 
-#: src/tables/bom/BomTable.tsx:423
-#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:42
-#: src/tables/purchasing/ManufacturerPartTable.tsx:154
-#: src/tables/purchasing/SupplierPartTable.tsx:259
+#: src/tables/bom/BomTable.tsx:430
+#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:44
+#: src/tables/purchasing/ManufacturerPartTable.tsx:134
+#: src/tables/purchasing/SupplierPartTable.tsx:220
 msgid "Active Part"
 msgstr "激活的零件"
 
-#: src/tables/bom/BomTable.tsx:424
+#: src/tables/bom/BomTable.tsx:431
 msgid "Show active items"
-msgstr "显示有效项"
+msgstr "显示活跃项目"
 
-#: src/tables/bom/BomTable.tsx:429
-#: src/tables/build/BuildLineTable.tsx:214
+#: src/tables/bom/BomTable.tsx:436
+#: src/tables/build/BuildLineTable.tsx:209
 msgid "Show assembled items"
 msgstr "显示已装配的项目"
 
-#: src/tables/bom/BomTable.tsx:434
+#: src/tables/bom/BomTable.tsx:441
 msgid "Show virtual items"
 msgstr "显示虚拟项"
 
-#: src/tables/bom/BomTable.tsx:439
+#: src/tables/bom/BomTable.tsx:446
 msgid "Show items with available stock"
 msgstr "显示有可用库存的项目"
 
-#: src/tables/bom/BomTable.tsx:444
+#: src/tables/bom/BomTable.tsx:451
 msgid "Show items on order"
 msgstr "按顺序显示项目"
 
-#: src/tables/bom/BomTable.tsx:448
+#: src/tables/bom/BomTable.tsx:455
 msgid "Validated"
 msgstr "已验证"
 
-#: src/tables/bom/BomTable.tsx:449
+#: src/tables/bom/BomTable.tsx:456
 msgid "Show validated items"
 msgstr "显示已验证的项目"
 
-#: src/tables/bom/BomTable.tsx:453
-#: src/tables/bom/UsedInTable.tsx:85
+#: src/tables/bom/BomTable.tsx:460
+#: src/tables/bom/UsedInTable.tsx:80
 msgid "Inherited"
 msgstr "继承项"
 
-#: src/tables/bom/BomTable.tsx:454
-#: src/tables/bom/UsedInTable.tsx:86
+#: src/tables/bom/BomTable.tsx:461
+#: src/tables/bom/UsedInTable.tsx:81
 msgid "Show inherited items"
 msgstr "显示继承的项目"
 
-#: src/tables/bom/BomTable.tsx:458
+#: src/tables/bom/BomTable.tsx:465
 msgid "Allow Variants"
 msgstr "允许变体"
 
-#: src/tables/bom/BomTable.tsx:459
+#: src/tables/bom/BomTable.tsx:466
 msgid "Show items which allow variant substitution"
 msgstr "显示允许变体替换的项目"
 
-#: src/tables/bom/BomTable.tsx:463
-#: src/tables/bom/UsedInTable.tsx:90
-#: src/tables/build/BuildLineTable.tsx:208
+#: src/tables/bom/BomTable.tsx:470
+#: src/tables/bom/UsedInTable.tsx:85
+#: src/tables/build/BuildLineTable.tsx:203
 msgid "Optional"
 msgstr "可选项"
 
-#: src/tables/bom/BomTable.tsx:464
-#: src/tables/bom/UsedInTable.tsx:91
+#: src/tables/bom/BomTable.tsx:471
+#: src/tables/bom/UsedInTable.tsx:86
 msgid "Show optional items"
 msgstr "显示可选项目"
 
-#: src/tables/bom/BomTable.tsx:468
-#: src/tables/build/BuildLineTable.tsx:203
+#: src/tables/bom/BomTable.tsx:475
+#: src/tables/build/BuildLineTable.tsx:198
 msgid "Consumable"
 msgstr "消耗品"
 
-#: src/tables/bom/BomTable.tsx:469
+#: src/tables/bom/BomTable.tsx:476
 msgid "Show consumable items"
 msgstr "显示可消耗项目"
 
-#: src/tables/bom/BomTable.tsx:473
-#: src/tables/part/PartTable.tsx:310
+#: src/tables/bom/BomTable.tsx:480
+#: src/tables/part/PartTable.tsx:313
 msgid "Has Pricing"
 msgstr "是否有价格"
 
-#: src/tables/bom/BomTable.tsx:474
+#: src/tables/bom/BomTable.tsx:481
 msgid "Show items with pricing"
 msgstr "显示带定价的项目"
 
-#: src/tables/bom/BomTable.tsx:496
+#: src/tables/bom/BomTable.tsx:503
 msgid "Import BOM Data"
 msgstr "导入物料清单数据"
 
-#: src/tables/bom/BomTable.tsx:507
-#: src/tables/bom/BomTable.tsx:631
+#: src/tables/bom/BomTable.tsx:513
+#: src/tables/bom/BomTable.tsx:637
 msgid "Add BOM Item"
 msgstr "添加物料清单项"
 
-#: src/tables/bom/BomTable.tsx:512
+#: src/tables/bom/BomTable.tsx:518
 msgid "BOM item created"
 msgstr "BOM 项目已创建"
 
-#: src/tables/bom/BomTable.tsx:519
-#: src/tables/bom/UsedInTable.tsx:111
+#: src/tables/bom/BomTable.tsx:525
 msgid "Edit BOM Item"
 msgstr "编辑物料清单项目"
 
-#: src/tables/bom/BomTable.tsx:521
-#: src/tables/bom/UsedInTable.tsx:115
+#: src/tables/bom/BomTable.tsx:527
 msgid "BOM item updated"
 msgstr "物料清单 项目已更新"
 
-#: src/tables/bom/BomTable.tsx:528
+#: src/tables/bom/BomTable.tsx:534
 msgid "Delete BOM Item"
 msgstr "删除物料清单项目"
 
-#: src/tables/bom/BomTable.tsx:529
+#: src/tables/bom/BomTable.tsx:535
 msgid "BOM item deleted"
 msgstr "物料清单项目已删除"
 
-#: src/tables/bom/BomTable.tsx:549
+#: src/tables/bom/BomTable.tsx:555
 msgid "BOM item validated"
 msgstr "物料清单项目已验证"
 
-#: src/tables/bom/BomTable.tsx:558
+#: src/tables/bom/BomTable.tsx:564
 msgid "Failed to validate BOM item"
 msgstr "验证物料清单项目失败"
 
-#: src/tables/bom/BomTable.tsx:570
+#: src/tables/bom/BomTable.tsx:576
 msgid "View BOM"
 msgstr "查看 物料清单"
 
-#: src/tables/bom/BomTable.tsx:581
+#: src/tables/bom/BomTable.tsx:587
 msgid "Validate BOM Line"
 msgstr "验证物料清单行"
 
-#: src/tables/bom/BomTable.tsx:600
+#: src/tables/bom/BomTable.tsx:606
 msgid "Edit Substitutes"
 msgstr "编辑替代零件"
 
-#: src/tables/bom/BomTable.tsx:625
+#: src/tables/bom/BomTable.tsx:631
 msgid "Add BOM Items"
-msgstr "添加物料清单项目"
+msgstr "添加工料清单项目"
 
-#: src/tables/bom/BomTable.tsx:633
+#: src/tables/bom/BomTable.tsx:639
 msgid "Add a single BOM item"
 msgstr "添加单个物料清单项目"
 
-#: src/tables/bom/BomTable.tsx:637
-#: src/tables/general/ParameterTable.tsx:202
-#: src/tables/part/PartTable.tsx:549
+#: src/tables/bom/BomTable.tsx:643
+#: src/tables/general/ParameterTable.tsx:206
+#: src/tables/part/PartTable.tsx:546
 msgid "Import from File"
 msgstr "从文件导入"
 
-#: src/tables/bom/BomTable.tsx:639
+#: src/tables/bom/BomTable.tsx:645
 msgid "Import BOM items from a file"
 msgstr "从文件导入物料清单项目"
 
-#: src/tables/bom/BomTable.tsx:662
+#: src/tables/bom/BomTable.tsx:668
 msgid "Bill of materials cannot be edited, as the part is locked"
 msgstr "无法编辑材料清单，因为零件已锁定"
 
-#: src/tables/bom/UsedInTable.tsx:41
-#: src/tables/build/BuildLineTable.tsx:213
+#: src/tables/bom/UsedInTable.tsx:34
+#: src/tables/build/BuildLineTable.tsx:208
 #: src/tables/part/ParametricPartTable.tsx:29
 #: src/tables/part/PartBuildAllocationsTable.tsx:60
-#: src/tables/part/PartTable.tsx:210
-#: src/tables/stock/StockItemTable.tsx:187
+#: src/tables/part/PartTable.tsx:209
+#: src/tables/stock/StockItemTable.tsx:333
 msgid "Assembly"
 msgstr "装配"
 
-#: src/tables/bom/UsedInTable.tsx:96
+#: src/tables/bom/UsedInTable.tsx:91
 msgid "Show active assemblies"
 msgstr "显示活动装配体"
 
-#: src/tables/bom/UsedInTable.tsx:100
-#: src/tables/part/PartTable.tsx:240
+#: src/tables/bom/UsedInTable.tsx:95
+#: src/tables/part/PartTable.tsx:239
 #: src/tables/part/PartVariantTable.tsx:30
 msgid "Trackable"
 msgstr "可追踪"
 
-#: src/tables/bom/UsedInTable.tsx:101
+#: src/tables/bom/UsedInTable.tsx:96
 msgid "Show trackable assemblies"
 msgstr "显示可跟踪装配体"
 
-#: src/tables/build/BuildAllocatedStockTable.tsx:67
+#: src/tables/build/BuildAllocatedStockTable.tsx:64
 msgid "Allocated to Output"
 msgstr "分配至输出"
 
-#: src/tables/build/BuildAllocatedStockTable.tsx:68
+#: src/tables/build/BuildAllocatedStockTable.tsx:65
 msgid "Show items allocated to a build output"
 msgstr "显示分配给构建输出的项目"
 
@@ -9827,62 +9593,52 @@ msgstr "显示分配给构建输出的项目"
 #~ msgid "Include orders for part variants"
 #~ msgstr "Include orders for part variants"
 
-#: src/tables/build/BuildAllocatedStockTable.tsx:97
+#: src/tables/build/BuildAllocatedStockTable.tsx:94
 #: src/tables/part/PartBuildAllocationsTable.tsx:84
 #: src/tables/part/PartPurchaseOrdersTable.tsx:132
-#: src/tables/part/PartSalesAllocationsTable.tsx:67
-#: src/tables/sales/SalesOrderAllocationTable.tsx:123
-#: src/tables/sales/SalesOrderShipmentTable.tsx:145
+#: src/tables/part/PartSalesAllocationsTable.tsx:69
+#: src/tables/sales/SalesOrderAllocationTable.tsx:122
+#: src/tables/sales/SalesOrderShipmentTable.tsx:151
 msgid "Order Status"
 msgstr "订单状态"
+
+#: src/tables/build/BuildAllocatedStockTable.tsx:164
+#: src/tables/build/BuildLineTable.tsx:652
+msgid "Edit Stock Allocation"
+msgstr "编辑库存分配"
 
 #: src/tables/build/BuildAllocatedStockTable.tsx:164
 #~ msgid "Edit Build Item"
 #~ msgstr "Edit Build Item"
 
-#: src/tables/build/BuildAllocatedStockTable.tsx:166
-#: src/tables/build/BuildLineTable.tsx:657
-msgid "Edit Stock Allocation"
-msgstr "编辑库存分配"
-
 #: src/tables/build/BuildAllocatedStockTable.tsx:174
 #~ msgid "Delete Build Item"
 #~ msgstr "Delete Build Item"
 
-#: src/tables/build/BuildAllocatedStockTable.tsx:179
-#: src/tables/build/BuildLineTable.tsx:670
-#: src/tables/sales/SalesOrderAllocationTable.tsx:217
+#: src/tables/build/BuildAllocatedStockTable.tsx:177
+#: src/tables/build/BuildLineTable.tsx:665
+#: src/tables/sales/SalesOrderAllocationTable.tsx:218
 msgid "Remove Allocated Stock"
-msgstr "移除已分配的库存"
+msgstr "移除已分配库存"
 
 #: src/tables/build/BuildAllocatedStockTable.tsx:180
 #: src/tables/build/BuildLineTable.tsx:663
 #~ msgid "Delete Stock Allocation"
 #~ msgstr "Delete Stock Allocation"
 
-#: src/tables/build/BuildAllocatedStockTable.tsx:184
-#: src/tables/build/BuildLineTable.tsx:675
-#: src/tables/sales/SalesOrderAllocationTable.tsx:220
+#: src/tables/build/BuildAllocatedStockTable.tsx:182
+#: src/tables/build/BuildLineTable.tsx:670
+#: src/tables/sales/SalesOrderAllocationTable.tsx:221
 msgid "Are you sure you want to remove this allocated stock from the order?"
-msgstr "您确定要从订单中删除此分配的库存吗？"
+msgstr "确定要从订单中移除此已分配库存吗？"
 
-#: src/tables/build/BuildAllocatedStockTable.tsx:199
-#: src/tables/build/BuildLineTable.tsx:690
-msgid "Consuming allocated stock"
-msgstr "正在消耗已分配库存"
-
-#: src/tables/build/BuildAllocatedStockTable.tsx:200
-#: src/tables/build/BuildLineTable.tsx:691
-msgid "Stock consumed successfully"
-msgstr "库存消耗成功"
-
-#: src/tables/build/BuildAllocatedStockTable.tsx:260
+#: src/tables/build/BuildAllocatedStockTable.tsx:242
 msgid "Consume"
 msgstr "库存消耗"
 
-#: src/tables/build/BuildAllocatedStockTable.tsx:277
-#: src/tables/build/BuildLineTable.tsx:117
-#: src/tables/sales/SalesOrderAllocationTable.tsx:247
+#: src/tables/build/BuildAllocatedStockTable.tsx:259
+#: src/tables/build/BuildLineTable.tsx:112
+#: src/tables/sales/SalesOrderAllocationTable.tsx:248
 msgid "Remove allocated stock"
 msgstr "移除已分配库存"
 
@@ -9890,60 +9646,66 @@ msgstr "移除已分配库存"
 #~ msgid "Show lines with available stock"
 #~ msgstr "Show lines with available stock"
 
-#: src/tables/build/BuildLineTable.tsx:126
+#: src/tables/build/BuildLineTable.tsx:121
 msgid "View Stock Item"
 msgstr "查看库存物料详情"
 
-#: src/tables/build/BuildLineTable.tsx:189
+#: src/tables/build/BuildLineTable.tsx:184
 msgid "Show fully allocated lines"
 msgstr "显示已完全分配的行"
+
+#: src/tables/build/BuildLineTable.tsx:189
+msgid "Show fully consumed lines"
+msgstr "显示已完全消耗的行"
 
 #: src/tables/build/BuildLineTable.tsx:189
 #~ msgid "Show allocated lines"
 #~ msgstr "Show allocated lines"
 
 #: src/tables/build/BuildLineTable.tsx:194
-msgid "Show fully consumed lines"
-msgstr "显示已完全消耗的行"
+msgid "Show items with sufficient available stock"
+msgstr "显示库存充足的项目"
 
 #: src/tables/build/BuildLineTable.tsx:199
-msgid "Show items with sufficient available stock"
-msgstr "显示库存充足的物料"
-
-#: src/tables/build/BuildLineTable.tsx:204
 msgid "Show consumable lines"
 msgstr "显示可消耗项目"
 
-#: src/tables/build/BuildLineTable.tsx:209
+#: src/tables/build/BuildLineTable.tsx:204
 msgid "Show optional lines"
 msgstr "显示可选项目"
 
-#: src/tables/build/BuildLineTable.tsx:218
-#: src/tables/part/PartTable.tsx:234
+#: src/tables/build/BuildLineTable.tsx:213
+#: src/tables/part/PartTable.tsx:233
 msgid "Testable"
 msgstr "可测试"
 
-#: src/tables/build/BuildLineTable.tsx:223
-#: src/tables/stock/StockItemTable.tsx:242
+#: src/tables/build/BuildLineTable.tsx:218
+#: src/tables/stock/StockItemTable.tsx:388
 msgid "Tracked"
 msgstr "已跟踪"
 
-#: src/tables/build/BuildLineTable.tsx:224
+#: src/tables/build/BuildLineTable.tsx:219
 msgid "Show tracked lines"
 msgstr "显示已跟踪项目"
 
-#: src/tables/build/BuildLineTable.tsx:229
+#: src/tables/build/BuildLineTable.tsx:224
 msgid "Show items with stock on order"
-msgstr "显示已订购在途库存的物料"
+msgstr "显示已订购库存的项目"
 
-#: src/tables/build/BuildLineTable.tsx:264
-#: src/tables/sales/SalesOrderLineItemTable.tsx:168
+#: src/tables/build/BuildLineTable.tsx:259
+#: src/tables/sales/SalesOrderLineItemTable.tsx:172
 msgid "In production"
 msgstr "生产中"
 
-#: src/tables/build/BuildLineTable.tsx:292
+#: src/tables/build/BuildLineTable.tsx:287
 msgid "Insufficient stock"
 msgstr "库存不足"
+
+#: src/tables/build/BuildLineTable.tsx:303
+#: src/tables/sales/SalesOrderLineItemTable.tsx:160
+#: src/tables/stock/StockItemTable.tsx:191
+msgid "No stock available"
+msgstr "无可用库存"
 
 #: src/tables/build/BuildLineTable.tsx:377
 msgid "Gets Inherited"
@@ -9975,66 +9737,50 @@ msgid "Fully allocated"
 msgstr "完全分配"
 
 #: src/tables/build/BuildLineTable.tsx:565
-#: src/tables/sales/SalesOrderLineItemTable.tsx:309
+#: src/tables/sales/SalesOrderLineItemTable.tsx:311
 msgid "Create Build Order"
 msgstr "创建生产订单"
 
-#: src/tables/build/BuildLineTable.tsx:577
-#: src/tables/build/BuildOutputTable.tsx:223
-msgid "Allocating stock to build order"
-msgstr "正在为生产订单分配库存"
+#: src/tables/build/BuildLineTable.tsx:594
+msgid "Auto allocation in progress"
+msgstr "自动分配进行中"
 
-#: src/tables/build/BuildLineTable.tsx:578
-#: src/tables/build/BuildOutputTable.tsx:224
-msgid "Stock allocation complete"
-msgstr "库存分配完成"
-
-#: src/tables/build/BuildLineTable.tsx:585
-#~ msgid "Auto allocation in progress"
-#~ msgstr "Auto allocation in progress"
-
-#: src/tables/build/BuildLineTable.tsx:598
-#~ msgid "Automatically allocate stock to this build according to the selected options"
-#~ msgstr "Automatically allocate stock to this build according to the selected options"
-
-#: src/tables/build/BuildLineTable.tsx:602
-#: src/tables/build/BuildLineTable.tsx:831
-#: src/tables/build/BuildOutputTable.tsx:247
-#: src/tables/build/BuildOutputTable.tsx:482
+#: src/tables/build/BuildLineTable.tsx:597
+#: src/tables/build/BuildLineTable.tsx:810
 msgid "Auto Allocate Stock"
 msgstr "自动分配库存量"
 
-#: src/tables/build/BuildLineTable.tsx:603
-msgid "Automatically allocate untracked BOM items to this build according to the selected options"
-msgstr "根据所选选项，自动将未追踪的 BOM 物料分配到本次生产任务"
+#: src/tables/build/BuildLineTable.tsx:598
+msgid "Automatically allocate stock to this build according to the selected options"
+msgstr "根据选定的选项自动分配库存到此版本"
 
-#: src/tables/build/BuildLineTable.tsx:623
-#: src/tables/build/BuildLineTable.tsx:637
-#: src/tables/build/BuildLineTable.tsx:780
-#: src/tables/build/BuildLineTable.tsx:881
-#: src/tables/build/BuildOutputTable.tsx:393
-#: src/tables/build/BuildOutputTable.tsx:398
+#: src/tables/build/BuildLineTable.tsx:618
+#: src/tables/build/BuildLineTable.tsx:632
+#: src/tables/build/BuildLineTable.tsx:759
+#: src/tables/build/BuildLineTable.tsx:860
+#: src/tables/build/BuildOutputTable.tsx:355
+#: src/tables/build/BuildOutputTable.tsx:360
 msgid "Deallocate Stock"
 msgstr "取消库存分配"
 
-#: src/tables/build/BuildLineTable.tsx:639
+#: src/tables/build/BuildLineTable.tsx:634
 msgid "Deallocate all untracked stock for this build order"
 msgstr "为这个构建订单取消分配所有未跟踪库存"
 
-#: src/tables/build/BuildLineTable.tsx:641
+#: src/tables/build/BuildLineTable.tsx:636
 msgid "Deallocate stock from the selected line item"
 msgstr "从选中的行项中取消分配库存"
 
-#: src/tables/build/BuildLineTable.tsx:645
+#: src/tables/build/BuildLineTable.tsx:640
 msgid "Stock has been deallocated"
 msgstr "库存已经取消分配"
 
-#: src/tables/build/BuildLineTable.tsx:800
+#: src/tables/build/BuildLineTable.tsx:779
 msgid "Build Stock"
 msgstr "生产库存"
 
-#: src/tables/build/BuildLineTable.tsx:813
-#: src/tables/sales/SalesOrderLineItemTable.tsx:485
+#: src/tables/build/BuildLineTable.tsx:792
+#: src/tables/sales/SalesOrderLineItemTable.tsx:487
 msgid "View Part"
 msgstr "查看零件"
 
@@ -10065,31 +9811,31 @@ msgstr "查看零件"
 #~ msgid "Filter by whether the purchase order has a project code"
 #~ msgstr "Filter by whether the purchase order has a project code"
 
-#: src/tables/build/BuildOrderTable.tsx:171
-#: src/tables/purchasing/PurchaseOrderTable.tsx:94
-#: src/tables/sales/ReturnOrderTable.tsx:94
-#: src/tables/sales/SalesOrderTable.tsx:92
+#: src/tables/build/BuildOrderTable.tsx:166
+#: src/tables/purchasing/PurchaseOrderTable.tsx:83
+#: src/tables/sales/ReturnOrderTable.tsx:79
+#: src/tables/sales/SalesOrderTable.tsx:81
 msgid "Has Target Date"
 msgstr "有目标日期"
 
-#: src/tables/build/BuildOrderTable.tsx:172
-#: src/tables/purchasing/PurchaseOrderTable.tsx:95
-#: src/tables/sales/ReturnOrderTable.tsx:95
-#: src/tables/sales/SalesOrderTable.tsx:93
+#: src/tables/build/BuildOrderTable.tsx:167
+#: src/tables/purchasing/PurchaseOrderTable.tsx:84
+#: src/tables/sales/ReturnOrderTable.tsx:80
+#: src/tables/sales/SalesOrderTable.tsx:82
 msgid "Show orders with a target date"
 msgstr "显示目标日期的订单"
 
-#: src/tables/build/BuildOrderTable.tsx:177
-#: src/tables/purchasing/PurchaseOrderTable.tsx:100
-#: src/tables/sales/ReturnOrderTable.tsx:100
-#: src/tables/sales/SalesOrderTable.tsx:98
+#: src/tables/build/BuildOrderTable.tsx:172
+#: src/tables/purchasing/PurchaseOrderTable.tsx:89
+#: src/tables/sales/ReturnOrderTable.tsx:85
+#: src/tables/sales/SalesOrderTable.tsx:87
 msgid "Has Start Date"
 msgstr "有开始日期"
 
-#: src/tables/build/BuildOrderTable.tsx:178
-#: src/tables/purchasing/PurchaseOrderTable.tsx:101
-#: src/tables/sales/ReturnOrderTable.tsx:101
-#: src/tables/sales/SalesOrderTable.tsx:99
+#: src/tables/build/BuildOrderTable.tsx:173
+#: src/tables/purchasing/PurchaseOrderTable.tsx:90
+#: src/tables/sales/ReturnOrderTable.tsx:86
+#: src/tables/sales/SalesOrderTable.tsx:88
 msgid "Show orders with a start date"
 msgstr "显示开始日期的订单"
 
@@ -10097,7 +9843,7 @@ msgstr "显示开始日期的订单"
 #~ msgid "Filter by user who issued this order"
 #~ msgstr "Filter by user who issued this order"
 
-#: src/tables/build/BuildOutputTable.tsx:102
+#: src/tables/build/BuildOutputTable.tsx:99
 msgid "Build Output Stock Allocation"
 msgstr "生成产出库存分配"
 
@@ -10105,107 +9851,99 @@ msgstr "生成产出库存分配"
 #~ msgid "Delete build output"
 #~ msgstr "Delete build output"
 
-#: src/tables/build/BuildOutputTable.tsx:229
-#~ msgid "Auto-allocation in progress"
-#~ msgstr "Auto-allocation in progress"
+#: src/tables/build/BuildOutputTable.tsx:290
+#: src/tables/build/BuildOutputTable.tsx:475
+msgid "Add Build Output"
+msgstr "添加生成输出"
 
-#: src/tables/build/BuildOutputTable.tsx:248
-msgid "Automatically allocate tracked BOM items to this build according to the selected options"
-msgstr "根据所选选项，自动将已追踪的 BOM 物料分配到本次生产任务"
+#: src/tables/build/BuildOutputTable.tsx:293
+msgid "Build output created"
+msgstr "生成产出已创建"
 
 #: src/tables/build/BuildOutputTable.tsx:304
 #~ msgid "Edit build output"
 #~ msgstr "Edit build output"
 
-#: src/tables/build/BuildOutputTable.tsx:327
-#: src/tables/build/BuildOutputTable.tsx:523
-msgid "Add Build Output"
-msgstr "添加生成输出"
-
-#: src/tables/build/BuildOutputTable.tsx:330
-msgid "Build output created"
-msgstr "生成产出已创建"
-
-#: src/tables/build/BuildOutputTable.tsx:384
-#: src/tables/build/BuildOutputTable.tsx:593
+#: src/tables/build/BuildOutputTable.tsx:346
+#: src/tables/build/BuildOutputTable.tsx:543
 msgid "Edit Build Output"
 msgstr "编辑生成输出"
 
-#: src/tables/build/BuildOutputTable.tsx:400
+#: src/tables/build/BuildOutputTable.tsx:362
 msgid "This action will deallocate all stock from the selected build output"
 msgstr "解除产出库存分配"
 
-#: src/tables/build/BuildOutputTable.tsx:425
+#: src/tables/build/BuildOutputTable.tsx:387
 msgid "Serialize Build Output"
 msgstr "序列化生产产出"
 
-#: src/tables/build/BuildOutputTable.tsx:443
-#: src/tables/part/PartTestResultTable.tsx:319
-#: src/tables/stock/StockItemTable.tsx:182
+#: src/tables/build/BuildOutputTable.tsx:405
+#: src/tables/part/PartTestResultTable.tsx:318
+#: src/tables/stock/StockItemTable.tsx:328
 msgid "Filter by stock status"
 msgstr "按库存状态筛选"
 
-#: src/tables/build/BuildOutputTable.tsx:490
+#: src/tables/build/BuildOutputTable.tsx:442
 msgid "Complete selected outputs"
 msgstr "完成选定的输出"
+
+#: src/tables/build/BuildOutputTable.tsx:453
+msgid "Scrap selected outputs"
+msgstr "报废选定的输出"
+
+#: src/tables/build/BuildOutputTable.tsx:464
+msgid "Cancel selected outputs"
+msgstr "取消选定的输出"
+
+#: src/tables/build/BuildOutputTable.tsx:494
+msgid "Allocate"
+msgstr "分配"
+
+#: src/tables/build/BuildOutputTable.tsx:495
+msgid "Allocate stock to build output"
+msgstr "为生产产出分配库存"
 
 #: src/tables/build/BuildOutputTable.tsx:498
 #~ msgid "View Build Output"
 #~ msgstr "View Build Output"
 
-#: src/tables/build/BuildOutputTable.tsx:501
-msgid "Scrap selected outputs"
-msgstr "报废选定的输出"
-
-#: src/tables/build/BuildOutputTable.tsx:512
-msgid "Cancel selected outputs"
-msgstr "取消选定的输出"
-
-#: src/tables/build/BuildOutputTable.tsx:543
-msgid "Allocate"
-msgstr "分配"
-
-#: src/tables/build/BuildOutputTable.tsx:544
-msgid "Allocate stock to build output"
-msgstr "为生产产出分配库存"
-
-#: src/tables/build/BuildOutputTable.tsx:557
+#: src/tables/build/BuildOutputTable.tsx:508
 msgid "Deallocate"
 msgstr "取消分配"
 
-#: src/tables/build/BuildOutputTable.tsx:558
+#: src/tables/build/BuildOutputTable.tsx:509
 msgid "Deallocate stock from build output"
 msgstr "从生产输出中取消分配库存"
 
-#: src/tables/build/BuildOutputTable.tsx:572
+#: src/tables/build/BuildOutputTable.tsx:523
 msgid "Serialize build output"
 msgstr "序列化生产产出"
 
-#: src/tables/build/BuildOutputTable.tsx:583
+#: src/tables/build/BuildOutputTable.tsx:534
 msgid "Complete build output"
 msgstr "完成生产输出"
 
-#: src/tables/build/BuildOutputTable.tsx:600
+#: src/tables/build/BuildOutputTable.tsx:550
 msgid "Scrap"
 msgstr "报废件"
 
-#: src/tables/build/BuildOutputTable.tsx:601
+#: src/tables/build/BuildOutputTable.tsx:551
 msgid "Scrap build output"
 msgstr "报废生产输出"
 
-#: src/tables/build/BuildOutputTable.tsx:611
+#: src/tables/build/BuildOutputTable.tsx:561
 msgid "Cancel build output"
 msgstr "取消生产输出"
 
-#: src/tables/build/BuildOutputTable.tsx:675
+#: src/tables/build/BuildOutputTable.tsx:625
 msgid "Required Tests"
 msgstr "需要测试"
 
-#: src/tables/build/BuildOutputTable.tsx:751
+#: src/tables/build/BuildOutputTable.tsx:700
 msgid "External Build"
 msgstr "外部生产"
 
-#: src/tables/build/BuildOutputTable.tsx:753
+#: src/tables/build/BuildOutputTable.tsx:702
 msgid "This build order is fulfilled by an external purchase order"
 msgstr "外部采购订单关联的生产订单"
 
@@ -10230,28 +9968,28 @@ msgstr "删除地址"
 msgid "Are you sure you want to delete this address?"
 msgstr "您确定要删除该地址？"
 
+#: src/tables/company/CompanyTable.tsx:70
+#: src/tables/company/CompanyTable.tsx:120
+msgid "Add Company"
+msgstr "添加公司"
+
 #: src/tables/company/CompanyTable.tsx:71
 #~ msgid "New Company"
 #~ msgstr "New Company"
 
-#: src/tables/company/CompanyTable.tsx:79
-#: src/tables/company/CompanyTable.tsx:130
-msgid "Add Company"
-msgstr "添加公司"
-
-#: src/tables/company/CompanyTable.tsx:102
+#: src/tables/company/CompanyTable.tsx:92
 msgid "Show active companies"
 msgstr "显示活跃的公司"
 
-#: src/tables/company/CompanyTable.tsx:107
+#: src/tables/company/CompanyTable.tsx:97
 msgid "Show companies which are suppliers"
 msgstr "显示供应商公司"
 
-#: src/tables/company/CompanyTable.tsx:112
+#: src/tables/company/CompanyTable.tsx:102
 msgid "Show companies which are manufacturers"
 msgstr "显示属于制造商的公司"
 
-#: src/tables/company/CompanyTable.tsx:117
+#: src/tables/company/CompanyTable.tsx:107
 msgid "Show companies which are customers"
 msgstr "显示客户公司"
 
@@ -10360,31 +10098,31 @@ msgstr "型号"
 msgid "View Item"
 msgstr "查看项目"
 
-#: src/tables/general/ExtraLineItemTable.tsx:97
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:298
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:404
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:85
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:186
-#: src/tables/sales/SalesOrderLineItemTable.tsx:248
-#: src/tables/sales/SalesOrderLineItemTable.tsx:355
+#: src/tables/general/ExtraLineItemTable.tsx:95
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:300
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:406
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:83
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:187
+#: src/tables/sales/SalesOrderLineItemTable.tsx:252
+#: src/tables/sales/SalesOrderLineItemTable.tsx:357
 msgid "Add Line Item"
 msgstr "添加行项目"
 
-#: src/tables/general/ExtraLineItemTable.tsx:110
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:321
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:98
-#: src/tables/sales/SalesOrderLineItemTable.tsx:267
+#: src/tables/general/ExtraLineItemTable.tsx:108
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:323
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:96
+#: src/tables/sales/SalesOrderLineItemTable.tsx:271
 msgid "Edit Line Item"
 msgstr "编辑行项目"
 
-#: src/tables/general/ExtraLineItemTable.tsx:119
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:330
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:107
-#: src/tables/sales/SalesOrderLineItemTable.tsx:276
+#: src/tables/general/ExtraLineItemTable.tsx:117
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:332
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:105
+#: src/tables/sales/SalesOrderLineItemTable.tsx:280
 msgid "Delete Line Item"
 msgstr "删除行项目"
 
-#: src/tables/general/ExtraLineItemTable.tsx:157
+#: src/tables/general/ExtraLineItemTable.tsx:155
 msgid "Add Extra Line Item"
 msgstr "添加额外行项目"
 
@@ -10405,40 +10143,40 @@ msgstr "显示已启用模板的参数"
 msgid "Filter by user who last updated the parameter"
 msgstr "按最后更新参数的用户筛选"
 
-#: src/tables/general/ParameterTable.tsx:149
+#: src/tables/general/ParameterTable.tsx:154
 msgid "Import Parameters"
 msgstr "导入参数"
 
-#: src/tables/general/ParameterTable.tsx:160
-#: src/tables/general/ParametricDataTable.tsx:271
-#: src/tables/general/ParametricDataTable.tsx:402
+#: src/tables/general/ParameterTable.tsx:164
+#: src/tables/general/ParametricDataTable.tsx:261
+#: src/tables/general/ParametricDataTable.tsx:392
 msgid "Add Parameter"
 msgstr "添加参数"
 
-#: src/tables/general/ParameterTable.tsx:171
-#: src/tables/general/ParameterTable.tsx:218
-#: src/tables/general/ParametricDataTable.tsx:295
+#: src/tables/general/ParameterTable.tsx:175
+#: src/tables/general/ParameterTable.tsx:222
+#: src/tables/general/ParametricDataTable.tsx:285
 msgid "Edit Parameter"
 msgstr "编辑参数"
 
-#: src/tables/general/ParameterTable.tsx:179
-#: src/tables/general/ParameterTable.tsx:226
+#: src/tables/general/ParameterTable.tsx:183
+#: src/tables/general/ParameterTable.tsx:230
 msgid "Delete Parameter"
 msgstr "删除参数"
 
-#: src/tables/general/ParameterTable.tsx:187
+#: src/tables/general/ParameterTable.tsx:191
 msgid "Add Parameters"
 msgstr "添加参数"
 
-#: src/tables/general/ParameterTable.tsx:193
+#: src/tables/general/ParameterTable.tsx:197
 msgid "Create Parameter"
 msgstr "创建参数"
 
-#: src/tables/general/ParameterTable.tsx:195
+#: src/tables/general/ParameterTable.tsx:199
 msgid "Create a new parameter"
-msgstr "创建一个新参数"
+msgstr "创建新参数"
 
-#: src/tables/general/ParameterTable.tsx:204
+#: src/tables/general/ParameterTable.tsx:208
 msgid "Import parameters from a file"
 msgstr "从文件导入参数"
 
@@ -10476,7 +10214,7 @@ msgid "Show templates with choices"
 msgstr "显示有选项的模板"
 
 #: src/tables/general/ParameterTemplateTable.tsx:148
-#: src/tables/part/PartTable.tsx:246
+#: src/tables/part/PartTable.tsx:245
 msgid "Has Units"
 msgstr "有单位"
 
@@ -10489,14 +10227,14 @@ msgid "Show enabled templates"
 msgstr "显示已启用的模板"
 
 #: src/tables/general/ParameterTemplateTable.tsx:158
-#: src/tables/settings/ImportSessionTable.tsx:112
+#: src/tables/settings/ImportSessionTable.tsx:111
 #: src/tables/settings/TemplateTable.tsx:368
 msgid "Model Type"
 msgstr "型号类型"
 
 #: src/tables/general/ParameterTemplateTable.tsx:159
 msgid "Filter by model type"
-msgstr "按型号类型筛选"
+msgstr "按模型类型筛选"
 
 #: src/tables/general/ParametricDataTable.tsx:79
 msgid "Click to edit"
@@ -10736,7 +10474,7 @@ msgid "Notification"
 msgstr "通知"
 
 #: src/tables/notifications/NotificationTable.tsx:41
-#: src/tables/plugin/PluginErrorTable.tsx:39
+#: src/tables/plugin/PluginErrorTable.tsx:37
 #: src/tables/settings/ErrorTable.tsx:50
 msgid "Message"
 msgstr "信息"
@@ -10780,49 +10518,49 @@ msgid "Required Stock"
 msgstr "所需库存"
 
 #: src/tables/part/PartBuildAllocationsTable.tsx:124
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:382
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:384
 msgid "View Build Order"
 msgstr "查看生产订单"
 
-#: src/tables/part/PartCategoryTable.tsx:52
+#: src/tables/part/PartCategoryTable.tsx:51
 msgid "You are subscribed to notifications for this category"
 msgstr "您已订阅此类别的通知"
 
-#: src/tables/part/PartCategoryTable.tsx:86
-#: src/tables/part/PartTable.tsx:222
+#: src/tables/part/PartCategoryTable.tsx:84
+#: src/tables/part/PartTable.tsx:221
 msgid "Include Subcategories"
 msgstr "包含子类别"
 
-#: src/tables/part/PartCategoryTable.tsx:87
+#: src/tables/part/PartCategoryTable.tsx:85
 msgid "Include subcategories in results"
 msgstr "在结果中包含子类别"
 
-#: src/tables/part/PartCategoryTable.tsx:92
+#: src/tables/part/PartCategoryTable.tsx:90
 msgid "Show structural categories"
 msgstr "显示结构性类别"
 
-#: src/tables/part/PartCategoryTable.tsx:97
+#: src/tables/part/PartCategoryTable.tsx:95
 msgid "Show categories to which the user is subscribed"
 msgstr "显示用户订阅的类别"
 
-#: src/tables/part/PartCategoryTable.tsx:106
+#: src/tables/part/PartCategoryTable.tsx:104
 msgid "New Part Category"
 msgstr "新建零件类别"
 
-#: src/tables/part/PartCategoryTable.tsx:133
+#: src/tables/part/PartCategoryTable.tsx:130
 msgid "Set Parent Category"
 msgstr "设置父类别"
 
-#: src/tables/part/PartCategoryTable.tsx:151
-#: src/tables/stock/StockLocationTable.tsx:150
+#: src/tables/part/PartCategoryTable.tsx:148
+#: src/tables/stock/StockLocationTable.tsx:147
 msgid "Set Parent"
 msgstr "设置父级"
 
-#: src/tables/part/PartCategoryTable.tsx:153
+#: src/tables/part/PartCategoryTable.tsx:150
 msgid "Set parent category for the selected items"
 msgstr "为所选项目设置父类别"
 
-#: src/tables/part/PartCategoryTable.tsx:164
+#: src/tables/part/PartCategoryTable.tsx:161
 msgid "Add Part Category"
 msgstr "增加零件类别"
 
@@ -10861,7 +10599,7 @@ msgstr "删除类别参数"
 #~ msgstr "Add parameter template"
 
 #: src/tables/part/PartPurchaseOrdersTable.tsx:79
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:193
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:197
 msgid "Total Quantity"
 msgstr "总数量"
 
@@ -10873,136 +10611,136 @@ msgstr "显示待定的订单"
 msgid "Show received items"
 msgstr "显示已收到的条目"
 
-#: src/tables/part/PartSalesAllocationsTable.tsx:88
-#: src/tables/sales/SalesOrderShipmentTable.tsx:258
+#: src/tables/part/PartSalesAllocationsTable.tsx:90
+#: src/tables/sales/SalesOrderShipmentTable.tsx:263
 msgid "View Sales Order"
 msgstr "查看销售订单"
 
-#: src/tables/part/PartTable.tsx:100
+#: src/tables/part/PartTable.tsx:99
 msgid "Minimum stock"
 msgstr "最低库存数"
 
-#: src/tables/part/PartTable.tsx:199
+#: src/tables/part/PartTable.tsx:198
 msgid "Filter by part active status"
 msgstr "按零件活动状态筛选"
 
-#: src/tables/part/PartTable.tsx:205
+#: src/tables/part/PartTable.tsx:204
 msgid "Filter by part locked status"
 msgstr "按零件锁定状态筛选"
 
-#: src/tables/part/PartTable.tsx:211
+#: src/tables/part/PartTable.tsx:210
 msgid "Filter by assembly attribute"
 msgstr "按装配属性筛选"
 
-#: src/tables/part/PartTable.tsx:216
+#: src/tables/part/PartTable.tsx:215
 msgid "BOM Valid"
 msgstr "物料清单有效性"
 
-#: src/tables/part/PartTable.tsx:217
+#: src/tables/part/PartTable.tsx:216
 msgid "Filter by parts with a valid BOM"
 msgstr "筛选具有有效物料清单的零件"
 
-#: src/tables/part/PartTable.tsx:223
+#: src/tables/part/PartTable.tsx:222
 msgid "Include parts in subcategories"
 msgstr "包括子类别中的零件"
 
-#: src/tables/part/PartTable.tsx:229
+#: src/tables/part/PartTable.tsx:228
 msgid "Filter by component attribute"
 msgstr "按组件属性筛选"
 
-#: src/tables/part/PartTable.tsx:235
+#: src/tables/part/PartTable.tsx:234
 msgid "Filter by testable attribute"
 msgstr "按可跟踪属性筛选"
 
-#: src/tables/part/PartTable.tsx:241
+#: src/tables/part/PartTable.tsx:240
 msgid "Filter by trackable attribute"
 msgstr "按可跟踪属性筛选"
 
-#: src/tables/part/PartTable.tsx:247
+#: src/tables/part/PartTable.tsx:246
 msgid "Filter by parts which have units"
 msgstr "按拥有单位的零件筛选"
 
-#: src/tables/part/PartTable.tsx:252
+#: src/tables/part/PartTable.tsx:251
 msgid "Has IPN"
 msgstr "有内部零件编码"
 
-#: src/tables/part/PartTable.tsx:253
+#: src/tables/part/PartTable.tsx:252
 msgid "Filter by parts which have an internal part number"
 msgstr "按具有内部零件编号的零件筛选"
 
-#: src/tables/part/PartTable.tsx:258
+#: src/tables/part/PartTable.tsx:257
 msgid "Has Stock"
 msgstr "有库存"
 
-#: src/tables/part/PartTable.tsx:259
+#: src/tables/part/PartTable.tsx:258
 msgid "Filter by parts which have stock"
 msgstr "按有库存的零件筛选"
 
-#: src/tables/part/PartTable.tsx:265
+#: src/tables/part/PartTable.tsx:264
 msgid "Filter by parts which have low stock"
 msgstr "按库存少的零件筛选"
 
-#: src/tables/part/PartTable.tsx:270
+#: src/tables/part/PartTable.tsx:269
 msgid "Purchaseable"
 msgstr "可购买"
 
-#: src/tables/part/PartTable.tsx:271
+#: src/tables/part/PartTable.tsx:270
 msgid "Filter by parts which are purchaseable"
 msgstr "按可购买的零件筛选"
 
-#: src/tables/part/PartTable.tsx:276
+#: src/tables/part/PartTable.tsx:275
 msgid "Salable"
 msgstr "可销售"
 
-#: src/tables/part/PartTable.tsx:277
+#: src/tables/part/PartTable.tsx:276
 msgid "Filter by parts which are salable"
 msgstr "按可出售的零件筛选"
 
-#: src/tables/part/PartTable.tsx:283
+#: src/tables/part/PartTable.tsx:282
 msgid "Filter by parts which are virtual"
 msgstr "按虚拟零件筛选"
 
-#: src/tables/part/PartTable.tsx:287
-#~ msgid "Not Virtual"
-#~ msgstr "Not Virtual"
+#: src/tables/part/PartTable.tsx:286
+msgid "Not Virtual"
+msgstr "非虚拟的"
 
-#: src/tables/part/PartTable.tsx:288
+#: src/tables/part/PartTable.tsx:291
 msgid "Is Template"
 msgstr "是模板"
 
-#: src/tables/part/PartTable.tsx:289
+#: src/tables/part/PartTable.tsx:292
 msgid "Filter by parts which are templates"
 msgstr "按模板部分筛选零件"
 
-#: src/tables/part/PartTable.tsx:294
+#: src/tables/part/PartTable.tsx:297
 msgid "Is Variant"
 msgstr "是变体"
 
-#: src/tables/part/PartTable.tsx:295
+#: src/tables/part/PartTable.tsx:298
 msgid "Filter by parts which are variants"
 msgstr "按变体零件筛选"
 
-#: src/tables/part/PartTable.tsx:300
+#: src/tables/part/PartTable.tsx:303
 msgid "Is Revision"
 msgstr "是否修订"
 
-#: src/tables/part/PartTable.tsx:301
+#: src/tables/part/PartTable.tsx:304
 msgid "Filter by parts which are revisions"
 msgstr "按修订零件筛选"
 
-#: src/tables/part/PartTable.tsx:305
+#: src/tables/part/PartTable.tsx:308
 msgid "Has Revisions"
 msgstr "有修订"
 
-#: src/tables/part/PartTable.tsx:306
+#: src/tables/part/PartTable.tsx:309
 msgid "Filter by parts which have revisions"
 msgstr "按有修订的零件筛选"
 
-#: src/tables/part/PartTable.tsx:311
+#: src/tables/part/PartTable.tsx:314
 msgid "Filter by parts which have pricing information"
 msgstr "按有定价信息的零件筛选"
 
-#: src/tables/part/PartTable.tsx:317
+#: src/tables/part/PartTable.tsx:320
 msgid "Filter by parts which have available stock"
 msgstr "按有可用库存的零件筛选"
 
@@ -11011,58 +10749,58 @@ msgstr "按有可用库存的零件筛选"
 #~ msgstr "Has Stocktake"
 
 #: src/tables/part/PartTable.tsx:323
-msgid "Filter by parts to which the user is subscribed"
-msgstr "按用户订阅的零件筛选"
-
-#: src/tables/part/PartTable.tsx:323
 #~ msgid "Filter by parts which have stocktake information"
 #~ msgstr "Filter by parts which have stocktake information"
 
-#: src/tables/part/PartTable.tsx:378
+#: src/tables/part/PartTable.tsx:326
+msgid "Filter by parts to which the user is subscribed"
+msgstr "按用户订阅的零件筛选"
+
+#: src/tables/part/PartTable.tsx:377
 msgid "Import Parts"
 msgstr "导入零件"
 
-#: src/tables/part/PartTable.tsx:467
-#: src/tables/part/PartTable.tsx:515
+#: src/tables/part/PartTable.tsx:464
+#: src/tables/part/PartTable.tsx:512
 msgid "Set Category"
 msgstr "设置类别"
 
-#: src/tables/part/PartTable.tsx:517
+#: src/tables/part/PartTable.tsx:514
 msgid "Set category for selected parts"
 msgstr "设置所选零件的类别"
 
-#: src/tables/part/PartTable.tsx:527
+#: src/tables/part/PartTable.tsx:524
 msgid "Order selected parts"
 msgstr "订购选定的零件"
 
-#: src/tables/part/PartTable.tsx:537
+#: src/tables/part/PartTable.tsx:534
 msgid "Add Parts"
 msgstr "添加零件"
 
-#: src/tables/part/PartTable.tsx:543
+#: src/tables/part/PartTable.tsx:540
 msgid "Create Part"
 msgstr "创建零件"
 
-#: src/tables/part/PartTable.tsx:545
+#: src/tables/part/PartTable.tsx:542
 msgid "Create a new part"
-msgstr "创建一个新零件"
+msgstr "创建新零件"
 
-#: src/tables/part/PartTable.tsx:551
+#: src/tables/part/PartTable.tsx:548
 msgid "Import parts from a file"
 msgstr "从文件导入零件"
 
-#: src/tables/part/PartTable.tsx:556
+#: src/tables/part/PartTable.tsx:553
 msgid "Import from Supplier"
 msgstr "从供应商导入"
 
-#: src/tables/part/PartTable.tsx:558
+#: src/tables/part/PartTable.tsx:555
 msgid "Import parts from a supplier plugin"
-msgstr "从供应商插件导入零件"
+msgstr "通过供应商插件导入零件"
 
 #: src/tables/part/PartTestResultTable.tsx:103
 #: src/tables/part/PartTestResultTable.tsx:181
-#: src/tables/part/PartTestResultTable.tsx:329
-#: src/tables/part/PartTestResultTable.tsx:343
+#: src/tables/part/PartTestResultTable.tsx:328
+#: src/tables/part/PartTestResultTable.tsx:342
 #: src/tables/stock/StockItemTestResultTable.tsx:296
 #: src/tables/stock/StockItemTestResultTable.tsx:369
 #: src/tables/stock/StockItemTestResultTable.tsx:430
@@ -11087,7 +10825,7 @@ msgstr "测试结果已添加"
 msgid "No Result"
 msgstr "无结果"
 
-#: src/tables/part/PartTestResultTable.tsx:307
+#: src/tables/part/PartTestResultTable.tsx:306
 msgid "Show build outputs currently in production"
 msgstr "显示当前生产中的构建输出"
 
@@ -11172,15 +10910,7 @@ msgstr "查看父部分"
 msgid "Part templates cannot be edited, as the part is locked"
 msgstr "模板参数无法编辑，因为组件已锁定"
 
-#: src/tables/part/PartThumbTable.tsx:123
-msgid "Image updated"
-msgstr "图片已更新"
-
-#: src/tables/part/PartThumbTable.tsx:124
-msgid "The image has been updated successfully"
-msgstr "图片已成功更新"
-
-#: src/tables/part/PartThumbTable.tsx:233
+#: src/tables/part/PartThumbTable.tsx:222
 msgid "Select"
 msgstr "选择"
 
@@ -11204,8 +10934,8 @@ msgstr "显示虚拟变体"
 msgid "Show trackable variants"
 msgstr "显示可跟踪变体"
 
-#: src/tables/part/RelatedPartTable.tsx:105
-#: src/tables/part/RelatedPartTable.tsx:138
+#: src/tables/part/RelatedPartTable.tsx:104
+#: src/tables/part/RelatedPartTable.tsx:137
 msgid "Add Related Part"
 msgstr "添加关联零件"
 
@@ -11213,11 +10943,11 @@ msgstr "添加关联零件"
 #~ msgid "Add related part"
 #~ msgstr "Add related part"
 
-#: src/tables/part/RelatedPartTable.tsx:120
+#: src/tables/part/RelatedPartTable.tsx:119
 msgid "Delete Related Part"
 msgstr "删除关联零件"
 
-#: src/tables/part/RelatedPartTable.tsx:127
+#: src/tables/part/RelatedPartTable.tsx:126
 msgid "Edit Related Part"
 msgstr "编辑关联零件"
 
@@ -11234,7 +10964,7 @@ msgstr "编辑选择列表"
 msgid "Delete Selection List"
 msgstr "删除选择列表"
 
-#: src/tables/plugin/PluginErrorTable.tsx:31
+#: src/tables/plugin/PluginErrorTable.tsx:29
 msgid "Stage"
 msgstr "阶段"
 
@@ -11264,7 +10994,7 @@ msgstr "插件"
 #~ msgstr "An error occurred while fetching plugin details"
 
 #: src/tables/plugin/PluginListTable.tsx:106
-#: src/tables/plugin/PluginListTable.tsx:430
+#: src/tables/plugin/PluginListTable.tsx:422
 msgid "Mandatory"
 msgstr "必填"
 
@@ -11294,68 +11024,68 @@ msgstr "描述不可用."
 #~ msgid "Reload"
 #~ msgstr "Reload"
 
-#: src/tables/plugin/PluginListTable.tsx:159
+#: src/tables/plugin/PluginListTable.tsx:153
 msgid "Confirm plugin activation"
 msgstr "确认插件激活"
 
-#: src/tables/plugin/PluginListTable.tsx:160
+#: src/tables/plugin/PluginListTable.tsx:154
 msgid "Confirm plugin deactivation"
 msgstr "确认插件停用"
+
+#: src/tables/plugin/PluginListTable.tsx:159
+msgid "The selected plugin will be activated"
+msgstr "所选插件将被激活"
+
+#: src/tables/plugin/PluginListTable.tsx:160
+msgid "The selected plugin will be deactivated"
+msgstr "所选插件将被停用"
 
 #: src/tables/plugin/PluginListTable.tsx:163
 #~ msgid "Package information"
 #~ msgstr "Package information"
 
-#: src/tables/plugin/PluginListTable.tsx:165
-msgid "The selected plugin will be activated"
-msgstr "所选插件将被激活"
-
-#: src/tables/plugin/PluginListTable.tsx:166
-msgid "The selected plugin will be deactivated"
-msgstr "所选插件将被停用"
-
-#: src/tables/plugin/PluginListTable.tsx:184
+#: src/tables/plugin/PluginListTable.tsx:178
 msgid "Deactivate"
 msgstr "停用"
+
+#: src/tables/plugin/PluginListTable.tsx:192
+msgid "Activate"
+msgstr "激活"
+
+#: src/tables/plugin/PluginListTable.tsx:193
+msgid "Activate selected plugin"
+msgstr "激活所选插件"
 
 #: src/tables/plugin/PluginListTable.tsx:197
 #~ msgid "Plugin settings"
 #~ msgstr "Plugin settings"
 
-#: src/tables/plugin/PluginListTable.tsx:198
-msgid "Activate"
-msgstr "激活"
-
-#: src/tables/plugin/PluginListTable.tsx:199
-msgid "Activate selected plugin"
-msgstr "激活所选插件"
-
-#: src/tables/plugin/PluginListTable.tsx:211
+#: src/tables/plugin/PluginListTable.tsx:205
 msgid "Update selected plugin"
 msgstr "更新所选插件"
 
-#: src/tables/plugin/PluginListTable.tsx:229
-#: src/tables/stock/InstalledItemsTable.tsx:98
+#: src/tables/plugin/PluginListTable.tsx:224
+#: src/tables/stock/InstalledItemsTable.tsx:107
 msgid "Uninstall"
 msgstr "卸载"
 
-#: src/tables/plugin/PluginListTable.tsx:230
+#: src/tables/plugin/PluginListTable.tsx:225
 msgid "Uninstall selected plugin"
 msgstr "卸载所选插件"
 
-#: src/tables/plugin/PluginListTable.tsx:248
+#: src/tables/plugin/PluginListTable.tsx:244
 msgid "Delete selected plugin configuration"
 msgstr "删除选中的插件配置"
 
-#: src/tables/plugin/PluginListTable.tsx:264
+#: src/tables/plugin/PluginListTable.tsx:260
 msgid "Activate Plugin"
 msgstr "激活插件"
 
-#: src/tables/plugin/PluginListTable.tsx:271
+#: src/tables/plugin/PluginListTable.tsx:267
 msgid "The plugin was activated"
 msgstr "插件已激活"
 
-#: src/tables/plugin/PluginListTable.tsx:272
+#: src/tables/plugin/PluginListTable.tsx:268
 msgid "The plugin was deactivated"
 msgstr "插件已停用"
 
@@ -11363,20 +11093,20 @@ msgstr "插件已停用"
 #~ msgid "Install plugin"
 #~ msgstr "Install plugin"
 
-#: src/tables/plugin/PluginListTable.tsx:285
-#: src/tables/plugin/PluginListTable.tsx:377
+#: src/tables/plugin/PluginListTable.tsx:281
+#: src/tables/plugin/PluginListTable.tsx:368
 msgid "Install Plugin"
 msgstr "安装插件"
 
-#: src/tables/plugin/PluginListTable.tsx:298
+#: src/tables/plugin/PluginListTable.tsx:294
 msgid "Install"
 msgstr "安装"
 
-#: src/tables/plugin/PluginListTable.tsx:299
+#: src/tables/plugin/PluginListTable.tsx:295
 msgid "Plugin installed successfully"
 msgstr "插件安装成功"
 
-#: src/tables/plugin/PluginListTable.tsx:304
+#: src/tables/plugin/PluginListTable.tsx:300
 msgid "Uninstall Plugin"
 msgstr "卸载插件"
 
@@ -11384,23 +11114,23 @@ msgstr "卸载插件"
 #~ msgid "This action cannot be undone."
 #~ msgstr "This action cannot be undone."
 
-#: src/tables/plugin/PluginListTable.tsx:316
+#: src/tables/plugin/PluginListTable.tsx:312
 msgid "Confirm plugin uninstall"
 msgstr "确认插件卸载"
 
-#: src/tables/plugin/PluginListTable.tsx:319
+#: src/tables/plugin/PluginListTable.tsx:315
 msgid "The selected plugin will be uninstalled."
 msgstr "所选插件将被卸载。"
 
-#: src/tables/plugin/PluginListTable.tsx:324
+#: src/tables/plugin/PluginListTable.tsx:320
 msgid "Plugin uninstalled successfully"
 msgstr "插件卸载成功"
 
-#: src/tables/plugin/PluginListTable.tsx:332
+#: src/tables/plugin/PluginListTable.tsx:328
 msgid "Delete Plugin"
 msgstr "刪除插件"
 
-#: src/tables/plugin/PluginListTable.tsx:333
+#: src/tables/plugin/PluginListTable.tsx:329
 msgid "Deleting this plugin configuration will remove all associated settings and data. Are you sure you want to delete this plugin?"
 msgstr "删除此插件配置将删除所有相关的设置和数据。您确定要删除此插件吗？"
 
@@ -11408,11 +11138,11 @@ msgstr "删除此插件配置将删除所有相关的设置和数据。您确定
 #~ msgid "Deactivate Plugin"
 #~ msgstr "Deactivate Plugin"
 
-#: src/tables/plugin/PluginListTable.tsx:346
+#: src/tables/plugin/PluginListTable.tsx:342
 msgid "Plugins reloaded"
 msgstr "插件已重载"
 
-#: src/tables/plugin/PluginListTable.tsx:347
+#: src/tables/plugin/PluginListTable.tsx:343
 msgid "Plugins were reloaded successfully"
 msgstr "插件重载成功"
 
@@ -11424,7 +11154,7 @@ msgstr "插件重载成功"
 #~ msgid "The following plugin will be deactivated"
 #~ msgstr "The following plugin will be deactivated"
 
-#: src/tables/plugin/PluginListTable.tsx:370
+#: src/tables/plugin/PluginListTable.tsx:361
 msgid "Reload Plugins"
 msgstr "重载插件"
 
@@ -11436,24 +11166,24 @@ msgstr "重载插件"
 #~ msgid "Deactivating plugin"
 #~ msgstr "Deactivating plugin"
 
+#: src/tables/plugin/PluginListTable.tsx:385
+msgid "Plugin Detail"
+msgstr "插件详情"
+
 #: src/tables/plugin/PluginListTable.tsx:392
 #~ msgid "Plugin updated"
 #~ msgstr "Plugin updated"
-
-#: src/tables/plugin/PluginListTable.tsx:393
-msgid "Plugin Detail"
-msgstr "插件详情"
 
 #: src/tables/plugin/PluginListTable.tsx:403
 #~ msgid "Error updating plugin"
 #~ msgstr "Error updating plugin"
 
-#: src/tables/plugin/PluginListTable.tsx:435
+#: src/tables/plugin/PluginListTable.tsx:427
 msgid "Sample"
 msgstr "样本"
 
-#: src/tables/plugin/PluginListTable.tsx:440
-#: src/tables/stock/StockItemTable.tsx:226
+#: src/tables/plugin/PluginListTable.tsx:432
+#: src/tables/stock/StockItemTable.tsx:372
 msgid "Installed"
 msgstr "已安装"
 
@@ -11473,24 +11203,24 @@ msgstr "已安装"
 #~ msgid "Are you sure you want to delete this parameter?"
 #~ msgstr "Are you sure you want to delete this parameter?"
 
-#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:31
-#: src/tables/purchasing/ManufacturerPartTable.tsx:100
-#: src/tables/purchasing/SupplierPartTable.tsx:122
+#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:34
+#: src/tables/purchasing/ManufacturerPartTable.tsx:82
+#: src/tables/purchasing/SupplierPartTable.tsx:99
 msgid "MPN"
 msgstr "制造商零件编号 (MPN)"
 
-#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:43
-#: src/tables/purchasing/ManufacturerPartTable.tsx:155
+#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:45
+#: src/tables/purchasing/ManufacturerPartTable.tsx:135
 msgid "Show manufacturer parts for active internal parts."
-msgstr "显示当前内部零件对应的厂商零件信息。"
+msgstr "显示内部零件的制造商零件"
 
-#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:48
-#: src/tables/purchasing/ManufacturerPartTable.tsx:160
+#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:50
+#: src/tables/purchasing/ManufacturerPartTable.tsx:140
 msgid "Active Manufacturer"
 msgstr "添加制造商"
 
-#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:49
-#: src/tables/purchasing/ManufacturerPartTable.tsx:162
+#: src/tables/purchasing/ManufacturerPartParametricTable.tsx:51
+#: src/tables/purchasing/ManufacturerPartTable.tsx:142
 msgid "Show manufacturer parts for active manufacturers."
 msgstr "显示活动制造商部件。"
 
@@ -11510,24 +11240,24 @@ msgstr "显示活动制造商部件。"
 #~ msgid "Are you sure you want to remove this manufacturer part?"
 #~ msgstr "Are you sure you want to remove this manufacturer part?"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:109
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:398
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:115
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:400
 msgid "Import Line Items"
 msgstr "导入行项目"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:233
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:237
 msgid "Supplier Code"
 msgstr "供应商代码"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:241
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:244
 msgid "Supplier Link"
 msgstr "供应商链接"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:248
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:251
 msgid "Manufacturer Code"
 msgstr "制造商编号"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:282
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:284
 msgid "Show line items which have been received"
 msgstr "显示已收到的行项目"
 
@@ -11537,21 +11267,29 @@ msgstr "显示已收到的行项目"
 #~ msgid "Add line item"
 #~ msgstr "Add line item"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:351
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:353
 msgid "Receive line item"
 msgstr "接收这行项目"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:415
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:417
 msgid "Receive items"
 msgstr "收到项目"
 
-#: src/tables/purchasing/SupplierPartTable.tsx:160
+#: src/tables/purchasing/SupplierPartTable.tsx:129
 msgid "Base units"
 msgstr "基础单位"
+
+#: src/tables/purchasing/SupplierPartTable.tsx:192
+msgid "Add supplier part"
+msgstr "添加供应商零件"
 
 #: src/tables/purchasing/SupplierPartTable.tsx:193
 #~ msgid "Supplier part updated"
 #~ msgstr "Supplier part updated"
+
+#: src/tables/purchasing/SupplierPartTable.tsx:200
+msgid "Import supplier part"
+msgstr "导入供应商零件"
 
 #: src/tables/purchasing/SupplierPartTable.tsx:205
 #~ msgid "Supplier part deleted"
@@ -11561,89 +11299,77 @@ msgstr "基础单位"
 #~ msgid "Are you sure you want to remove this supplier part?"
 #~ msgstr "Are you sure you want to remove this supplier part?"
 
-#: src/tables/purchasing/SupplierPartTable.tsx:226
-msgid "Add supplier part"
-msgstr "添加供应商零件"
-
-#: src/tables/purchasing/SupplierPartTable.tsx:234
-msgid "Import supplier part"
-msgstr "导入供应商零件"
-
-#: src/tables/purchasing/SupplierPartTable.tsx:250
+#: src/tables/purchasing/SupplierPartTable.tsx:216
 msgid "Show active supplier parts"
 msgstr "显示活动供应商零件"
 
-#: src/tables/purchasing/SupplierPartTable.tsx:255
-msgid "Show primary supplier parts"
-msgstr "显示主要供应商零件"
-
-#: src/tables/purchasing/SupplierPartTable.tsx:260
+#: src/tables/purchasing/SupplierPartTable.tsx:221
 msgid "Show active internal parts"
 msgstr "显示活动内部零件"
 
-#: src/tables/purchasing/SupplierPartTable.tsx:264
+#: src/tables/purchasing/SupplierPartTable.tsx:225
 msgid "Active Supplier"
 msgstr "活跃的供应商"
 
-#: src/tables/purchasing/SupplierPartTable.tsx:265
+#: src/tables/purchasing/SupplierPartTable.tsx:226
 msgid "Show active suppliers"
 msgstr "显示活跃供应商"
 
-#: src/tables/purchasing/SupplierPartTable.tsx:270
+#: src/tables/purchasing/SupplierPartTable.tsx:231
 msgid "Show supplier parts with stock"
 msgstr "显示供应商零件库存"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:157
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:158
 msgid "Received Date"
 msgstr "接收日期"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:171
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:172
 msgid "Show items which have been received"
 msgstr "显示已收到的项目"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:176
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:177
 msgid "Filter by line item status"
 msgstr "按行项目状态筛选"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:194
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:195
 msgid "Receive selected items"
 msgstr "接收选中项目"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:229
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:230
 msgid "Receive Item"
 msgstr "接收物品"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:90
+#: src/tables/sales/SalesOrderAllocationTable.tsx:89
 msgid "Show outstanding allocations"
 msgstr "显示未完成的分配"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:94
+#: src/tables/sales/SalesOrderAllocationTable.tsx:93
 msgid "Assigned to Shipment"
 msgstr "已安排发货"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:95
+#: src/tables/sales/SalesOrderAllocationTable.tsx:94
 msgid "Show allocations assigned to a shipment"
 msgstr "显示已分配至货运的库存"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:155
+#: src/tables/sales/SalesOrderAllocationTable.tsx:156
 msgid "Available Quantity"
 msgstr "可用数量"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:162
+#: src/tables/sales/SalesOrderAllocationTable.tsx:163
 msgid "Allocated Quantity"
 msgstr "已分配数量"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:176
-#: src/tables/sales/SalesOrderAllocationTable.tsx:190
+#: src/tables/sales/SalesOrderAllocationTable.tsx:177
+#: src/tables/sales/SalesOrderAllocationTable.tsx:191
 msgid "No shipment"
 msgstr "无货运记录"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:188
+#: src/tables/sales/SalesOrderAllocationTable.tsx:189
 msgid "Not shipped"
 msgstr "未发货"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:210
-#: src/tables/sales/SalesOrderAllocationTable.tsx:234
+#: src/tables/sales/SalesOrderAllocationTable.tsx:211
+#: src/tables/sales/SalesOrderAllocationTable.tsx:235
 msgid "Edit Allocation"
 msgstr "编辑分配"
 
@@ -11652,16 +11378,16 @@ msgstr "编辑分配"
 #~ msgid "Delete Allocation"
 #~ msgstr "Delete Allocation"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:260
 #: src/tables/sales/SalesOrderAllocationTable.tsx:261
+#: src/tables/sales/SalesOrderAllocationTable.tsx:262
 msgid "View Shipment"
 msgstr "查看发货"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:316
+#: src/tables/sales/SalesOrderAllocationTable.tsx:317
 msgid "Assign to Shipment"
 msgstr "安排发货"
 
-#: src/tables/sales/SalesOrderAllocationTable.tsx:332
+#: src/tables/sales/SalesOrderAllocationTable.tsx:333
 msgid "Assign to shipment"
 msgstr "安排发货"
 
@@ -11669,35 +11395,31 @@ msgstr "安排发货"
 #~ msgid "Allocate stock"
 #~ msgstr "Allocate stock"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:289
-msgid "Allocate Serial Numbers"
-msgstr "分配序列号"
-
 #: src/tables/sales/SalesOrderLineItemTable.tsx:291
 #~ msgid "Allocate Serials"
 #~ msgstr "Allocate Serials"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:297
-msgid "Stock allocated successfully"
-msgstr "库存分配成功"
+#: src/tables/sales/SalesOrderLineItemTable.tsx:293
+msgid "Allocate Serial Numbers"
+msgstr "分配序列号"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:341
+#: src/tables/sales/SalesOrderLineItemTable.tsx:343
 msgid "Show lines which are fully allocated"
 msgstr "显示已完全分配的行"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:346
+#: src/tables/sales/SalesOrderLineItemTable.tsx:348
 msgid "Show lines which are completed"
 msgstr "显示已完成的行"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:419
+#: src/tables/sales/SalesOrderLineItemTable.tsx:421
 msgid "Allocate serials"
 msgstr "分配序列号"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:437
+#: src/tables/sales/SalesOrderLineItemTable.tsx:439
 msgid "Build stock"
 msgstr "生产库存"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:455
+#: src/tables/sales/SalesOrderLineItemTable.tsx:457
 msgid "Order stock"
 msgstr "订单库存"
 
@@ -11709,82 +11431,78 @@ msgstr "订单库存"
 msgid "Create Shipment"
 msgstr "创建配送"
 
-#: src/tables/sales/SalesOrderShipmentTable.tsx:80
-msgid "Shipment created"
-msgstr "发货单已创建"
-
-#: src/tables/sales/SalesOrderShipmentTable.tsx:159
+#: src/tables/sales/SalesOrderShipmentTable.tsx:164
 msgid "Items"
 msgstr "项目"
 
-#: src/tables/sales/SalesOrderShipmentTable.tsx:243
+#: src/tables/sales/SalesOrderShipmentTable.tsx:248
 msgid "Edit shipment"
 msgstr "编辑配送"
 
-#: src/tables/sales/SalesOrderShipmentTable.tsx:251
+#: src/tables/sales/SalesOrderShipmentTable.tsx:256
 msgid "Cancel shipment"
 msgstr "取消配送"
 
-#: src/tables/sales/SalesOrderShipmentTable.tsx:281
+#: src/tables/sales/SalesOrderShipmentTable.tsx:286
 msgid "Add shipment"
 msgstr "添加配送"
 
-#: src/tables/sales/SalesOrderShipmentTable.tsx:295
+#: src/tables/sales/SalesOrderShipmentTable.tsx:300
 msgid "Show shipments which have been checked"
 msgstr "显示已发货的货物"
 
-#: src/tables/sales/SalesOrderShipmentTable.tsx:300
+#: src/tables/sales/SalesOrderShipmentTable.tsx:305
 msgid "Show shipments which have been shipped"
 msgstr "显示已发货的货物"
 
-#: src/tables/sales/SalesOrderShipmentTable.tsx:305
+#: src/tables/sales/SalesOrderShipmentTable.tsx:310
 msgid "Show shipments which have been delivered"
 msgstr "显示已送达的货物"
 
-#: src/tables/settings/ApiTokenTable.tsx:31
-#: src/tables/settings/ApiTokenTable.tsx:45
+#: src/tables/settings/ApiTokenTable.tsx:30
+#: src/tables/settings/ApiTokenTable.tsx:44
 msgid "Generate Token"
 msgstr "生成令牌"
 
-#: src/tables/settings/ApiTokenTable.tsx:33
+#: src/tables/settings/ApiTokenTable.tsx:32
 msgid "Token generated"
 msgstr "令牌已生成"
 
-#: src/tables/settings/ApiTokenTable.tsx:68
-#: src/tables/settings/ApiTokenTable.tsx:118
+#: src/tables/settings/ApiTokenTable.tsx:67
+#: src/tables/settings/ApiTokenTable.tsx:117
 msgid "Revoked"
 msgstr "撤销"
 
-#: src/tables/settings/ApiTokenTable.tsx:72
-#: src/tables/settings/ApiTokenTable.tsx:180
+#: src/tables/settings/ApiTokenTable.tsx:71
+#: src/tables/settings/ApiTokenTable.tsx:179
 msgid "Token"
 msgstr "令牌"
 
-#: src/tables/settings/ApiTokenTable.tsx:79
+#: src/tables/settings/ApiTokenTable.tsx:78
 msgid "In Use"
 msgstr "使用中"
 
-#: src/tables/settings/ApiTokenTable.tsx:88
+#: src/tables/settings/ApiTokenTable.tsx:87
 msgid "Last Seen"
 msgstr "最近一次在线"
 
-#: src/tables/settings/ApiTokenTable.tsx:93
+#: src/tables/settings/ApiTokenTable.tsx:92
 msgid "Expiry"
 msgstr "到期"
 
-#: src/tables/settings/ApiTokenTable.tsx:119
+#: src/tables/settings/ApiTokenTable.tsx:118
 msgid "Show revoked tokens"
 msgstr "显示已撤销的令牌"
 
-#: src/tables/settings/ApiTokenTable.tsx:138
+#: src/tables/settings/ApiTokenTable.tsx:137
 msgid "Revoke"
 msgstr "撤销"
 
-#: src/tables/settings/ApiTokenTable.tsx:162
+#: src/tables/settings/ApiTokenTable.tsx:161
 msgid "Error revoking token"
 msgstr "撤销令牌时出错"
 
-#: src/tables/settings/ApiTokenTable.tsx:185
+#: src/tables/settings/ApiTokenTable.tsx:183
 msgid "Tokens are only shown once - make sure to note it down."
 msgstr "令牌只显示一次 - 请务必记住它。"
 
@@ -12022,7 +11740,7 @@ msgstr "用户组名称"
 #~ msgstr "Permission set"
 
 #: src/tables/settings/GroupTable.tsx:170
-#: src/tables/settings/UserTable.tsx:316
+#: src/tables/settings/UserTable.tsx:315
 msgid "Open Profile"
 msgstr "打开个人资料"
 
@@ -12054,29 +11772,29 @@ msgstr "编辑组"
 msgid "Add Group"
 msgstr "添加组"
 
-#: src/tables/settings/ImportSessionTable.tsx:37
+#: src/tables/settings/ImportSessionTable.tsx:38
 msgid "Delete Import Session"
 msgstr "删除导入的会话"
 
-#: src/tables/settings/ImportSessionTable.tsx:43
-#: src/tables/settings/ImportSessionTable.tsx:130
+#: src/tables/settings/ImportSessionTable.tsx:44
+#: src/tables/settings/ImportSessionTable.tsx:129
 msgid "Create Import Session"
 msgstr "创建导入会话"
 
-#: src/tables/settings/ImportSessionTable.tsx:73
+#: src/tables/settings/ImportSessionTable.tsx:72
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/tables/settings/ImportSessionTable.tsx:84
+#: src/tables/settings/ImportSessionTable.tsx:83
 msgid "Imported Rows"
 msgstr "导入的行"
 
-#: src/tables/settings/ImportSessionTable.tsx:113
+#: src/tables/settings/ImportSessionTable.tsx:112
 #: src/tables/settings/TemplateTable.tsx:369
 msgid "Filter by target model type"
 msgstr "按目标型号筛选"
 
-#: src/tables/settings/ImportSessionTable.tsx:119
+#: src/tables/settings/ImportSessionTable.tsx:118
 msgid "Filter by import session status"
 msgstr "按导入会话状态筛选"
 
@@ -12222,12 +11940,8 @@ msgid "Designates whether this user should be treated as active. Unselect this i
 msgstr "指定是否将此用户视为激活用户。取消选择此选项将不会删除账户。"
 
 #: src/tables/settings/UserTable.tsx:183
-msgid "Is Administrator"
-msgstr "拥有管理员权限"
-
-#: src/tables/settings/UserTable.tsx:183
-#~ msgid "Is Staff"
-#~ msgstr "Is Staff"
+msgid "Is Staff"
+msgstr "员工"
 
 #: src/tables/settings/UserTable.tsx:184
 msgid "Designates whether the user can log into the django admin site."
@@ -12253,96 +11967,92 @@ msgstr "用户组"
 #~ msgid "Edit user"
 #~ msgstr "Edit user"
 
-#: src/tables/settings/UserTable.tsx:333
+#: src/tables/settings/UserTable.tsx:332
 msgid "Lock user"
 msgstr "锁定用户"
 
-#: src/tables/settings/UserTable.tsx:343
+#: src/tables/settings/UserTable.tsx:342
 msgid "Unlock user"
 msgstr "解锁用户"
 
-#: src/tables/settings/UserTable.tsx:359
+#: src/tables/settings/UserTable.tsx:358
 msgid "Delete user"
 msgstr "删除用户"
 
-#: src/tables/settings/UserTable.tsx:360
+#: src/tables/settings/UserTable.tsx:359
 msgid "User deleted"
 msgstr "用户已删除"
 
-#: src/tables/settings/UserTable.tsx:363
+#: src/tables/settings/UserTable.tsx:362
 msgid "Are you sure you want to delete this user?"
 msgstr "您确定要删除该用户吗？"
 
-#: src/tables/settings/UserTable.tsx:373
+#: src/tables/settings/UserTable.tsx:372
 msgid "Set Password"
 msgstr "设定密码"
 
-#: src/tables/settings/UserTable.tsx:378
+#: src/tables/settings/UserTable.tsx:377
 msgid "Password updated"
 msgstr "密码已更新"
 
-#: src/tables/settings/UserTable.tsx:389
+#: src/tables/settings/UserTable.tsx:388
 msgid "Add user"
 msgstr "添加用户"
 
-#: src/tables/settings/UserTable.tsx:402
+#: src/tables/settings/UserTable.tsx:401
 msgid "Show active users"
 msgstr "显示活跃用户"
 
 #: src/tables/settings/UserTable.tsx:406
-#~ msgid "Show staff users"
-#~ msgstr "Show staff users"
+msgid "Show staff users"
+msgstr "显示工作人员用户"
 
-#: src/tables/settings/UserTable.tsx:407
-msgid "Show administrators"
-msgstr "显示管理员列表"
-
-#: src/tables/settings/UserTable.tsx:412
+#: src/tables/settings/UserTable.tsx:411
 msgid "Show superusers"
 msgstr "显示超级用户"
 
-#: src/tables/settings/UserTable.tsx:431
+#: src/tables/settings/UserTable.tsx:430
 msgid "Edit User"
 msgstr "编辑用户"
 
-#: src/tables/settings/UserTable.tsx:464
+#: src/tables/settings/UserTable.tsx:463
 msgid "Add User"
 msgstr "添加用户"
 
-#: src/tables/settings/UserTable.tsx:472
+#: src/tables/settings/UserTable.tsx:471
 msgid "Added user"
 msgstr "已添加用户"
 
-#: src/tables/settings/UserTable.tsx:482
+#: src/tables/settings/UserTable.tsx:481
 msgid "User updated"
 msgstr "用户信息已更新"
 
-#: src/tables/settings/UserTable.tsx:483
+#: src/tables/settings/UserTable.tsx:482
 msgid "User updated successfully"
 msgstr "用户信息更新成功"
 
-#: src/tables/settings/UserTable.tsx:489
+#: src/tables/settings/UserTable.tsx:488
 msgid "Error updating user"
 msgstr "更新用户时出错"
 
-#: src/tables/stock/InstalledItemsTable.tsx:37
-#: src/tables/stock/InstalledItemsTable.tsx:81
+#: src/tables/stock/InstalledItemsTable.tsx:38
+#: src/tables/stock/InstalledItemsTable.tsx:90
 msgid "Install Item"
 msgstr "安装项目"
 
-#: src/tables/stock/InstalledItemsTable.tsx:39
+#: src/tables/stock/InstalledItemsTable.tsx:40
 msgid "Item installed"
 msgstr "已安装项目"
 
-#: src/tables/stock/InstalledItemsTable.tsx:50
+#: src/tables/stock/InstalledItemsTable.tsx:51
 msgid "Uninstall Item"
 msgstr "卸载项目"
 
-#: src/tables/stock/InstalledItemsTable.tsx:52
+#: src/tables/stock/InstalledItemsTable.tsx:53
 msgid "Item uninstalled"
 msgstr "已卸载项目"
 
-#: src/tables/stock/InstalledItemsTable.tsx:99
+#: src/tables/stock/InstalledItemsTable.tsx:108
 msgid "Uninstall stock item"
 msgstr "卸载库存项目"
 
@@ -12363,158 +12073,206 @@ msgstr "删除位置类型"
 msgid "Icon"
 msgstr "图标"
 
-#: src/tables/stock/StockItemTable.tsx:159
-msgid "Stocktake Date"
-msgstr "盘点日期"
+#: src/tables/stock/StockItemTable.tsx:106
+msgid "This stock item is in production"
+msgstr "该库存项正在生产"
 
-#: src/tables/stock/StockItemTable.tsx:177
-msgid "Show stock for active parts"
-msgstr "显示激活零件的库存"
+#: src/tables/stock/StockItemTable.tsx:113
+msgid "This stock item has been assigned to a sales order"
+msgstr "库存项已分配到销售订单"
 
-#: src/tables/stock/StockItemTable.tsx:188
-msgid "Show stock for assembled parts"
-msgstr "显示已组装零件的库存"
+#: src/tables/stock/StockItemTable.tsx:120
+msgid "This stock item has been assigned to a customer"
+msgstr "库存项已分配给客户"
 
-#: src/tables/stock/StockItemTable.tsx:193
-msgid "Show items which have been allocated"
-msgstr "显示已分配的项目"
+#: src/tables/stock/StockItemTable.tsx:127
+msgid "This stock item is installed in another stock item"
+msgstr "此库存项已安装在另一个库存项中"
 
-#: src/tables/stock/StockItemTable.tsx:198
-msgid "Show items which are available"
-msgstr "显示可用的项目"
+#: src/tables/stock/StockItemTable.tsx:134
+msgid "This stock item has been consumed by a build order"
+msgstr "此库存项已被生产订单消耗"
 
-#: src/tables/stock/StockItemTable.tsx:202
-#: src/tables/stock/StockLocationTable.tsx:38
-msgid "Include Sublocations"
-msgstr "包括子地点"
+#: src/tables/stock/StockItemTable.tsx:141
+msgid "This stock item is unavailable"
+msgstr "此库存项不可用"
 
-#: src/tables/stock/StockItemTable.tsx:203
-msgid "Include stock in sublocations"
-msgstr "包括子地点的库存"
+#: src/tables/stock/StockItemTable.tsx:150
+msgid "This stock item has expired"
+msgstr "此库存项已过期"
 
-#: src/tables/stock/StockItemTable.tsx:207
-msgid "Depleted"
-msgstr "耗尽"
+#: src/tables/stock/StockItemTable.tsx:154
+msgid "This stock item is stale"
+msgstr "此库存项是过期项"
 
-#: src/tables/stock/StockItemTable.tsx:208
-msgid "Show depleted stock items"
-msgstr "显示耗尽的库存项"
+#: src/tables/stock/StockItemTable.tsx:166
+msgid "This stock item is fully allocated"
+msgstr "此库存项已完全分配"
 
-#: src/tables/stock/StockItemTable.tsx:214
-msgid "Show items which are in production"
-msgstr "显示正在生产的项目"
+#: src/tables/stock/StockItemTable.tsx:173
+msgid "This stock item is partially allocated"
+msgstr "此库存项已被部分分配"
 
-#: src/tables/stock/StockItemTable.tsx:222
-msgid "Show items which have been consumed by a build order"
-msgstr "显示被生产订单消耗的项目"
-
-#: src/tables/stock/StockItemTable.tsx:227
-msgid "Show stock items which are installed in other items"
-msgstr "显示安装在其他项目中的库存项"
-
-#: src/tables/stock/StockItemTable.tsx:231
-msgid "Sent to Customer"
-msgstr "发送给客户"
-
-#: src/tables/stock/StockItemTable.tsx:232
-msgid "Show items which have been sent to a customer"
-msgstr "显示已发送给客户的项目"
-
-#: src/tables/stock/StockItemTable.tsx:243
-msgid "Show tracked items"
-msgstr "显示已跟踪项目"
-
-#: src/tables/stock/StockItemTable.tsx:247
-msgid "Has Purchase Price"
-msgstr "有采购价格"
-
-#: src/tables/stock/StockItemTable.tsx:248
-msgid "Show items which have a purchase price"
-msgstr "显示有购买价格的项目"
-
-#: src/tables/stock/StockItemTable.tsx:253
-msgid "Show items which have expired"
-msgstr "显示已过期的项目"
-
-#: src/tables/stock/StockItemTable.tsx:259
-msgid "Show items which are stale"
-msgstr "显示旧项目"
-
-#: src/tables/stock/StockItemTable.tsx:264
-msgid "Expired Before"
-msgstr "过期前"
-
-#: src/tables/stock/StockItemTable.tsx:265
-msgid "Show items which expired before this date"
-msgstr "显示在此日期之前过期的项目"
-
-#: src/tables/stock/StockItemTable.tsx:271
-msgid "Expired After"
-msgstr "过期后"
-
-#: src/tables/stock/StockItemTable.tsx:272
-msgid "Show items which expired after this date"
-msgstr "显示在此日期后过期的项目"
-
-#: src/tables/stock/StockItemTable.tsx:279
-msgid "Show items updated before this date"
-msgstr "显示此日期之前更新的项目"
-
-#: src/tables/stock/StockItemTable.tsx:285
-msgid "Show items updated after this date"
-msgstr "显示此日期后更新的项目"
-
-#: src/tables/stock/StockItemTable.tsx:290
-msgid "Stocktake Before"
-msgstr "在此之前的盘点"
-
-#: src/tables/stock/StockItemTable.tsx:291
-msgid "Show items counted before this date"
-msgstr "显示在此日期之前计数的项目"
-
-#: src/tables/stock/StockItemTable.tsx:296
-msgid "Stocktake After"
-msgstr "在此之后的盘点"
-
-#: src/tables/stock/StockItemTable.tsx:297
-msgid "Show items counted after this date"
-msgstr "显示在此日期后计数的项目"
+#: src/tables/stock/StockItemTable.tsx:201
+msgid "This stock item has been depleted"
+msgstr "库存项已耗尽"
 
 #: src/tables/stock/StockItemTable.tsx:301
 #~ msgid "Show stock for assmebled parts"
 #~ msgstr "Show stock for assmebled parts"
 
-#: src/tables/stock/StockItemTable.tsx:302
-msgid "External Location"
-msgstr "外部地点"
+#: src/tables/stock/StockItemTable.tsx:305
+msgid "Stocktake Date"
+msgstr "盘点日期"
 
-#: src/tables/stock/StockItemTable.tsx:303
-msgid "Show items in an external location"
-msgstr "显示外部库存地点的项目"
+#: src/tables/stock/StockItemTable.tsx:323
+msgid "Show stock for active parts"
+msgstr "显示激活零件的库存"
+
+#: src/tables/stock/StockItemTable.tsx:334
+msgid "Show stock for assembled parts"
+msgstr "显示已组装零件的库存"
+
+#: src/tables/stock/StockItemTable.tsx:339
+msgid "Show items which have been allocated"
+msgstr "显示已分配的项目"
+
+#: src/tables/stock/StockItemTable.tsx:344
+msgid "Show items which are available"
+msgstr "显示可用的项目"
+
+#: src/tables/stock/StockItemTable.tsx:348
+#: src/tables/stock/StockLocationTable.tsx:38
+msgid "Include Sublocations"
+msgstr "包括子地点"
+
+#: src/tables/stock/StockItemTable.tsx:349
+msgid "Include stock in sublocations"
+msgstr "包括子地点的库存"
+
+#: src/tables/stock/StockItemTable.tsx:353
+msgid "Depleted"
+msgstr "耗尽"
+
+#: src/tables/stock/StockItemTable.tsx:354
+msgid "Show depleted stock items"
+msgstr "显示耗尽的库存项"
+
+#: src/tables/stock/StockItemTable.tsx:360
+msgid "Show items which are in production"
+msgstr "显示正在生产的项目"
 
 #: src/tables/stock/StockItemTable.tsx:362
 #~ msgid "Include stock items for variant parts"
 #~ msgstr "Include stock items for variant parts"
 
+#: src/tables/stock/StockItemTable.tsx:368
+msgid "Show items which have been consumed by a build order"
+msgstr "显示被生产订单消耗的项目"
+
+#: src/tables/stock/StockItemTable.tsx:373
+msgid "Show stock items which are installed in other items"
+msgstr "显示安装在其他项目中的库存项"
+
+#: src/tables/stock/StockItemTable.tsx:377
+msgid "Sent to Customer"
+msgstr "发送给客户"
+
+#: src/tables/stock/StockItemTable.tsx:378
+msgid "Show items which have been sent to a customer"
+msgstr "显示已发送给客户的项目"
+
+#: src/tables/stock/StockItemTable.tsx:389
+msgid "Show tracked items"
+msgstr "显示已跟踪项目"
+
+#: src/tables/stock/StockItemTable.tsx:393
+msgid "Has Purchase Price"
+msgstr "有采购价格"
+
+#: src/tables/stock/StockItemTable.tsx:394
+msgid "Show items which have a purchase price"
+msgstr "显示有购买价格的项目"
+
 #: src/tables/stock/StockItemTable.tsx:397
 #~ msgid "Serial Number LTE"
 #~ msgstr "Serial Number LTE"
+
+#: src/tables/stock/StockItemTable.tsx:399
+msgid "Show items which have expired"
+msgstr "显示已过期的项目"
 
 #: src/tables/stock/StockItemTable.tsx:403
 #~ msgid "Serial Number GTE"
 #~ msgstr "Serial Number GTE"
 
-#: src/tables/stock/StockItemTable.tsx:420
-msgid "Stock item created"
-msgstr "库存项已创建"
+#: src/tables/stock/StockItemTable.tsx:405
+msgid "Show items which are stale"
+msgstr "显示旧项目"
+
+#: src/tables/stock/StockItemTable.tsx:410
+msgid "Expired Before"
+msgstr "过期前"
+
+#: src/tables/stock/StockItemTable.tsx:411
+msgid "Show items which expired before this date"
+msgstr "显示在此日期之前过期的项目"
+
+#: src/tables/stock/StockItemTable.tsx:417
+msgid "Expired After"
+msgstr "过期后"
+
+#: src/tables/stock/StockItemTable.tsx:418
+msgid "Show items which expired after this date"
+msgstr "显示在此日期后过期的项目"
+
+#: src/tables/stock/StockItemTable.tsx:424
+msgid "Updated Before"
+msgstr "在此之前更新"
+
+#: src/tables/stock/StockItemTable.tsx:425
+msgid "Show items updated before this date"
+msgstr "显示此日期之前更新的项目"
+
+#: src/tables/stock/StockItemTable.tsx:430
+msgid "Updated After"
+msgstr "在此之后更新"
+
+#: src/tables/stock/StockItemTable.tsx:431
+msgid "Show items updated after this date"
+msgstr "显示此日期后更新的项目"
+
+#: src/tables/stock/StockItemTable.tsx:436
+msgid "Stocktake Before"
+msgstr "在此之前的盘点"
+
+#: src/tables/stock/StockItemTable.tsx:437
+msgid "Show items counted before this date"
+msgstr "显示在此日期之前计数的项目"
 
 #: src/tables/stock/StockItemTable.tsx:442
-msgid "Order items"
-msgstr "订单明细"
+msgid "Stocktake After"
+msgstr "在此之后的盘点"
+
+#: src/tables/stock/StockItemTable.tsx:443
+msgid "Show items counted after this date"
+msgstr "显示在此日期后计数的项目"
+
+#: src/tables/stock/StockItemTable.tsx:448
+msgid "External Location"
+msgstr "外部地点"
+
+#: src/tables/stock/StockItemTable.tsx:449
+msgid "Show items in an external location"
+msgstr "显示外部库存地点的项目"
 
 #: src/tables/stock/StockItemTable.tsx:528
 #~ msgid "Delete stock items"
 #~ msgstr "Delete stock items"
+
+#: src/tables/stock/StockItemTable.tsx:559
+msgid "Order items"
+msgstr "订单明细"
 
 #: src/tables/stock/StockItemTable.tsx:595
 #~ msgid "Add a new stock item"
@@ -12666,36 +12424,32 @@ msgstr "有位置类型"
 msgid "Filter by location type"
 msgstr "按位置类型筛选"
 
-#: src/tables/stock/StockLocationTable.tsx:107
-#: src/tables/stock/StockLocationTable.tsx:163
+#: src/tables/stock/StockLocationTable.tsx:105
+#: src/tables/stock/StockLocationTable.tsx:160
 msgid "Add Stock Location"
 msgstr "添加库存地点"
 
-#: src/tables/stock/StockLocationTable.tsx:132
+#: src/tables/stock/StockLocationTable.tsx:129
 msgid "Set Parent Location"
 msgstr "设置父级位置"
 
-#: src/tables/stock/StockLocationTable.tsx:152
+#: src/tables/stock/StockLocationTable.tsx:149
 msgid "Set parent location for the selected items"
 msgstr "为选定项目设置父级位置"
 
-#: src/tables/stock/StockTrackingTable.tsx:93
+#: src/tables/stock/StockTrackingTable.tsx:76
 msgid "Old Status"
 msgstr "旧状态"
 
-#: src/tables/stock/StockTrackingTable.tsx:109
+#: src/tables/stock/StockTrackingTable.tsx:92
 msgid "Added"
 msgstr "已添加"
 
-#: src/tables/stock/StockTrackingTable.tsx:114
+#: src/tables/stock/StockTrackingTable.tsx:97
 msgid "Removed"
 msgstr "已删除"
 
-#: src/tables/stock/StockTrackingTable.tsx:250
-msgid "Stock item no longer exists"
-msgstr "此库存项已不存在"
-
-#: src/tables/stock/StockTrackingTable.tsx:276
+#: src/tables/stock/StockTrackingTable.tsx:236
 msgid "No user information"
 msgstr "没有用户信息"
 

--- a/src/frontend/src/locales/zh_Hans/messages.po
+++ b/src/frontend/src/locales/zh_Hans/messages.po
@@ -1,5 +1,5 @@
 msgid ""
-msgstr ""
+msgstr "空字符串"
 "POT-Creation-Date: 2023-06-09 22:10+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -9117,7 +9117,7 @@ msgstr "已分配的项目"
 
 #: src/tables/ColumnRenderers.tsx:774
 msgid "Line Item"
-msgstr ""
+msgstr "明细项"
 
 #: src/tables/ColumnSelect.tsx:16
 #: src/tables/ColumnSelect.tsx:23


### PR DESCRIPTION
后端 django.po:
- Invalid URL: no hostname -> 无效 URL：无主机名
- Invalid URL: hostname could not be resolved -> 无效 URL：无法解析主机名
- URL points to a private or reserved IP address -> URL 指向私有或保留 IP 地址
- Too many redirects -> 重定向次数过多
- Line Number -> 行号
- Line number for this item (optional) -> 此项目的行号（可选）
- Only superuser accounts can administer plugins -> 只有超级用户账户才能管理插件
- No package name or URL provided for installation -> 未提供安装所需的包名或 URL
- Invalid characters in package name or URL -> 包名或 URL 中存在无效字符
- User must be authenticated -> 用户必须经过身份验证
- Only a superuser can create a token for another user -> 只有超级用户才能为其他用户创建令牌
- Staff -> 职员
- Does this user have staff permissions -> 此用户是否具有职员权限

前端 messages.po:
- 空字符串 -> 空字符串
- Line Item -> 明细项