### PR TITLE
Catch keyboard interrupts

### DIFF
--- a/docs/docs/settings/error_codes.md
+++ b/docs/docs/settings/error_codes.md
@@ -216,6 +216,11 @@ This warning will not prevent you from restoring the backup but it is recommende
 A user is logged in with elevated privileges. This might be a superuser or a administrator user. These types of users have elevated permissions and should not be used for regular usage.
 Use separate accounts for administrative tasks and regular usage to reduce risk. Make sure to review the [permission documentation](../settings/permissions.md#dangerous-user-flags).
 
+#### INVE-W15
+**Process interrupted by user - Backend**
+
+A process was interrupted by the user, likely by a keyboard interrupt. This might lead to issues with the process that was interrupted, as it might not have completed its task. This is especially relevant for processes that are not idempotent or that do not have a good rollback mechanism.
+
 
 ### INVE-I (InvenTree Information)
 Information — These are not errors but information messages. They might point out potential issues or just provide information.

--- a/src/backend/InvenTree/manage.py
+++ b/src/backend/InvenTree/manage.py
@@ -22,4 +22,8 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('INVE-W15: Process interrupted by user.')
+        sys.exit(1)

--- a/tasks.py
+++ b/tasks.py
@@ -203,7 +203,14 @@ def state_logger(fn=None, method_name=None):
                 info(f'# task | {func.method_name} | start')
 
             t1 = time.time()
-            func(c, *args, **kwargs)
+            try:
+                func(c, *args, **kwargs)
+            except KeyboardInterrupt:
+                error('INVE-W15: Process interrupted by user.')
+                sys.exit(1)
+            except UnexpectedExit:
+                error(f"Task '{func.method_name}' failed with an error.")
+                raise
             t2 = time.time()
 
             if do_log:


### PR DESCRIPTION
Handle invoke tasks being cancelled by the user, present a simple error message rather than the entire stacktrace from the keyboard interrupt