### PR TITLE
Pin python version for teyit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,3 +97,4 @@ repos:
     rev: 0.4.3
     hooks:
     -   id: teyit
+        language_version: python3.11


### PR DESCRIPTION
Pre-Commit hooks fail for me since teyit uses an internal CPython API which only existed up to (including) python version 3.12. Here's the trace:

```
teyit....................................................................Failed
- hook id: teyit
- exit code: 1

Traceback (most recent call last):
  File "/home/daniel/.cache/pre-commit/repokwvueu6g/py_env-python3/bin/teyit", line 5, in <module>
    from teyit import main
  File "/home/daniel/.cache/pre-commit/repokwvueu6g/py_env-python3/lib/python3.14/site-packages/teyit.py", line 12, in <module>
    from refactor.ast import PreciseUnparser
  File "/home/daniel/.cache/pre-commit/repokwvueu6g/py_env-python3/lib/python3.14/site-packages/refactor/__init__.py", line 4, in <module>
    from refactor.actions import *
  File "/home/daniel/.cache/pre-commit/repokwvueu6g/py_env-python3/lib/python3.14/site-packages/refactor/actions.py", line 9, in <module>
    from refactor.ast import split_lines
  File "/home/daniel/.cache/pre-commit/repokwvueu6g/py_env-python3/lib/python3.14/site-packages/refactor/ast.py", line 110, in <module>
    class BaseUnparser(ast._Unparser):  # type: ignore
                       ^^^^^^^^^^^^^
AttributeError: module 'ast' has no attribute '_Unparser'. Did you mean: 'unparse'?
``` 

Also see: https://github.com/isidentical/teyit/issues/23 Unfortunately, it seems that development on teyit has come to a standstill. So there is no fix.

I've pinned the python version for teyit to 3.11 since this is the version used in the corresponding github workflow. Hopefully this helps other devs who run into the same issue.