### PR TITLE
feat(frontend): add inline create modal to PurchaseOrderLineItem dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#11778](https://github.com/inventree/InvenTree/pull/11778) adds inline supplier part creation to po line item addition dialog.
+
 ### Changed
 
 ### Removed

--- a/src/frontend/lib/types/Forms.tsx
+++ b/src/frontend/lib/types/Forms.tsx
@@ -114,6 +114,7 @@ export type ApiFormFieldType = {
   placeholderAutofill?: boolean;
   placeholderWarningCompare?: string | number;
   placeholderWarning?: string;
+  addCreateFields?: ApiFormFieldSet;
   description?: string;
   preFieldContent?: JSX.Element;
   postFieldContent?: JSX.Element;

--- a/src/frontend/src/components/forms/fields/RelatedModelField.tsx
+++ b/src/frontend/src/components/forms/fields/RelatedModelField.tsx
@@ -561,9 +561,10 @@ function InlineCreateButton(
     () => calculateModalData(definition, form),
     [definition.filters, definition.addCreateFields, form]
   );
+  const model = useMemo(() => modelInfo?.label() ?? '', [modelInfo]);
 
   const create_modal = useCreateApiFormModal({
-    title: t`Create New ${modelInfo.label() ?? ''}`,
+    title: t`Create New ${model}`,
     url: apiUrl(modelInfo.api_endpoint),
     modelType: definition.model,
     initialData: relatedInitialData,

--- a/src/frontend/src/components/forms/fields/RelatedModelField.tsx
+++ b/src/frontend/src/components/forms/fields/RelatedModelField.tsx
@@ -8,17 +8,32 @@ import {
 } from '@mantine/core';
 import { useDebouncedValue, useId } from '@mantine/hooks';
 import { useQuery } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import {
   type FieldValues,
   type UseControllerReturn,
+  type UseFormReturn,
   useFormContext
 } from 'react-hook-form';
 import Select from 'react-select';
 
-import { ModelInformationDict } from '@lib/enums/ModelInformation';
+import { ActionButton } from '@lib/components/ActionButton';
+import {
+  ModelInformationDict,
+  type TranslatableModelInformationInterface
+} from '@lib/enums/ModelInformation';
+import { apiUrl } from '@lib/functions/Api';
 import type { ApiFormFieldType } from '@lib/types/Forms';
+import { IconPlus } from '@tabler/icons-react';
 import { useApi } from '../../../contexts/ApiContext';
+import { useCreateApiFormModal } from '../../../hooks/UseForm';
 import {
   useGlobalSettingsState,
   useUserSettingsState
@@ -53,6 +68,10 @@ export function RelatedModelField({
 
   // Keep track of the primary key value for this field
   const [pk, setPk] = useState<number | null>(null);
+
+  function setValuefromPK(pk: number) {
+    fetchSingleField(pk);
+  }
 
   // Handle condition where the form is rebuilt dynamically
   useEffect(() => {
@@ -138,6 +157,17 @@ export function RelatedModelField({
     }
     return ModelInformationDict[definition.model];
   }, [definition.model]);
+
+  // Determine whether an add button should be added for this field
+  const addButton = useMemo(() => {
+    if (!modelInfo) {
+      return false;
+    }
+    if (definition.addCreateFields) {
+      return true;
+    }
+    return false;
+  }, [definition.addCreateFields, modelInfo]);
 
   // Determine whether a barcode field should be added
   const addBarcodeField: boolean = useMemo(() => {
@@ -296,15 +326,7 @@ export function RelatedModelField({
         return null;
       }
 
-      let _filters = definition.filters ?? {};
-
-      if (definition.adjustFilters) {
-        _filters =
-          definition.adjustFilters({
-            filters: _filters,
-            data: form.getValues()
-          }) ?? _filters;
-      }
+      const _filters = retrieveFilters(definition, form);
 
       // If the filters have changed, clear the data
       if (JSON.stringify(_filters) !== JSON.stringify(filters)) {
@@ -461,6 +483,9 @@ export function RelatedModelField({
       styles={{ description: { paddingBottom: '5px' } }}
     >
       <Group justify='space-between' wrap='nowrap' gap={3}>
+        {addButton &&
+          modelInfo &&
+          InlineCreateButton(definition, modelInfo, form, setValuefromPK)}
         <Expand>
           <Select
             id={fieldId}
@@ -523,5 +548,71 @@ export function RelatedModelField({
         )}
       </Group>
     </Input.Wrapper>
+  );
+}
+
+function InlineCreateButton(
+  definition: ApiFormFieldType,
+  modelInfo: TranslatableModelInformationInterface,
+  form: UseFormReturn<FieldValues, any, FieldValues>,
+  setValue: (value: number) => void
+): ReactNode {
+  const relatedInitialData = useMemo(
+    () => calculateModalData(definition, form),
+    [definition.filters, definition.addCreateFields, form]
+  );
+
+  const create_modal = useCreateApiFormModal({
+    title: t`Create New ${modelInfo.label() ?? ''}`,
+    url: apiUrl(modelInfo.api_endpoint),
+    modelType: definition.model,
+    initialData: relatedInitialData,
+    fields: definition.addCreateFields,
+    onFormSuccess: (response: any) => {
+      setValue(response.pk);
+    }
+  });
+  return (
+    <>
+      {create_modal.modal}
+      <ActionButton
+        onClick={() => {
+          create_modal.open();
+        }}
+        color='green'
+        icon={<IconPlus />}
+      />
+    </>
+  );
+}
+
+function retrieveFilters(
+  definition: ApiFormFieldType,
+  form: UseFormReturn<FieldValues, any, FieldValues>
+) {
+  let _filters = definition.filters ?? {};
+
+  if (definition.adjustFilters) {
+    _filters =
+      definition.adjustFilters({
+        filters: _filters,
+        data: form.getValues()
+      }) ?? _filters;
+  }
+  return _filters;
+}
+
+function calculateModalData(
+  definition: ApiFormFieldType,
+  form: UseFormReturn<FieldValues, any, FieldValues>
+) {
+  if (!definition.addCreateFields) {
+    return {};
+  }
+  const fields = new Set(Object.keys(definition.addCreateFields));
+  return Object.fromEntries(
+    Object.entries(retrieveFilters(definition, form)).filter(([key]) =>
+      fields.has(key)
+    )
   );
 }

--- a/src/frontend/src/forms/PurchaseOrderForms.tsx
+++ b/src/frontend/src/forms/PurchaseOrderForms.tsx
@@ -142,6 +142,12 @@ export function usePurchaseOrderLineItemFields({
             ...adjust.filters,
             supplier: supplierId
           };
+        },
+        addCreateFields: {
+          part: {},
+          SKU: {},
+          description: {},
+          supplier: { hidden: true }
         }
       },
       line: {},


### PR DESCRIPTION
Based on real-world user feedback from a HW producing company this reduces the amount of required context switches by adding inline addition dialogs.
<img width="1512" height="680" alt="image" src="https://github.com/user-attachments/assets/f7fa0b21-062d-4617-8e7a-49f900e62647" />
In this specific example I have chosen to keep the new dialog as slim as possible as the goal is speed - not adding a new entry point to the existing dialog. Maybe a link to the full creation dialog might be interesting.
<img width="1808" height="954" alt="image" src="https://github.com/user-attachments/assets/b588d33e-84c8-4785-9b7e-478b5bdc7e42" />
The newly created item is directly selected in the related field. This needs to be specifically enabled per form
 

fixes https://github.com/invenhost/InvenTree/issues/299