### PR TITLE
Model permission tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#11778](https://github.com/inventree/InvenTree/pull/11778) adds inline supplier part creation to po line item addition dialog.
 - [#11772](https://github.com/inventree/InvenTree/pull/11772) the UI now warns if you navigate away from a note panel with unsaved changes
+- [#11788](https://github.com/inventree/InvenTree/pull/11788) adds support for custom permissions checks on database models defined in plugins. If a model defines a `check_user_permission` classmethod, this will be called to determine if a user has permission to view the model. This is required for plugin models which do not have the required ruleset definitions for the standard permission system.
 
 ### Changed
 

--- a/docs/docs/plugins/mixins/app.md
+++ b/docs/docs/plugins/mixins/app.md
@@ -8,3 +8,24 @@ If this mixin is added to a plugin the directory the plugin class is defined in 
 
 !!! warning "Danger Zone"
     Only use this mixin if you have an understanding of Django's [app system]({% include "django.html" %}/ref/applications). Plugins with this mixin are deeply integrated into InvenTree and can cause difficult to reproduce or long-running errors. Use the built-in testing functions of Django to make sure your code does not cause unwanted behaviour in InvenTree before releasing.
+
+## Custom Models
+
+This mixin allows you to define custom database models within your plugin. These models will be automatically registered with the InvenTree server, and will be available for use within your plugin code.
+
+### Model Permissions
+
+Some database operations within the InvenTree ecosystem may require custom permissions checks - to determine which actions a user can perform against a given model. If your plugin defines custom models, you may need to implement a custom permission check method on your model class.
+
+Each model class can implement a `check_user_permission` classmethod, which will be called by the InvenTree permission system when checking permissions for that model. This method should return `True` if the user has the required permissions, and `False` otherwise.
+
+
+```python
+class MyCustomModel(models.Model):
+    # model fields here
+
+    @classmethod
+    def check_user_permission(cls, user: User, permission: str) -> bool:
+        # custom permission logic here
+        return True  # or False
+```

--- a/docs/docs/plugins/mixins/app.md
+++ b/docs/docs/plugins/mixins/app.md
@@ -29,3 +29,6 @@ class MyCustomModel(models.Model):
         # custom permission logic here
         return True  # or False
 ```
+
+!!! warning "Default Permissions"
+    By default, if the `check_user_permission` method is not implemented, the InvenTree permission system will return `False` for all permission checks against that model. This is to ensure that no permissions are granted by default, and that the plugin developer must explicitly define the required permissions for their custom models.

--- a/src/backend/InvenTree/users/permissions.py
+++ b/src/backend/InvenTree/users/permissions.py
@@ -195,6 +195,11 @@ def check_user_permission(
 
     result = user.has_perm(permission_name)
 
+    # If the user does not have permissions (as determined above), check if the model class provides a custom permission check method
+    # This is required for non-standard models (i.e. defined via plugins), which do not have the required ruleset definitions
+    if not result and hasattr(model, 'check_user_permission'):  # pragma: no cover
+        result = model.check_user_permission(user, permission)
+
     # Save result to session-cache
     InvenTree.cache.set_session_cache(cache_key, result)
 


### PR DESCRIPTION
This PR adds support for generic permissions checks against a model (if other permission checks fail).

This is required for complex interactions with models defined in plugins (e.g. when importing a dataset into a plugin-defined table).

The current permissions system determines table permissions based on the hard-coded "rulesets" - and this approach knows nothing about plugin defined models.

So, if a permission is not found, the code can optionally check for a `check_user_permission` `@classmethod` on the table, allowing plugins to hook their tables into the permissions system dynamically.

Example implementation here - https://github.com/SchrodingersGat/inventree-manufacturing-costs/pull/60