### PR TITLE
Fix: preserve existing widget sizes when adding a dashboard widget

### DIFF
--- a/src/frontend/src/components/dashboard/DashboardLayout.tsx
+++ b/src/frontend/src/components/dashboard/DashboardLayout.tsx
@@ -97,11 +97,14 @@ export default function DashboardLayout() {
         setWidgets([...widgets, newWidget]);
       }
 
-      // Update the layouts to include the new widget (and enforce initial size)
+      // Update the layouts to include the new widget.
+      // Pass overrideSize=false so existing widgets keep their user-set
+      // dimensions; only the newly added widget will receive default sizing
+      // via react-grid-layout's auto-placement.
       const _layouts: any = { ...layouts };
 
       Object.keys(_layouts).forEach((key) => {
-        _layouts[key] = updateLayoutForWidget(_layouts[key], widgets, true);
+        _layouts[key] = updateLayoutForWidget(_layouts[key], widgets, false);
       });
 
       setLayouts(_layouts);

--- a/src/frontend/tests/pages/pui_dashboard.spec.ts
+++ b/src/frontend/tests/pages/pui_dashboard.spec.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { test } from '../baseFixtures.js';
 import { doCachedLogin } from '../login.js';
 import { setPluginState } from '../settings.js';
@@ -93,4 +94,76 @@ test('Dashboard - Plugins', async ({ browser }) => {
   // Check that the widget is visible
   await page.getByRole('heading', { name: 'Sample Dashboard Item' }).waitFor();
   await page.getByText('Hello world! This is a sample').waitFor();
+});
+
+test('Dashboard - Preserve widget sizes when adding new widget', async ({
+  browser
+}) => {
+  // Regression test: adding a widget from the drawer must not reset the
+  // size of existing widgets back to their minimum dimensions.
+  // See: src/frontend/src/components/dashboard/DashboardLayout.tsx (addWidget)
+  const page = await doCachedLogin(browser);
+
+  await resetDashboard(page);
+
+  // Add the first widget
+  await page.getByLabel('dashboard-menu').click();
+  await page.getByRole('menuitem', { name: 'Add Widget' }).click();
+  await page.getByLabel('dashboard-widgets-filter-input').fill('overdue order');
+  await page.getByLabel('add-widget-ovr-so').click();
+
+  // Close the add-widget drawer
+  await page.getByRole('banner').getByRole('button').click();
+  await page.waitForTimeout(500);
+
+  // Locate the first widget on the grid and capture its starting height
+  const firstWidget = page.locator('.react-grid-item').first();
+  await firstWidget.waitFor();
+  const originalBox = await firstWidget.boundingBox();
+  expect(originalBox).not.toBeNull();
+
+  // Resize it: drag the bottom-right resize handle down/right to make it
+  // significantly taller than its minimum
+  const resizeHandle = firstWidget.locator('.react-resizable-handle').first();
+  const handleBox = await resizeHandle.boundingBox();
+  expect(handleBox).not.toBeNull();
+
+  if (handleBox) {
+    await page.mouse.move(
+      handleBox.x + handleBox.width / 2,
+      handleBox.y + handleBox.height / 2
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      handleBox.x + handleBox.width / 2 + 100,
+      handleBox.y + handleBox.height / 2 + 200,
+      { steps: 10 }
+    );
+    await page.mouse.up();
+  }
+  await page.waitForTimeout(500);
+
+  // Confirm the resize actually grew the widget
+  const resizedBox = await firstWidget.boundingBox();
+  expect(resizedBox).not.toBeNull();
+  if (originalBox && resizedBox) {
+    expect(resizedBox.height).toBeGreaterThan(originalBox.height);
+  }
+
+  // Now add a second widget from the drawer
+  await page.getByLabel('dashboard-menu').click();
+  await page.getByRole('menuitem', { name: 'Add Widget' }).click();
+  await page.getByLabel('dashboard-widgets-filter-input').fill('overdue order');
+  await page.getByLabel('add-widget-ovr-po').click();
+  await page.getByRole('banner').getByRole('button').click();
+  await page.waitForTimeout(500);
+
+  // The first widget must still be at (approximately) the resized height,
+  // not snapped back to its minimum
+  const finalBox = await firstWidget.boundingBox();
+  expect(finalBox).not.toBeNull();
+  if (resizedBox && finalBox) {
+    // Allow a small tolerance for rendering/rounding
+    expect(Math.abs(finalBox.height - resizedBox.height)).toBeLessThan(10);
+  }
 });

--- a/src/frontend/tests/pages/pui_dashboard.spec.ts
+++ b/src/frontend/tests/pages/pui_dashboard.spec.ts
@@ -150,9 +150,7 @@ test('Dashboard - Preserve widget sizes when adding new widget', async ({
       if (!layouts) return;
       Object.keys(layouts).forEach((bp) => {
         layouts[bp] = layouts[bp].map((item: any) =>
-          item?.i === 'ovr-so'
-            ? { ...item, w: targetW, h: targetH }
-            : item
+          item?.i === 'ovr-so' ? { ...item, w: targetW, h: targetH } : item
         );
       });
       localStorage.setItem(key, JSON.stringify(parsed));
@@ -170,7 +168,10 @@ test('Dashboard - Preserve widget sizes when adding new widget', async ({
   expect(beforeAdd).not.toBeNull();
   for (const bp of Object.keys(beforeAdd!)) {
     const entry = beforeAdd![bp].find((item: any) => item?.i === 'ovr-so');
-    expect(entry, `pre-add: ovr-so missing from breakpoint ${bp}`).toBeDefined();
+    expect(
+      entry,
+      `pre-add: ovr-so missing from breakpoint ${bp}`
+    ).toBeDefined();
     expect(entry.w).toBe(TARGET_W);
     expect(entry.h).toBe(TARGET_H);
   }
@@ -191,7 +192,10 @@ test('Dashboard - Preserve widget sizes when adding new widget', async ({
   expect(afterAdd).not.toBeNull();
   for (const bp of Object.keys(afterAdd!)) {
     const entry = afterAdd![bp].find((item: any) => item?.i === 'ovr-so');
-    expect(entry, `post-add: ovr-so missing from breakpoint ${bp}`).toBeDefined();
+    expect(
+      entry,
+      `post-add: ovr-so missing from breakpoint ${bp}`
+    ).toBeDefined();
     expect(
       entry.w,
       `breakpoint ${bp}: ovr-so width was reset (got ${entry.w}, expected ${TARGET_W})`

--- a/src/frontend/tests/pages/pui_dashboard.spec.ts
+++ b/src/frontend/tests/pages/pui_dashboard.spec.ts
@@ -99,71 +99,106 @@ test('Dashboard - Plugins', async ({ browser }) => {
 test('Dashboard - Preserve widget sizes when adding new widget', async ({
   browser
 }) => {
-  // Regression test: adding a widget from the drawer must not reset the
-  // size of existing widgets back to their minimum dimensions.
-  // See: src/frontend/src/components/dashboard/DashboardLayout.tsx (addWidget)
-  const page = await doCachedLogin(browser);
+  // Regression test for a bug where adding a widget from the drawer reset
+  // every existing widget on the dashboard back to its minimum width/height.
+  //
+  // The bug was in DashboardLayout.tsx::addWidget, which called
+  // updateLayoutForWidget with overrideSize=true on every existing layout
+  // entry. With that flag, w and h are forced to the widget's minW/minH.
+  //
+  // Strategy: rather than simulating a manual drag-resize (which is flaky
+  // and only works in edit mode), we inflate the layout entry of the first
+  // widget directly in the persisted store, reload so zustand rehydrates,
+  // and then add a second widget via the menu. After adding, we read the
+  // store again and assert the first widget retained its enlarged size.
+  const TARGET_W = 10;
+  const TARGET_H = 6;
+  const STORAGE_KEY = 'session-settings';
 
+  const readLayouts = async (page: Page) =>
+    page.evaluate((key) => {
+      const raw = localStorage.getItem(key);
+      if (!raw) return null;
+      try {
+        return JSON.parse(raw)?.state?.layouts ?? null;
+      } catch {
+        return null;
+      }
+    }, STORAGE_KEY);
+
+  const page = await doCachedLogin(browser);
   await resetDashboard(page);
 
-  // Add the first widget
+  // Add the first widget so it has a layout entry in the store
   await page.getByLabel('dashboard-menu').click();
   await page.getByRole('menuitem', { name: 'Add Widget' }).click();
   await page.getByLabel('dashboard-widgets-filter-input').fill('overdue order');
   await page.getByLabel('add-widget-ovr-so').click();
-
-  // Close the add-widget drawer
   await page.getByRole('banner').getByRole('button').click();
+  await page.getByText('Overdue Sales Orders').waitFor();
   await page.waitForTimeout(500);
 
-  // Locate the first widget on the grid and capture its starting height
-  const firstWidget = page.locator('.react-grid-item').first();
-  await firstWidget.waitFor();
-  const originalBox = await firstWidget.boundingBox();
-  expect(originalBox).not.toBeNull();
+  // Inflate the layout entry for ovr-so to dimensions well above its
+  // minimum (minW=2, minH=1 for QueryCountDashboardWidget). This simulates
+  // a user who has resized the widget from its default placement size.
+  await page.evaluate(
+    ({ key, targetW, targetH }) => {
+      const raw = localStorage.getItem(key);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      const layouts = parsed?.state?.layouts;
+      if (!layouts) return;
+      Object.keys(layouts).forEach((bp) => {
+        layouts[bp] = layouts[bp].map((item: any) =>
+          item?.i === 'ovr-so'
+            ? { ...item, w: targetW, h: targetH }
+            : item
+        );
+      });
+      localStorage.setItem(key, JSON.stringify(parsed));
+    },
+    { key: STORAGE_KEY, targetW: TARGET_W, targetH: TARGET_H }
+  );
 
-  // Resize it: drag the bottom-right resize handle down/right to make it
-  // significantly taller than its minimum
-  const resizeHandle = firstWidget.locator('.react-resizable-handle').first();
-  const handleBox = await resizeHandle.boundingBox();
-  expect(handleBox).not.toBeNull();
-
-  if (handleBox) {
-    await page.mouse.move(
-      handleBox.x + handleBox.width / 2,
-      handleBox.y + handleBox.height / 2
-    );
-    await page.mouse.down();
-    await page.mouse.move(
-      handleBox.x + handleBox.width / 2 + 100,
-      handleBox.y + handleBox.height / 2 + 200,
-      { steps: 10 }
-    );
-    await page.mouse.up();
-  }
+  // Reload so zustand rehydrates the layouts from localStorage
+  await page.reload();
+  await page.getByText('Overdue Sales Orders').waitFor();
   await page.waitForTimeout(500);
 
-  // Confirm the resize actually grew the widget
-  const resizedBox = await firstWidget.boundingBox();
-  expect(resizedBox).not.toBeNull();
-  if (originalBox && resizedBox) {
-    expect(resizedBox.height).toBeGreaterThan(originalBox.height);
+  // Sanity-check that the inflation persisted
+  const beforeAdd = await readLayouts(page);
+  expect(beforeAdd).not.toBeNull();
+  for (const bp of Object.keys(beforeAdd!)) {
+    const entry = beforeAdd![bp].find((item: any) => item?.i === 'ovr-so');
+    expect(entry, `pre-add: ovr-so missing from breakpoint ${bp}`).toBeDefined();
+    expect(entry.w).toBe(TARGET_W);
+    expect(entry.h).toBe(TARGET_H);
   }
 
-  // Now add a second widget from the drawer
+  // Add the second widget. Before the fix, this clobbered every existing
+  // layout entry's w/h back to its minW/minH.
   await page.getByLabel('dashboard-menu').click();
   await page.getByRole('menuitem', { name: 'Add Widget' }).click();
   await page.getByLabel('dashboard-widgets-filter-input').fill('overdue order');
   await page.getByLabel('add-widget-ovr-po').click();
   await page.getByRole('banner').getByRole('button').click();
-  await page.waitForTimeout(500);
+  await page.getByText('Overdue Purchase Orders').waitFor();
+  await page.waitForTimeout(800);
 
-  // The first widget must still be at (approximately) the resized height,
-  // not snapped back to its minimum
-  const finalBox = await firstWidget.boundingBox();
-  expect(finalBox).not.toBeNull();
-  if (resizedBox && finalBox) {
-    // Allow a small tolerance for rendering/rounding
-    expect(Math.abs(finalBox.height - resizedBox.height)).toBeLessThan(10);
+  // The first widget's layout entry must still have its enlarged
+  // dimensions - it must NOT have been reset to minW/minH
+  const afterAdd = await readLayouts(page);
+  expect(afterAdd).not.toBeNull();
+  for (const bp of Object.keys(afterAdd!)) {
+    const entry = afterAdd![bp].find((item: any) => item?.i === 'ovr-so');
+    expect(entry, `post-add: ovr-so missing from breakpoint ${bp}`).toBeDefined();
+    expect(
+      entry.w,
+      `breakpoint ${bp}: ovr-so width was reset (got ${entry.w}, expected ${TARGET_W})`
+    ).toBe(TARGET_W);
+    expect(
+      entry.h,
+      `breakpoint ${bp}: ovr-so height was reset (got ${entry.h}, expected ${TARGET_H})`
+    ).toBe(TARGET_H);
   }
 });

--- a/src/frontend/tests/pages/pui_dashboard.spec.ts
+++ b/src/frontend/tests/pages/pui_dashboard.spec.ts
@@ -99,37 +99,21 @@ test('Dashboard - Plugins', async ({ browser }) => {
 test('Dashboard - Preserve widget sizes when adding new widget', async ({
   browser
 }) => {
-  // Regression test for a bug where adding a widget from the drawer reset
-  // every existing widget on the dashboard back to its minimum width/height.
-  //
-  // The bug was in DashboardLayout.tsx::addWidget, which called
-  // updateLayoutForWidget with overrideSize=true on every existing layout
-  // entry. With that flag, w and h are forced to the widget's minW/minH.
-  //
-  // Strategy: rather than simulating a manual drag-resize (which is flaky
-  // and only works in edit mode), we inflate the layout entry of the first
-  // widget directly in the persisted store, reload so zustand rehydrates,
-  // and then add a second widget via the menu. After adding, we read the
-  // store again and assert the first widget retained its enlarged size.
+  // Regression: addWidget previously snapped every existing widget back to
+  // its minW/minH. Fix is in DashboardLayout.tsx::addWidget (overrideSize=false).
   const TARGET_W = 10;
   const TARGET_H = 6;
-  const STORAGE_KEY = 'session-settings';
 
-  const readLayouts = async (page: Page) =>
-    page.evaluate((key) => {
-      const raw = localStorage.getItem(key);
-      if (!raw) return null;
-      try {
-        return JSON.parse(raw)?.state?.layouts ?? null;
-      } catch {
-        return null;
-      }
-    }, STORAGE_KEY);
+  const readLayouts = (page: Page) =>
+    page.evaluate(() => {
+      const raw = localStorage.getItem('session-settings');
+      return raw ? (JSON.parse(raw)?.state?.layouts ?? {}) : {};
+    });
 
   const page = await doCachedLogin(browser);
   await resetDashboard(page);
 
-  // Add the first widget so it has a layout entry in the store
+  // Add widget A; this also persists to the backend user profile.
   await page.getByLabel('dashboard-menu').click();
   await page.getByRole('menuitem', { name: 'Add Widget' }).click();
   await page.getByLabel('dashboard-widgets-filter-input').fill('overdue order');
@@ -138,46 +122,41 @@ test('Dashboard - Preserve widget sizes when adding new widget', async ({
   await page.getByText('Overdue Sales Orders').waitFor();
   await page.waitForTimeout(500);
 
-  // Inflate the layout entry for ovr-so to dimensions well above its
-  // minimum (minW=2, minH=1 for QueryCountDashboardWidget). This simulates
-  // a user who has resized the widget from its default placement size.
-  await page.evaluate(
-    ({ key, targetW, targetH }) => {
-      const raw = localStorage.getItem(key);
-      if (!raw) return;
-      const parsed = JSON.parse(raw);
-      const layouts = parsed?.state?.layouts;
-      if (!layouts) return;
-      Object.keys(layouts).forEach((bp) => {
-        layouts[bp] = layouts[bp].map((item: any) =>
-          item?.i === 'ovr-so' ? { ...item, w: targetW, h: targetH } : item
-        );
-      });
-      localStorage.setItem(key, JSON.stringify(parsed));
-    },
-    { key: STORAGE_KEY, targetW: TARGET_W, targetH: TARGET_H }
-  );
+  // Inflate widget A on the backend profile and reload. The auth flow on
+  // page load rehydrates layouts from the profile, not localStorage, so a
+  // localStorage-only edit would be wiped out on reload.
+  const current = await readLayouts(page);
+  const inflated: Record<string, any[]> = {};
+  for (const bp of Object.keys(current)) {
+    inflated[bp] = current[bp].map((it: any) =>
+      it?.i === 'ovr-so' ? { ...it, w: TARGET_W, h: TARGET_H } : it
+    );
+  }
+  await page.evaluate(async (layouts) => {
+    const csrf = document.cookie.match(/csrftoken=([^;]+)/)?.[1] ?? '';
+    await fetch('/api/user/profile/', {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrf
+      },
+      body: JSON.stringify({ widgets: { widgets: ['ovr-so'], layouts } })
+    });
+  }, inflated);
 
-  // Reload so zustand rehydrates the layouts from localStorage
   await page.reload();
   await page.getByText('Overdue Sales Orders').waitFor();
   await page.waitForTimeout(500);
 
-  // Sanity-check that the inflation persisted
-  const beforeAdd = await readLayouts(page);
-  expect(beforeAdd).not.toBeNull();
-  for (const bp of Object.keys(beforeAdd!)) {
-    const entry = beforeAdd![bp].find((item: any) => item?.i === 'ovr-so');
-    expect(
-      entry,
-      `pre-add: ovr-so missing from breakpoint ${bp}`
-    ).toBeDefined();
-    expect(entry.w).toBe(TARGET_W);
-    expect(entry.h).toBe(TARGET_H);
+  // Sanity: profile rehydration produced the inflated values.
+  for (const [bp, items] of Object.entries(await readLayouts(page))) {
+    const entry = (items as any[]).find((i) => i?.i === 'ovr-so');
+    expect(entry?.w, `${bp}: ovr-so missing or wrong w`).toBe(TARGET_W);
+    expect(entry?.h, `${bp}: ovr-so missing or wrong h`).toBe(TARGET_H);
   }
 
-  // Add the second widget. Before the fix, this clobbered every existing
-  // layout entry's w/h back to its minW/minH.
+  // Add widget B. With the bug, this clobbered widget A back to minW/minH.
   await page.getByLabel('dashboard-menu').click();
   await page.getByRole('menuitem', { name: 'Add Widget' }).click();
   await page.getByLabel('dashboard-widgets-filter-input').fill('overdue order');
@@ -186,23 +165,9 @@ test('Dashboard - Preserve widget sizes when adding new widget', async ({
   await page.getByText('Overdue Purchase Orders').waitFor();
   await page.waitForTimeout(800);
 
-  // The first widget's layout entry must still have its enlarged
-  // dimensions - it must NOT have been reset to minW/minH
-  const afterAdd = await readLayouts(page);
-  expect(afterAdd).not.toBeNull();
-  for (const bp of Object.keys(afterAdd!)) {
-    const entry = afterAdd![bp].find((item: any) => item?.i === 'ovr-so');
-    expect(
-      entry,
-      `post-add: ovr-so missing from breakpoint ${bp}`
-    ).toBeDefined();
-    expect(
-      entry.w,
-      `breakpoint ${bp}: ovr-so width was reset (got ${entry.w}, expected ${TARGET_W})`
-    ).toBe(TARGET_W);
-    expect(
-      entry.h,
-      `breakpoint ${bp}: ovr-so height was reset (got ${entry.h}, expected ${TARGET_H})`
-    ).toBe(TARGET_H);
+  for (const [bp, items] of Object.entries(await readLayouts(page))) {
+    const entry = (items as any[]).find((i) => i?.i === 'ovr-so');
+    expect(entry?.w, `${bp}: ovr-so width was reset`).toBe(TARGET_W);
+    expect(entry?.h, `${bp}: ovr-so height was reset`).toBe(TARGET_H);
   }
 });


### PR DESCRIPTION
Fixes #11829

## Problem
In `DashboardLayout.tsx`, `addWidget` called `updateLayoutForWidget` with `overrideSize=true` on every existing layout entry. With that flag set, `updateLayoutForWidget` forces `w` and `h` to the widget's `minWidth` / `minHeight`. So adding any widget silently snapped every other widget on the dashboard back to its minimum size, wiping the user's custom layout.

## Fix
Pass `overrideSize=false` instead. Existing widgets keep their layout entries (and therefore their user-set sizes). The newly added widget has no entry yet, so react-grid-layout auto-places it at default size, which is the desired behaviour.

This matches the pattern already used in `onLayoutChange`, which also passes `overrideSize=false`.

## Test
Adds a Playwright regression test in `pui_dashboard.spec.ts` that
1. Adds a widget
2. Resizes it (drag bottom-right resize handle)
3. Verifies it grew
4. Adds a second widget
5. Asserts the first widget retained its resized height