### PR TITLE
[UI] Fix child builds panel

### DIFF
--- a/src/frontend/src/pages/build/BuildDetail.tsx
+++ b/src/frontend/src/pages/build/BuildDetail.tsx
@@ -197,6 +197,27 @@ export default function BuildDetail() {
     defaultValue: {}
   });
 
+  // Fetch the number of child build orders associated with this build order
+  const { instance: childBuildData } = useInstance({
+    endpoint: ApiEndpoints.build_order_list,
+    params: {
+      parent: id,
+      limit: 1
+    },
+    disabled: !id,
+    hasPrimaryKey: false,
+    defaultValue: {}
+  });
+
+  /**
+   * Display the "Child Build Orders" panel if either:
+   * - There are any child build orders (childBuildData.count > 0)
+   * - There are any sub-assembly items (subassemblyLineData.count > 0)
+   */
+  const showChildBuilds = useMemo(() => {
+    return childBuildData?.count > 0 || subassemblyLineData?.count > 0;
+  }, [childBuildData, subassemblyLineData]);
+
   const buildStatus = useStatusCodes({ modelType: ModelType.build });
 
   const {
@@ -540,7 +561,7 @@ export default function BuildDetail() {
         name: 'child-orders',
         label: t`Child Build Orders`,
         icon: <IconSitemap />,
-        hidden: (subassemblyLineData?.count ?? 0) <= 0, // Hide if no sub-assembly items
+        hidden: !showChildBuilds,
         content: build.pk ? (
           <BuildOrderTable parentBuildId={build.pk} />
         ) : (
@@ -578,7 +599,7 @@ export default function BuildDetail() {
     user,
     buildStatus,
     globalSettings,
-    subassemblyLineData,
+    showChildBuilds,
     buildLineQuery.isFetching,
     buildLineQuery.isLoading,
     buildLineData

--- a/src/frontend/tests/pages/pui_build.spec.ts
+++ b/src/frontend/tests/pages/pui_build.spec.ts
@@ -437,6 +437,12 @@ test('Build Order - Auto Allocate Tracked', async ({ browser }) => {
     url: 'manufacturing/build-order/27/consumed-stock'
   });
 
+  // Check some tabs along the way
+  await loadTab(page, 'Child Build Orders');
+  await page
+    .getByRole('button', { name: 'action-button-add-build-order' })
+    .waitFor();
+
   await loadTab(page, 'Incomplete Outputs');
 
   await page.getByRole('cell', { name: '0 / 6' }).waitFor();


### PR DESCRIPTION
- Adjust logic for displaying or hiding child build panel
- Prevent panel from being hidden if there *are* child build orders 