### PR TITLE
feat(frontend): bump node build enviroment to 24

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   python_version: 3.11
-  node_version: 20
+  node_version: 24
   # The OS version must be set per job
   server_start_sleep: 60
 
@@ -329,7 +329,7 @@ jobs:
       INVENTREE_SITE_URL: http://127.0.0.1:12345
       INVENTREE_DEBUG: true
       INVENTREE_LOG_LEVEL: WARNING
-      node_version: '>=20.19.6'
+      node_version: '>=24'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
@@ -452,7 +452,7 @@ jobs:
           update: true
           npm: true
         env:
-          node_version: '>=20.19.0'
+          node_version: '>=24'
       - name: Performance Reporting
         uses: CodSpeedHQ/action@658a901452bb54c799643e060733b7afe9121b8d # pin@v4.14.0
         with:

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   python_version: 3.11
-  node_version: 20
+  node_version: 24
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- [#11893](https://github.com/inventree/InvenTree/pull/11893) bumps Node environment to version 24 LTS - this is only relevant if you build the frontend assets yourself
+
 ### Added
 
 - [#11872](https://github.com/inventree/InvenTree/pull/11872) adds a global setting to allow or disallow the deletion of serialized stock items.

--- a/docs/docs/develop/contributing.md
+++ b/docs/docs/develop/contributing.md
@@ -162,7 +162,7 @@ The core software modules are targeting the following versions:
 | Python | {{ config.extra.min_python_version }} | Minimum required version |
 | Invoke | {{ config.extra.min_invoke_version }} | Minimum required version |
 | Django | {{ config.extra.django_version }} | Pinned version |
-| Node | 20 | Only needed for frontend development |
+| Node | 24 | Only needed for frontend development |
 
 Any other software dependencies are handled by the project package config.
 


### PR DESCRIPTION
Node 20 went EOL per April 30th - this bumps our build environment to 24 which should be supported [till mid 2027](https://nodejs.org/en/about/previous-releases).
Should not really cause issues, but I still added a changelog entry out of an abundance of caution