### PR TITLE
[1.3.x] fix(CI): adress zimor warnings in the release workflow (#11916)

### DIFF
--- a/.github/workflows/qc_checks.yaml
+++ b/.github/workflows/qc_checks.yaml
@@ -789,13 +789,5 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           persist-credentials: false
-      - uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51 # pin@v2
-      - name: Run zizmor
-        run: uvx zizmor --format sarif . > results.sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # pin@v3
-        with:
-          sarif_file: results.sarif
-          category: zizmor
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,26 +78,21 @@ jobs:
           subject-path: "${{ github.workspace }}/src/backend/InvenTree/web/static/frontend-build.zip"
 
       - name: Upload frontend
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # pin@2.11.5
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: src/backend/InvenTree/web/static/frontend-build.zip
-          asset_name: frontend-build.zip
-          tag: ${{ github.ref }}
-          overwrite: true
+        run: gh release upload ${REF} src/backend/InvenTree/web/static/frontend-build.zip#frontend-build.zip
+        env:
+          REF: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload frontend to artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin@v7.0.0
         with:
           name: frontend-build
           path: src/backend/InvenTree/web/static/frontend-build.zip
       - name: Upload Attestation
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # pin@2.11.5
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          asset_name: frontend-build.intoto.jsonl
-          file: ${{ steps.attest.outputs.bundle-path}}
-          tag: ${{ github.ref }}
-          overwrite: true
+        run: gh release upload ${REF} ${BUNDLE_PATH}#frontend-build.intoto.jsonl
+        env:
+          REF: ${{ github.ref_name }}
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docs:
     runs-on: ubuntu-24.04
@@ -134,13 +129,10 @@ jobs:
           cd docs/site
           zip -r docs-html.zip *
       - name: Publish documentation
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # pin@2.11.5
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: docs/site/docs-html.zip
-          asset_name: docs-html.zip
-          tag: ${{ github.ref }}
-          overwrite: true
+        run: gh release upload ${REF} docs/site/docs-html.zip#docs-html.zip
+        env:
+          REF: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-pkgr:
     if: github.repository == 'inventree/InvenTree'
@@ -244,10 +236,9 @@ jobs:
           channel: ${{ env.pkg_channel }}
           file: ${{ steps.package.outputs.package_path }}
       - name: Publish to artifact
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # pin@2.11.5
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ steps.package.outputs.package_path }}
-          asset_name: ${{ matrix.target }}-{{ steps.setup.outputs.version }}.tar.gz
-          tag: ${{ github.ref }}
-          overwrite: true
+        run: gh release upload ${REF} ${PACKAGE_PATH}#${PACKAGE_NAME}
+        env:
+          REF: ${{ github.ref_name }}
+          PACKAGE_PATH: ${{ steps.package.outputs.package_path }}
+          PACKAGE_NAME: ${{ matrix.target }}-{{ steps.setup.outputs.version }}.tar.gz
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.3.x`:
 - [fix(CI): adress zimor warnings in the release workflow (#11916)](https://github.com/inventree/InvenTree/pull/11916)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)