### PR TITLE
feat(frontend): custom model render registration

### DIFF
--- a/src/frontend/lib/states/types.tsx
+++ b/src/frontend/lib/states/types.tsx
@@ -1,5 +1,5 @@
-import type { InstanceRenderInterface } from '@lib/types/Rendering';
 import type { ReactNode } from 'react';
+import type { InstanceRenderInterface } from '../types/Rendering';
 
 export type setRenderProps = (
   model: string,

--- a/src/frontend/lib/states/types.tsx
+++ b/src/frontend/lib/states/types.tsx
@@ -1,0 +1,7 @@
+import type { InstanceRenderInterface } from '@lib/types/Rendering';
+import type { ReactNode } from 'react';
+
+export type setRenderProps = (
+  model: string,
+  renderer: (props: Readonly<InstanceRenderInterface>) => ReactNode
+) => void;

--- a/src/frontend/lib/types/Forms.tsx
+++ b/src/frontend/lib/types/Forms.tsx
@@ -45,6 +45,7 @@ export type ApiFormFieldHeader = {
  * @param api_url : The API endpoint to fetch data from (for related fields)
  * @param pk_field : The primary key field for the related field (default = "pk")
  * @param model : The model to use for related fields
+ * @param custom_model : Optional custom model name (plugins may register renderers for custom models)
  * @param modelRenderer : Optional function to render the related model instance (for related fields)
  * @param filters : Optional API filters to apply to related fields
  * @param child: Optional definition of a child field (for nested objects)
@@ -101,6 +102,7 @@ export type ApiFormFieldType = {
   api_url?: string;
   pk_field?: string;
   model?: ModelType;
+  custom_model?: string;
   modelRenderer?: (instance: any) => ReactNode;
   filters?: any;
   child?: ApiFormFieldType;

--- a/src/frontend/lib/types/Plugins.tsx
+++ b/src/frontend/lib/types/Plugins.tsx
@@ -1,4 +1,3 @@
-import type { setRenderProps } from '@lib/states/types';
 import type { I18n } from '@lingui/core';
 import type { MantineColorScheme, MantineTheme } from '@mantine/core';
 import type { QueryClient } from '@tanstack/react-query';
@@ -6,6 +5,7 @@ import type { AxiosInstance } from 'axios';
 import type { NavigateFunction } from 'react-router-dom';
 import type { ModelDict } from '../enums/ModelInformation';
 import type { ModelType } from '../enums/ModelType';
+import type { setRenderProps } from '../states/types';
 import type {
   ApiFormModalProps,
   ApiFormProps,

--- a/src/frontend/lib/types/Plugins.tsx
+++ b/src/frontend/lib/types/Plugins.tsx
@@ -1,3 +1,4 @@
+import type { setRenderProps } from '@lib/states/types';
 import type { I18n } from '@lingui/core';
 import type { MantineColorScheme, MantineTheme } from '@mantine/core';
 import type { QueryClient } from '@tanstack/react-query';
@@ -109,6 +110,9 @@ export type InvenTreePluginContext = {
   theme: MantineTheme;
   colorScheme: MantineColorScheme;
   forms: InvenTreeFormsContext;
+  stateFnc: {
+    setRenderer: setRenderProps;
+  };
   tables: InvenTreeTablesContext<any>;
   importer: ImporterDrawerContext;
   model?: ModelType | string;

--- a/src/frontend/lib/types/Rendering.tsx
+++ b/src/frontend/lib/types/Rendering.tsx
@@ -29,7 +29,7 @@ export type ModelRendererDict = EnumDictionary<
 
 export type RenderInstanceProps = {
   model: ModelType | undefined;
-  custom_model?: string | undefined;
+  custom_model?: string;
 } & InstanceRenderInterface;
 
 export interface UseInstanceResult {

--- a/src/frontend/lib/types/Rendering.tsx
+++ b/src/frontend/lib/types/Rendering.tsx
@@ -29,7 +29,7 @@ export type ModelRendererDict = EnumDictionary<
 
 export type RenderInstanceProps = {
   model: ModelType | undefined;
-  custom_model?: string;
+  custom_model?: string | undefined;
 } & InstanceRenderInterface;
 
 export interface UseInstanceResult {

--- a/src/frontend/src/components/forms/fields/RelatedModelField.tsx
+++ b/src/frontend/src/components/forms/fields/RelatedModelField.tsx
@@ -384,10 +384,14 @@ export function RelatedModelField({
       }
 
       return (
-        <RenderInstance instance={data} model={definition.model ?? undefined} />
+        <RenderInstance
+          instance={data}
+          model={definition.model ?? undefined}
+          custom_model={definition.custom_model ?? undefined}
+        />
       );
     },
-    [definition.model, definition.modelRenderer]
+    [definition.model, definition.modelRenderer, definition.custom_model]
   );
 
   // Update form values when the selected value changes

--- a/src/frontend/src/components/plugins/PluginContext.tsx
+++ b/src/frontend/src/components/plugins/PluginContext.tsx
@@ -45,6 +45,7 @@ import {
   getGlobalImporterState,
   openGlobalImporter
 } from '../../states/ImporterState';
+import { usePluginState } from '../../states/PluginState';
 import { useServerApiState } from '../../states/ServerApiState';
 import { InvenTreeTableInternal } from '../../tables/InvenTreeTable';
 import { EditApiForm } from '../forms/ApiForm';
@@ -53,6 +54,7 @@ import { RenderInstance, RenderRemoteInstance } from '../render/Instance';
 export const useInvenTreeContext = () => {
   const [locale, host] = useLocalState(useShallow((s) => [s.language, s.host]));
   const [server] = useServerApiState(useShallow((s) => [s.server]));
+  const [setRenderer] = usePluginState(useShallow((s) => [s.setRenderer]));
   const navigate = useNavigate();
   const user = useUserState();
   const { colorScheme } = useMantineColorScheme();
@@ -116,6 +118,9 @@ export const useInvenTreeContext = () => {
           transferStock: useTransferStockItem,
           returnStock: useReturnStockItem
         }
+      },
+      stateFnc: {
+        setRenderer: setRenderer
       }
     };
   }, [

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -110,14 +110,19 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
   let RenderComponent:
     | ((props: Readonly<InstanceRenderInterface>) => ReactNode)
     | undefined;
-  if (props.model !== undefined) {
+  // core model renderer
+  if (props.model !== undefined && props.custom_model === undefined) {
     RenderComponent =
       RendererLookup[props.model.toString().toLowerCase() as ModelType];
   }
-  if (RenderComponent === undefined && props.custom_model !== undefined) {
-    RenderComponent = usePluginState().getRenderer(props.custom_model);
+  // custom model renderer (registered by a plugin)
+  if (RenderComponent === undefined) {
+    RenderComponent = usePluginState().getRenderer(
+      props.custom_model ?? props.model ?? ''
+    );
   }
 
+  // provider component
   if (!RenderComponent) {
     return <UnknownRenderer model={props.model} />;
   }

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -17,6 +17,7 @@ import { ModelType } from '@lib/enums/ModelType';
 import { apiUrl } from '@lib/functions/Api';
 import { getBaseUrl, navigateToLink } from '@lib/functions/Navigation';
 import type {
+  InstanceRenderInterface,
   ModelRendererDict,
   RemoteInstanceProps,
   RenderInstanceProps
@@ -105,18 +106,17 @@ export const RendererLookup: ModelRendererDict = {
  * Render an instance of a database model, depending on the provided data
  */
 export function RenderInstance(props: RenderInstanceProps): ReactNode {
-  if (props.model === undefined) {
-    return <UnknownRenderer model={props.model} />;
+  let RenderComponent:
+    | ((props: Readonly<InstanceRenderInterface>) => ReactNode)
+    | undefined;
+  if (props.model !== undefined) {
+    RenderComponent =
+      RendererLookup[props.model.toString().toLowerCase() as ModelType];
   }
-
-  const model_name = props.model.toString().toLowerCase() as ModelType;
-
-  const RenderComponent = RendererLookup[model_name];
 
   if (!RenderComponent) {
     return <UnknownRenderer model={props.model} />;
   }
-
   return <RenderComponent {...props} />;
 }
 

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -115,12 +115,10 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
     RenderComponent =
       RendererLookup[props.model.toString().toLowerCase() as ModelType];
   }
-  // custom model renderer (registered by a plugin)
-  if (RenderComponent === undefined) {
-    RenderComponent = usePluginState().getRenderer(
-      props.custom_model ?? props.model ?? ''
-    );
-  }
+  // custom model renderer (registered by a plugin) as a fallback to the core model renderer
+  RenderComponent ??= usePluginState().getRenderer(
+    props.custom_model ?? props.model ?? ''
+  );
 
   // provider component
   if (!RenderComponent) {

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -113,7 +113,8 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
   if (props.model !== undefined) {
     RenderComponent =
       RendererLookup[props.model.toString().toLowerCase() as ModelType];
-  } else if (props.custom_model !== undefined) {
+  }
+  if (RenderComponent === undefined && props.custom_model !== undefined) {
     RenderComponent = usePluginState().getRenderer(props.custom_model);
   }
 

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -25,6 +25,7 @@ import type {
 export type { InstanceRenderInterface } from '@lib/types/Rendering';
 import { shortenString } from '@lib/functions/String';
 import { useApi } from '../../contexts/ApiContext';
+import { usePluginState } from '../../states/PluginState';
 import { Thumbnail } from '../images/Thumbnail';
 import { RenderBuildItem, RenderBuildLine, RenderBuildOrder } from './Build';
 import {
@@ -112,6 +113,8 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
   if (props.model !== undefined) {
     RenderComponent =
       RendererLookup[props.model.toString().toLowerCase() as ModelType];
+  } else if (props.custom_model !== undefined) {
+    RenderComponent = usePluginState().getRenderer(props.custom_model);
   }
 
   if (!RenderComponent) {

--- a/src/frontend/src/states/PluginState.tsx
+++ b/src/frontend/src/states/PluginState.tsx
@@ -21,7 +21,7 @@ interface PluginStateProps {
 export const usePluginState = create<PluginStateProps>()((set, get) => ({
   customRenders: {},
   getRenderer: (model: string) => {
-    return get().customRenders[model];
+    return get().customRenders[model] || undefined;
   },
   setRenderer: (
     model: string,

--- a/src/frontend/src/states/PluginState.tsx
+++ b/src/frontend/src/states/PluginState.tsx
@@ -1,0 +1,44 @@
+import type { setRenderProps } from '@lib/states/types';
+import type { InstanceRenderInterface } from '@lib/types/Rendering';
+import type { ReactNode } from 'react';
+import { create } from 'zustand';
+
+interface PluginStateProps {
+  customRenders: Record<
+    string,
+    (props: Readonly<InstanceRenderInterface>) => ReactNode
+  >;
+  getRenderer: (
+    model: string
+  ) => ((props: Readonly<InstanceRenderInterface>) => ReactNode) | undefined;
+  setRenderer: setRenderProps;
+}
+
+/**
+ * Global state manager for handling plugin-provided states, such as custom renderers for models.
+ * This allows plugins to register custom renderers for specific models
+ */
+export const usePluginState = create<PluginStateProps>()((set, get) => ({
+  customRenders: {},
+  getRenderer: (model: string) => {
+    return get().customRenders[model];
+  },
+  setRenderer: (
+    model: string,
+    renderer: (props: Readonly<InstanceRenderInterface>) => ReactNode
+  ) => {
+    // ensure model is not already registered
+    if (get().customRenders[model]) {
+      console.warn(
+        `Overriding existing renderer is not allowed; model ${model}`
+      );
+      return;
+    }
+    set((state) => ({
+      customRenders: {
+        ...state.customRenders,
+        [model]: renderer
+      }
+    }));
+  }
+}));

--- a/src/frontend/src/states/PluginState.tsx
+++ b/src/frontend/src/states/PluginState.tsx
@@ -29,9 +29,6 @@ export const usePluginState = create<PluginStateProps>()((set, get) => ({
   ) => {
     // ensure model is not already registered
     if (get().customRenders[model]) {
-      console.warn(
-        `Overriding existing renderer is not allowed; model ${model}`
-      );
       return;
     }
     set((state) => ({


### PR DESCRIPTION
This adds the facilities to register custom model renders; while this is functional similar to providing `modelRenderer` for each field definition it enables plugins to be written more similar to core code and makes providing smaller, reusable plugins that just provide data classes and basic UI blocks easier.

The registered renderer acts as a fallback by default but can be prioritized by setting custom_model on the field definition.

follow up to https://github.com/inventree/InvenTree/pull/11897 / #11917
works towards https://github.com/inventree/org/issues/50
closes https://github.com/inventree/org/issues/56