### PR TITLE
[API] Role fix

### DIFF
--- a/src/backend/InvenTree/part/api.py
+++ b/src/backend/InvenTree/part/api.py
@@ -599,7 +599,7 @@ class PartValidateBOM(RetrieveUpdateAPI):
 
     queryset = Part.objects.all()
     serializer_class = part_serializers.PartBomValidateSerializer
-    role_required = 'bom.change'
+    role_required = 'bom'
 
     @extend_schema(
         responses={
@@ -610,7 +610,7 @@ class PartValidateBOM(RetrieveUpdateAPI):
     def update(self, request, *args, **kwargs):
         """Validate the referenced BomItem instance.
 
-        As this task if offloaded to the background worker,
+        As this task is offloaded to the background worker,
         we return information about the background task which is performing the validation.
         """
         part = self.get_object()


### PR DESCRIPTION
- Allow users to view BOM validation information with bom.view role
- The `bom` role is sufficient here, as the permission is determined by the HTTP request method
- Ref: https://github.com/inventree/InvenTree/pull/11527