### PR TITLE
[bug] Fix for report generation context

### DIFF
--- a/src/backend/InvenTree/plugin/base/integration/ReportMixin.py
+++ b/src/backend/InvenTree/plugin/base/integration/ReportMixin.py
@@ -24,7 +24,7 @@ class ReportMixin:
         super().__init__()
         self.add_mixin(PluginMixinEnum.REPORT, True, __class__)
 
-    def add_report_context(self, report_instance, model_instance, request, context):
+    def add_report_context(self, report_instance, model_instance, user, context):
         """Add extra context to the provided report instance.
 
         By default, this method does nothing.
@@ -32,11 +32,11 @@ class ReportMixin:
         Args:
             report_instance: The report instance to add context to
             model_instance: The model instance which initiated the report generation
-            request: The request object which initiated the report generation
+            user: The user to associate with the generated report
             context: The context dictionary to add to
         """
 
-    def add_label_context(self, label_instance, model_instance, request, context):
+    def add_label_context(self, label_instance, model_instance, user, context):
         """Add extra context to the provided label instance.
 
         By default, this method does nothing.
@@ -44,18 +44,18 @@ class ReportMixin:
         Args:
             label_instance: The label instance to add context to
             model_instance: The model instance which initiated the label generation
-            request: The request object which initiated the label generation
+            user: The user to associate with the generated label
             context: The context dictionary to add to
         """
 
-    def report_callback(self, template, instance, report, request, **kwargs):
+    def report_callback(self, template, instance, report, user, **kwargs):
         """Callback function called after a report is generated.
 
         Arguments:
             template: The ReportTemplate model
             instance: The instance of the target model
             report: The generated report object
-            request: The initiating request object
+            user: The user to associate with the generated report
 
         The default implementation does nothing.
         """

--- a/src/backend/InvenTree/plugin/base/label/mixins.py
+++ b/src/backend/InvenTree/plugin/base/label/mixins.py
@@ -38,41 +38,51 @@ class LabelPrintingMixin:
 
     BLOCKING_PRINT = True
 
-    def render_to_pdf(self, label: LabelTemplate, instance, request, **kwargs):
+    def render_to_pdf(
+        self, label: LabelTemplate, instance, request, user=None, **kwargs
+    ):
         """Render this label to PDF format.
 
         Arguments:
             label: The LabelTemplate object to render against
             instance: The model instance to render
-            request: The HTTP request object which triggered this print job
+            request: The HTTP request object which triggered this print job (optional, may be None)
+            user: The user who triggered this print job (optional, may be None)
         """
         try:
-            return label.render(instance, request)
+            return label.render(instance, request=request, user=user)
         except Exception:
             log_error('render_to_pdf', plugin=self.slug)
             raise ValidationError(_('Error rendering label to PDF'))
 
-    def render_to_html(self, label: LabelTemplate, instance, request, **kwargs):
+    def render_to_html(
+        self, label: LabelTemplate, instance, request, user=None, **kwargs
+    ):
         """Render this label to HTML format.
 
         Arguments:
             label: The LabelTemplate object to render against
             instance: The model instance to render
-            request: The HTTP request object which triggered this print job
+            request: The HTTP request object which triggered this print job (optional, may be None)
+            user: The user who triggered this print job (optional, may be None)
         """
         try:
-            return label.render_as_string(instance, request)
+            return label.render_as_string(instance, request=request, user=user)
         except Exception:
             log_error('render_to_html', plugin=self.slug)
             raise ValidationError(_('Error rendering label to HTML'))
 
-    def render_to_png(self, label: LabelTemplate, instance, request=None, **kwargs):
+    def render_to_png(
+        self, label: LabelTemplate, instance, request=None, user=None, **kwargs
+    ):
         """Render this label to PNG format.
 
         Arguments:
             label: The LabelTemplate object to render against
             instance: The model instance to render
-            request: The HTTP request object which triggered this print job
+            request: The HTTP request object which triggered this print job (optional, may be None)
+            user: The user who triggered this print job (optional, may be None)
+
         Keyword Arguments:
             pdf_data: The raw PDF data of the rendered label (if already rendered)
             dpi: The DPI to use for the PNG rendering
@@ -85,7 +95,7 @@ class LabelPrintingMixin:
         pdf_data = kwargs.get('pdf_data')
 
         if not pdf_data:
-            pdf_data = self.render_to_pdf(label, instance, request, **kwargs)
+            pdf_data = self.render_to_pdf(label, instance, request, user=user, **kwargs)
 
         pdf2image_kwargs = {
             'dpi': kwargs.get('dpi', InvenTreeSetting.get_setting('LABEL_DPI', 300)),
@@ -106,7 +116,6 @@ class LabelPrintingMixin:
         output: DataOutput,
         items: list,
         request: Request,
-        user_id: int,
         **kwargs,
     ) -> None:
         """Print one or more labels with the provided template and items.
@@ -116,7 +125,6 @@ class LabelPrintingMixin:
             output: The DataOutput object used to store the results
             items: The list of database items to print (e.g. StockItem instances)
             request: The HTTP request object which triggered this print job
-            user_id: The ID of the user to associate with the generated labels
 
         Keyword Arguments:
             printing_options: The printing options set for this print job defined in the PrintingOptionsSerializer
@@ -132,7 +140,7 @@ class LabelPrintingMixin:
         """
         # Extract user information, in decreasing order of preference
         user = (
-            kwargs.get('user')
+            kwargs.pop('user', None)
             or getattr(request, 'user', None)
             or getattr(output, 'user', None)
         )
@@ -151,9 +159,9 @@ class LabelPrintingMixin:
         for item in items:
             context = label.get_context(item, request, user=user)
             filename = label.generate_filename(context)
-            pdf_data = self.render_to_pdf(label, item, request, **kwargs)
+            pdf_data = self.render_to_pdf(label, item, request, user=user, **kwargs)
             png_file = self.render_to_png(
-                label, item, request, pdf_data=pdf_data, **kwargs
+                label, item, request, pdf_data=pdf_data, user=user, **kwargs
             )
 
             print_args = {

--- a/src/backend/InvenTree/plugin/base/label/mixins.py
+++ b/src/backend/InvenTree/plugin/base/label/mixins.py
@@ -106,6 +106,7 @@ class LabelPrintingMixin:
         output: DataOutput,
         items: list,
         request: Request,
+        user_id: int,
         **kwargs,
     ) -> None:
         """Print one or more labels with the provided template and items.
@@ -115,6 +116,7 @@ class LabelPrintingMixin:
             output: The DataOutput object used to store the results
             items: The list of database items to print (e.g. StockItem instances)
             request: The HTTP request object which triggered this print job
+            user_id: The ID of the user to associate with the generated labels
 
         Keyword Arguments:
             printing_options: The printing options set for this print job defined in the PrintingOptionsSerializer
@@ -128,10 +130,12 @@ class LabelPrintingMixin:
         The default implementation simply calls print_label() for each label, producing multiple single label output "jobs"
         but this can be overridden by the particular plugin.
         """
-        try:
-            user = request.user
-        except AttributeError:
-            user = None
+        # Extract user information, in decreasing order of preference
+        user = (
+            kwargs.get('user')
+            or getattr(request, 'user', None)
+            or getattr(output, 'user', None)
+        )
 
         # Initial state for the output print job
         output.progress = 0
@@ -145,7 +149,7 @@ class LabelPrintingMixin:
 
         # Generate a label output for each provided item
         for item in items:
-            context = label.get_context(item, request)
+            context = label.get_context(item, request, user=user)
             filename = label.generate_filename(context)
             pdf_data = self.render_to_pdf(label, item, request, **kwargs)
             png_file = self.render_to_png(

--- a/src/backend/InvenTree/plugin/builtin/labels/inventree_label.py
+++ b/src/backend/InvenTree/plugin/builtin/labels/inventree_label.py
@@ -20,6 +20,7 @@ class InvenTreeLabelPlugin(LabelPrintingMixin, SettingsMixin, InvenTreePlugin):
     """
 
     NAME = 'InvenTreeLabel'
+    SLUG = 'inventreelabel'
     TITLE = _('InvenTree PDF label printer')
     DESCRIPTION = _('Provides native support for printing PDF labels')
     VERSION = '1.1.0'

--- a/src/backend/InvenTree/report/api.py
+++ b/src/backend/InvenTree/report/api.py
@@ -215,6 +215,7 @@ class LabelPrint(GenericAPIView):
             template.pk,
             [item.pk for item in items_to_print],
             output.pk,
+            user.pk if user else None,
             plugin.slug,
             options=(plugin_serializer.data if plugin_serializer else {}),
         )
@@ -297,7 +298,13 @@ class ReportPrint(GenericAPIView):
         item_ids = [item.pk for item in items_to_print]
 
         # Offload the task to the background worker
-        offload_task(report.tasks.print_reports, template.pk, item_ids, output.pk)
+        offload_task(
+            report.tasks.print_reports,
+            template.pk,
+            item_ids,
+            output.pk,
+            user.pk if user else None,
+        )
 
         output.refresh_from_db()
 

--- a/src/backend/InvenTree/report/models.py
+++ b/src/backend/InvenTree/report/models.py
@@ -819,7 +819,9 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
             if hasattr(plugin, 'before_printing'):
                 plugin.before_printing()
 
-            plugin.print_labels(self, output, items, request, printing_options=options)
+            plugin.print_labels(
+                self, output, items, request, user=user, printing_options=options
+            )
 
             if hasattr(plugin, 'after_printing'):
                 plugin.after_printing()

--- a/src/backend/InvenTree/report/models.py
+++ b/src/backend/InvenTree/report/models.py
@@ -255,7 +255,7 @@ class ReportTemplateBase(
         Arguments:
             instance: The model instance to render against
             request: A HTTPRequest object (optional)
-            user: The user to associate with the generated report (if provided)
+            user: The user to associate with the generated report
             context: Django template language contexts (optional)
 
         Returns:
@@ -275,7 +275,7 @@ class ReportTemplateBase(
             instance: The model instance to render against
             request: A HTTPRequest object (optional)
             context: Django template language contexts (optional)
-            user: The user to associate with the generated report (if provided)
+            user: The user to associate with the generated report
 
         Returns:
             bytes: PDF data
@@ -336,7 +336,7 @@ class ReportTemplateBase(
 
         Arguments:
             request: The request object (optional)
-            user: The user to associate with the generated report (if provided)
+            user: The user to associate with the generated report
         """
         return {
             'base_url': get_base_url(request=request),
@@ -355,7 +355,7 @@ class ReportTemplateBase(
         Arguments:
             instance: The model instance we are printing against
             request: The request object (optional)
-            user: The user to associate with the generated report (if provided)
+            user: The user to associate with the generated report
         """
         # Provide base context information to all templates
         base_context = self.base_context(request=request, user=user, **kwargs)
@@ -443,7 +443,7 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
         Arguments:
             instance: The model instance we are printing against
             request: The request object (optional)
-            user: The user to associate with the generated report (if provided)
+            user: The user to associate with the generated report
         """
         base_context = super().get_context(instance, request, user=user, **kwargs)
         report_context: ReportContextExtension = self.get_report_context()
@@ -492,8 +492,8 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
 
         Arguments:
             items: A list of items to print reports for (model instance)
-            output: The DataOutput object to use (if provided)
-            user: The user to associate with the generated report (if provided)
+            output: The DataOutput object to use
+            user: The user to associate with the generated report
             request: The request object (optional)
 
         Returns:
@@ -734,7 +734,7 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
         Arguments:
             instance: The model instance we are printing against
             request: The request object (optional)
-            user: The user to associate with the generated label (if provided)
+            user: The user to associate with the generated label
         """
         base_context = super().get_context(instance, request, user=user, **kwargs)
 
@@ -776,10 +776,10 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
         Arguments:
             items: A list of items to print labels for (model instance)
             plugin: The plugin to use for label rendering
-            output: The DataOutput object to use (if provided)
+            output: The DataOutput object to use
             options: Additional options for the label printing plugin (optional)
             request: The request object (optional)
-            user: The user to associate with the generated labels (if provided)
+            user: The user to associate with the generated labels
 
         Returns:
             output: The DataOutput object representing the generated label(s)

--- a/src/backend/InvenTree/report/models.py
+++ b/src/backend/InvenTree/report/models.py
@@ -148,7 +148,7 @@ class BaseContextExtension(TypedDict):
         template_description: Description of the report template
         template_name: Name of the report template
         template_revision: Revision of the report template
-        user: User who made the request to render the template
+        user: User who is creating the report (if available)
     """
 
     base_url: str
@@ -247,41 +247,40 @@ class ReportTemplateBase(
         return template_string.render(Context(context))
 
     def render_as_string(
-        self, instance, request=None, user=None, context=None, **kwargs
+        self, instance: models.Model, context: Optional[dict] = None, **kwargs
     ) -> str:
         """Render the report to a HTML string.
 
         Arguments:
             instance: The model instance to render against
-            request: A HTTPRequest object (optional)
-            user: The user to associate with the generated report
             context: Django template language contexts (optional)
 
         Returns:
             str: HTML string
         """
         if context is None:
-            context = self.get_context(instance, request, user=user, **kwargs)
+            context = self.get_context(instance, **kwargs)
 
-        return render_to_string(self.template_name, context, request)
+        return render_to_string(self.template_name, context)
 
     def render(
-        self, instance, request=None, context=None, user=None, **kwargs
+        self,
+        instance: models.Model,
+        context: Optional[dict] = None,
+        user: Optional[AbstractUser] = None,
+        **kwargs,
     ) -> bytes:
         """Render the template to a PDF file.
 
         Arguments:
             instance: The model instance to render against
-            request: A HTTPRequest object (optional)
             context: Django template language contexts (optional)
             user: The user to associate with the generated report
 
         Returns:
             bytes: PDF data
         """
-        html = self.render_as_string(
-            instance, request, user=user, context=context, **kwargs
-        )
+        html = self.render_as_string(instance, user=user, context=context, **kwargs)
         pdf = HTML(string=html).write_pdf(pdf_forms=True)
 
         return pdf
@@ -330,34 +329,28 @@ class ReportTemplateBase(
         """Return a filter dict which can be applied to the target model."""
         return report.validators.validate_filters(self.filters, model=self.get_model())
 
-    def base_context(self, request=None, user=None, **kwargs) -> BaseContextExtension:
-        """Return base context data (available to all templates).
-
-        Arguments:
-            request: The request object (optional)
-            user: The user to associate with the generated report
-        """
+    def base_context(self, **kwargs) -> BaseContextExtension:
+        """Return base context data (available to all templates)."""
         return {
-            'base_url': get_base_url(request=request),
+            'base_url': get_base_url(),
             'date': InvenTree.helpers.current_date(),
             'datetime': InvenTree.helpers.current_time(),
             'template': self,
             'template_description': self.description,
             'template_name': self.name,
             'template_revision': self.revision,
-            'user': user or getattr(request, 'user', None),
+            'user': kwargs.get('user'),
         }
 
-    def get_context(self, instance, request=None, user=None, **kwargs):
+    def get_context(self, instance: models.Model, **kwargs):
         """Supply context data to the generic template for rendering.
 
         Arguments:
             instance: The model instance we are printing against
-            request: The request object (optional)
             user: The user to associate with the generated report
         """
         # Provide base context information to all templates
-        base_context = self.base_context(request=request, user=user, **kwargs)
+        base_context = self.base_context(**kwargs)
 
         # Add in an context information provided by the model instance itself
         context = {**base_context, **instance.report_context()}
@@ -436,56 +429,70 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
 
         return report_context
 
-    def get_context(self, instance, request=None, user=None, **kwargs):
+    def get_context(self, instance: models.Model, **kwargs):
         """Supply context data to the report template for rendering.
 
         Arguments:
             instance: The model instance we are printing against
-            request: The request object (optional)
-            user: The user to associate with the generated report
         """
-        base_context = super().get_context(instance, request, user=user, **kwargs)
+        base_context = super().get_context(instance, **kwargs)
         report_context: ReportContextExtension = self.get_report_context()
 
         context = {**base_context, **report_context}
 
         # Pass the context through to the plugin registry for any additional information
-        context = self.get_plugin_context(instance, request, context)
+        context = self.get_plugin_context(instance, context, **kwargs)
         return context
 
-    def get_plugin_context(self, instance, request, context):
-        """Get the context for the plugin."""
+    def get_plugin_context(self, instance: models.Model, context: dict, **kwargs):
+        """Get the context for the plugin.
+
+        Arguments:
+            instance: The model instance we are printing against
+            context: The context dictionary to add to
+            user: The user to associate with the generated report
+        """
+        user = kwargs.get('user')
+
         for plugin in registry.with_mixin(PluginMixinEnum.REPORT):
             try:
-                plugin.add_report_context(self, instance, request, context)
+                plugin.add_report_context(self, instance, user, context)
             except Exception:
                 InvenTree.exceptions.log_error('add_report_context', plugin=plugin.slug)
 
         return context
 
-    def handle_attachment(self, instance, report, report_name, request, debug_mode):
+    def handle_attachment(self, instance, report, report_name, user, debug_mode):
         """Attach the generated report to the model instance (if required)."""
         if self.attach_to_model and not debug_mode:
             instance.create_attachment(
                 attachment=ContentFile(report, report_name),
                 comment=_(f'Report generated from template {self.name}'),
-                upload_user=request.user
-                if request and request.user.is_authenticated
-                else None,
+                upload_user=user,
             )
 
-    def notify_plugins(self, instance, report, request):
-        """Provide generated report to any interested plugins."""
+    def notify_plugins(self, instance, report, user):
+        """Provide generated report to any interested plugins.
+
+        Arguments:
+            instance: The model instance we are printing against
+            report: The generated report object
+            user: The user to associate with the generated report
+        """
         report_plugins = registry.with_mixin(PluginMixinEnum.REPORT)
 
         for plugin in report_plugins:
             try:
-                plugin.report_callback(self, instance, report, request)
+                plugin.report_callback(self, instance, report, user)
             except Exception:
                 InvenTree.exceptions.log_error('report_callback', plugin=plugin.slug)
 
     def print(
-        self, items: list, request=None, output=None, user=None, **kwargs
+        self,
+        items: list,
+        output: Optional[DataOutput] = None,
+        user: Optional[AbstractUser] = None,
+        **kwargs,
     ) -> DataOutput:
         """Print reports for a list of items against this template.
 
@@ -493,7 +500,6 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
             items: A list of items to print reports for (model instance)
             output: The DataOutput object to use
             user: The user to associate with the generated report
-            request: The request object (optional)
 
         Returns:
             output: The DataOutput object representing the generated report(s)
@@ -512,7 +518,7 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
         logger.info("Printing %s reports against template '%s'", len(items), self.name)
 
         # Extract user information from the provided context
-        user = user or getattr(request, 'user', None) or getattr(output, 'user', None)
+        user = user or getattr(output, 'user', None)
 
         outputs = []
 
@@ -539,13 +545,13 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
 
         try:
             if self.merge:
-                base_context = super().base_context(request=request, user=user)
+                base_context = super().base_context(user=user)
                 report_context = self.get_report_context()
                 item_contexts = []
                 for instance in items:
                     instance_context = instance.report_context()
                     instance_context = self.get_plugin_context(
-                        instance, request, instance_context
+                        instance, instance_context, user=user
                     )
                     item_contexts.append(instance_context)
 
@@ -561,12 +567,10 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
                 try:
                     if debug_mode:
                         report = self.render_as_string(
-                            instance, request, user=user, context=contexts
+                            instance, user=user, context=contexts
                         )
                     else:
-                        report = self.render(
-                            instance, request, user=user, context=contexts
-                        )
+                        report = self.render(instance, user=user, context=contexts)
                 except TemplateDoesNotExist as e:
                     t_name = str(e) or self.template
                     msg = f'Template file {t_name} does not exist'
@@ -585,17 +589,15 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
                     raise ValidationError(f'{msg}: {e!s}')
 
                 outputs.append(report)
-                self.handle_attachment(
-                    instance, report, report_name, request, debug_mode
-                )
-                self.notify_plugins(instance, report, request)
+                self.handle_attachment(instance, report, report_name, user, debug_mode)
+                self.notify_plugins(instance, report, user)
 
                 # Update the progress of the report generation
                 output.progress += 1
                 output.save()
             else:
                 for instance in items:
-                    context = self.get_context(instance, request, user=user)
+                    context = self.get_context(instance, user=user)
 
                     if report_name is None:
                         report_name = self.generate_filename(context)
@@ -604,12 +606,10 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
                     try:
                         if debug_mode:
                             report = self.render_as_string(
-                                instance, request, user=user, context=context
+                                instance, user=user, context=context
                             )
                         else:
-                            report = self.render(
-                                instance, request, user=user, context=None
-                            )
+                            report = self.render(instance, user=user, context=None)
                     except TemplateDoesNotExist as e:
                         t_name = str(e) or self.template
                         msg = f'Template file {t_name} does not exist'
@@ -630,9 +630,10 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
                     outputs.append(report)
 
                     self.handle_attachment(
-                        instance, report, report_name, request, debug_mode
+                        instance, report, report_name, user, debug_mode
                     )
-                    self.notify_plugins(instance, report, request)
+
+                    self.notify_plugins(instance, report, user)
 
                     # Update the progress of the report generation
                     output.progress += 1
@@ -645,7 +646,6 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
             raise ValidationError({
                 'error': _('Error generating report'),
                 'detail': str(exc),
-                'path': request.path if request else None,
             })
 
         if not report_name:
@@ -735,15 +735,15 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
         }}
         """
 
-    def get_context(self, instance, request=None, user=None, **kwargs):
+    def get_context(self, instance: models.Model, *args, **kwargs):
         """Supply context data to the label template for rendering.
 
         Arguments:
             instance: The model instance we are printing against
-            request: The request object (optional)
-            user: The user to associate with the generated label
         """
-        base_context = super().get_context(instance, request, user=user, **kwargs)
+        user = kwargs.get('user')
+
+        base_context = super().get_context(instance, **kwargs)
 
         label_context: LabelContextExtension = {
             'width': self.width,
@@ -762,7 +762,7 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
         for plugin in plugins:
             # Let each plugin add its own context data
             try:
-                plugin.add_label_context(self, instance, request, context)
+                plugin.add_label_context(self, instance, user, context)
             except Exception:
                 InvenTree.exceptions.log_error('add_label_context', plugin=plugin.slug)
 
@@ -772,10 +772,9 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
         self,
         items: list,
         plugin: InvenTreePlugin,
-        output=None,
-        options=None,
-        request=None,
-        user=None,
+        output: Optional[DataOutput] = None,
+        options: Optional[dict] = None,
+        user: Optional[AbstractUser] = None,
         **kwargs,
     ) -> DataOutput:
         """Print labels for a list of items against this template.
@@ -785,7 +784,6 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
             plugin: The plugin to use for label rendering
             output: The DataOutput object to use
             options: Additional options for the label printing plugin (optional)
-            request: The request object (optional)
             user: The user to associate with the generated labels
 
         Returns:
@@ -798,7 +796,7 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
             f"Printing {len(items)} labels against template '{self.name}' using plugin '{plugin.slug}'"
         )
 
-        user = user or getattr(request, 'user', None) or getattr(output, 'user', None)
+        user = user or getattr(output, 'user', None)
 
         if not output:
             output = DataOutput.objects.create(
@@ -820,7 +818,7 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
                 plugin.before_printing()
 
             plugin.print_labels(
-                self, output, items, request, user=user, printing_options=options
+                self, output, items, None, user=user, printing_options=options
             )
 
             if hasattr(plugin, 'after_printing'):

--- a/src/backend/InvenTree/report/models.py
+++ b/src/backend/InvenTree/report/models.py
@@ -264,11 +264,7 @@ class ReportTemplateBase(
         return render_to_string(self.template_name, context)
 
     def render(
-        self,
-        instance: models.Model,
-        context: Optional[dict] = None,
-        user: Optional[AbstractUser] = None,
-        **kwargs,
+        self, instance: models.Model, context: Optional[dict] = None, **kwargs
     ) -> bytes:
         """Render the template to a PDF file.
 
@@ -280,7 +276,7 @@ class ReportTemplateBase(
         Returns:
             bytes: PDF data
         """
-        html = self.render_as_string(instance, user=user, context=context, **kwargs)
+        html = self.render_as_string(instance, context=context, **kwargs)
         pdf = HTML(string=html).write_pdf(pdf_forms=True)
 
         return pdf

--- a/src/backend/InvenTree/report/models.py
+++ b/src/backend/InvenTree/report/models.py
@@ -247,34 +247,42 @@ class ReportTemplateBase(
 
         return template_string.render(Context(context))
 
-    def render_as_string(self, instance, request=None, context=None, **kwargs) -> str:
+    def render_as_string(
+        self, instance, request=None, user=None, context=None, **kwargs
+    ) -> str:
         """Render the report to a HTML string.
 
         Arguments:
             instance: The model instance to render against
             request: A HTTPRequest object (optional)
+            user: The user to associate with the generated report (if provided)
             context: Django template language contexts (optional)
 
         Returns:
             str: HTML string
         """
         if context is None:
-            context = self.get_context(instance, request, **kwargs)
+            context = self.get_context(instance, request, user=user, **kwargs)
 
         return render_to_string(self.template_name, context, request)
 
-    def render(self, instance, request=None, context=None, **kwargs) -> bytes:
+    def render(
+        self, instance, request=None, context=None, user=None, **kwargs
+    ) -> bytes:
         """Render the template to a PDF file.
 
         Arguments:
             instance: The model instance to render against
             request: A HTTPRequest object (optional)
-            context: Django template langaguage contexts (optional)
+            context: Django template language contexts (optional)
+            user: The user to associate with the generated report (if provided)
 
         Returns:
             bytes: PDF data
         """
-        html = self.render_as_string(instance, request, context, **kwargs)
+        html = self.render_as_string(
+            instance, request, user=user, context=context, **kwargs
+        )
         pdf = HTML(string=html).write_pdf(pdf_forms=True)
 
         return pdf
@@ -323,8 +331,13 @@ class ReportTemplateBase(
         """Return a filter dict which can be applied to the target model."""
         return report.validators.validate_filters(self.filters, model=self.get_model())
 
-    def base_context(self, request=None) -> BaseContextExtension:
-        """Return base context data (available to all templates)."""
+    def base_context(self, request=None, user=None, **kwargs) -> BaseContextExtension:
+        """Return base context data (available to all templates).
+
+        Arguments:
+            request: The request object (optional)
+            user: The user to associate with the generated report (if provided)
+        """
         return {
             'base_url': get_base_url(request=request),
             'date': InvenTree.helpers.current_date(),
@@ -333,18 +346,19 @@ class ReportTemplateBase(
             'template_description': self.description,
             'template_name': self.name,
             'template_revision': self.revision,
-            'user': request.user if request else None,
+            'user': user or getattr(request, 'user', None),
         }
 
-    def get_context(self, instance, request=None, **kwargs):
+    def get_context(self, instance, request=None, user=None, **kwargs):
         """Supply context data to the generic template for rendering.
 
         Arguments:
             instance: The model instance we are printing against
             request: The request object (optional)
+            user: The user to associate with the generated report (if provided)
         """
         # Provide base context information to all templates
-        base_context = self.base_context(request=request)
+        base_context = self.base_context(request=request, user=user, **kwargs)
 
         # Add in an context information provided by the model instance itself
         context = {**base_context, **instance.report_context()}
@@ -423,9 +437,15 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
 
         return report_context
 
-    def get_context(self, instance, request=None, **kwargs):
-        """Supply context data to the report template for rendering."""
-        base_context = super().get_context(instance, request)
+    def get_context(self, instance, request=None, user=None, **kwargs):
+        """Supply context data to the report template for rendering.
+
+        Arguments:
+            instance: The model instance we are printing against
+            request: The request object (optional)
+            user: The user to associate with the generated report (if provided)
+        """
+        base_context = super().get_context(instance, request, user=user, **kwargs)
         report_context: ReportContextExtension = self.get_report_context()
 
         context = {**base_context, **report_context}
@@ -465,12 +485,15 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
             except Exception:
                 InvenTree.exceptions.log_error('report_callback', plugin=plugin.slug)
 
-    def print(self, items: list, request=None, output=None, **kwargs) -> DataOutput:
+    def print(
+        self, items: list, request=None, output=None, user=None, **kwargs
+    ) -> DataOutput:
         """Print reports for a list of items against this template.
 
         Arguments:
             items: A list of items to print reports for (model instance)
             output: The DataOutput object to use (if provided)
+            user: The user to associate with the generated report (if provided)
             request: The request object (optional)
 
         Returns:
@@ -489,6 +512,9 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
         """
         logger.info("Printing %s reports against template '%s'", len(items), self.name)
 
+        # Extract user information from the provided context
+        user = user or getattr(request, 'user', None) or getattr(output, 'user', None)
+
         outputs = []
 
         debug_mode = get_global_setting('REPORT_DEBUG_MODE', False)
@@ -500,9 +526,7 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
         if not output:
             output = DataOutput.objects.create(
                 total=len(items),
-                user=request.user
-                if request and request.user and request.user.is_authenticated
-                else None,
+                user=user,
                 progress=0,
                 complete=False,
                 output_type=DataOutput.DataOutputTypes.REPORT,
@@ -704,9 +728,16 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
         }}
         """
 
-    def get_context(self, instance, request=None, **kwargs):
-        """Supply context data to the label template for rendering."""
-        base_context = super().get_context(instance, request, **kwargs)
+    def get_context(self, instance, request=None, user=None, **kwargs):
+        """Supply context data to the label template for rendering.
+
+        Arguments:
+            instance: The model instance we are printing against
+            request: The request object (optional)
+            user: The user to associate with the generated label (if provided)
+        """
+        base_context = super().get_context(instance, request, user=user, **kwargs)
+
         label_context: LabelContextExtension = {
             'width': self.width,
             'height': self.height,
@@ -737,6 +768,7 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
         output=None,
         options=None,
         request=None,
+        user=None,
         **kwargs,
     ) -> DataOutput:
         """Print labels for a list of items against this template.
@@ -747,6 +779,7 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
             output: The DataOutput object to use (if provided)
             options: Additional options for the label printing plugin (optional)
             request: The request object (optional)
+            user: The user to associate with the generated labels (if provided)
 
         Returns:
             output: The DataOutput object representing the generated label(s)
@@ -758,11 +791,11 @@ class LabelTemplate(TemplateUploadMixin, ReportTemplateBase):
             f"Printing {len(items)} labels against template '{self.name}' using plugin '{plugin.slug}'"
         )
 
+        user = user or getattr(request, 'user', None) or getattr(output, 'user', None)
+
         if not output:
             output = DataOutput.objects.create(
-                user=request.user
-                if request and request.user.is_authenticated
-                else None,
+                user=user,
                 total=len(items),
                 progress=0,
                 complete=False,

--- a/src/backend/InvenTree/report/models.py
+++ b/src/backend/InvenTree/report/models.py
@@ -244,7 +244,6 @@ class ReportTemplateBase(
     def generate_filename(self, context, **kwargs) -> str:
         """Generate a filename for this report."""
         template_string = Template(self.filename_pattern)
-
         return template_string.render(Context(context))
 
     def render_as_string(
@@ -540,7 +539,7 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
 
         try:
             if self.merge:
-                base_context = super().base_context(request)
+                base_context = super().base_context(request=request, user=user)
                 report_context = self.get_report_context()
                 item_contexts = []
                 for instance in items:
@@ -561,9 +560,13 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
 
                 try:
                     if debug_mode:
-                        report = self.render_as_string(instance, request, contexts)
+                        report = self.render_as_string(
+                            instance, request, user=user, context=contexts
+                        )
                     else:
-                        report = self.render(instance, request, contexts)
+                        report = self.render(
+                            instance, request, user=user, context=contexts
+                        )
                 except TemplateDoesNotExist as e:
                     t_name = str(e) or self.template
                     msg = f'Template file {t_name} does not exist'
@@ -592,7 +595,7 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
                 output.save()
             else:
                 for instance in items:
-                    context = self.get_context(instance, request)
+                    context = self.get_context(instance, request, user=user)
 
                     if report_name is None:
                         report_name = self.generate_filename(context)
@@ -600,9 +603,13 @@ class ReportTemplate(TemplateUploadMixin, ReportTemplateBase):
                     # Render the report output
                     try:
                         if debug_mode:
-                            report = self.render_as_string(instance, request, None)
+                            report = self.render_as_string(
+                                instance, request, user=user, context=context
+                            )
                         else:
-                            report = self.render(instance, request, None)
+                            report = self.render(
+                                instance, request, user=user, context=None
+                            )
                     except TemplateDoesNotExist as e:
                         t_name = str(e) or self.template
                         msg = f'Template file {t_name} does not exist'

--- a/src/backend/InvenTree/report/tasks.py
+++ b/src/backend/InvenTree/report/tasks.py
@@ -20,8 +20,8 @@ def print_reports(
     Arguments:
         template_id: The ID of the ReportTemplate to use
         item_ids: List of item IDs to generate the report against
-        output_id: The ID of the DataOutput to use (if provided)
-        user_id: The ID of the user to associate with the generated report (if provided)
+        output_id: The ID of the DataOutput to use
+        user_id: The ID of the user to associate with the generated report
 
     This function is intended to be called by the background worker,
     and will continuously update the status of the DataOutput object.
@@ -72,9 +72,9 @@ def print_labels(
     Arguments:
         template_id: The ID of the LabelTemplate to use
         item_ids: List of item IDs to generate the labels against
-        output_id: The ID of the DataOutput to use (if provided)
-        user_id: The ID of the user to associate with the generated labels (if provided)
-        plugin_slug: The ID of the LabelPlugin to use (if provided)
+        output_id: The ID of the DataOutput to use
+        user_id: The ID of the user to associate with the generated labels
+        plugin_slug: The ID of the LabelPlugin to use
 
     This function is intended to be called by the background worker,
     and will continuously update the status of the DataOutput object.

--- a/src/backend/InvenTree/report/tasks.py
+++ b/src/backend/InvenTree/report/tasks.py
@@ -1,5 +1,7 @@
 """Background tasks for the report app."""
 
+from django.contrib.auth import get_user_model
+
 import structlog
 from opentelemetry import trace
 
@@ -10,13 +12,16 @@ logger = structlog.get_logger('inventree')
 
 
 @tracer.start_as_current_span('print_reports')
-def print_reports(template_id: int, item_ids: list[int], output_id: int, **kwargs):
+def print_reports(
+    template_id: int, item_ids: list[int], output_id: int, user_id: int, **kwargs
+):
     """Print multiple reports against the provided template.
 
     Arguments:
         template_id: The ID of the ReportTemplate to use
         item_ids: List of item IDs to generate the report against
         output_id: The ID of the DataOutput to use (if provided)
+        user_id: The ID of the user to associate with the generated report (if provided)
 
     This function is intended to be called by the background worker,
     and will continuously update the status of the DataOutput object.
@@ -31,6 +36,18 @@ def print_reports(template_id: int, item_ids: list[int], output_id: int, **kwarg
         log_error('report.tasks.print_reports')
         return
 
+    # Fetch user information
+    user = None
+
+    if user_id:
+        try:
+            user = get_user_model().objects.get(pk=user_id)
+        except Exception:
+            log_error('report.tasks.print_reports', user_id=user_id)
+
+    if not user:
+        user = getattr(output, 'user', None)
+
     # Fetch the items to be included in the report
     model = template.get_model()
     items = model.objects.filter(pk__in=item_ids)
@@ -43,7 +60,12 @@ def print_reports(template_id: int, item_ids: list[int], output_id: int, **kwarg
 
 @tracer.start_as_current_span('print_labels')
 def print_labels(
-    template_id: int, item_ids: list[int], output_id: int, plugin_slug: str, **kwargs
+    template_id: int,
+    item_ids: list[int],
+    output_id: int,
+    user_id: int,
+    plugin_slug: str,
+    **kwargs,
 ):
     """Print multiple labels against the provided template.
 
@@ -51,6 +73,7 @@ def print_labels(
         template_id: The ID of the LabelTemplate to use
         item_ids: List of item IDs to generate the labels against
         output_id: The ID of the DataOutput to use (if provided)
+        user_id: The ID of the user to associate with the generated labels (if provided)
         plugin_slug: The ID of the LabelPlugin to use (if provided)
 
     This function is intended to be called by the background worker,
@@ -66,6 +89,18 @@ def print_labels(
     except Exception:
         log_error('report.tasks.print_labels')
         return
+
+    # Fetch user information
+    user = None
+
+    if user_id:
+        try:
+            user = get_user_model().objects.get(pk=user_id)
+        except Exception:
+            log_error('report.tasks.print_labels', user_id=user_id)
+
+    if not user:
+        user = getattr(output, 'user', None)
 
     # Fetch the items to be included in the report
     model = template.get_model()
@@ -83,4 +118,4 @@ def print_labels(
     # Extract optional arguments for label printing
     options = kwargs.pop('options') or {}
 
-    template.print(items, plugin, output=output, options=options)
+    template.print(items, plugin, output=output, user=user, options=options)

--- a/src/backend/InvenTree/report/tasks.py
+++ b/src/backend/InvenTree/report/tasks.py
@@ -55,7 +55,7 @@ def print_reports(
     # Ensure they are sorted by the order of the provided item IDs
     items = sorted(items, key=lambda item: item_ids.index(item.pk))
 
-    template.print(items, output=output)
+    template.print(items, output=output, user=user)
 
 
 @tracer.start_as_current_span('print_labels')

--- a/src/backend/InvenTree/report/tests.py
+++ b/src/backend/InvenTree/report/tests.py
@@ -335,9 +335,6 @@ class ReportTest(InvenTreeAPITestCase):
 
         item = StockItem.objects.first()
 
-        # Enable report debug mode - so we can read the output as HTML
-        set_global_setting('REPORT_DEBUG_MODE', True)
-
         test_strings = [
             f'Hello {self.user.username} - your user ID is {self.user.pk}.',
             f'Template name: {template.name}',
@@ -438,6 +435,67 @@ class LabelTest(InvenTreeAPITestCase):
         self.assertIsNotNone(output.output)
         self.assertEqual(output.plugin, 'inventreelabel')
         self.assertTrue(output.output.name.endswith('.pdf'))
+
+    def test_print_custom_template(self):
+        """Test printing against a custom template file."""
+        template_string = """
+        Hello {{ user.username }} - your user ID is {{ user.pk }}.
+        Template name: {{ template.name }}
+        Barcode: {{ qr_data }}
+        Location ID: {{ location.pk }}
+        """
+
+        template_file = ContentFile(
+            template_string.encode('utf-8'), name='TestLabelTemplate.html'
+        )
+
+        # Create a new label template with the above string as the template
+        template = LabelTemplate.objects.create(
+            name='Test label template',
+            model_type='stocklocation',
+            template=template_file,
+            filename_pattern='unit_test_label.pdf',
+        )
+
+        location = StockItem.objects.exclude(location=None).first().location
+
+        url = reverse('api-label-print')
+        post_data = {'template': template.pk, 'items': [location.pk]}
+
+        plugin = registry.get_plugin('inventreelabel')
+
+        test_strings = [
+            f'Hello {self.user.username} - your user ID is {self.user.pk}.',
+            f'Template name: {template.name}',
+            f'Location ID: {location.pk}',
+            f'INV-SL{location.pk}',
+        ]
+
+        # Test with "debug" both enabled and disabled
+        for debug in [True, False]:
+            plugin.set_setting('DEBUG', debug)
+
+            # Generate label via the API
+            data = self.post(url, data=post_data).data
+
+            self.assertEqual(data['user'], self.user.pk)
+            self.assertTrue(data['output'].endswith('.html' if debug else '.pdf'))
+
+            # Read the file contents back out, and validate
+            if debug:
+                # Read raw HTML file
+                output = default_storage.open(data['output'].replace('/media/', '', 1))
+                file_content = str(output.read(), 'utf-8')
+            else:
+                # Convert from PDF bytes to string for testing purposes
+                output_path = os.path.join(
+                    settings.MEDIA_ROOT, data['output'].replace('/media/', '', 1)
+                )
+                reader = PdfReader(output_path)
+                file_content = ''.join(page.extract_text() for page in reader.pages)
+
+            for ts in test_strings:
+                self.assertIn(ts, file_content)
 
     def test_filters(self):
         """Test that template filters are correctly validated."""

--- a/src/backend/InvenTree/report/tests.py
+++ b/src/backend/InvenTree/report/tests.py
@@ -6,7 +6,11 @@ from io import StringIO
 from django.apps import apps
 from django.conf import settings
 from django.core.cache import cache
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.urls import reverse
+
+from pypdf import PdfReader
 
 import report.models as report_models
 from build.models import Build
@@ -298,6 +302,90 @@ class ReportTest(InvenTreeAPITestCase):
         self.assertEqual(output.total, 5)
         self.assertIsNotNone(output.output)
         self.assertTrue(output.output.name.endswith('.pdf'))
+
+    def test_print_custom_template(self):
+        """Create a new template, print it, and check the output."""
+        template_string = """
+        Hello {{ user.username }} - your user ID is {{ user.pk }}.
+        Template name: {{ template.name }}
+        {% if merge %}
+        REPORT OUTPUT: MERGE = ENABLED
+        {% for instance in instances %}
+        Part Name: {{ instance.part.name }}
+        Stock ID: {{ instance.stock_item.pk }}
+        {% endfor %}
+        {% else %}
+        REPORT OUTPUT: MERGE = DISABLED
+        Part Name: {{ part.name }}
+        Stock ID: {{ stock_item.pk }}
+        {% endif %}
+        """
+
+        template_file = ContentFile(
+            template_string.encode('utf-8'), name='TestPrintTemplate.html'
+        )
+
+        # Create a new report template with the above string as the template
+        template = ReportTemplate.objects.create(
+            name='Test template for print output',
+            model_type='stockitem',
+            template=template_file,
+            filename_pattern='unit_test_report.pdf',
+        )
+
+        item = StockItem.objects.first()
+
+        # Enable report debug mode - so we can read the output as HTML
+        set_global_setting('REPORT_DEBUG_MODE', True)
+
+        test_strings = [
+            f'Hello {self.user.username} - your user ID is {self.user.pk}.',
+            f'Template name: {template.name}',
+            f'Part Name: {item.part.name}',
+            f'Stock ID: {item.pk}',
+        ]
+
+        url = reverse('api-report-print')
+        post_data = {'template': template.pk, 'items': [item.pk]}
+
+        # Test with "debug" both enabled and disabled
+        for debug in [True, False]:
+            set_global_setting('REPORT_DEBUG_MODE', debug)
+
+            # Test with "merge" both enabled and disabled
+            for merge in [True, False]:
+                template.merge = merge
+                template.save()
+
+                # Generate report via the API
+                data = self.post(url, data=post_data).data
+
+                self.assertEqual(data['user'], self.user.pk)
+                self.assertIsNotNone(data['output'])
+                self.assertTrue(data['output'].endswith('.html' if debug else '.pdf'))
+                self.assertIn('unit_test_report', data['output'])
+
+                if debug:
+                    # Read raw HTML file
+                    output = default_storage.open(
+                        data['output'].replace('/media/', '', 1)
+                    )
+                    file_content = str(output.read(), 'utf-8')
+                else:
+                    # Convert from PDF bytes to string for testing purposes
+                    output_path = os.path.join(
+                        settings.MEDIA_ROOT, data['output'].replace('/media/', '', 1)
+                    )
+                    reader = PdfReader(output_path)
+                    file_content = ''.join(page.extract_text() for page in reader.pages)
+
+                for ts in test_strings:
+                    self.assertIn(ts, file_content)
+
+                self.assertIn(
+                    f'REPORT OUTPUT: MERGE = {"ENABLED" if merge else "DISABLED"}',
+                    file_content,
+                )
 
 
 class LabelTest(InvenTreeAPITestCase):

--- a/src/backend/InvenTree/report/tests.py
+++ b/src/backend/InvenTree/report/tests.py
@@ -306,7 +306,8 @@ class ReportTest(InvenTreeAPITestCase):
     def test_print_custom_template(self):
         """Create a new template, print it, and check the output."""
         template_string = """
-        Hello {{ user.username }} - your user ID is {{ user.pk }}.
+        Hello {{ user.username }}
+        Your user ID is {{ user.pk }}.
         Template name: {{ template.name }}
         {% if merge %}
         REPORT OUTPUT: MERGE = ENABLED
@@ -327,7 +328,7 @@ class ReportTest(InvenTreeAPITestCase):
 
         # Create a new report template with the above string as the template
         template = ReportTemplate.objects.create(
-            name='Test template for print output',
+            name='Test report template',
             model_type='stockitem',
             template=template_file,
             filename_pattern='unit_test_report.pdf',
@@ -336,7 +337,8 @@ class ReportTest(InvenTreeAPITestCase):
         item = StockItem.objects.first()
 
         test_strings = [
-            f'Hello {self.user.username} - your user ID is {self.user.pk}.',
+            f'Hello {self.user.username}',
+            f'Your user ID is {self.user.pk}.',
             f'Template name: {template.name}',
             f'Part Name: {item.part.name}',
             f'Stock ID: {item.pk}',
@@ -375,6 +377,9 @@ class ReportTest(InvenTreeAPITestCase):
                     )
                     reader = PdfReader(output_path)
                     file_content = ''.join(page.extract_text() for page in reader.pages)
+
+                # Replace any newline characters for testing purposes
+                file_content = file_content.replace('\n', ' ')
 
                 for ts in test_strings:
                     self.assertIn(ts, file_content)
@@ -494,6 +499,9 @@ class LabelTest(InvenTreeAPITestCase):
                 )
                 reader = PdfReader(output_path)
                 file_content = ''.join(page.extract_text() for page in reader.pages)
+
+            # Replace any newline for testing purposes
+            file_content = file_content.replace('\n', ' ')
 
             for ts in test_strings:
                 self.assertIn(ts, file_content)

--- a/src/backend/InvenTree/report/tests.py
+++ b/src/backend/InvenTree/report/tests.py
@@ -443,6 +443,7 @@ class LabelTest(InvenTreeAPITestCase):
         Template name: {{ template.name }}
         Barcode: {{ qr_data }}
         Location ID: {{ location.pk }}
+        Base URL: {{ base_url }}
         """
 
         template_file = ContentFile(


### PR DESCRIPTION
### Summary
- Closes https://github.com/inventree/InvenTree/issues/11940
- Fixes a long-standing issue where user information was unavailable to report and label context
- This bug has been present ever since we offloaded report generation to the background worker

### Changes

- Fixes bug, ensures user information  is correctly retrieved by the background worker
- Removes existing references to "request" - which is *NOT* transferred across to the background worker anyway
- Substantial refactoring of the report generation pipeline code
- Adds a large amount of new test coverage to report generation
- Improved typing / code cleanup as we go

### Breaking Change

Any custom report plugins which implement any of the following methods will need to assess the impact of the changes to the plugin API:

```python
    def add_report_context(self, report_instance, model_instance, user, context):
        """Add extra context to the provided report instance.

        By default, this method does nothing.

        Args:
            report_instance: The report instance to add context to
            model_instance: The model instance which initiated the report generation
            user: The user to associate with the generated report
            context: The context dictionary to add to
        """

    def add_label_context(self, label_instance, model_instance, user, context):
        """Add extra context to the provided label instance.

        By default, this method does nothing.

        Args:
            label_instance: The label instance to add context to
            model_instance: The model instance which initiated the label generation
            user: The user to associate with the generated label
            context: The context dictionary to add to
        """

    def report_callback(self, template, instance, report, user, **kwargs):
        """Callback function called after a report is generated.

        Arguments:
            template: The ReportTemplate model
            instance: The instance of the target model
            report: The generated report object
            user: The user to associate with the generated report

        The default implementation does nothing.
        """
```

*However* - up to this point, the "request" object was being passed through instead of the user, and that has (for years) been `None`.

### Backporting

This will *not* be backported to `1.3.x` branch due to the change in the plugin API