### PR TITLE
Update schema to match server responses for SelectionList and TreePath

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,14 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 486
+INVENTREE_API_VERSION = 487
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v487 -> 2026-05-15 : https://github.com/inventree/InvenTree/pull/11948
+    - Make SelectionList default nullable
+    - Add icon to TreePath schema
 
 v486 -> 2026-05-10 : https://github.com/inventree/InvenTree/pull/11914
     - Adds "maximum_stock" field to the Part model and associated API endpoints

--- a/src/backend/InvenTree/InvenTree/serializers.py
+++ b/src/backend/InvenTree/InvenTree/serializers.py
@@ -315,13 +315,16 @@ class TreePathSerializer(serializers.Serializer):
 
         allowed_fields = ['pk', 'name', *(extra_fields or [])]
 
+        if InvenTree.ready.isGeneratingSchema():
+            return
+
         for field in list(self.fields.keys()):
             if field not in allowed_fields:
                 self.fields.pop(field, None)
 
     pk = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)
-    icon = serializers.CharField(required=False, read_only=True)
+    icon = serializers.CharField(required=False, read_only=True, allow_null=True)
 
 
 class InvenTreeMoneySerializer(MoneyField):

--- a/src/backend/InvenTree/common/api.py
+++ b/src/backend/InvenTree/common/api.py
@@ -1145,6 +1145,10 @@ class SelectionListDetail(RetrieveUpdateDestroyAPI):
     serializer_class = common.serializers.SelectionListSerializer
     permission_classes = [IsAuthenticatedOrReadScope]
 
+    def get_queryset(self):
+        """Override the queryset method to include entry count."""
+        return self.serializer_class.annotate_queryset(super().get_queryset())
+
 
 class EntryMixin:
     """Mixin for SelectionEntry views."""

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -995,7 +995,7 @@ class SelectionListSerializer(InvenTreeModelSerializer):
             'entry_count',
         ]
 
-    default = SelectionEntrySerializer(read_only=True, many=False)
+    default = SelectionEntrySerializer(read_only=True, allow_null=True, many=False)
     choices = SelectionEntrySerializer(source='entries', many=True, required=False)
     entry_count = serializers.IntegerField(read_only=True)
 


### PR DESCRIPTION
I finally had time to catch up with recent schema changes. Just a few changes to ensure the schema matches the server responses from my testing:

- Make SelectionList default nullable
- Ensure SelectionList entry_count is set for both the list and details endpoints
- Add icon to the TreePath schema