### PR TITLE
Add MariaDB link to database section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ InvenTree is designed to be **extensible**, and provides multiple options for **
   <ul>
     <li><a href="https://www.postgresql.org/">PostgreSQL</a></li>
     <li><a href="https://www.mysql.com/">MySQL</a></li>
+    <li><a href="https://www.mariadb.com/">MariaDB</a></li>
     <li><a href="https://www.sqlite.org/">SQLite</a></li>
     <li><a href="https://redis.io/">Redis</a></li>
   </ul>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ InvenTree is designed to be **extensible**, and provides multiple options for **
   <ul>
     <li><a href="https://www.postgresql.org/">PostgreSQL</a></li>
     <li><a href="https://www.mysql.com/">MySQL</a></li>
-    <li><a href="https://www.mariadb.com/">MariaDB</a></li>
+    <li><a href="https://www.mariadb.org/">MariaDB</a></li>
     <li><a href="https://www.sqlite.org/">SQLite</a></li>
     <li><a href="https://redis.io/">Redis</a></li>
   </ul>


### PR DESCRIPTION
InvenTree already documents MySQL and MariaDB installation in the docs and includes MariaDB-specific database options in the backend. The README tech stack only listed MySQL. This adds MariaDB as a supported database alongside the existing entries.