### PR TITLE
chore(backend): also release packages to stable in the new packager.io repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -227,13 +227,21 @@ jobs:
             INVENTREE_PLUGIN_FILE=/opt/inventree/plugins.txt
             INVENTREE_CONFIG_FILE=/opt/inventree/config.yaml
             APP_REPO=inventree/InvenTree
-      - name: Publish to go.packager.io
+      - name: Publish to go.packager.io - current release channel
         uses: pkgr/action/publish@3bce081ae512c5020856e237d37b3f5479d4aa71 # pin@main
         with:
           target: ${{ matrix.target }}
           token: ${{ secrets.PACKAGER_RELEASE_TOKEN }}
           repository: inventree/InvenTree
           channel: ${{ env.pkg_channel }}
+          file: ${{ steps.package.outputs.package_path }}
+      - name: Publish to go.packager.io - stable release channel
+        uses: pkgr/action/publish@3bce081ae512c5020856e237d37b3f5479d4aa71 # pin@main
+        with:
+          target: ${{ matrix.target }}
+          token: ${{ secrets.PACKAGER_RELEASE_TOKEN }}
+          repository: inventree/InvenTree
+          channel: stable
           file: ${{ steps.package.outputs.package_path }}
       - name: Publish to artifact
         run: gh release upload ${REF} ${PACKAGE_PATH}#${PACKAGE_NAME}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -248,5 +248,5 @@ jobs:
         env:
           REF: ${{ github.ref_name }}
           PACKAGE_PATH: ${{ steps.package.outputs.package_path }}
-          PACKAGE_NAME: ${{ matrix.target }}-{{ steps.setup.outputs.version }}.tar.gz
+          PACKAGE_NAME: ${{ matrix.target }}-${{ steps.setup.outputs.version }}.tar.gz
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
brings the new setup to the same channel setup as the new one;

General note:
I do not plan to add a `master` channel but might consider adding a short-term (5-14 days) artifact to `master` push CI runs if the need arises.