### PR TITLE
[1.3.x] chore(backend): also release packages to stable in the new packager.io repo (#12023)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -227,7 +227,7 @@ jobs:
             INVENTREE_PLUGIN_FILE=/opt/inventree/plugins.txt
             INVENTREE_CONFIG_FILE=/opt/inventree/config.yaml
             APP_REPO=inventree/InvenTree
-      - name: Publish to go.packager.io
+      - name: Publish to go.packager.io - current release channel
         uses: pkgr/action/publish@3bce081ae512c5020856e237d37b3f5479d4aa71 # pin@main
         with:
           target: ${{ matrix.target }}
@@ -235,10 +235,18 @@ jobs:
           repository: inventree/InvenTree
           channel: ${{ env.pkg_channel }}
           file: ${{ steps.package.outputs.package_path }}
+      - name: Publish to go.packager.io - stable release channel
+        uses: pkgr/action/publish@3bce081ae512c5020856e237d37b3f5479d4aa71 # pin@main
+        with:
+          target: ${{ matrix.target }}
+          token: ${{ secrets.PACKAGER_RELEASE_TOKEN }}
+          repository: inventree/InvenTree
+          channel: stable
+          file: ${{ steps.package.outputs.package_path }}
       - name: Publish to artifact
         run: gh release upload ${REF} ${PACKAGE_PATH}#${PACKAGE_NAME}
         env:
           REF: ${{ github.ref_name }}
           PACKAGE_PATH: ${{ steps.package.outputs.package_path }}
-          PACKAGE_NAME: ${{ matrix.target }}-{{ steps.setup.outputs.version }}.tar.gz
+          PACKAGE_NAME: ${{ matrix.target }}-${{ steps.setup.outputs.version }}.tar.gz
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.3.x`:
 - [chore(backend): also release packages to stable in the new packager.io repo (#12023)](https://github.com/inventree/InvenTree/pull/12023)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)