### PR TITLE
[UI] Hover instance

### DIFF
--- a/docs/docs/settings/user.md
+++ b/docs/docs/settings/user.md
@@ -29,6 +29,7 @@ The *Display Settings* screen shows general display configuration options:
 {{ usersetting("SHOW_FULL_CATEGORY_IN_TABLES")}}
 {{ usersetting("SHOW_BOM_SUBASSEMBLY_LEVELS")}}
 {{ usersetting("ENABLE_LAST_BREADCRUMB") }}
+{{ usersetting("SHOW_EXTRA_MODEL_INFO") }}
 {{ usersetting("SHOW_FULL_LOCATION_IN_TABLES") }}
 {{ usersetting("DISPLAY_ITEMS_FINAL_LEVEL") }}
 

--- a/src/backend/InvenTree/common/setting/user.py
+++ b/src/backend/InvenTree/common/setting/user.py
@@ -235,6 +235,12 @@ USER_SETTINGS: dict[str, InvenTreeSettingsKeyType] = {
         'default': False,
         'validator': bool,
     },
+    'SHOW_EXTRA_MODEL_INFO': {
+        'name': _('Show Extra Model Information'),
+        'description': _('Display extra information in model selection dropdowns'),
+        'default': False,
+        'validator': bool,
+    },
     'SHOW_FULL_LOCATION_IN_TABLES': {
         'name': _('Show full stock location in tables'),
         'description': _(

--- a/src/frontend/lib/enums/ModelInformation.tsx
+++ b/src/frontend/lib/enums/ModelInformation.tsx
@@ -10,6 +10,7 @@ export interface ModelInformationInterface {
   url_detail?: string;
   api_endpoint: ApiEndpoints;
   admin_url?: string;
+  pk_field?: string;
   supports_barcode?: boolean;
   icon: keyof InvenTreeIconType;
 }

--- a/src/frontend/lib/types/Rendering.tsx
+++ b/src/frontend/lib/types/Rendering.tsx
@@ -15,6 +15,7 @@ export interface InstanceRenderInterface {
   link?: boolean;
   navigate?: any;
   showSecondary?: boolean;
+  showHover?: boolean;
   extra?: Record<string, any>;
 }
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -115,7 +115,7 @@
         "@lingui/babel-plugin-lingui-macro": "^5.9.2",
         "@lingui/cli": "^5.9.2",
         "@lingui/macro": "^5.9.2",
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "^1.16.0",
         "@types/node": "^25.5.0",
         "@types/qrcode": "^1.5.5",
         "@types/react": "^19.2.14",

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -151,8 +151,9 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
       return false;
     }
 
-    if (props.showHover === false) {
-      return false;
+    // Override with the props.showHover attribute
+    if (props.showHover !== undefined) {
+      return props.showHover;
     }
 
     return userSettings.isSet('SHOW_EXTRA_MODEL_INFO') && !!modelInfo;

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -1,5 +1,6 @@
 import { t } from '@lingui/core/macro';
 import {
+  ActionIcon,
   Alert,
   Anchor,
   Box,
@@ -28,6 +29,7 @@ import type {
 
 export type { InstanceRenderInterface } from '@lib/types/Rendering';
 import { getBaseUrl, navigateToLink, shortenString } from '@lib/index';
+import { IconLink } from '@tabler/icons-react';
 import { useNavigate } from 'react-router-dom';
 import { useApi } from '../../contexts/ApiContext';
 import { usePluginState } from '../../states/PluginState';
@@ -205,7 +207,12 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
               target='_blank'
               onClick={(event) => navigateToLink(detailUrl, navigate, event)}
             >
-              <Text size='sm'>{t`View details`}</Text>
+              <Group gap='xs' wrap='nowrap'>
+                <ActionIcon variant='transparent' size='xs'>
+                  <IconLink />
+                </ActionIcon>
+                <Text size='sm'>{t`View details`}</Text>
+              </Group>
             </Anchor>
           )}
         </Stack>

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -1,6 +1,5 @@
 import { t } from '@lingui/core/macro';
 import {
-  ActionIcon,
   Alert,
   Anchor,
   Box,
@@ -29,7 +28,6 @@ import type {
 
 export type { InstanceRenderInterface } from '@lib/types/Rendering';
 import { getBaseUrl, navigateToLink, shortenString } from '@lib/index';
-import { IconLink } from '@tabler/icons-react';
 import { useNavigate } from 'react-router-dom';
 import { useApi } from '../../contexts/ApiContext';
 import { usePluginState } from '../../states/PluginState';
@@ -207,12 +205,7 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
               target='_blank'
               onClick={(event) => navigateToLink(detailUrl, navigate, event)}
             >
-              <Group gap='xs' align='space-between'>
-                <Text size='sm'>{t`View details`}</Text>
-                <ActionIcon variant='transparent' size='xs'>
-                  <IconLink />
-                </ActionIcon>
-              </Group>
+              <Text size='sm'>{t`View details`}</Text>
             </Anchor>
           )}
         </Stack>

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -156,7 +156,8 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
       return props.showHover;
     }
 
-    return userSettings.isSet('SHOW_EXTRA_MODEL_INFO') && !!modelInfo;
+    // If not specified, fall back to the user configured setting
+    return userSettings.isSet('SHOW_EXTRA_MODEL_INFO');
   }, [props.showHover, modelInfo, userSettings]);
 
   // Extract model ID from the provided instance data, using the defined primary key field (or 'pk' as a fallback)

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -151,8 +151,12 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
       return false;
     }
 
+    if (props.showHover === false) {
+      return false;
+    }
+
     return userSettings.isSet('SHOW_EXTRA_MODEL_INFO') && !!modelInfo;
-  }, [modelInfo, userSettings]);
+  }, [props.showHover, modelInfo, userSettings]);
 
   // Extract model ID from the provided instance data, using the defined primary key field (or 'pk' as a fallback)
   const modelId = useMemo(() => {

--- a/src/frontend/src/components/render/Instance.tsx
+++ b/src/frontend/src/components/render/Instance.tsx
@@ -1,16 +1,20 @@
 import { t } from '@lingui/core/macro';
 import {
+  ActionIcon,
   Alert,
   Anchor,
+  Box,
   Group,
+  HoverCard,
   type MantineSize,
   Paper,
   Skeleton,
   Space,
+  Stack,
   Text
 } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
-import { type ReactNode, useCallback } from 'react';
+import { type ReactNode, useCallback, useMemo } from 'react';
 
 import { ModelInformationDict } from '@lib/enums/ModelInformation';
 import { ModelType } from '@lib/enums/ModelType';
@@ -25,8 +29,11 @@ import type {
 
 export type { InstanceRenderInterface } from '@lib/types/Rendering';
 import { getBaseUrl, navigateToLink, shortenString } from '@lib/index';
+import { IconLink } from '@tabler/icons-react';
+import { useNavigate } from 'react-router-dom';
 import { useApi } from '../../contexts/ApiContext';
 import { usePluginState } from '../../states/PluginState';
+import { useUserSettingsState } from '../../states/SettingsStates';
 import { Thumbnail } from '../images/Thumbnail';
 import { RenderBuildItem, RenderBuildLine, RenderBuildOrder } from './Build';
 import {
@@ -125,11 +132,89 @@ export function RenderInstance(props: RenderInstanceProps): ReactNode {
     props.custom_model ?? props.model ?? ''
   );
 
-  // provider component
-  if (!RenderComponent) {
-    return <UnknownRenderer model={props.model} />;
-  }
-  return <RenderComponent {...props} />;
+  const navigate = useNavigate();
+  const userSettings = useUserSettingsState();
+
+  // Extract model information from the defined model type
+  const modelInfo = useMemo(() => {
+    if (!props.model) {
+      return undefined;
+    }
+
+    return ModelInformationDict[
+      props.model.toString().toLowerCase() as ModelType
+    ];
+  }, [props.model]);
+
+  const showHover: boolean = useMemo(() => {
+    if (!modelInfo) {
+      return false;
+    }
+
+    return userSettings.isSet('SHOW_EXTRA_MODEL_INFO') && !!modelInfo;
+  }, [modelInfo, userSettings]);
+
+  // Extract model ID from the provided instance data, using the defined primary key field (or 'pk' as a fallback)
+  const modelId = useMemo(() => {
+    if (!modelInfo || !props.instance) {
+      return undefined;
+    }
+
+    return props.instance[modelInfo.pk_field ?? 'pk'];
+  }, [modelInfo, props.instance]);
+
+  const detailUrl = useMemo(() => {
+    if (!modelInfo || !modelId || !modelInfo.url_detail) {
+      return undefined;
+    }
+
+    return modelInfo.url_detail.replace(':pk', modelId.toString());
+  }, [modelInfo, modelId]);
+
+  return (
+    <HoverCard
+      disabled={!showHover}
+      position='top-end'
+      withinPortal
+      openDelay={500}
+      closeDelay={100}
+      zIndex={99999}
+    >
+      <HoverCard.Target>
+        <Box>
+          {!!RenderComponent ? (
+            <RenderComponent {...props} />
+          ) : (
+            <UnknownRenderer model={props.model} />
+          )}
+        </Box>
+      </HoverCard.Target>
+      <HoverCard.Dropdown>
+        <Stack gap='xs'>
+          <Group justify='space-between'>
+            <Text size='sm' fw='bold'>
+              {modelInfo?.label()}
+            </Text>
+            {modelId && <Text size='xs'>{`[${t`ID`}: ${modelId}]`}</Text>}
+          </Group>
+          {detailUrl && (
+            <Anchor
+              href={detailUrl}
+              target='_blank'
+              onClick={(event) => navigateToLink(detailUrl, navigate, event)}
+            >
+              <Group gap='xs' align='space-between'>
+                <Text size='sm'>{t`View details`}</Text>
+                <ActionIcon variant='transparent' size='xs'>
+                  <IconLink />
+                </ActionIcon>
+              </Group>
+            </Anchor>
+          )}
+        </Stack>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
 }
 
 export function RenderRemoteInstance({

--- a/src/frontend/src/pages/Index/Settings/UserSettings.tsx
+++ b/src/frontend/src/pages/Index/Settings/UserSettings.tsx
@@ -61,6 +61,7 @@ export default function UserSettings() {
               'FORMS_CLOSE_USING_ESCAPE',
               'DISPLAY_STOCKTAKE_TAB',
               'ENABLE_LAST_BREADCRUMB',
+              'SHOW_EXTRA_MODEL_INFO',
               'SHOW_FULL_LOCATION_IN_TABLES',
               'SHOW_FULL_CATEGORY_IN_TABLES',
               'SHOW_BOM_SUBASSEMBLY_LEVELS'

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1405,12 +1405,12 @@
   dependencies:
     "@octokit/openapi-types" "^24.2.0"
 
-"@playwright/test@^1.58.2":
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#b0ad585d2e950d690ef52424967a42f40c6d2cbd"
-  integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
+"@playwright/test@^1.16.0":
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.60.0.tgz#e696c31427e8882851235cd556dc2490c3206d97"
+  integrity sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==
   dependencies:
-    playwright "1.58.2"
+    playwright "1.60.0"
 
 "@reduxjs/toolkit@^1.9.0 || 2.x.x":
   version "2.11.2"
@@ -4195,17 +4195,17 @@ pkg-types@^2.3.0:
     exsolve "^1.0.7"
     pathe "^2.0.3"
 
-playwright-core@1.58.2:
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.2.tgz#ac5f5b4b10d29bcf934415f0b8d133b34b0dcb13"
-  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
 
-playwright@1.58.2:
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.2.tgz#afe547164539b0bcfcb79957394a7a3fa8683cfd"
-  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+playwright@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
   dependencies:
-    playwright-core "1.58.2"
+    playwright-core "1.60.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
Replaces https://github.com/inventree/InvenTree/pull/11137 as a more generic implementation

This PR adds a (user optional) hover card which displays over related items in forms, allowing the user to:

- See the raw ID of the item
- Open the detail view for that item in a new page

### Example

<img width="826" height="836" alt="image" src="https://github.com/user-attachments/assets/d349b22a-f914-46cf-be32-2f6624a322dc" />
