### PR TITLE
Fix for offloading of check_for_migrations

### DIFF
--- a/src/backend/InvenTree/InvenTree/apps.py
+++ b/src/backend/InvenTree/InvenTree/apps.py
@@ -64,9 +64,20 @@ class InvenTreeConfig(AppConfig):
             self.collect_tasks()
             self.start_background_tasks()
 
-            if not InvenTree.ready.isInTestMode():  # pragma: no cover
+            if (
+                not InvenTree.ready.isInTestMode()
+                and not InvenTree.ready.isInWorkerThread()
+            ):  # pragma: no cover
                 # Let the background worker check for migrations
-                InvenTree.tasks.offload_task(InvenTree.tasks.check_for_migrations)
+                # Don't offload task if we are already *in* the background worker, otherwise we might end up in a deadlock situation
+
+                try:
+                    InvenTree.tasks.offload_task(InvenTree.tasks.check_for_migrations)
+                except Exception as exc:
+                    logger.exception(
+                        'Failed to offload check_for_migrations task: %s', exc
+                    )
+
                 # Update exchange rates
                 InvenTree.tasks.offload_task(
                     InvenTree.tasks.update_exchange_rates, force_async=True

--- a/src/backend/InvenTree/InvenTree/tasks.py
+++ b/src/backend/InvenTree/InvenTree/tasks.py
@@ -326,7 +326,7 @@ def offload_task(
         except Exception as exc:
             log_error('offload_task', scope='worker')
             raise_warning(f"WARNING: '{taskname}' failed due to {exc!s}")
-            return False
+            raise exc
 
     # Finally, task either completed successfully or was offloaded
     return True

--- a/src/backend/InvenTree/InvenTree/tasks.py
+++ b/src/backend/InvenTree/InvenTree/tasks.py
@@ -326,7 +326,7 @@ def offload_task(
         except Exception as exc:
             log_error('offload_task', scope='worker')
             raise_warning(f"WARNING: '{taskname}' failed due to {exc!s}")
-            raise exc
+            return False
 
     # Finally, task either completed successfully or was offloaded
     return True

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -115,7 +115,7 @@
         "@lingui/babel-plugin-lingui-macro": "^5.9.2",
         "@lingui/cli": "^5.9.2",
         "@lingui/macro": "^5.9.2",
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "^1.16.0",
         "@types/node": "^25.5.0",
         "@types/qrcode": "^1.5.5",
         "@types/react": "^19.2.14",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1405,12 +1405,12 @@
   dependencies:
     "@octokit/openapi-types" "^24.2.0"
 
-"@playwright/test@^1.58.2":
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#b0ad585d2e950d690ef52424967a42f40c6d2cbd"
-  integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
+"@playwright/test@^1.16.0":
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.60.0.tgz#e696c31427e8882851235cd556dc2490c3206d97"
+  integrity sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==
   dependencies:
-    playwright "1.58.2"
+    playwright "1.60.0"
 
 "@reduxjs/toolkit@^1.9.0 || 2.x.x":
   version "2.11.2"
@@ -4195,17 +4195,17 @@ pkg-types@^2.3.0:
     exsolve "^1.0.7"
     pathe "^2.0.3"
 
-playwright-core@1.58.2:
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.2.tgz#ac5f5b4b10d29bcf934415f0b8d133b34b0dcb13"
-  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
 
-playwright@1.58.2:
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.2.tgz#afe547164539b0bcfcb79957394a7a3fa8683cfd"
-  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+playwright@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
   dependencies:
-    playwright-core "1.58.2"
+    playwright-core "1.60.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
Fixes an issue where worker processes can get into an infinite crash loop if a task cannot be offloaded during startup.

- Unhandled exception causes the worker to crash
- Worker process restarted
- Hits the same unhandled exception
- Infinite loop