### PR TITLE
Fix: Install postgres driver dynamically in packager script (#12052)

### DIFF
--- a/contrib/packager.io/functions.sh
+++ b/contrib/packager.io/functions.sh
@@ -328,6 +328,15 @@ function update_or_install() {
   # Run update as app user
   echo "# POI12| Updating InvenTree"
   sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && pip install wheel python-dotenv"
+  
+  if [[ "${INVENTREE_DB_ENGINE}" == *"postgres"* ]]; then
+    echo "# POI12| Installing postgresql driver"
+    sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && pip install psycopg2-binary"
+  elif [[ "${INVENTREE_DB_ENGINE}" == *"mysql"* ]] || [[ "${INVENTREE_DB_ENGINE}" == *"mariadb"* ]]; then
+    echo "# POI12| Installing mysql driver"
+    sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && pip install mysqlclient"
+  fi
+
   sudo -u ${APP_USER} --preserve-env=$SETUP_ENVS bash -c "cd ${APP_HOME} && set -e && invoke update | sed -e 's/^/# POI12| u | /;'"
 
   # Make sure permissions are correct again


### PR DESCRIPTION
Fixes #12052.

When users upgrade their host OS (e.g., Debian 11 -> 12), the Python version increments, requiring the packager to build a new virtual environment. Because database drivers are intentionally omitted from `requirements.txt`, the installer would crash during `manage.py collectplugins` or migrations with `ModuleNotFoundError: No module named 'psycopg2'`.

This PR updates `contrib/packager.io/functions.sh` to dynamically evaluate `INVENTREE_DB_ENGINE` and explicitly install `psycopg2-binary` (or `mysqlclient` for MySQL/MariaDB) immediately before `invoke update` runs.