### PR TITLE
fix(tasks): bypass Invoke PTY for interactive superuser/flush commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#11990](https://github.com/inventree/InvenTree/pull/11990) build output operations performed via the API now offload the work to a background task, and now return a task ID which can be used to monitor the progress of the task. This allows for better performance and responsiveness when performing build output operations, as the work is performed asynchronously in the background.
 - [#11825](https://github.com/inventree/InvenTree/pull/11825) adds a new "bom" ruleset and associated permissions for BOM management, separate from the "part" ruleset which remains focused on part management. This allows for more granular control over user permissions, allowing users to have different levels of access to part management and BOM management functionality.
 - [#11816](https://github.com/inventree/InvenTree/pull/11816) makes the `issued_by` field on the `Build` API read only, and instead sets the `issued_by` field to the current user when a build is created. This change was made to ensure that the `issued_by` field accurately reflects the user who created the build, and to prevent users from setting this field to an arbitrary value when creating or updating a build.
-- [#11751](https://github.com/inventree/InvenTree/issues/11751) updates interactive CLI handling for `invoke superuser` (and interactive `delete_data`) to bypass Invoke PTY mediation in Docker TTY environments, preventing dropped first keypress and username prompt stalls.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#11990](https://github.com/inventree/InvenTree/pull/11990) build output operations performed via the API now offload the work to a background task, and now return a task ID which can be used to monitor the progress of the task. This allows for better performance and responsiveness when performing build output operations, as the work is performed asynchronously in the background.
 - [#11825](https://github.com/inventree/InvenTree/pull/11825) adds a new "bom" ruleset and associated permissions for BOM management, separate from the "part" ruleset which remains focused on part management. This allows for more granular control over user permissions, allowing users to have different levels of access to part management and BOM management functionality.
 - [#11816](https://github.com/inventree/InvenTree/pull/11816) makes the `issued_by` field on the `Build` API read only, and instead sets the `issued_by` field to the current user when a build is created. This change was made to ensure that the `issued_by` field accurately reflects the user who created the build, and to prevent users from setting this field to an arbitrary value when creating or updating a build.
+- [#11751](https://github.com/inventree/InvenTree/issues/11751) updates interactive CLI handling for `invoke superuser` (and interactive `delete_data`) to bypass Invoke PTY mediation in Docker TTY environments, preventing dropped first keypress and username prompt stalls.
 
 ### Removed
 

--- a/tasks.py
+++ b/tasks.py
@@ -5,6 +5,7 @@ import json
 import os
 import pathlib
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -17,7 +18,7 @@ from typing import Optional
 
 import invoke
 from invoke import Collection, task
-from invoke.exceptions import UnexpectedExit
+from invoke.exceptions import Exit, UnexpectedExit
 
 
 def safe_value(fnc):
@@ -497,6 +498,43 @@ def manage(c, cmd, pty: bool = False, env=None, verbose: bool = False, **kwargs)
     )
 
 
+def manage_interactive(cmd: str, env=None, verbose: bool = False):
+    """Run a Django management command with inherited stdio.
+
+    This bypasses Invoke PTY mediation and mirrors direct shell usage, which is
+    required for some interactive commands in Docker environments.
+
+    Args:
+        cmd: Django management command and arguments.
+        env: Optional environment variables to add for command execution.
+        verbose: If True, print the resolved command before execution.
+
+    Raises:
+        Exit: If the subprocess returns a non-zero exit code.
+    """
+    args = ['python3', 'manage.py', *shlex.split(cmd)]
+
+    # Keep behavior aligned with `manage`: default to quiet output.
+    if '-v' not in cmd and '--verbosity' not in cmd:
+        args.extend(['-v', '1' if verbose else '0'])
+
+    if verbose:
+        info(f'Running interactive command: {" ".join(args)}')
+
+    cmd_env = dict(os.environ)
+    if env:
+        cmd_env.update(env)
+
+    # Avoid Invoke's PTY stdin mediation for interactive commands; run with
+    # inherited stdio to match direct `manage.py` behavior in Docker TTYs.
+    result = subprocess.run(args, cwd=manage_py_dir(), env=cmd_env, check=False)
+
+    if result.returncode != 0:
+        error(f"ERROR: InvenTree command failed: '{' '.join(args)}'")
+        warning('- Refer to the error messages in the log above for more information')
+        raise Exit(code=result.returncode)
+
+
 def installed_apps(c) -> list[str]:
     """Returns a list of all installed apps, including plugins."""
     result = manage(c, 'list_apps', pty=False, hide=True)
@@ -762,7 +800,7 @@ def shell(c):
 @task
 def superuser(c):
     """Create a superuser/admin account for the database."""
-    manage(c, 'createsuperuser', pty=True)
+    manage_interactive('createsuperuser')
 
 
 @task
@@ -1456,7 +1494,10 @@ def delete_data(c, force: bool = False, migrate: bool = False, verbose: bool = F
     if migrate:
         manage(c, 'migrate --run-syncdb', verbose=verbose)
 
-    manage(c, f'flush{" --noinput" if force else ""}', verbose=verbose)
+    if force:
+        manage(c, 'flush --noinput', verbose=verbose)
+    else:
+        manage_interactive('flush', verbose=verbose)
 
     success('Existing data deleted')
 


### PR DESCRIPTION
### Summary
This PR fixes an interactive CLI regression where `invoke superuser` (and interactive delete_data/flush) can drop the first typed character and then stall at the username/confirmation prompt in Docker terminal sessions.

The fix routes these specific interactive commands through a direct subprocess call (`python3 manage.py ...`) with inherited stdio instead of Invoke’s PTY execution path.

Closes: #11751

### Problem
In affected Docker environments, running interactive commands via Invoke task execution shows:

- First keypress is dropped (e.g. admin becomes dmin)
- Prompt flow stalls after username/confirmation input
- Superuser is not created

This was reproducible for:

```
docker compose run --rm inventree-server invoke superuser
docker compose exec -it inventree-server invoke superuser
```
But raw Django interactive command worked in the same container:

`docker compose exec -it inventree-server python3 manage.py createsuperuser -v 0`
That isolates the issue to the Invoke-mediated interactive path, not Django createsuperuser itself.

### Reproduced Environment

- Deployment: Docker Compose (`contrib/container/docker-compose.yml`)
- Host OS: Debian 12 (bookworm)
- InvenTree image tag: `INVENTREE_TAG=1.3.0`
- Container runtime:
  - Python `3.14.3`
  - invoke `2.2.1`

Raw `manage.py createsuperuser` worked in the same environment, isolating the issue to the Invoke-mediated task path.

### Why this happens
Invoke with pty=True performs its own stdin/TTY mediation (character-buffered input loop, stdin polling, PTY handling). In Docker interactive sessions, this adds an extra terminal mediation layer on top of Docker’s TTY handling. In some runtime combinations, this leads to input timing/forwarding issues (observed as dropped first character and prompt stalls).

Interactive input through the Invoke PTY path seems fragile here, while direct process stdio is stable.

### Fix approach
For interactive management commands only:

- Add `manage_interactive(...)` helper that executes `python3 manage.py ...` via `subprocess.run(...)` with inherited stdio.
- Use `manage_interactive('createsuperuser')` in superuser.
- Use `manage_interactive('flush')` for the interactive (non-force) delete_data path.
- Non-interactive command paths remain unchanged and still use existing Invoke wrappers.

### Why this is appropriate

Narrow scope: only touches commands that require interactive stdin behavior.
Preserves UX: invoke superuser remains interactive and now matches direct Django CLI behavior.
Evidence-based: raw Django interactive works in the same environment; only Invoke-mediated path fails.
Lower risk than broad task-runner changes.

### Validation performed

Reproduced failure mode for invoke superuser in Docker interactive sessions.
Confirmed raw `manage.py createsuperuser` works in same environment.
Verified updated task code compiles and follows existing command error handling patterns.
Confirmed behaviour rationale in changelog update.
- `invoke superuser` tested successfully (interactive input accepted correctly; no dropped first character; prompt flow completed).
- `invoke dev.delete-data` tested successfully in interactive mode (confirmation input accepted correctly).

### Files changed

- `tasks.py`
- `CHANGELOG.md`
