### PR TITLE
plugin-validation-purchase-orders

### DIFF
--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -1191,6 +1191,10 @@ class PurchaseOrder(TotalPriceMixin, Order):
 
                 for item in new_items:
                     item.set_status(status, custom_values=custom_stock_status_values)
+                    # run validation for serialized items plugin.validate_batch_code
+                    item.validate_batch_code()
+                    # run validation for serialized items plugin.validate_model_instance
+                    item.run_plugin_validation()
                     stock_items.append(item)
 
             else:
@@ -1213,6 +1217,13 @@ class PurchaseOrder(TotalPriceMixin, Order):
 
         # Bulk create new stock items
         if len(bulk_create_items) > 0:
+            # bulk_create() bypasses save()/clean() methods, so manual validation is required for each item
+            for item in bulk_create_items:
+                # run validation for items plugin.validate_batch_code
+                item.validate_batch_code()
+                # run validation for items plugin.validate_model_instance
+                item.run_plugin_validation()
+
             stock.models.StockItem.objects.bulk_create(
                 bulk_create_items, batch_size=250
             )


### PR DESCRIPTION
Fixes #12076

## Problem
Custom validation plugins implementing the `validate_batch_code` hook are enforced
when stock is created directly, but not when receiving stock against a Purchase
Order. Invalid/empty batch codes (and any other plugin validation) silently pass on
the PO receipt path.

## Cause
Plugin validation hooks only fire through the model lifecycle:
- `validate_batch_code` via `StockItem.clean()`
- `validate_model_instance` via `StockItem.save()` / `full_clean()`
  (`PluginValidationMixin.run_plugin_validation()`)

`PurchaseOrder.receive_line_items()` creates stock via `StockItem.objects.bulk_create()`
and `StockItem._create_serial_numbers()`, both of which bypass `save()`/`clean()`, so
the hooks are never reached. (Serial-number validation already worked because it is
called explicitly in the receive serializer.)

## Fix
Invoke the existing plugin validation hooks explicitly in `receive_line_items()` — no
validation logic is added to core, the hooks the bulk path skips are simply called:

- `item.validate_batch_code()` → `plugin.validate_batch_code`
- `item.run_plugin_validation()` → `plugin.validate_model_instance`

Both creation branches are covered:
- **Non-serialized** items are validated *before* `bulk_create()`.
- **Serialized** items are validated after `_create_serial_numbers()`.

`receive_line_items()` is wrapped in `@transaction.atomic`, so a `ValidationError`
raised by any plugin rolls back all inserts — no partial/invalid stock is committed.

## Testing
Manual testing has been performed by using a plugin that checks for the existence of various elements such as batch code, unit price, qr code etc. Tested adding stock the default way and via receiving stock in purchase orders. Tested nothing strange happens if no plugin is added. All seems ok.