### PR TITLE
Make plugin registry hash independent of plugin discovery order

### DIFF
--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -1027,7 +1027,11 @@ class PluginsRegistry:
         data = md5()
 
         # Hash for all loaded plugins
-        for slug, plug in self.plugins.items():
+        # Note: Sort by slug, so the hash is independent of discovery order.
+        # Different processes can discover the same plugins in a different
+        # order, and the hash must represent the registry *state*, not the
+        # iteration order of any particular process.
+        for slug, plug in sorted(self.plugins.items()):
             data.update(str(slug).encode())
             data.update(str(plug.name).encode())
             data.update(str(plug.version).encode())

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -1031,7 +1031,7 @@ class PluginsRegistry:
         # Different processes can discover the same plugins in a different
         # order, and the hash must represent the registry *state*, not the
         # iteration order of any particular process.
-        for slug, plug in sorted(self.plugins.items()):
+        for slug, plug in sorted(self.plugins.items(), key=lambda item: item[0]):
             data.update(str(slug).encode())
             data.update(str(plug.name).encode())
             data.update(str(plug.version).encode())

--- a/src/backend/InvenTree/plugin/test_plugin.py
+++ b/src/backend/InvenTree/plugin/test_plugin.py
@@ -538,6 +538,27 @@ class RegistryTests(TestQueryMixin, PluginRegistryMixin, TestCase):
             registry.registry_hash = 'abc'
             self.assertTrue(registry.check_reload())
 
+    def test_registry_hash_order_independence(self):
+        """Test that the registry hash does not depend on plugin iteration order.
+
+        Different processes (gunicorn workers, background worker, shell) can
+        discover the same set of plugins in a different order. If the hash
+        depends on iteration order, processes disagree about the hash for the
+        same registry state, and ping-pong each other into endless reloads
+        via check_reload.
+        """
+        original_plugins = registry.plugins
+
+        try:
+            hash_original = registry.calculate_plugin_hash()
+
+            # Simulate a process which discovered the same plugins in reverse order
+            registry.plugins = dict(reversed(list(original_plugins.items())))
+
+            self.assertEqual(hash_original, registry.calculate_plugin_hash())
+        finally:
+            registry.plugins = original_plugins
+
     def test_builtin_mandatory_plugins(self):
         """Test that mandatory builtin plugins are always loaded."""
         from plugin.models import PluginConfig

--- a/src/backend/InvenTree/plugin/test_plugin.py
+++ b/src/backend/InvenTree/plugin/test_plugin.py
@@ -549,6 +549,9 @@ class RegistryTests(TestQueryMixin, PluginRegistryMixin, TestCase):
         """
         original_plugins = registry.plugins
 
+        # Reversing a dict with fewer than 2 entries would not change anything
+        self.assertGreater(len(original_plugins), 1)
+
         try:
             hash_original = registry.calculate_plugin_hash()
 


### PR DESCRIPTION
Fixes #12150

`calculate_plugin_hash()` iterated `self.plugins.items()` in insertion order, which is the plugin discovery order of the local process. Two processes holding the same registry state in a different order computed different hashes and ping-ponged `_PLUGIN_REGISTRY_HASH`, driving each other into endless registry reloads via `check_reload()` (full forensics in the issue).

This sorts by slug before hashing, so the hash represents the registry state rather than any process's iteration order.

Also adds a regression test: reverse `registry.plugins` and assert the hash is unchanged. The test fails against the old implementation and passes with the sort.

One behavioural note: existing deployments will compute a different hash the first time they run this code, causing exactly one reload wave on upgrade — same as any plugin set change today.
