### PR TITLE
fix: support non-integer PKs in NotificationMessage (fixes UUID overflow)

### DIFF
--- a/src/backend/InvenTree/common/migrations/0044_notificationmessage_charfield_pk.py
+++ b/src/backend/InvenTree/common/migrations/0044_notificationmessage_charfield_pk.py
@@ -1,0 +1,29 @@
+"""Migration to change NotificationMessage object_id fields from PositiveIntegerField to CharField.
+
+This allows notifications to reference models that use non-integer primary keys,
+such as UUIDField (e.g. MachineConfig), without a database overflow error.
+
+See: https://github.com/inventree/InvenTree/issues/12131
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('common', '0043_auto_20260518_1206'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='notificationmessage',
+            name='target_object_id',
+            field=models.CharField(max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='notificationmessage',
+            name='source_object_id',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/src/backend/InvenTree/common/models.py
+++ b/src/backend/InvenTree/common/models.py
@@ -1678,7 +1678,7 @@ class NotificationMessage(models.Model):
         ContentType, on_delete=models.CASCADE, related_name='notification_target'
     )
 
-    target_object_id = models.PositiveIntegerField()
+    target_object_id = models.CharField(max_length=255)
 
     target_object = GenericForeignKey('target_content_type', 'target_object_id')
 
@@ -1691,7 +1691,7 @@ class NotificationMessage(models.Model):
         blank=True,
     )
 
-    source_object_id = models.PositiveIntegerField(null=True, blank=True)
+    source_object_id = models.CharField(max_length=255, null=True, blank=True)
 
     source_object = GenericForeignKey('source_content_type', 'source_object_id')
 

--- a/src/backend/InvenTree/order/tests.py
+++ b/src/backend/InvenTree/order/tests.py
@@ -523,7 +523,7 @@ class OrderTest(ExchangeRateMixin, PluginRegistryMixin, TestCase):
 
             msg = messages.first()
 
-            self.assertEqual(msg.target_object_id, 1)
+            self.assertEqual(msg.target_object_id, str(1))
             self.assertEqual(msg.name, 'Overdue Purchase Order')
 
     def test_new_po_notification(self):


### PR DESCRIPTION
## Summary

Fixes #12131.

`NotificationMessage.target_object_id` and `source_object_id` were declared as `PositiveIntegerField`. This works fine for models with integer PKs, but overflows when the referenced model uses a UUID primary key — for example `MachineConfig`, which defines:

```python
id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
```

Django's `GenericForeignKey` stores the PK value as a string regardless of its original type, so the backing database column should be a `CharField` to accommodate any PK type (integer, UUID, slug, etc.).

## Root cause

```
psycopg.errors.NumericValueOutOfRange: value "137023719040805274638741863464503989598" is out of range for type integer
```

The UUID is cast to an integer by the database driver, which overflows `integer` (max ~2.1 billion).

## Changes

- `common/models.py`: change `target_object_id` and `source_object_id` from `PositiveIntegerField` to `CharField(max_length=255)` on `NotificationMessage`
- `common/migrations/0044`: `AlterField` migration for both columns
- `order/tests.py`: update one assertion from integer `1` to `str(1)` since `CharField` stores the PK as a string

## Backwards compatibility

Existing rows with integer PKs are unaffected — `CharField` stores them as `'1'`, `'2'`, etc. Django's `GenericForeignKey` resolution already casts the stored string back to the target model's PK type via `ContentType.get_object_for_this_type()`, so lookups continue to work correctly for both integer and UUID PKs.