### PR TITLE
fix(ci): improve release pipe stability

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,12 +154,12 @@ jobs:
           - ubuntu:22.04
           - ubuntu:24.04
           - debian:12
+
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin@v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
-
       - name: Get frontend artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
@@ -215,7 +215,7 @@ jobs:
           echo "calculate release channel"
           pip install --require-hashes -r contrib/dev_reqs/requirements.txt
           python3 .github/scripts/version_check.py
-      - name: Package
+      - name: Package - current release channel
         uses: pkgr/action/package@c5666febcd31750da6428042193fc5b2fb765435 # pin@main
         id: package
         with:
@@ -241,14 +241,6 @@ jobs:
           repository: inventree/InvenTree
           channel: ${{ env.pkg_channel }}
           file: ${{ steps.package.outputs.package_path }}
-      - name: Publish to go.packager.io - stable release channel
-        uses: pkgr/action/publish@3bce081ae512c5020856e237d37b3f5479d4aa71 # pin@main
-        with:
-          target: ${{ matrix.target }}
-          token: ${{ secrets.PACKAGER_RELEASE_TOKEN }}
-          repository: inventree/InvenTree
-          channel: stable
-          file: ${{ steps.package.outputs.package_path }}
       - name: Publish to artifact
         run: gh release upload ${REF} ${PACKAGE_PATH}#${PACKAGE_NAME}
         env:
@@ -256,3 +248,29 @@ jobs:
           PACKAGE_PATH: ${{ steps.package.outputs.package_path }}
           PACKAGE_NAME: ${{ matrix.target }}-${{ steps.setup.outputs.version }}.tar.gz
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Package - stable release channel
+        uses: pkgr/action/package@c5666febcd31750da6428042193fc5b2fb765435 # pin@main
+        id: package-stable
+        with:
+          target: ${{ matrix.target }}
+          version: ${{ steps.setup.outputs.version }}
+          debug: true
+          cache_prefix: ${{ github.ref_name }}
+          env: |
+            INVENTREE_DB_ENGINE=sqlite3
+            INVENTREE_DB_NAME=database.sqlite3
+            INVENTREE_PLUGINS_ENABLED=true
+            INVENTREE_MEDIA_ROOT=/opt/inventree/media
+            INVENTREE_STATIC_ROOT=/opt/inventree/static
+            INVENTREE_BACKUP_DIR=/opt/inventree/backup
+            INVENTREE_PLUGIN_FILE=/opt/inventree/plugins.txt
+            INVENTREE_CONFIG_FILE=/opt/inventree/config.yaml
+            APP_REPO=inventree/InvenTree
+      - name: Publish to go.packager.io - stable release channel
+        uses: pkgr/action/publish@3bce081ae512c5020856e237d37b3f5479d4aa71 # pin@main
+        with:
+          target: ${{ matrix.target }}
+          token: ${{ secrets.PACKAGER_RELEASE_TOKEN }}
+          repository: inventree/InvenTree
+          channel: stable
+          file: ${{ steps.package-stable.outputs.package_path }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,8 @@ jobs:
       id-token: write
       contents: write
       attestations: write
+      artifact-metadata: write
+
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin@v6.0.3
         with:
@@ -73,7 +75,7 @@ jobs:
           zip -r ../frontend-build.zip * .vite
       - name: Attest Build Provenance
         id: attest
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # pin@v1
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # pin@v4
         with:
           subject-path: "${{ github.workspace }}/src/backend/InvenTree/web/static/frontend-build.zip"
 
@@ -87,11 +89,15 @@ jobs:
         with:
           name: frontend-build
           path: src/backend/InvenTree/web/static/frontend-build.zip
+      - name: Rename Attestation Bundle
+        run: |
+          mv ${BUNDLE_PATH} src/backend/InvenTree/web/static/frontend-build.intoto.jsonl
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path}}
       - name: Upload Attestation
-        run: gh release upload ${REF} ${BUNDLE_PATH}#frontend-build.intoto.jsonl
+        run: gh release upload ${REF} src/backend/InvenTree/web/static/frontend-build.intoto.jsonl#frontend-build.intoto.jsonl
         env:
           REF: ${{ github.ref_name }}
-          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path}}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docs:


### PR DESCRIPTION
- updates to the newer attestation flow (the old one is a soft link there)
- build `stable` channel packages separately to ensure there is no id duplication