### PR TITLE
[bug] Fix order event name

### DIFF
--- a/src/backend/InvenTree/order/events.py
+++ b/src/backend/InvenTree/order/events.py
@@ -20,7 +20,7 @@ class SalesOrderEvents(BaseEventEnum):
     """Event enumeration for the SalesOrder models."""
 
     ISSUED = 'salesorder.issued'
-    HOLD = 'salesorder.onhold'
+    HOLD = 'salesorder.hold'
     COMPLETED = 'salesorder.completed'
     CANCELLED = 'salesorder.cancelled'
 


### PR DESCRIPTION
Fixes sales order event name, "onhold" should be "hold".

Note: this is maybe considered a breaking change for any plugins which listen for this event - although they *should* be listening for the enumerated value, not the raw string...