### PR TITLE
build(docker): compile backend translations during image build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -84,6 +84,11 @@ jobs:
           docker run --rm inventree-test test -f /home/inventree/gunicorn.conf.py
           docker run --rm inventree-test test -f /home/inventree/src/backend/requirements.txt
           docker run --rm inventree-test test -f /home/inventree/src/backend/InvenTree/manage.py
+          # Check that backend translations were compiled into the image (a few representative languages)
+          docker run --rm inventree-test test -f /home/inventree/src/backend/InvenTree/locale/de/LC_MESSAGES/django.mo
+          docker run --rm inventree-test test -f /home/inventree/src/backend/InvenTree/locale/fr/LC_MESSAGES/django.mo
+          docker run --rm inventree-test test -f /home/inventree/src/backend/InvenTree/locale/ru/LC_MESSAGES/django.mo
+          docker run --rm inventree-test test -f /home/inventree/src/backend/InvenTree/locale/zh_Hans/LC_MESSAGES/django.mo
       - name: Build Docker Image
         # Build the development docker image (using docker-compose.yml)
         run: docker compose --project-directory . -f contrib/container/dev-docker-compose.yml build --no-cache

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -89,6 +89,11 @@ jobs:
           docker run --rm inventree-test test -f /home/inventree/src/backend/InvenTree/locale/fr/LC_MESSAGES/django.mo
           docker run --rm inventree-test test -f /home/inventree/src/backend/InvenTree/locale/ru/LC_MESSAGES/django.mo
           docker run --rm inventree-test test -f /home/inventree/src/backend/InvenTree/locale/zh_Hans/LC_MESSAGES/django.mo
+          # Check that frontend translations (lingui) were compiled into the static build output (a few representative languages)
+          docker run --rm inventree-test grep -q '"src/locales/de/messages.ts"' /home/inventree/src/backend/InvenTree/web/static/web/.vite/manifest.json
+          docker run --rm inventree-test grep -q '"src/locales/fr/messages.ts"' /home/inventree/src/backend/InvenTree/web/static/web/.vite/manifest.json
+          docker run --rm inventree-test grep -q '"src/locales/ru/messages.ts"' /home/inventree/src/backend/InvenTree/web/static/web/.vite/manifest.json
+          docker run --rm inventree-test grep -q '"src/locales/zh_Hans/messages.ts"' /home/inventree/src/backend/InvenTree/web/static/web/.vite/manifest.json
       - name: Build Docker Image
         # Build the development docker image (using docker-compose.yml)
         run: docker compose --project-directory . -f contrib/container/dev-docker-compose.yml build --no-cache

--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -145,6 +145,9 @@ ENV PATH=/root/.local/bin:$PATH
 COPY --from=builder_stage ${INVENTREE_BACKEND_DIR}/InvenTree/web/static/web ${INVENTREE_BACKEND_DIR}/InvenTree/web/static/web
 COPY --from=builder_stage /root/.local /root/.local
 
+# Compile Django backend translations during image build
+RUN bash -c "cd '${INVENTREE_HOME}' && invoke int.backend-compilemessages"
+
 # Launch the production server
 CMD ["sh", "-c", "exec gunicorn -c ./gunicorn.conf.py InvenTree.wsgi -b ${INVENTREE_WEB_ADDR}:${INVENTREE_WEB_PORT} --chdir ${INVENTREE_BACKEND_DIR}/InvenTree"]
 

--- a/tasks.py
+++ b/tasks.py
@@ -906,6 +906,23 @@ def backend_trans(c, verbose: bool = False):
     success('Backend translations compiled successfully')
 
 
+@task(help={'verbose': 'Print verbose output'})
+@state_logger('backend_compilemessages')
+def backend_compilemessages(c, verbose: bool = False):
+    """Compile backend Django translation files without loading InvenTree settings."""
+    info('Compiling backend translations...')
+
+    cmd = 'python3 -m django compilemessages'
+
+    if verbose:
+        cmd += ' -v 1'
+    else:
+        cmd += ' -v 0'
+
+    run(c, cmd, manage_py_dir())
+    success('Backend translations compiled successfully')
+
+
 @task(
     help={
         'clean': 'Clean up old backup files',
@@ -2490,6 +2507,7 @@ internal = Collection(
     clear_generated,
     export_settings_definitions,
     export_definitions,
+    backend_compilemessages,
     frontend_build,
     frontend_check,
     frontend_compile,


### PR DESCRIPTION
# Summary

This PR compiles the Django backend translation files (.mo) during the production Docker image build, instead of relying on them being generated at runtime.

# Changed

- `contrib/container/Dockerfile`: Added a build step in the production stage that runs invoke int.backend-compilemessages, so compiled `.mo` files are baked into the image.
- `tasks.py`: Added a new int.backend-compilemessages invoke task that compiles the backend translations via django compilemessages without loading the full InvenTree settings (lightweight, build-friendly).
- `.github/workflows/docker.yaml`: Extended the Test Docker Image step to assert the compiled .mo artifacts exist for a few representative languages (de, fr, ru, zh_Hans), guarding the new build step.

# Testing approach

The check is added to the existing Test Docker Image step in docker.yaml, consistent with how other in-image artifacts (manage.py, requirements.txt, etc.) are already verified — a docker run ... test -f against each expected path.

It intentionally covers only a few representative languages rather than the full set. The compilation step runs django compilemessages, which iterates over every language in the locale/ directory in a single pass. If compilation fails for any reason (a malformed .po file, a missing gettext, an incorrect working directory), the command returns a non-zero exit code and the Docker build itself fails — so "all languages compiled" is already enforced by the build succeeding. The CI check therefore isn't trying to re-verify every language; its purpose is narrower and complementary:
- Confirm the artifacts landed at the expected path — that .mo files actually exist under locale/<lang>/LC_MESSAGES/, not just that the command exited cleanly.
- Guard against regressions — if someone later removes or relocates the compile step, or the output path changes, the check fails fast.

A small, diverse sample (de, fr, ru, zh_Hans — covering Latin, Cyrillic, and CJK scripts) is enough to catch these failure modes. Iterating over all ~40 languages would add noticeable runtime, make the step brittle against a single edge-case locale, and provide no additional signal that the build success doesn't already give us.

---

Fixes #12188