### PR TITLE
Fix signup warning

### DIFF
--- a/src/backend/InvenTree/InvenTree/auth_overrides.py
+++ b/src/backend/InvenTree/InvenTree/auth_overrides.py
@@ -114,9 +114,12 @@ class RegistrationMixin:
         """
         if registration_enabled(self.REGISTRATION_SETTING):
             return True
-        logger.warning(
-            f'INVE-W12: Signup attempt blocked, because registration is disabled via setting {self.REGISTRATION_SETTING}.'
-        )
+        # Only warn when this is an actual signup submission, not when called as
+        # a feature-availability check during login or other auth flows.
+        if request and request.method == 'POST' and 'signup' in request.path:
+            logger.warning(
+                f'INVE-W12: Signup attempt blocked, because registration is disabled via setting {self.REGISTRATION_SETTING}.'
+            )
         return False
 
     def clean_email(self, email):


### PR DESCRIPTION
- Ref: https://github.com/inventree/InvenTree/issues/12209
- Prevents "signup blocked" warning from firing on every login attempt
- Should only fire on an actual signup attempt
- Reduces noise in server logs and help to diagnose the real issues