### PR TITLE
devops: fix chromium test uploads to flakiness.io

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -195,6 +195,9 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    permissions:
+      contents: read # Required for actions/checkout
+      id-token: write # Required for GitHub OIDC
 
     env:
       COVERAGE: true


### PR DESCRIPTION
Currently, only Firefox test results get uploaded to Flakiness.io.
This patch fixes the upload for chromium results as well, per
https://docs.flakiness.io/ci/github-actions-setup/
