### PR TITLE
precommit - Remove python version pinning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,4 +97,3 @@ repos:
     rev: 0.4.3
     hooks:
     -   id: teyit
-        language_version: python3.12


### PR DESCRIPTION
Allows pre-commit hooks to be installed with other python versions too