### PR TITLE
Skip "many" fields in DataExport

### DIFF
--- a/src/backend/InvenTree/data_exporter/mixins.py
+++ b/src/backend/InvenTree/data_exporter/mixins.py
@@ -99,6 +99,10 @@ class DataExportSerializerMixin:
                 fields.update(self.get_child_fields(name, field))
                 continue
 
+            # Skip 'many' fields (e.g. nested serializers)
+            if getattr(field, 'many', False):
+                continue
+
             fields[name] = field
 
         return fields


### PR DESCRIPTION
- Exporting multi-dimensional datasets requires a custom exporter