### PR TITLE
Fix for STOCK_COUNT event

### DIFF
--- a/src/backend/InvenTree/stock/models.py
+++ b/src/backend/InvenTree/stock/models.py
@@ -2728,10 +2728,7 @@ class StockItem(
             )
 
         trigger_event(
-            StockEvents.ITEM_COUNTED,
-            'stockitem.counted',
-            id=self.id,
-            quantity=float(self.quantity),
+            StockEvents.ITEM_COUNTED, id=self.id, quantity=float(self.quantity)
         )
 
         return True

--- a/src/backend/InvenTree/stock/tests.py
+++ b/src/backend/InvenTree/stock/tests.py
@@ -378,10 +378,8 @@ class StockTest(StockTestBase):
         self.assertEqual(it.status, StockStatus.OK.value)
 
         # Next, perform a valid stocktake
-        self.assertTrue(
-            it.stocktake(
-                100, None, notes='test stocktake', status=StockStatus.DAMAGED.value
-            )
+        it.stocktake(
+            100, None, notes='test stocktake', status=StockStatus.DAMAGED.value
         )
 
         it.refresh_from_db()


### PR DESCRIPTION
- Prevent double emission of event type string