### PR TITLE
[bug] Plugin load fix

### DIFF
--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -677,6 +677,11 @@ class PluginsRegistry:
 
         if plg_key in configs:
             plg_db = configs[plg_key]
+
+            # Handle edge case where PluginConfig has been created without a valid name
+            if plg_name and plg_db.name != plg_name:
+                plg_db.name = plg_name
+                plg_db.save()
         else:
             plg_db = self.get_plugin_config(plg_key, plg_name)
 

--- a/src/backend/InvenTree/plugin/registry.py
+++ b/src/backend/InvenTree/plugin/registry.py
@@ -679,7 +679,7 @@ class PluginsRegistry:
             plg_db = configs[plg_key]
 
             # Handle edge case where PluginConfig has been created without a valid name
-            if plg_name and plg_db.name != plg_name:
+            if plg_name and plg_db and plg_db.name != plg_name:
                 plg_db.name = plg_name
                 plg_db.save()
         else:

--- a/src/frontend/src/tables/plugin/PluginListTable.tsx
+++ b/src/frontend/src/tables/plugin/PluginListTable.tsx
@@ -85,10 +85,12 @@ export default function PluginListTable() {
             return;
           }
 
+          const name: string = record.name || record.meta?.human_name;
+
           return (
             <Group justify='left'>
               <PluginIcon plugin={record} />
-              <Text>{record.name}</Text>
+              <Text size='sm'>{name}</Text>
             </Group>
           );
         }


### PR DESCRIPTION
Fixes an edge case in plugin loading which prevents plugin name from being updated correctly.

This is *likely* not an issue in a normal setup, I ended up with a set of "corrupted" plugin data with empty names, which did not get "updated" on a system reload as expected.