### PR TITLE
Fix notes being dropped on part creation

### DIFF
--- a/src/backend/InvenTree/InvenTree/serializers.py
+++ b/src/backend/InvenTree/InvenTree/serializers.py
@@ -822,9 +822,13 @@ class NotesFieldMixin:
         super().__init__(*args, **kwargs)
 
         if hasattr(self, 'context'):
+            request = self.context.get('request', None)
+            method = getattr(request, 'method', None)
+
             if view := self.context.get('view', None):
                 if (
                     issubclass(view.__class__, ListModelMixin)
+                    and method in SAFE_METHODS
                     and not InvenTree.ready.isGeneratingSchema()
                 ):
                     self.fields.pop('notes', None)

--- a/src/backend/InvenTree/part/test_api.py
+++ b/src/backend/InvenTree/part/test_api.py
@@ -1495,6 +1495,40 @@ class PartCreationTests(PartAPITestBase):
         self.assertFalse(response.data['active'])
         self.assertFalse(response.data['purchaseable'])
 
+    def test_notes_on_create(self):
+        """Test that notes can be set when creating a Part."""
+        list_url = reverse('api-part-list')
+
+        notes = """
+        ### Created from importer
+
+        Notes should persist during part creation.
+        """
+        expected_notes = notes.strip()
+
+        response = self.post(
+            list_url,
+            {
+                'name': 'part with notes',
+                'description': 'Part notes are created in the same request',
+                'category': 1,
+                'notes': notes,
+            },
+            expected_code=201,
+        )
+
+        self.assertEqual(response.data['notes'], expected_notes)
+
+        part = Part.objects.get(pk=response.data['pk'])
+        self.assertEqual(part.notes, expected_notes)
+
+        detail_url = reverse('api-part-detail', kwargs={'pk': part.pk})
+        response = self.get(detail_url, expected_code=200)
+        self.assertEqual(response.data['notes'], expected_notes)
+
+        response = self.get(list_url, {'limit': 1}, expected_code=200)
+        self.assertNotIn('notes', response.data['results'][0])
+
     def test_initial_stock(self):
         """Tests for initial stock quantity creation."""
 


### PR DESCRIPTION
  ## Summary
 
  Fix `POST /api/part/` so the `notes` field is preserved during part creation. Previously, `NotesFieldMixin` stripped `notes` for any serializer used by a list-capable view, which also affected `ListCreateAPI` write  requests.
 
  ## Changes
 
  - Only hide `notes` for safe/read list requests
  - Keep `notes` available for create/update validation and persistence
  - Add regression coverage for creating a part with notes
  - Preserve existing behavior where part list responses omit `notes`
 
  ## Testing
 
  - Verified live API behavior on local dev server:
    - `POST /api/part/` with `notes`
    - `GET /api/part/{pk}/`
    - `GET /api/part/?limit=1`
  - Ran `python3 -m py_compile` for edited backend files
