### PR TITLE
feat: Add RepairOrder feature (#12064)

### DIFF
--- a/src/backend/InvenTree/common/setting/system.py
+++ b/src/backend/InvenTree/common/setting/system.py
@@ -889,6 +889,28 @@ SYSTEM_SETTINGS: dict[str, InvenTreeSettingsKeyType] = {
         'default': False,
         'validator': bool,
     },
+    'REPAIRORDER_ENABLED': {
+        'name': _('Enable Repair Orders'),
+        'description': _('Enable repair order functionality in the user interface'),
+        'validator': bool,
+        'default': False,
+    },
+    'REPAIRORDER_REFERENCE_PATTERN': {
+        'name': _('Repair Order Reference Pattern'),
+        'description': _(
+            'Required pattern for generating Repair Order reference field'
+        ),
+        'default': 'REP-{ref:04d}',
+        'validator': order.validators.validate_repair_order_reference_pattern,
+    },
+    'REPAIRORDER_EDIT_COMPLETED_ORDERS': {
+        'name': _('Edit Completed Repair Orders'),
+        'description': _(
+            'Allow editing of repair orders after they have been completed'
+        ),
+        'default': False,
+        'validator': bool,
+    },
     'SALESORDER_REFERENCE_PATTERN': {
         'name': _('Sales Order Reference Pattern'),
         'description': _('Required pattern for generating Sales Order reference field'),

--- a/src/backend/InvenTree/order/admin.py
+++ b/src/backend/InvenTree/order/admin.py
@@ -172,6 +172,55 @@ class ReturnOrdeerExtraLineAdmin(GeneralExtraLineAdmin, admin.ModelAdmin):
     """Admin class for the ReturnOrderExtraLine model."""
 
 
+class RepairOrderLineInlineAdmin(admin.StackedInline):
+    """Inline admin class for the RepairOrderLine model."""
+
+    model = models.RepairOrderLine
+    extra = 0
+
+    autocomplete_fields = ['part', 'stock_item']
+
+
+@admin.register(models.RepairOrder)
+class RepairOrderAdmin(admin.ModelAdmin):
+    """Admin class for the RepairOrder model."""
+
+    exclude = ['reference_int']
+
+    list_display = ['reference', 'customer', 'status', 'description', 'creation_date']
+
+    search_fields = ['reference', 'customer__name', 'description', 'serial']
+
+    inlines = [RepairOrderLineInlineAdmin]
+
+    autocomplete_fields = [
+        'address',
+        'contact',
+        'created_by',
+        'customer',
+        'item',
+        'part',
+        'project_code',
+        'responsible',
+    ]
+
+
+@admin.register(models.RepairOrderLine)
+class RepairOrderLineAdmin(admin.ModelAdmin):
+    """Admin class for RepairOrderLine model."""
+
+    list_display = ['order', 'part', 'stock_item', 'quantity', 'reference']
+
+    search_fields = [
+        'order__reference',
+        'part__name',
+        'stock_item__serial',
+        'reference',
+    ]
+
+    autocomplete_fields = ['order', 'part', 'stock_item']
+
+
 class TransferOrderLineItemInlineAdmin(admin.StackedInline):
     """Inline admin class for the TransferOrderLineItem model."""
 

--- a/src/backend/InvenTree/order/api.py
+++ b/src/backend/InvenTree/order/api.py
@@ -55,6 +55,7 @@ from order import models, serializers
 from order.status_codes import (
     PurchaseOrderStatus,
     PurchaseOrderStatusGroups,
+    RepairOrderStatus,
     ReturnOrderLineStatus,
     ReturnOrderStatus,
     SalesOrderStatus,
@@ -1833,6 +1834,240 @@ class ReturnOrderExtraLineDetail(RetrieveUpdateDestroyAPI):
     serializer_class = serializers.ReturnOrderExtraLineSerializer
 
 
+# ─── Repair Order API ─────────────────────────────────────────────────────────
+
+
+class RepairOrderFilter(OrderFilter):
+    """Custom API filters for the RepairOrderList endpoint."""
+
+    class Meta:
+        """Metaclass options."""
+
+        model = models.RepairOrder
+        fields = ['customer']
+
+    completed_before = InvenTreeDateFilter(
+        label=_('Completed Before'), field_name='complete_date', lookup_expr='lt'
+    )
+
+    completed_after = InvenTreeDateFilter(
+        label=_('Completed After'), field_name='complete_date', lookup_expr='gt'
+    )
+
+
+class RepairOrderMixin(SerializerContextMixin):
+    """Mixin class for RepairOrder endpoints."""
+
+    queryset = models.RepairOrder.objects.all()
+    serializer_class = serializers.RepairOrderSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        """Return annotated queryset for this endpoint."""
+        queryset = super().get_queryset(*args, **kwargs)
+        queryset = serializers.RepairOrderSerializer.annotate_queryset(queryset)
+        queryset = queryset.prefetch_related(
+            'contact', 'created_by', 'customer', 'item', 'item__part', 'part', 'responsible'
+        )
+
+        return queryset
+
+
+class RepairOrderOutputOptions(OutputConfiguration):
+    """Output options for the RepairOrder endpoint."""
+
+    OPTIONS = [
+        InvenTreeOutputOption(flag='customer_detail'),
+        InvenTreeOutputOption(flag='item_detail'),
+        InvenTreeOutputOption(flag='part_detail'),
+    ]
+
+
+class RepairOrderList(
+    RepairOrderMixin,
+    OrderCreateMixin,
+    DataExportViewMixin,
+    OutputOptionsMixin,
+    ParameterListMixin,
+    ListCreateAPI,
+):
+    """API endpoint for accessing a list of RepairOrder objects."""
+
+    filterset_class = RepairOrderFilter
+    filter_backends = SEARCH_ORDER_FILTER
+
+    output_options = RepairOrderOutputOptions
+
+    ordering_field_aliases = {
+        'reference': ['reference_int', 'reference'],
+        'project_code': ['project_code__code'],
+    }
+
+    ordering_fields = [
+        'creation_date',
+        'created_by',
+        'reference',
+        'customer__name',
+        'customer_reference',
+        'line_items',
+        'status',
+        'start_date',
+        'target_date',
+        'complete_date',
+        'project_code',
+        'updated_at',
+    ]
+
+    search_fields = [
+        'customer__name',
+        'reference',
+        'description',
+        'customer_reference',
+        'serial',
+        'project_code__code',
+        'part__name',
+        'part__IPN',
+        'item__serial',
+    ]
+
+    ordering = '-reference'
+
+
+class RepairOrderDetail(RepairOrderMixin, OutputOptionsMixin, RetrieveUpdateDestroyAPI):
+    """API endpoint for detail view of a single RepairOrder object."""
+
+    output_options = RepairOrderOutputOptions
+
+
+class RepairOrderContextMixin:
+    """Simple mixin class to add a RepairOrder to the serializer context."""
+
+    queryset = models.RepairOrder.objects.all()
+
+    def get_serializer_context(self):
+        """Add the RepairOrder object to the serializer context."""
+        context = super().get_serializer_context()
+
+        try:
+            context['order'] = models.RepairOrder.objects.get(
+                pk=self.kwargs.get('pk', None)
+            )
+        except Exception:
+            pass
+
+        context['request'] = self.request
+
+        return context
+
+
+class RepairOrderCancel(RepairOrderContextMixin, CreateAPI):
+    """API endpoint to cancel a RepairOrder."""
+
+    serializer_class = serializers.RepairOrderCancelSerializer
+
+
+class RepairOrderHold(RepairOrderContextMixin, CreateAPI):
+    """API endpoint to hold a RepairOrder."""
+
+    serializer_class = serializers.RepairOrderHoldSerializer
+
+
+class RepairOrderComplete(RepairOrderContextMixin, CreateAPI):
+    """API endpoint to complete a RepairOrder."""
+
+    serializer_class = serializers.RepairOrderCompleteSerializer
+
+
+class RepairOrderIssue(RepairOrderContextMixin, CreateAPI):
+    """API endpoint to issue a RepairOrder."""
+
+    serializer_class = serializers.RepairOrderIssueSerializer
+
+
+class RepairOrderLineFilter(LineItemFilter):
+    """Custom filters for the RepairOrderLineList endpoint."""
+
+    class Meta:
+        """Metaclass options."""
+
+        model = models.RepairOrderLine
+        fields = ['order', 'part', 'stock_item']
+
+    consumed = rest_filters.BooleanFilter(label='consumed', method='filter_consumed')
+
+    def filter_consumed(self, queryset, name, value):
+        """Filter by consumed date."""
+        if str2bool(value):
+            return queryset.exclude(consumed_date=None)
+        return queryset.filter(consumed_date=None)
+
+
+class RepairOrderLineMixin(SerializerContextMixin):
+    """Mixin class for RepairOrderLine endpoints."""
+
+    queryset = models.RepairOrderLine.objects.all()
+    serializer_class = serializers.RepairOrderLineSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        """Return annotated queryset for this endpoint."""
+        queryset = super().get_queryset(*args, **kwargs)
+        queryset = queryset.prefetch_related(
+            'order', 'order__customer', 'part', 'stock_item', 'stock_item__part'
+        )
+        return queryset
+
+
+class RepairOrderLineOutputOptions(OutputConfiguration):
+    """Output options for the RepairOrderLine endpoint."""
+
+    OPTIONS = [
+        InvenTreeOutputOption('part_detail'),
+        InvenTreeOutputOption('stock_item_detail'),
+        InvenTreeOutputOption('order_detail'),
+    ]
+
+
+class RepairOrderLineList(
+    RepairOrderLineMixin,
+    DataExportViewMixin,
+    OutputOptionsMixin,
+    ListCreateAPI,
+):
+    """API endpoint for accessing a list of RepairOrderLine objects."""
+
+    filterset_class = RepairOrderLineFilter
+    filter_backends = SEARCH_ORDER_FILTER
+
+    output_options = RepairOrderLineOutputOptions
+
+    ordering_fields = [
+        'line',
+        'quantity',
+        'reference',
+        'target_date',
+    ]
+
+    ordering_field_aliases = {
+        'line': ['line_int', 'line'],
+    }
+
+    ordering = 'line'
+
+    search_fields = [
+        'reference',
+        'part__name',
+        'part__description',
+        'stock_item__serial',
+    ]
+
+
+class RepairOrderLineDetail(
+    RepairOrderLineMixin, OutputOptionsMixin, RetrieveUpdateDestroyAPI
+):
+    """API endpoint for detail view of a RepairOrderLine object."""
+
+    output_options = RepairOrderLineOutputOptions
+
+
 class TransferOrderFilter(OrderFilter):
     """Custom API filters for the TransferOrderList endpoint."""
 
@@ -2816,6 +3051,59 @@ order_api_urls = [
                 '',
                 ReturnOrderExtraLineList.as_view(),
                 name='api-return-order-extra-line-list',
+            ),
+        ]),
+    ),
+    # API endpoints for repair orders
+    path(
+        'repair/',
+        include([
+            path(
+                '<int:pk>/',
+                include([
+                    path(
+                        'cancel/',
+                        RepairOrderCancel.as_view(),
+                        name='api-repair-order-cancel',
+                    ),
+                    path('hold/', RepairOrderHold.as_view(), name='api-repair-order-hold'),
+                    path(
+                        'complete/',
+                        RepairOrderComplete.as_view(),
+                        name='api-repair-order-complete',
+                    ),
+                    path(
+                        'issue/',
+                        RepairOrderIssue.as_view(),
+                        name='api-repair-order-issue',
+                    ),
+                    meta_path(models.RepairOrder),
+                    path(
+                        '', RepairOrderDetail.as_view(), name='api-repair-order-detail'
+                    ),
+                ]),
+            ),
+            # Repair Order list
+            path('', RepairOrderList.as_view(), name='api-repair-order-list'),
+        ]),
+    ),
+    # API endpoints for repair order lines
+    path(
+        'repair-line/',
+        include([
+            path(
+                '<int:pk>/',
+                include([
+                    meta_path(models.RepairOrderLine),
+                    path(
+                        '',
+                        RepairOrderLineDetail.as_view(),
+                        name='api-repair-order-line-detail',
+                    ),
+                ]),
+            ),
+            path(
+                '', RepairOrderLineList.as_view(), name='api-repair-order-line-list'
             ),
         ]),
     ),

--- a/src/backend/InvenTree/order/events.py
+++ b/src/backend/InvenTree/order/events.py
@@ -39,6 +39,15 @@ class ReturnOrderEvents(BaseEventEnum):
     HOLD = 'returnorder.hold'
 
 
+class RepairOrderEvents(BaseEventEnum):
+    """Event enumeration for the RepairOrder models."""
+
+    ISSUED = 'repairorder.issued'
+    COMPLETED = 'repairorder.completed'
+    CANCELLED = 'repairorder.cancelled'
+    HOLD = 'repairorder.hold'
+
+
 class TransferOrderEvents(BaseEventEnum):
     """Event enumeration for the PurchaseOrder models."""
 

--- a/src/backend/InvenTree/order/migrations/0121_repair_order_and_repair_order_line.py
+++ b/src/backend/InvenTree/order/migrations/0121_repair_order_and_repair_order_line.py
@@ -1,0 +1,87 @@
+# Generated manually for RepairOrder feature
+
+import InvenTree.fields
+import InvenTree.models
+import django.core.validators
+import django.db.models.deletion
+import generic.states.fields
+import generic.states.states
+import generic.states.transition
+import generic.states.validators
+import order.status_codes
+import order.validators
+import taggit.managers
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('common', '0046_alter_emailmessage_global_id_and_more'),
+        ('company', '0080_company_tags'),
+        ('order', '0120_purchaseorder_tags_returnorder_tags_salesorder_tags_and_more'),
+        ('part', '0151_part_consumable'),
+        ('stock', '0123_remove_stockitem_review_needed'),
+        ('taggit', '0006_rename_taggeditem_content_type_object_id_taggit_tagg_content_8fc721_idx'),
+        ('users', '0015_alter_userprofile_type'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RepairOrder',
+            fields=[
+                ('metadata', models.JSONField(blank=True, help_text='JSON metadata field, for use by external plugins', null=True, verbose_name='Plugin Metadata')),
+                ('reference_int', models.BigIntegerField(default=0)),
+                ('notes', InvenTree.fields.InvenTreeNotesField(blank=True, help_text='Markdown notes (optional)', max_length=50000, null=True, verbose_name='Notes')),
+                ('barcode_data', models.CharField(blank=True, help_text='Third party barcode data', max_length=500, verbose_name='Barcode Data')),
+                ('barcode_hash', models.CharField(blank=True, help_text='Unique hash of barcode data', max_length=128, verbose_name='Barcode Hash')),
+                ('description', models.CharField(blank=True, help_text='Order description (optional)', max_length=250, verbose_name='Description')),
+                ('link', InvenTree.fields.InvenTreeURLField(blank=True, help_text='Link to external page', max_length=2000, verbose_name='Link')),
+                ('start_date', models.DateField(blank=True, help_text='Scheduled start date for this order', null=True, verbose_name='Start date')),
+                ('target_date', models.DateField(blank=True, help_text='Expected date for order delivery. Order will be overdue after this date.', null=True, verbose_name='Target Date')),
+                ('creation_date', models.DateField(blank=True, null=True, verbose_name='Creation Date')),
+                ('issue_date', models.DateField(blank=True, help_text='Date order was issued', null=True, verbose_name='Issue Date')),
+                ('updated_at', models.DateTimeField(blank=True, help_text='Timestamp of last update', null=True, verbose_name='Updated At')),
+                ('reference', models.CharField(default=order.validators.generate_next_repair_order_reference, help_text='Repair Order reference', max_length=64, unique=True, validators=[order.validators.validate_repair_order_reference], verbose_name='Reference')),
+                ('serial', models.CharField(blank=True, help_text='Serial number for the item being repaired', max_length=100, verbose_name='Serial Number')),
+                ('status', generic.states.fields.InvenTreeCustomStatusModelField(choices=[(10, 'Pending'), (20, 'In Progress'), (25, 'On Hold'), (30, 'Complete'), (40, 'Cancelled')], default=10, help_text='Repair order status', validators=[generic.states.validators.CustomStatusCodeValidator(status_class=order.status_codes.RepairOrderStatus)], verbose_name='Status')),
+                ('customer_reference', models.CharField(blank=True, help_text='Customer order reference code', max_length=64, verbose_name='Customer Reference')),
+                ('complete_date', models.DateField(blank=True, help_text='Date order was completed', null=True, verbose_name='Completion Date')),
+                ('address', models.ForeignKey(blank=True, help_text='Company address for this order', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='company.address', verbose_name='Address')),
+                ('contact', models.ForeignKey(blank=True, help_text='Point of contact for this order', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='company.contact', verbose_name='Contact')),
+                ('created_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL, verbose_name='Created By')),
+                ('customer', models.ForeignKey(help_text='Company for which repair work is performed', limit_choices_to={'is_customer': True}, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='repair_orders', to='company.company', verbose_name='Customer')),
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('item', models.ForeignKey(blank=True, help_text='Stock item being repaired', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='repair_orders', to='stock.stockitem', verbose_name='Stock Item')),
+                ('part', models.ForeignKey(blank=True, help_text='Part being repaired', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='repair_orders', to='part.part', verbose_name='Part')),
+                ('project_code', models.ForeignKey(blank=True, help_text='Project code for this order', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='repair_orders', to='common.projectcode', verbose_name='Project Code')),
+                ('responsible', models.ForeignKey(blank=True, help_text='User responsible for this order', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='repair_orders', to='users.owner', verbose_name='Responsible')),
+            ],
+            options={
+                'verbose_name': 'Repair Order',
+            },
+        ),
+        migrations.CreateModel(
+            name='RepairOrderLine',
+            fields=[
+                ('metadata', models.JSONField(blank=True, help_text='JSON metadata field, for use by external plugins', null=True, verbose_name='Plugin Metadata')),
+                ('reference', models.CharField(blank=True, help_text='Line item reference', max_length=100, verbose_name='Reference')),
+                ('line_int', models.BigIntegerField(default=0)),
+                ('notes', models.TextField(blank=True, help_text='Line item notes', verbose_name='Notes')),
+                ('link', InvenTree.fields.InvenTreeURLField(blank=True, help_text='Link to external information', max_length=2000, verbose_name='Link')),
+                ('target_date', models.DateField(blank=True, help_text='Expected date for delivery of this line item', null=True, verbose_name='Target Date')),
+                ('consumed_date', models.DateField(blank=True, help_text='The date this repair line item was consumed', null=True, verbose_name='Consumed Date')),
+                ('quantity', models.DecimalField(decimal_places=5, default=1, help_text='Quantity required for repair', max_digits=15, validators=[django.core.validators.MinValueValidator(0)], verbose_name='Quantity')),
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('order', models.ForeignKey(help_text='Repair Order', on_delete=django.db.models.deletion.CASCADE, related_name='lines', to='order.repairorder', verbose_name='Order')),
+                ('part', models.ForeignKey(blank=True, help_text='Part required for repair', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='repair_order_lines', to='part.part', verbose_name='Part')),
+                ('stock_item', models.ForeignKey(blank=True, help_text='Stock item required for repair', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='repair_order_lines', to='stock.stockitem', verbose_name='Stock Item')),
+                ('project_code', models.ForeignKey(blank=True, help_text='Project code for this line item', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='repair_order_lines', to='common.projectcode', verbose_name='Project Code')),
+            ],
+            options={
+                'verbose_name': 'Repair Order Line Item',
+            },
+        ),
+    ]

--- a/src/backend/InvenTree/order/models.py
+++ b/src/backend/InvenTree/order/models.py
@@ -48,6 +48,7 @@ from InvenTree.helpers_db import bulk_create_and_fetch
 from InvenTree.helpers_model import notify_responsible
 from order.events import (
     PurchaseOrderEvents,
+    RepairOrderEvents,
     ReturnOrderEvents,
     SalesOrderEvents,
     TransferOrderEvents,
@@ -55,6 +56,8 @@ from order.events import (
 from order.status_codes import (
     PurchaseOrderStatus,
     PurchaseOrderStatusGroups,
+    RepairOrderStatus,
+    RepairOrderStatusGroups,
     ReturnOrderLineStatus,
     ReturnOrderStatus,
     ReturnOrderStatusGroups,
@@ -3440,6 +3443,322 @@ class ReturnOrderLineItem(StatusCodeMixin, OrderLineItem):
         blank=True,
         verbose_name=_('Price'),
         help_text=_('Cost associated with return or repair for this line item'),
+    )
+
+
+class RepairOrder(Order):
+    """A RepairOrder represents repair work performed for a customer.
+
+    A RepairOrder tracks the repair of a customer's stock item, capturing the
+    customer, the item to be repaired, any part(s) consumed for the repair, and
+    the status of the repair workflow.
+
+    Attributes:
+        customer: Reference to the customer whose item is being repaired (required)
+        item: Reference to the StockItem being repaired (optional)
+        part: Reference to the Part being repaired (optional, used when there
+            is no serialized stock item available)
+        serial: Reported serial number of the item being repaired (optional)
+        customer_reference: External customer order reference (optional)
+        status: The status of the order (refer to status_codes.RepairOrderStatus)
+        complete_date: Date the repair was completed
+    """
+
+    REFERENCE_PATTERN_SETTING = 'REPAIRORDER_REFERENCE_PATTERN'
+    REQUIRE_RESPONSIBLE_SETTING = None
+    STATUS_CLASS = RepairOrderStatus
+    UNLOCK_SETTING = 'REPAIRORDER_EDIT_COMPLETED_ORDERS'
+
+    class Meta:
+        """Model meta options."""
+
+        verbose_name = _('Repair Order')
+
+    def clean_line_item(self, line):
+        """Clean a line item for this RepairOrder."""
+        super().clean_line_item(line)
+        line.consumed_date = None
+
+    def get_absolute_url(self):
+        """Get the 'web' URL for this order."""
+        return pui_url(f'/sales/repair-order/{self.pk}')
+
+    @staticmethod
+    def get_api_url():
+        """Return the API URL associated with the RepairOrder model."""
+        return reverse('api-repair-order-list')
+
+    @classmethod
+    def get_status_class(cls):
+        """Return the RepairOrderStatus class."""
+        return RepairOrderStatusGroups
+
+    @classmethod
+    def api_defaults(cls, request=None):
+        """Return default values for this model when issuing an API OPTIONS request."""
+        return {'reference': order.validators.generate_next_repair_order_reference()}
+
+    @classmethod
+    def barcode_model_type_code(cls):
+        """Return the associated barcode model type code for this model."""
+        return 'REPAIR'
+
+    def __str__(self):
+        """Render a string representation of this RepairOrder."""
+        return f'{self.reference} - {self.customer.name if self.customer else _("no customer")}'
+
+    reference = models.CharField(
+        unique=True,
+        max_length=64,
+        blank=False,
+        verbose_name=_('Reference'),
+        help_text=_('Repair Order reference'),
+        default=order.validators.generate_next_repair_order_reference,
+        validators=[order.validators.validate_repair_order_reference],
+    )
+
+    customer = models.ForeignKey(
+        Company,
+        on_delete=models.SET_NULL,
+        null=True,
+        limit_choices_to={'is_customer': True},
+        related_name='repair_orders',
+        verbose_name=_('Customer'),
+        help_text=_('Company for which repair work is performed'),
+    )
+
+    @property
+    def company(self):
+        """Accessor helper for Order base class."""
+        return self.customer
+
+    item = models.ForeignKey(
+        stock.models.StockItem,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name='repair_orders',
+        verbose_name=_('Stock Item'),
+        help_text=_('Stock item being repaired'),
+    )
+
+    part = models.ForeignKey(
+        'part.Part',
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name='repair_orders',
+        verbose_name=_('Part'),
+        help_text=_('Part being repaired'),
+    )
+
+    serial = models.CharField(
+        max_length=100,
+        blank=True,
+        verbose_name=_('Serial Number'),
+        help_text=_('Serial number for the item being repaired'),
+    )
+
+    status = InvenTreeCustomStatusModelField(
+        default=RepairOrderStatus.PENDING.value,
+        choices=RepairOrderStatus.items(),
+        status_class=RepairOrderStatus,
+        verbose_name=_('Status'),
+        help_text=_('Repair order status'),
+    )
+
+    customer_reference = models.CharField(
+        max_length=64,
+        blank=True,
+        verbose_name=_('Customer Reference'),
+        help_text=_('Customer order reference code'),
+    )
+
+    complete_date = models.DateField(
+        blank=True,
+        null=True,
+        verbose_name=_('Completion Date'),
+        help_text=_('Date order was completed'),
+    )
+
+    def clean(self):
+        """Perform extra validation steps for RepairOrder."""
+        super().clean()
+
+        if not self.customer:
+            raise ValidationError({'customer': _('Customer must be specified')})
+
+        if not any([self.item, self.part, self.serial, self.description]):
+            raise ValidationError({
+                'description': _(
+                    'Repair order requires an item, part, serial number, or description'
+                )
+            })
+
+        if self.item and self.customer and self.item.customer:
+            if self.item.customer != self.customer:
+                raise ValidationError({
+                    'item': _('Stock item customer does not match repair order customer')
+                })
+
+    @property
+    def can_hold(self):
+        """Return True if this order can be placed on hold."""
+        return self.status in [
+            RepairOrderStatus.PENDING.value,
+            RepairOrderStatus.IN_PROGRESS.value,
+        ]
+
+    def _action_hold(self, *args, **kwargs):
+        """Mark this order as on hold."""
+        if self.can_hold:
+            self.status = RepairOrderStatus.ON_HOLD.value
+            self.save()
+            trigger_event(RepairOrderEvents.HOLD, id=self.pk)
+
+    @property
+    def can_cancel(self):
+        """Return True if this order can be cancelled."""
+        return self.status in RepairOrderStatusGroups.OPEN
+
+    def _action_cancel(self, *args, **kwargs):
+        """Cancel this RepairOrder."""
+        if self.can_cancel:
+            self.status = RepairOrderStatus.CANCELLED.value
+            self.save()
+            trigger_event(RepairOrderEvents.CANCELLED, id=self.pk)
+
+    @property
+    def can_issue(self):
+        """Return True if this order can be issued."""
+        return self.status in [
+            RepairOrderStatus.PENDING.value,
+            RepairOrderStatus.ON_HOLD.value,
+        ]
+
+    def _action_issue(self, *args, **kwargs):
+        """Issue this RepairOrder."""
+        if self.can_issue:
+            self.status = RepairOrderStatus.IN_PROGRESS.value
+            self.issue_date = InvenTree.helpers.current_date()
+            self.save()
+            trigger_event(RepairOrderEvents.ISSUED, id=self.pk)
+
+    def _action_complete(self, *args, **kwargs):
+        """Complete this RepairOrder."""
+        if self.status == RepairOrderStatus.IN_PROGRESS.value:
+            self.status = RepairOrderStatus.COMPLETE.value
+            self.complete_date = InvenTree.helpers.current_date()
+            self.save()
+            trigger_event(RepairOrderEvents.COMPLETED, id=self.pk)
+
+    @transaction.atomic
+    def hold_order(self):
+        """Attempt to transition to ON_HOLD status."""
+        return self.handle_transition(
+            self.status, RepairOrderStatus.ON_HOLD.value, self, self._action_hold
+        )
+
+    @transaction.atomic
+    def issue_order(self):
+        """Attempt to transition to IN_PROGRESS status."""
+        return self.handle_transition(
+            self.status, RepairOrderStatus.IN_PROGRESS.value, self, self._action_issue
+        )
+
+    @transaction.atomic
+    def complete_order(self):
+        """Attempt to transition to COMPLETE status."""
+        return self.handle_transition(
+            self.status, RepairOrderStatus.COMPLETE.value, self, self._action_complete
+        )
+
+    @transaction.atomic
+    def cancel_order(self):
+        """Attempt to transition to CANCELLED status."""
+        return self.handle_transition(
+            self.status, RepairOrderStatus.CANCELLED.value, self, self._action_cancel
+        )
+
+
+class RepairOrderLine(OrderLineItem):
+    """Model for a single line item in a RepairOrder.
+
+    A line item represents either a part consumed during the repair or a stock
+    item that is being substituted for the unit being repaired.
+    """
+
+    class Meta:
+        """Metaclass options for this model."""
+
+        verbose_name = _('Repair Order Line Item')
+
+    @staticmethod
+    def get_api_url():
+        """Return the API URL associated with this model."""
+        return reverse('api-repair-order-line-list')
+
+    def clean(self):
+        """Perform extra validation steps for RepairOrderLine."""
+        super().clean()
+
+        if not self.part and not self.stock_item:
+            raise ValidationError({
+                'part': _('Repair order line requires a part or stock item')
+            })
+
+        if self.quantity <= 0:
+            raise ValidationError({
+                'quantity': _('Repair quantity must be greater than zero')
+            })
+
+        if self.stock_item and self.quantity > self.stock_item.quantity:
+            raise ValidationError({
+                'quantity': _('Repair quantity exceeds stock quantity')
+            })
+
+    order = models.ForeignKey(
+        RepairOrder,
+        on_delete=models.CASCADE,
+        related_name='lines',
+        verbose_name=_('Order'),
+        help_text=_('Repair Order'),
+    )
+
+    part = models.ForeignKey(
+        'part.Part',
+        on_delete=models.SET_NULL,
+        related_name='repair_order_lines',
+        blank=True,
+        null=True,
+        verbose_name=_('Part'),
+        help_text=_('Part required for repair'),
+    )
+
+    stock_item = models.ForeignKey(
+        stock.models.StockItem,
+        on_delete=models.SET_NULL,
+        related_name='repair_order_lines',
+        blank=True,
+        null=True,
+        verbose_name=_('Stock Item'),
+        help_text=_('Stock item required for repair'),
+    )
+
+    quantity = models.DecimalField(
+        verbose_name=_('Quantity'),
+        help_text=_('Quantity required for repair'),
+        max_digits=15,
+        decimal_places=5,
+        validators=[MinValueValidator(0)],
+        default=1,
+    )
+
+    consumed_date = models.DateField(
+        null=True,
+        blank=True,
+        verbose_name=_('Consumed Date'),
+        help_text=_('The date this repair line item was consumed'),
     )
 
 

--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -45,6 +45,7 @@ from InvenTree.serializers import (
 from InvenTree.tasks import batch_offload_tasks
 from order.status_codes import (
     PurchaseOrderStatusGroups,
+    RepairOrderStatusGroups,
     ReturnOrderLineStatus,
     ReturnOrderStatus,
     SalesOrderStatusGroups,
@@ -2404,6 +2405,196 @@ class ReturnOrderExtraLineSerializer(
             'read_only': True,
             'allow_null': True,
         },
+    )
+
+
+class RepairOrderSerializer(
+    NotesFieldMixin,
+    InvenTreeCustomStatusSerializerMixin,
+    AbstractOrderSerializer,
+    InvenTreeModelSerializer,
+):
+    """Serializer for the RepairOrder model class."""
+
+    class Meta:
+        """Metaclass options."""
+
+        model = order.models.RepairOrder
+        fields = AbstractOrderSerializer.order_fields([
+            'complete_date',
+            'customer',
+            'customer_detail',
+            'customer_reference',
+            'item',
+            'item_detail',
+            'part',
+            'part_detail',
+            'serial',
+            'updated_at',
+        ])
+        read_only_fields = ['creation_date', 'updated_at']
+
+    def skip_create_fields(self):
+        """Skip these fields when instantiating a new object."""
+        fields = super().skip_create_fields()
+
+        return [*fields, 'duplicate']
+
+    duplicate = DuplicateOptionsSerializer(
+        order.models.RepairOrder.objects.all(),
+        copy_extra_lines=False,
+        copy_parameters=True,
+    )
+
+    @staticmethod
+    def annotate_queryset(queryset):
+        """Custom annotation for the serializer queryset."""
+        queryset = AbstractOrderSerializer.annotate_queryset(queryset)
+
+        queryset = queryset.annotate(
+            completed_lines=SubqueryCount(
+                'lines', filter=~Q(consumed_date=None)
+            )
+        )
+
+        queryset = queryset.annotate(
+            overdue=Case(
+                When(
+                    order.models.RepairOrder.overdue_filter(),
+                    then=Value(True, output_field=BooleanField()),
+                ),
+                default=Value(False, output_field=BooleanField()),
+            )
+        )
+
+        return queryset
+
+    customer_detail = OptionalField(
+        serializer_class=CompanyBriefSerializer,
+        serializer_kwargs={
+            'source': 'customer',
+            'many': False,
+            'read_only': True,
+            'allow_null': True,
+        },
+        prefetch_fields=['customer'],
+    )
+
+    item_detail = OptionalField(
+        serializer_class=stock.serializers.StockItemSerializer,
+        serializer_kwargs={
+            'source': 'item',
+            'many': False,
+            'read_only': True,
+            'allow_null': True,
+        },
+        prefetch_fields=['item__part', 'item__supplier_part'],
+    )
+
+    part_detail = OptionalField(
+        serializer_class=PartBriefSerializer,
+        serializer_kwargs={
+            'source': 'part',
+            'many': False,
+            'read_only': True,
+            'allow_null': True,
+        },
+        prefetch_fields=['part'],
+    )
+
+
+class RepairOrderHoldSerializer(OrderAdjustSerializer):
+    """Serializer for holding a RepairOrder."""
+
+    def save(self):
+        """Save the serializer to hold the order."""
+        self.order.hold_order()
+
+
+class RepairOrderIssueSerializer(OrderAdjustSerializer):
+    """Serializer for issuing a RepairOrder."""
+
+    def save(self):
+        """Save the serializer to issue the order."""
+        self.order.issue_order()
+
+
+class RepairOrderCancelSerializer(OrderAdjustSerializer):
+    """Serializer for cancelling a RepairOrder."""
+
+    def save(self):
+        """Save the serializer to cancel the order."""
+        self.order.cancel_order()
+
+
+class RepairOrderCompleteSerializer(OrderAdjustSerializer):
+    """Serializer for completing a RepairOrder."""
+
+    def save(self):
+        """Save the serializer to complete the order."""
+        self.order.complete_order()
+
+
+@register_importer()
+class RepairOrderLineSerializer(
+    DataImportExportSerializerMixin,
+    AbstractLineItemSerializer,
+    InvenTreeModelSerializer,
+):
+    """Serializer for a RepairOrderLine object."""
+
+    class Meta:
+        """Metaclass options."""
+
+        model = order.models.RepairOrderLine
+        fields = AbstractLineItemSerializer.line_fields([
+            'part',
+            'part_detail',
+            'stock_item',
+            'stock_item_detail',
+            'consumed_date',
+        ])
+
+    order_detail = OptionalField(
+        serializer_class=RepairOrderSerializer,
+        serializer_kwargs={
+            'source': 'order',
+            'many': False,
+            'read_only': True,
+            'allow_null': True,
+        },
+        prefetch_fields=[
+            'order__created_by',
+            'order__responsible',
+            'order__address',
+            'order__project_code',
+            'order__contact',
+        ],
+    )
+
+    quantity = serializers.FloatField(
+        label=_('Quantity'), help_text=_('Quantity required for repair')
+    )
+
+    part_detail = OptionalField(
+        serializer_class=PartBriefSerializer,
+        serializer_kwargs={
+            'source': 'part',
+            'many': False,
+            'read_only': True,
+            'allow_null': True,
+        },
+    )
+
+    stock_item_detail = OptionalField(
+        serializer_class=stock.serializers.StockItemSerializer,
+        serializer_kwargs={
+            'source': 'stock_item',
+            'many': False,
+            'read_only': True,
+            'allow_null': True,
+        },
+        prefetch_fields=['stock_item__part', 'stock_item__supplier_part'],
     )
 
 

--- a/src/backend/InvenTree/order/status_codes.py
+++ b/src/backend/InvenTree/order/status_codes.py
@@ -143,3 +143,26 @@ class TransferOrderStatusGroups:
     FAILED = [TransferOrderStatus.CANCELLED.value]
 
     COMPLETE = [TransferOrderStatus.COMPLETE.value]
+
+
+class RepairOrderStatus(StatusCode):
+    """Defines a set of status codes for a RepairOrder."""
+
+    PENDING = 10, _('Pending'), ColorEnum.secondary  # Repair is pending
+    IN_PROGRESS = 20, _('In Progress'), ColorEnum.primary  # Repair is underway
+    ON_HOLD = 25, _('On Hold'), ColorEnum.warning  # Repair is on hold
+    COMPLETE = 30, _('Complete'), ColorEnum.success  # Repair has been completed
+    CANCELLED = 40, _('Cancelled'), ColorEnum.danger  # Repair was cancelled
+
+
+class RepairOrderStatusGroups:
+    """Groups for RepairOrderStatus codes."""
+
+    # Open orders
+    OPEN = [
+        RepairOrderStatus.PENDING.value,
+        RepairOrderStatus.ON_HOLD.value,
+        RepairOrderStatus.IN_PROGRESS.value,
+    ]
+
+    COMPLETE = [RepairOrderStatus.COMPLETE.value]

--- a/src/backend/InvenTree/order/test_api.py
+++ b/src/backend/InvenTree/order/test_api.py
@@ -26,6 +26,7 @@ from order import models
 from order.models import SalesOrderAllocation, SalesOrderLineItem, SalesOrderShipment
 from order.status_codes import (
     PurchaseOrderStatus,
+    RepairOrderStatus,
     ReturnOrderLineStatus,
     ReturnOrderStatus,
     SalesOrderStatus,
@@ -4828,3 +4829,229 @@ class SalesOrderAllocationBulkDeleteAPITest(InvenTreeAPITestCase):
         self.assertEqual(
             SalesOrderAllocation.objects.filter(pk__in=shipped_ids).count(), 2
         )
+
+
+class RepairOrderTests(InvenTreeAPITestCase):
+    """Unit tests for RepairOrder API endpoints."""
+
+    fixtures = [
+        'category',
+        'company',
+        'part',
+        'location',
+        'supplier_part',
+        'stock',
+    ]
+    roles = ['repair_order.view']
+
+    def test_options(self):
+        """Test the OPTIONS endpoint."""
+        self.assignRole('repair_order.add')
+        data = self.options(
+            reverse('api-repair-order-list'), expected_code=200
+        ).data
+
+        self.assertEqual(data['name'], 'Repair Order List')
+
+        reference = data['actions']['POST']['reference']
+
+        self.assertEqual(reference['default'], 'REP-0001')
+        self.assertEqual(reference['label'], 'Reference')
+        self.assertEqual(reference['help_text'], 'Repair Order reference')
+        self.assertTrue(reference['required'])
+
+    def test_model_validation(self):
+        """Test RepairOrder model validation rules."""
+        customer = Company.objects.get(pk=4)
+
+        order = models.RepairOrder(customer=customer)
+        with self.assertRaises(ValidationError):
+            order.full_clean()
+
+        order.description = 'Intermittent fault'
+        order.full_clean()
+        order.save()
+
+        self.assertEqual(order.reference, 'REP-0001')
+        self.assertEqual(order.status, RepairOrderStatus.PENDING.value)
+
+        other_customer = Company.objects.get(pk=5)
+        item = StockItem.objects.create(
+            part=Part.objects.get(pk=25),
+            customer=other_customer,
+            quantity=1,
+            serial='REPAIR-001',
+        )
+
+        order = models.RepairOrder(
+            customer=customer,
+            item=item,
+            description='Mismatched customer item',
+        )
+
+        with self.assertRaises(ValidationError):
+            order.full_clean()
+
+    def test_create_list_update(self):
+        """Test create, list, detail and update API operations."""
+        url = reverse('api-repair-order-list')
+
+        self.post(
+            url,
+            {'customer': 4, 'description': 'Repair order'},
+            expected_code=403,
+        )
+
+        self.assignRole('repair_order.add')
+
+        data = self.post(
+            url,
+            {
+                'customer': 4,
+                'customer_reference': 'RO-123',
+                'description': 'Repair order',
+                'serial': 'SN-123',
+            },
+            expected_code=201,
+        ).data
+
+        self.assertEqual(data['reference'], 'REP-0001')
+        self.assertEqual(data['customer_reference'], 'RO-123')
+        self.assertEqual(data['serial'], 'SN-123')
+
+        response = self.get(url, {'customer': 4}, expected_code=200)
+        self.assertEqual(len(response.data), 1)
+
+        detail_url = reverse('api-repair-order-detail', kwargs={'pk': data['pk']})
+        detail = self.get(detail_url, expected_code=200).data
+        self.assertEqual(detail['reference'], 'REP-0001')
+
+        self.assignRole('repair_order.change')
+        self.patch(detail_url, {'customer_reference': 'RO-456'}, expected_code=200)
+
+        order = models.RepairOrder.objects.get(pk=data['pk'])
+        self.assertEqual(order.customer_reference, 'RO-456')
+
+    def test_status_transitions(self):
+        """Test RepairOrder status transition endpoints."""
+        self.assignRole('repair_order.add')
+
+        order = models.RepairOrder.objects.create(
+            customer=Company.objects.get(pk=4),
+            description='Repair order',
+        )
+
+        self.assertEqual(order.status, RepairOrderStatus.PENDING.value)
+        self.assertIsNone(order.issue_date)
+
+        issue_url = reverse('api-repair-order-issue', kwargs={'pk': order.pk})
+        hold_url = reverse('api-repair-order-hold', kwargs={'pk': order.pk})
+        complete_url = reverse('api-repair-order-complete', kwargs={'pk': order.pk})
+
+        self.post(issue_url, expected_code=403)
+
+        self.assignRole('repair_order.add')
+
+        self.post(issue_url, expected_code=201)
+        order.refresh_from_db()
+        self.assertEqual(order.status, RepairOrderStatus.IN_PROGRESS.value)
+        self.assertIsNotNone(order.issue_date)
+
+        self.post(hold_url, expected_code=201)
+        order.refresh_from_db()
+        self.assertEqual(order.status, RepairOrderStatus.ON_HOLD.value)
+
+        self.post(issue_url, expected_code=201)
+        order.refresh_from_db()
+        self.assertEqual(order.status, RepairOrderStatus.IN_PROGRESS.value)
+
+        self.post(complete_url, expected_code=201)
+        order.refresh_from_db()
+        self.assertEqual(order.status, RepairOrderStatus.COMPLETE.value)
+        self.assertIsNotNone(order.complete_date)
+
+
+class RepairOrderLineTests(InvenTreeAPITestCase):
+    """Unit tests for RepairOrderLine API endpoints."""
+
+    fixtures = [
+        'category',
+        'company',
+        'part',
+        'location',
+        'supplier_part',
+        'stock',
+    ]
+    roles = ['repair_order.view', 'repair_order.add']
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a repair order for tests."""
+        super().setUpTestData()
+
+        cls.order = models.RepairOrder.objects.create(
+            customer=Company.objects.get(pk=4),
+            description='Test repair order',
+        )
+        cls.part = Part.objects.get(pk=25)
+
+    def test_create_line(self):
+        """Test creating a repair order line item."""
+        self.assignRole('repair_order.add')
+
+        url = reverse('api-repair-order-line-list')
+        data = self.post(
+            url,
+            {
+                'order': self.order.pk,
+                'part': self.part.pk,
+                'quantity': 2,
+            },
+            expected_code=201,
+        ).data
+
+        self.assertEqual(data['order'], self.order.pk)
+        self.assertEqual(data['part'], self.part.pk)
+        self.assertEqual(data['quantity'], 2.0)
+
+    def test_line_validation(self):
+        """Test RepairOrderLine model validation."""
+        self.assignRole('repair_order.add')
+
+        url = reverse('api-repair-order-line-list')
+
+        # Line with neither part nor stock_item should fail
+        self.post(
+            url,
+            {'order': self.order.pk, 'quantity': 1},
+            expected_code=400,
+        )
+
+        # Line with valid part should succeed
+        self.post(
+            url,
+            {
+                'order': self.order.pk,
+                'part': self.part.pk,
+                'quantity': 0,
+            },
+            expected_code=400,
+        )
+
+    def test_list_filter(self):
+        """Test listing and filtering repair order lines."""
+        self.assignRole('repair_order.add')
+
+        url = reverse('api-repair-order-line-list')
+
+        self.post(
+            url,
+            {'order': self.order.pk, 'part': self.part.pk, 'quantity': 1},
+            expected_code=201,
+        )
+
+        response = self.get(url, {'order': self.order.pk}, expected_code=200)
+        self.assertEqual(len(response.data), 1)
+
+        response = self.get(url, {'part': self.part.pk}, expected_code=200)
+        self.assertEqual(len(response.data), 1)

--- a/src/backend/InvenTree/order/validators.py
+++ b/src/backend/InvenTree/order/validators.py
@@ -29,6 +29,13 @@ def generate_next_transfer_order_reference():
     return TransferOrder.generate_reference()
 
 
+def generate_next_repair_order_reference():
+    """Generate the next available RepairOrder reference."""
+    from order.models import RepairOrder
+
+    return RepairOrder.generate_reference()
+
+
 def validate_sales_order_reference_pattern(pattern):
     """Validate the SalesOrder reference 'pattern' setting."""
     from order.models import SalesOrder
@@ -50,6 +57,13 @@ def validate_return_order_reference_pattern(pattern):
     ReturnOrder.validate_reference_pattern(pattern)
 
 
+def validate_repair_order_reference_pattern(pattern):
+    """Validate the RepairOrder reference 'pattern' setting."""
+    from order.models import RepairOrder
+
+    RepairOrder.validate_reference_pattern(pattern)
+
+
 def validate_sales_order_reference(value):
     """Validate that the SalesOrder reference field matches the required pattern."""
     from order.models import SalesOrder
@@ -69,6 +83,13 @@ def validate_return_order_reference(value):
     from order.models import ReturnOrder
 
     ReturnOrder.validate_reference_field(value)
+
+
+def validate_repair_order_reference(value):
+    """Validate that the RepairOrder reference field matches the required pattern."""
+    from order.models import RepairOrder
+
+    RepairOrder.validate_reference_field(value)
 
 
 def validate_transfer_order_reference_pattern(pattern):

--- a/src/backend/InvenTree/users/oauth2_scopes.py
+++ b/src/backend/InvenTree/users/oauth2_scopes.py
@@ -20,6 +20,7 @@ _roles = {
     'purchase_order': 'Role Purchase Orders',
     'sales_order': 'Role Sales Orders',
     'return_order': 'Role Return Orders',
+    'repair_order': 'Role Repair Orders',
     'transfer_order': 'Role Transfer Orders',
 }
 _methods = {'view': 'GET', 'add': 'POST', 'change': 'PUT / PATCH', 'delete': 'DELETE'}

--- a/src/backend/InvenTree/users/ruleset.py
+++ b/src/backend/InvenTree/users/ruleset.py
@@ -19,6 +19,7 @@ class RuleSetEnum(StringEnum):
     PURCHASE_ORDER = 'purchase_order'
     SALES_ORDER = 'sales_order'
     RETURN_ORDER = 'return_order'
+    REPAIR_ORDER = 'repair_order'
     TRANSFER_ORDER = 'transfer_order'
 
 
@@ -35,6 +36,7 @@ RULESET_CHOICES = [
     (RuleSetEnum.PURCHASE_ORDER, _('Purchase Orders')),
     (RuleSetEnum.SALES_ORDER, _('Sales Orders')),
     (RuleSetEnum.RETURN_ORDER, _('Return Orders')),
+    (RuleSetEnum.REPAIR_ORDER, _('Repair Orders')),
     (RuleSetEnum.TRANSFER_ORDER, _('Transfer Orders')),
 ]
 
@@ -162,6 +164,13 @@ def get_ruleset_models() -> dict:
             'order_returnorder',
             'order_returnorderlineitem',
             'order_returnorderextraline',
+        ],
+        RuleSetEnum.REPAIR_ORDER: [
+            'company_company',
+            'company_contact',
+            'company_address',
+            'order_repairorder',
+            'order_repairorderline',
         ],
         RuleSetEnum.TRANSFER_ORDER: [
             'order_transferorder',


### PR DESCRIPTION
## Summary

Implements the Repair Order feature requested in #12064. Adds a new RepairOrder type that tracks repair work performed for a customer against a stock item, part, or serial-numbered unit.

### Backend only

This PR implements the backend MVP. Frontend UI and stock consumption workflow are deferred to follow-up PRs to keep this change reviewable.

## Changes

- **Models**: Added `RepairOrder` and `RepairOrderLine` to the `order` app. `RepairOrder` extends the `Order` base class (uses statuses, references, barcode, notes, metadata, reports, tags). `RepairOrderLine` extends `OrderLineItem` for parts/stock consumed during the repair.
- **Status codes**: `RepairOrderStatus` with `PENDING`, `IN_PROGRESS`, `ON_HOLD`, `COMPLETE`, `CANCELLED`, plus `RepairOrderStatusGroups`.
- **Events**: `RepairOrderEvents` (`repairorder.issued`, `repairorder.completed`, `repairorder.cancelled`, `repairorder.hold`).
- **Validations**: `validate_repair_order_reference`, `validate_repair_order_reference_pattern`, `generate_next_repair_order_reference`.
- **API**: List/Detail endpoints for `RepairOrder` (`/api/order/repair/`) and `RepairOrderLine` (`/api/order/repair-line/`); plus status transition endpoints (`/cancel/`, `/hold/`, `/issue/`, `/complete/`) on each RepairOrder.
- **Serializers**: Full CRUD serializers with annotated querysets (`line_items`, `completed_lines`, `overdue`) and optional detail fields for customer / item / part.
- **Admin**: Django admin classes for `RepairOrder` and `RepairOrderLine`.
- **Settings**: `REPAIRORDER_ENABLED`, `REPAIRORDER_REFERENCE_PATTERN` (default `REP-{ref:04d}`), `REPAIRORDER_EDIT_COMPLETED_ORDERS`.
- **Permissions**: New `repair_order` ruleset in `users/ruleset.py` and OAuth2 scope entry in `users/oauth2_scopes.py`.
- **Migration**: `0121_repair_order_and_repair_order_line.py` (depends on `order.0120`, `company.0080`, `part.0151`, `stock.0123`, `common.0046`, `users.0015`).
- **Tests**: `RepairOrderTests` and `RepairOrderLineTests` in `order/test_api.py` covering options endpoint, model validation, create/list/update API, status transitions, and line item creation/validation/filtering.

References #12064

## Test plan

- [ ] `python InvenTree/manage.py makemigrations order --check` reports no missing migrations
- [ ] `python InvenTree/manage.py check` passes
- [ ] `python InvenTree/manage.py test order.test_api.RepairOrderTests order.test_api.RepairOrderLineTests --noinput` passes
- [ ] Manual API smoke test via OPTIONS endpoint returns `REP-0001` default reference

## Notes

- Extends the existing `Order` base class rather than introducing a parallel model, mirroring the `ReturnOrder` / `TransferOrder` pattern.
- This PR is inspired by the WIP work in #12072 (frontend scaffolding) and #12326 (backend MVP) but is a standalone, self-contained backend implementation that targets review without those drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
