### PR TITLE
Add revision to SO and BO tables

### DIFF
--- a/src/frontend/src/components/tables/ColumnRenderers.tsx
+++ b/src/frontend/src/components/tables/ColumnRenderers.tsx
@@ -129,6 +129,18 @@ export function IPNColumn(props: TableColumnProps): TableColumn {
   };
 }
 
+export function RevisionColumn(props: TableColumnProps): TableColumn {
+  return {
+    accessor: 'part_detail.revision',
+    sortable: true,
+    switchable: true,
+    title: t`Revision`,
+    copyable: true,
+    defaultVisible: false,
+    ...props
+  };
+}
+
 export type StockColumnProps = TableColumnProps & {
   nullMessage?: string | ReactNode;
 };

--- a/src/frontend/src/tables/build/BuildLineTable.tsx
+++ b/src/frontend/src/tables/build/BuildLineTable.tsx
@@ -33,7 +33,8 @@ import {
   IPNColumn,
   LocationColumn,
   PartColumn,
-  RenderPartColumn
+  RenderPartColumn,
+  RevisionColumn
 } from '../../components/tables/ColumnRenderers';
 import { PartCategoryFilter } from '../../components/tables/Filter';
 import { InvenTreeTable } from '../../components/tables/InvenTreeTable';
@@ -351,6 +352,7 @@ export default function BuildLineTable({
         }
       }),
       IPNColumn({}),
+      RevisionColumn({}),
       CategoryColumn({
         accessor: 'category_detail',
         defaultVisible: false,

--- a/src/frontend/src/tables/sales/SalesOrderAllocationTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderAllocationTable.tsx
@@ -129,14 +129,14 @@ export default function SalesOrderAllocationTable({
         hidden: showPartInfo != true,
         part: 'part_detail'
       }),
-      DescriptionColumn({
-        accessor: 'part_detail.description',
-        hidden: showPartInfo != true
-      }),
       IPNColumn({
         hidden: showPartInfo != true
       }),
       RevisionColumn({
+        hidden: showPartInfo != true
+      }),
+      DescriptionColumn({
+        accessor: 'part_detail.description',
         hidden: showPartInfo != true
       }),
       {

--- a/src/frontend/src/tables/sales/SalesOrderAllocationTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderAllocationTable.tsx
@@ -20,6 +20,7 @@ import {
   LocationColumn,
   PartColumn,
   ReferenceColumn,
+  RevisionColumn,
   StatusColumn
 } from '../../components/tables/ColumnRenderers';
 import {
@@ -133,6 +134,9 @@ export default function SalesOrderAllocationTable({
         hidden: showPartInfo != true
       }),
       IPNColumn({
+        hidden: showPartInfo != true
+      }),
+      RevisionColumn({
         hidden: showPartInfo != true
       }),
       {

--- a/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
+++ b/src/frontend/src/tables/sales/SalesOrderLineItemTable.tsx
@@ -38,7 +38,8 @@ import {
   LinkColumn,
   ProjectCodeColumn,
   ReferenceColumn,
-  RenderPartColumn
+  RenderPartColumn,
+  RevisionColumn
 } from '../../components/tables/ColumnRenderers';
 import { InvenTreeTable } from '../../components/tables/InvenTreeTable';
 
@@ -103,6 +104,7 @@ export default function SalesOrderLineItemTable({
         }
       },
       IPNColumn({}),
+      RevisionColumn({}),
       DescriptionColumn({
         accessor: 'part_detail.description'
       }),


### PR DESCRIPTION
Fixes #12384

Revision added to tables:

- Sales Order
  - Line Items
  - Allocated Stock
- Shipment
  - Allocated Stock
- Manufacturing
  - Required Parts

I also moved the Description column to after IPN and Revision in the SO allocation table to be consistent with other tables.

