### PR TITLE
fix(reports): read file as binary so content and content size matches

### DIFF
--- a/src/backend/InvenTree/report/apps.py
+++ b/src/backend/InvenTree/report/apps.py
@@ -96,7 +96,7 @@ class ReportConfig(AppConfig):
             raise FileNotFoundError(
                 'Template file %s does not exist in %s', file_name, file
             )
-        return ContentFile(file.open('r').read(), os.path.basename(file_name))
+        return ContentFile(file.open('rb').read(), os.path.basename(file_name))
 
     def create_default_labels(self):
         """Create default label templates."""


### PR DESCRIPTION
When reading files as text, the file size reported by python seems to mismatch the actual content size (for example 1458 instead of 1460 in inventree_transfer_order_report.html) which leads to Content-Length header being set to the wrong value when using S3 as the storage backend.

As this only seems to be happening with this file it might also be some weirdness with this specific template but reading in binary mode seems to be less error-prone in general.