### PR TITLE
fix: resolve update_available notification dedup and link

### DIFF
--- a/src/backend/InvenTree/InvenTree/tasks.py
+++ b/src/backend/InvenTree/InvenTree/tasks.py
@@ -815,7 +815,7 @@ def delete_old_emails():
 def check_for_updates():
     """Check if there is an update for InvenTree."""
     try:
-        from common.notifications import trigger_notification
+        from common.notifications import notification_dedup_uid, trigger_notification
         from plugin.builtin.integration.core_notifications import (
             InvenTreeUINotifications,
         )
@@ -856,6 +856,7 @@ def check_for_updates():
     data = json.loads(response.text)
 
     tag = data.get('tag_name', None)
+    html_url = data.get('html_url', None)
 
     if not tag:
         raise ValueError("'tag_name' missing from GitHub response")  # pragma: no cover
@@ -876,8 +877,8 @@ def check_for_updates():
     # Save the version to the database
     set_global_setting('_INVENTREE_LATEST_VERSION', tag, None)
 
-    # Record that this task was successful
-    record_task_success('check_for_updates')
+    if html_url:
+        set_global_setting('_INVENTREE_LATEST_VERSION_URL', html_url, None)
 
     # Send notification if there is a new version
     if not isInvenTreeUpToDate():
@@ -887,11 +888,18 @@ def check_for_updates():
             'update_available',
             targets=get_user_model().objects.filter(is_superuser=True),
             delivery_methods={InvenTreeUINotifications},
+            dedup_uid=notification_dedup_uid(f'update_available:{tag}'),
             context={
                 'name': _('Update Available'),
-                'message': _('An update for InvenTree is available'),
+                'message': _('An update for InvenTree is available: {version}').format(
+                    version=tag
+                ),
+                'link': html_url,
             },
         )
+
+    # Record that this task was successful
+    record_task_success('check_for_updates')
 
 
 @tracer.start_as_current_span('update_exchange_rates')

--- a/src/backend/InvenTree/InvenTree/test_tasks.py
+++ b/src/backend/InvenTree/InvenTree/test_tasks.py
@@ -1,7 +1,9 @@
 """Unit tests for task management."""
 
+import json
 import os
 from datetime import timedelta
+from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -15,7 +17,7 @@ from django_q.models import OrmQ, Schedule, Task
 from error_report.models import Error
 
 import InvenTree.tasks
-from common.models import InvenTreeSetting, InvenTreeUserSetting
+from common.models import InvenTreeSetting, InvenTreeUserSetting, NotificationEntry, NotificationMessage
 from InvenTree.unit_test import PluginRegistryMixin
 
 threshold = timezone.now() - timedelta(days=30)
@@ -167,6 +169,47 @@ class InvenTreeTaskTests(PluginRegistryMixin, TestCase):
         # Check that it is empty again
         errors = Error.objects.filter(when__lte=threshold)
         self.assertEqual(len(errors), 0)
+
+    @mock.patch('InvenTree.tasks.check_daily_holdoff', return_value=True)
+    @mock.patch('InvenTree.tasks.requests.get')
+    def test_task_check_for_updates_notification(self, mock_get, mock_holdoff):
+        """Test update notification path for check_for_updates (#12399)."""
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.text = json.dumps(
+            {
+                'tag_name': '9.9.9',
+                'html_url': 'https://github.com/inventree/InvenTree/releases/tag/9.9.9',
+            }
+        )
+
+        NotificationMessage.objects.filter(category='update_available').delete()
+        NotificationEntry.objects.filter(key='update_available').delete()
+
+        InvenTreeSetting.set_setting('_INVENTREE_LATEST_VERSION', '')
+        InvenTreeSetting.set_setting('_INVENTREE_LATEST_VERSION_URL', '')
+
+        self.assertTrue(User.objects.filter(is_superuser=True).exists())
+
+        InvenTree.tasks.check_for_updates()
+
+        self.assertEqual(InvenTreeSetting.get_setting('_INVENTREE_LATEST_VERSION'), '9.9.9')
+        self.assertEqual(
+            InvenTreeSetting.get_setting('_INVENTREE_LATEST_VERSION_URL'),
+            'https://github.com/inventree/InvenTree/releases/tag/9.9.9',
+        )
+        self.assertEqual(
+            NotificationMessage.objects.filter(category='update_available').count(), 1
+        )
+        self.assertEqual(NotificationEntry.objects.filter(key='update_available').count(), 1)
+
+        entry = NotificationEntry.objects.get(key='update_available')
+        self.assertIsNotNone(entry.uid)
+
+        # Second run should be deduplicated within the notification window
+        InvenTree.tasks.check_for_updates()
+        self.assertEqual(
+            NotificationMessage.objects.filter(category='update_available').count(), 1
+        )
 
     def test_task_check_for_updates(self):
         """Test the task check_for_updates."""

--- a/src/backend/InvenTree/common/models.py
+++ b/src/backend/InvenTree/common/models.py
@@ -1670,6 +1670,12 @@ class NotificationEntry(MetaMixin):
     @classmethod
     def notify(cls, key: str, uid: int):
         """Notify the database that a particular notification has been sent out."""
+        if uid is None:
+            logger.warning(
+                "Skipping NotificationEntry for key=%s with NULL uid", key
+            )
+            return
+
         entry, _ = cls.objects.get_or_create(key=key, uid=uid)
 
         entry.save()

--- a/src/backend/InvenTree/common/notifications.py
+++ b/src/backend/InvenTree/common/notifications.py
@@ -1,5 +1,6 @@
 """Base classes and functions for notifications."""
 
+import zlib
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Optional
@@ -19,6 +20,11 @@ from users.models import Owner
 from users.permissions import check_user_permission
 
 logger = structlog.get_logger('inventree')
+
+
+def notification_dedup_uid(value: str) -> int:
+    """Return a stable positive integer UID for notification deduplication."""
+    return zlib.crc32(value.encode('utf-8')) & 0x7FFFFFFF
 
 
 # region methods
@@ -105,6 +111,7 @@ def trigger_notification(obj: Model, category: str = '', obj_ref: str = 'pk', **
     context = kwargs.get('context', {})
     delivery_methods = kwargs.get('delivery_methods')
     check_recent = kwargs.get('check_recent', True)
+    dedup_uid = kwargs.get('dedup_uid')
 
     # Resolve object reference
     refs = [obj_ref, 'pk', 'id', 'uid']
@@ -122,12 +129,16 @@ def trigger_notification(obj: Model, category: str = '', obj_ref: str = 'pk', **
             raise KeyError(
                 f"Could not resolve an object reference for '{obj!s}' with {','.join(set(refs))}"
             )
+    elif dedup_uid is not None:
+        obj_ref_value = dedup_uid
 
     # Check if we have notified recently...
     delta = timedelta(days=1)
 
-    if check_recent and common.models.NotificationEntry.check_recent(
-        category, obj_ref_value, delta
+    if (
+        check_recent
+        and obj_ref_value is not None
+        and common.models.NotificationEntry.check_recent(category, obj_ref_value, delta)
     ):
         logger.info(
             "Notification '%s' has recently been sent for '%s' - SKIPPING",
@@ -214,5 +225,5 @@ def trigger_notification(obj: Model, category: str = '', obj_ref: str = 'pk', **
             log_error('send_notification', plugin=plugin.slug)
 
     # Log the notification entry
-    if result:
+    if result and obj_ref_value is not None:
         common.models.NotificationEntry.notify(category, obj_ref_value)

--- a/src/backend/InvenTree/common/serializers.py
+++ b/src/backend/InvenTree/common/serializers.py
@@ -316,6 +316,14 @@ class NotificationMessageSerializer(InvenTreeModelSerializer):
 
     def get_target(self, obj) -> dict:
         """Function to resolve generic object reference to target."""
+        if obj.category == 'update_available':
+            from common.settings import get_global_setting
+
+            link = get_global_setting('_INVENTREE_LATEST_VERSION_URL', create=False)
+
+            if link:
+                return {'link': link, 'name': obj.name}
+
         target = get_objectreference(obj, 'target_content_type', 'target_object_id')
 
         if target and 'link' not in target:

--- a/src/backend/InvenTree/common/tests.py
+++ b/src/backend/InvenTree/common/tests.py
@@ -22,7 +22,7 @@ from django.urls import reverse
 from PIL import Image
 
 import common.validators
-from common.notifications import trigger_notification
+from common.notifications import notification_dedup_uid, trigger_notification
 from common.settings import get_global_setting, set_global_setting
 from InvenTree.helpers import str2bool
 from InvenTree.unit_test import (
@@ -1461,6 +1461,46 @@ class NotificationTest(InvenTreeAPITestCase):
             trigger_notification(
                 grp, category='core', context={'name': 'test'}, targets=[self.user]
             )
+        self.assertEqual(NotificationMessage.objects.count(), 1)
+        self.assertIn('as recently been sent for', str(cm[1]))
+
+    def test_global_notification_dedup_uid(self):
+        """Test global notifications with explicit dedup UID (#12399)."""
+        from plugin.builtin.integration.core_notifications import InvenTreeUINotifications
+
+        NotificationEntry.objects.all().delete()
+        NotificationMessage.objects.all().delete()
+
+        uid = notification_dedup_uid('update_available:9.9.9')
+
+        trigger_notification(
+            None,
+            'update_available',
+            targets=[self.user],
+            delivery_methods={InvenTreeUINotifications},
+            dedup_uid=uid,
+            context={
+                'name': 'Update Available',
+                'message': 'Test update',
+                'link': 'https://github.com/inventree/InvenTree/releases/tag/9.9.9',
+            },
+        )
+
+        self.assertEqual(NotificationMessage.objects.count(), 1)
+        self.assertEqual(NotificationEntry.objects.count(), 1)
+        entry = NotificationEntry.objects.get(key='update_available')
+        self.assertEqual(entry.uid, uid)
+
+        with self.assertLogs(logger='inventree') as cm:
+            trigger_notification(
+                None,
+                'update_available',
+                targets=[self.user],
+                delivery_methods={InvenTreeUINotifications},
+                dedup_uid=uid,
+                context={'name': 'Update Available', 'message': 'Test update'},
+            )
+
         self.assertEqual(NotificationMessage.objects.count(), 1)
         self.assertIn('as recently been sent for', str(cm[1]))
 

--- a/src/frontend/src/components/nav/NotificationDrawer.tsx
+++ b/src/frontend/src/components/nav/NotificationDrawer.tsx
@@ -49,18 +49,23 @@ function NotificationEntry({
 
   let link = notification.target?.link;
 
+  const isExternal =
+    link?.startsWith('http://') || link?.startsWith('https://');
+
   const model_type = notification.target?.model_type;
   const model_id = notification.target?.model_id;
 
   // If a valid model type is provided, that overrides the specified link
   if (model_type as ModelType) {
     const model_info = ModelInformationDict[model_type as ModelType];
-    if (model_info?.url_detail && model_id) {
+    if (model_info?.url_detail && model_id && !isExternal) {
       link = getDetailUrl(model_type as ModelType, model_id);
-    } else if (model_info?.url_overview) {
+    } else if (model_info?.url_overview && !isExternal) {
       link = model_info.url_overview;
     }
   }
+
+  const href = isExternal ? link : link ? `/${getBaseUrl()}${link}` : '#';
 
   return (
     <Paper p='xs' shadow='xs'>
@@ -72,7 +77,7 @@ function NotificationEntry({
         >
           <Stack gap={2}>
             <Anchor
-              href={link ? `/${getBaseUrl()}${link}` : '#'}
+              href={href}
               underline='hover'
               target='_blank'
               onClick={(event: any) => {
@@ -81,7 +86,7 @@ function NotificationEntry({
                   onRead();
                 }
 
-                if (link.startsWith('/')) {
+                if (link?.startsWith('/')) {
                   navigateToLink(link, navigate, event);
                 }
               }}


### PR DESCRIPTION
## Summary
- Add explicit dedup UID support for global notifications via dedup_uid kwarg
- Fix check_for_updates to pass version-based UID and GitHub release html_url
- Return release link for update_available notifications instead of plugin admin URL
- Handle external notification links in the UI drawer
- Add regression tests for notification delivery and deduplication

Fixes #12399

## Test plan
- [x] check_for_updates creates NotificationMessage and NotificationEntry without NULL uid
- [x] Second run within dedup window does not create duplicate messages
- [x] Global notification dedup UID unit test
- [x] Release URL stored in _INVENTREE_LATEST_VERSION_URL setting