### PR TITLE
Fix creation date formatting on part detail page

### DIFF
--- a/src/frontend/src/pages/part/PartDetailsPanel.tsx
+++ b/src/frontend/src/pages/part/PartDetailsPanel.tsx
@@ -272,7 +272,7 @@ export function PartDetailsPanel({
   const br: DetailsField[] = useMemo(() => {
     const fields: DetailsField[] = [
       {
-        type: 'string',
+        type: 'date',
         name: 'creation_date',
         label: t`Creation Date`
       },


### PR DESCRIPTION
The Creation Date field on the part detail page is declared as a plain string, so it shows the raw ISO date from the API and ignores the user's date display format setting. The same field on the order and build pages is declared as 'date' and formats fine, so this just aligns the part page with those.

Seen on 1.4.2, still present on master.