### PR TITLE
Fix admin search for Address and Contact company foreign keys

### DIFF
--- a/src/backend/InvenTree/company/admin.py
+++ b/src/backend/InvenTree/company/admin.py
@@ -70,7 +70,7 @@ class AddressAdmin(admin.ModelAdmin):
 
     list_display = ('company', 'line1', 'postal_code', 'country')
 
-    search_fields = ['company', 'country', 'postal_code']
+    search_fields = ['company__name', 'country', 'postal_code']
 
     autocomplete_fields = ['company']
 
@@ -81,6 +81,6 @@ class ContactAdmin(admin.ModelAdmin):
 
     list_display = ('company', 'name', 'role', 'email', 'phone')
 
-    search_fields = ['company', 'name', 'email']
+    search_fields = ['company__name', 'name', 'email']
 
     autocomplete_fields = ['company']


### PR DESCRIPTION
## Summary

Fix a Django admin search error for the Address and Contact models.

## Problem

Searching in the Address or Contact admin pages raises the following error because `search_fields` includes the `company` `ForeignKey` directly:

```text
FieldError: Unsupported lookup 'icontains' for ForeignKey or join on the field not permitted.
```

Django attempts to apply the `icontains` lookup to the `ForeignKey`, which is not supported.

## Fix

Update the admin search configuration to search using the related company's name by replacing:

- `company` → `company__name`

in both `AddressAdmin` and `ContactAdmin`.

## Testing

- Reproduced the error by searching in the Django admin.
- Applied the fix.
- Verified that searching no longer raises the exception.