### PR TITLE
Add configurable default for PO line item merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds configurable default for merging purchase order line items via the `PURCHASEORDER_MERGE_LINE_ITEMS` global setting
 - [#12393](https://github.com/inventree/InvenTree/pull/12393) adds "discount" attribute to order line items, allowing users to specify a discount for each line item on an order. The discount can be specified as either a percentage or a fixed amount, and is applied to the line item total when calculating the order total.
 - [#12391](https://github.com/inventree/InvenTree/pull/12391) adds facility for bulk deleting line items against orders
 - [#12388](https://github.com/inventree/InvenTree/pull/12388) adds uniqueness requirements options for the Parameter and ParameterTemplate models. This allows users to specify whether a parameter value should be unique for a given model type, or globally unique across all models.

--- a/docs/docs/purchasing/purchase_order.md
+++ b/docs/docs/purchasing/purchase_order.md
@@ -225,3 +225,4 @@ The following [global settings](../settings/global.md) are available for purchas
 {{ globalsetting("PURCHASEORDER_CONVERT_CURRENCY") }}
 {{ globalsetting("PURCHASEORDER_EDIT_COMPLETED_ORDERS") }}
 {{ globalsetting("PURCHASEORDER_AUTO_COMPLETE") }}
+{{ globalsetting("PURCHASEORDER_MERGE_LINE_ITEMS") }}

--- a/src/backend/InvenTree/common/setting/system.py
+++ b/src/backend/InvenTree/common/setting/system.py
@@ -1003,6 +1003,14 @@ SYSTEM_SETTINGS: dict[str, InvenTreeSettingsKeyType] = {
         'default': True,
         'validator': bool,
     },
+    'PURCHASEORDER_MERGE_LINE_ITEMS': {
+        'name': _('Merge Purchase Order Line Items'),
+        'description': _(
+            'Merge new purchase order line items with existing lines that share the same part, destination, and target date'
+        ),
+        'default': True,
+        'validator': bool,
+    },
     # login / SSO
     'LOGIN_ENABLE_PWD_FORGOT': {
         'name': _('Enable password forgot'),

--- a/src/backend/InvenTree/order/api.py
+++ b/src/backend/InvenTree/order/api.py
@@ -684,7 +684,14 @@ class PurchaseOrderLineItemList(
 
         # possibly merge duplicate items
         line_item = None
-        if data.get('merge_items', True):
+        merge_items = data.get(
+            'merge_items',
+            common.settings.get_global_setting(
+                'PURCHASEORDER_MERGE_LINE_ITEMS', backup_value=True
+            ),
+        )
+
+        if merge_items:
             with transaction.atomic():
                 # Lock the matching row, so concurrent line creations cannot
                 # both read the same starting quantity (lost update)

--- a/src/backend/InvenTree/order/serializers.py
+++ b/src/backend/InvenTree/order/serializers.py
@@ -745,6 +745,14 @@ class PurchaseOrderLineItemSerializer(
         write_only=True,
     )
 
+    def __init__(self, *args, **kwargs):
+        """Set dynamic defaults for create-only fields."""
+        super().__init__(*args, **kwargs)
+
+        self.fields['merge_items'].default = get_global_setting(
+            'PURCHASEORDER_MERGE_LINE_ITEMS', backup_value=True
+        )
+
     sku = serializers.CharField(
         source='part.SKU', read_only=True, allow_null=True, label=_('SKU')
     )

--- a/src/backend/InvenTree/order/test_api.py
+++ b/src/backend/InvenTree/order/test_api.py
@@ -1074,21 +1074,13 @@ class PurchaseOrderLineItemTest(OrderTest):
 
         li1 = self.post(
             reverse('api-po-line-list'),
-            {
-                'order': po.pk,
-                'part': sp.pk,
-                'quantity': 1,
-            },
+            {'order': po.pk, 'part': sp.pk, 'quantity': 1},
             expected_code=201,
         ).json()
 
         li2 = self.post(
             reverse('api-po-line-list'),
-            {
-                'order': po.pk,
-                'part': sp.pk,
-                'quantity': 2,
-            },
+            {'order': po.pk, 'part': sp.pk, 'quantity': 2},
             expected_code=201,
         ).json()
 
@@ -1098,11 +1090,7 @@ class PurchaseOrderLineItemTest(OrderTest):
 
         li3 = self.post(
             reverse('api-po-line-list'),
-            {
-                'order': po.pk,
-                'part': sp.pk,
-                'quantity': 3,
-            },
+            {'order': po.pk, 'part': sp.pk, 'quantity': 3},
             expected_code=201,
         ).json()
 

--- a/src/backend/InvenTree/order/test_api.py
+++ b/src/backend/InvenTree/order/test_api.py
@@ -1060,6 +1060,54 @@ class PurchaseOrderLineItemTest(OrderTest):
         ).json()
         self.assertEqual(float(li5['purchase_price']), 1)
 
+    def test_po_line_merge_default_setting(self):
+        """Test that merge_items defaults to the global setting value."""
+        self.assignRole('purchase_order.add')
+
+        su = Company.objects.get(pk=1)
+        sp = SupplierPart.objects.get(pk=1)
+        po = models.PurchaseOrder.objects.create(
+            supplier=su, reference='PO-MERGE-DEFAULT'
+        )
+
+        set_global_setting('PURCHASEORDER_MERGE_LINE_ITEMS', False)
+
+        li1 = self.post(
+            reverse('api-po-line-list'),
+            {
+                'order': po.pk,
+                'part': sp.pk,
+                'quantity': 1,
+            },
+            expected_code=201,
+        ).json()
+
+        li2 = self.post(
+            reverse('api-po-line-list'),
+            {
+                'order': po.pk,
+                'part': sp.pk,
+                'quantity': 2,
+            },
+            expected_code=201,
+        ).json()
+
+        self.assertNotEqual(li1['pk'], li2['pk'])
+
+        set_global_setting('PURCHASEORDER_MERGE_LINE_ITEMS', True)
+
+        li3 = self.post(
+            reverse('api-po-line-list'),
+            {
+                'order': po.pk,
+                'part': sp.pk,
+                'quantity': 3,
+            },
+            expected_code=201,
+        ).json()
+
+        self.assertEqual(li1['pk'], li3['pk'])
+
     def test_output_options(self):
         """Test PurchaseOrderLineItem output option endpoint."""
         self.run_output_test(

--- a/src/frontend/src/components/wizards/OrderPartsWizard.tsx
+++ b/src/frontend/src/components/wizards/OrderPartsWizard.tsx
@@ -28,11 +28,11 @@ import {
 import { DataTable } from 'mantine-datatable';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSupplierPartFields } from '../../forms/CompanyForms';
-import { useGlobalSettingsState } from '../../states/SettingsStates';
 import { usePurchaseOrderFields } from '../../forms/PurchaseOrderForms';
 import { useCreateApiFormModal } from '../../hooks/UseForm';
 import { useInstance } from '../../hooks/UseInstance';
 import useWizard from '../../hooks/UseWizard';
+import { useGlobalSettingsState } from '../../states/SettingsStates';
 import RemoveRowButton from '../buttons/RemoveRowButton';
 import { StandaloneField } from '../forms/StandaloneField';
 import Expand from '../items/Expand';

--- a/src/frontend/src/components/wizards/OrderPartsWizard.tsx
+++ b/src/frontend/src/components/wizards/OrderPartsWizard.tsx
@@ -28,6 +28,7 @@ import {
 import { DataTable } from 'mantine-datatable';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSupplierPartFields } from '../../forms/CompanyForms';
+import { useGlobalSettingsState } from '../../states/SettingsStates';
 import { usePurchaseOrderFields } from '../../forms/PurchaseOrderForms';
 import { useCreateApiFormModal } from '../../hooks/UseForm';
 import { useInstance } from '../../hooks/UseInstance';
@@ -195,6 +196,7 @@ function SelectPartsStep({
   const [selectedRecord, setSelectedRecord] = useState<PartOrderRecord | null>(
     null
   );
+  const globalSettings = useGlobalSettingsState();
 
   const purchaseOrderFields = usePurchaseOrderFields({
     supplierId: selectedRecord?.supplier_part?.supplier
@@ -240,9 +242,11 @@ function SelectPartsStep({
       },
       purchase_price: {},
       purchase_price_currency: {},
-      merge_items: {}
+      merge_items: {
+        default: globalSettings.isSet('PURCHASEORDER_MERGE_LINE_ITEMS', true)
+      }
     };
-  }, [selectedRecord]);
+  }, [selectedRecord, globalSettings]);
 
   const addToOrder = useCreateApiFormModal({
     url: apiUrl(ApiEndpoints.purchase_order_line_list),

--- a/src/frontend/src/forms/PurchaseOrderForms.tsx
+++ b/src/frontend/src/forms/PurchaseOrderForms.tsx
@@ -220,7 +220,9 @@ export function usePurchaseOrderLineItemFields({
     }
 
     if (create) {
-      fields['merge_items'] = {};
+      fields['merge_items'] = {
+        default: globalSettings.isSet('PURCHASEORDER_MERGE_LINE_ITEMS', true)
+      };
     }
 
     return fields;


### PR DESCRIPTION
## Summary

Adds a `PURCHASEORDER_MERGE_LINE_ITEMS` global setting to control the default state of the **Merge Items** checkbox when creating purchase order line items.

Default remains `True` for backward compatibility. Administrators can set it to `False` so users get separate lines by default (e.g. when ordering the same part for different project codes).

Fixes #10947

## Changes

- **Backend:** new global setting, serializer default, API merge logic uses setting when `merge_items` is omitted
- **Frontend:** PO line item forms and Order Parts wizard read the setting for the checkbox default
- **Docs:** purchase order global settings table
- **Tests:** `test_po_line_merge_default_setting`

## Test plan

- [ ] Set `PURCHASEORDER_MERGE_LINE_ITEMS` to `False` in admin settings — new PO line form should have Merge Items unchecked by default
- [ ] Add two lines for the same part without toggling the checkbox — lines should remain separate
- [ ] Set setting back to `True` — merge behavior should work as before
- [ ] CI: `order.test_api.PurchaseOrderLineItemTest.test_po_line_merge_default_setting`
