### PR TITLE
Build output serial number docs

### DIFF
--- a/docs/docs/manufacturing/allocate.md
+++ b/docs/docs/manufacturing/allocate.md
@@ -35,10 +35,12 @@ A [Bill of Materials](./bom.md) to generate an assembly may consist of a mixture
 
 ### Tracked Build Outputs
 
-If a Build Order is created for an assembled part which is itself designed as *trackable*, some extra restrictions apply:
+If the [BOM](./bom.md) for the assembled part contains one or more *tracked* (trackable) components, some extra restrictions apply when creating build outputs:
 
-- Build outputs must be single quantity
-- Build outputs must be serialized as they are created
+- Serial numbers *must* be provided when the build output is created - this allows the tracked sub-components to be allocated against a specific unit
+- Each generated build output is single quantity (one output per serial number)
+
+If the assembled part itself is *trackable*, but the BOM does not contain any tracked components, serial numbers are *not* required at the point of creation - a single build output may be created with a batch quantity, and [serialized later](../part/trackable.md#build-outputs-without-serial-numbers).
 
 ## Allocating Untracked Stock
 

--- a/docs/docs/manufacturing/external.md
+++ b/docs/docs/manufacturing/external.md
@@ -65,6 +65,8 @@ Once the purchase order has been created, add the assembly part to the purchase 
 
 Follow the normal process for receiving items against the purchase order. When the items are received from the external supplier, they will be marked as "build outputs" against the external build order.
 
+If the assembled part is [trackable](../part/trackable.md), [serial numbers](../purchasing/purchase_order.md#serial-numbers) may optionally be entered at the point of receipt - or the items can be received without serial numbers, and [serialized later](../part/trackable.md#build-outputs-without-serial-numbers).
+
 {{ image("build/external_build_receive_items.png", "Receive items against purchase order") }}
 
 The received items will now be registered as "incomplete outputs" against the external build order:

--- a/docs/docs/manufacturing/output.md
+++ b/docs/docs/manufacturing/output.md
@@ -35,13 +35,22 @@ The following options are available when creating a new build output:
 | Option | Description |
 | --- | --- |
 | Quantity | The number of items to create as part of this build output |
-| Serial Numbers | If this is a tracked build output, the serial numbers for each of the generated outputs |
+| Serial Numbers | Optional serial numbers for the generated outputs - see [below](#creating-outputs-without-serial-numbers) for when this field may be left blank |
 | Batch Code | Batch code identifier for the generated output(s) |
 | Auto Allocate Serial Numbers | If selected, any available tracked subcomponents which already have serial numbers assigned, will be automatically assigned to matching build outputs |
 
 ### Specifying Serial Numbers
 
 Refer to the [serial number generation guide](../stock/tracking.md#generating-serial-numbers) for further information on serial number input.
+
+### Creating Outputs Without Serial Numbers
+
+Serial numbers are not required when creating a build output, even if the part being built is marked as [trackable](../part/trackable.md). This allows a batch quantity to be produced up-front - for example, a quantity of PCBs which will not be individually serialized until later in the manufacturing process, or units received into an [external build order](./external.md) which are not yet serialized.
+
+If the *Serial Numbers* field is left blank, a single build output is created with the specified *Quantity*, rather than one output per unit. This output remains a single (non-serialized) [stock item](../stock/index.md), which can be serialized at a later stage - for example, by splitting it into individual units and assigning serial numbers - before it is [completed](#complete-build-output).
+
+!!! note "Tracked BOM Items"
+    If the [Bill of Materials](./bom.md) for the assembled part contains tracked sub-components, serial numbers are still required when creating build outputs - see [tracked build outputs](./allocate.md#tracked-build-outputs) for further information.
 
 ## Complete Build Output
 

--- a/docs/docs/part/trackable.md
+++ b/docs/docs/part/trackable.md
@@ -8,7 +8,9 @@ Denoting a part as *Trackable* changes the way that [stock items](../stock/index
 
 For many parts in an InvenTree database, simply tracking current stock levels (and locations) is sufficient. However, some parts require more extensive tracking than simple stock level knowledge.
 
-Any stock item associated with a trackable part *must* have either a batch number or a serial number. This includes stock created manually or via an internal process (such as a [Purchase Order](../purchasing/purchase_order.md) or a [Build Order](../manufacturing/build.md)).
+Generally, a stock item associated with a trackable part should have either a batch number or a serial number. This includes stock created manually or via an internal process (such as a [Purchase Order](../purchasing/purchase_order.md) or a [Build Order](../manufacturing/build.md)).
+
+However, this is not strictly enforced when creating a [build output](../manufacturing/output.md#create-build-output) - see [below](#build-orders) for further information.
 
 ## Assign Serial Numbers
 
@@ -35,3 +37,12 @@ For example:
 ## Build Orders
 
 [Build orders](../manufacturing/build.md) have some extra requirements when either building a trackable part, or using parts in the Bill of Materials which are themselves trackable.
+
+### Build Outputs Without Serial Numbers
+
+When [creating a build output](../manufacturing/output.md#create-build-output) for a trackable part, serial numbers are *not* required at the point of creation. This allows a batch quantity of build outputs to be created up-front, and serialized at some later stage - for example, after receiving a batch of unserialized units against an [external build order](../manufacturing/external.md).
+
+If serial numbers are not provided, a single build output is created with the specified quantity, rather than one output per unit. This output can subsequently be assigned [serial numbers](#assign-serial-numbers), or split into individual serialized units, before it is completed.
+
+!!! note "Tracked BOM Items"
+    If the Bill of Materials for the part being built contains *tracked* (trackable) sub-components, serial numbers are still required when creating build outputs, regardless of whether the assembled part itself is trackable. This is necessary so that each tracked sub-component can be allocated against a specific build output. Refer to the [build allocation documentation](../manufacturing/allocate.md#tracked-build-outputs) for further information.

--- a/docs/docs/purchasing/purchase_order.md
+++ b/docs/docs/purchasing/purchase_order.md
@@ -139,6 +139,12 @@ Each item marked as "received" is automatically converted into a stock item.
 
 To see the list of stock items created from the purchase order, click on the <span class="badge inventree nav side">{{ icon("arrow-right") }} Received Items</span> tab.
 
+### Serial Numbers
+
+If the part being received is [trackable](../part/trackable.md), serial numbers can optionally be entered at the point of receipt. If provided, an individual (serialized) stock item is created for each unit received.
+
+Serial numbers are *not* required to receive a trackable part - if left blank, a single (non-serialized) stock item is created for the received quantity. This is useful, for example, when receiving a batch of units against an [external build order](../manufacturing/external.md) which will be [serialized later](../part/trackable.md#build-outputs-without-serial-numbers) in the manufacturing process.
+
 ### Item Value Currency
 
 The unit cost of the purchase order line item is transferred across to the created stock item. By default, the same currency is used for the stock item as was used for the purchase order line item.

--- a/src/backend/InvenTree/build/serializers.py
+++ b/src/backend/InvenTree/build/serializers.py
@@ -441,13 +441,6 @@ class BuildOutputCreateSerializer(serializers.Serializer):
         quantity = data['quantity']
         serial_numbers = data.get('serial_numbers', '')
 
-        if part.trackable and not serial_numbers:
-            raise ValidationError({
-                'serial_numbers': _(
-                    'Serial numbers must be provided for trackable parts'
-                )
-            })
-
         if serial_numbers:
             try:
                 self.serials = InvenTree.helpers.extract_serial_numbers(

--- a/src/backend/InvenTree/build/test_api.py
+++ b/src/backend/InvenTree/build/test_api.py
@@ -1388,6 +1388,35 @@ class BuildOutputCreateTest(BuildAPITest):
         # The new output must have a creation_date set
         self.assertIsNotNone(part.stock_items.order_by('-pk').first().creation_date)
 
+    def test_create_unserialized_output_trackable_part(self):
+        """A build output for a trackable part may be created without serial numbers.
+
+        This allows a batch quantity to be created (e.g. from an external build order)
+        which can be serialized at some later stage in the process.
+        """
+        build_id = 1
+        url = reverse('api-build-output-create', kwargs={'pk': build_id})
+
+        build = Build.objects.get(pk=build_id)
+        part = build.part
+
+        part.trackable = True
+        part.save()
+
+        n_outputs = build.output_count
+        n_items = part.stock_items.count()
+
+        # Create a single non-serialized output, even though the part is trackable
+        self.post(url, data={'quantity': 10}, expected_code=201)
+
+        # A single build output has been created (not one per unit of quantity)
+        self.assertEqual(n_outputs + 1, build.output_count)
+        self.assertEqual(n_items + 1, part.stock_items.count())
+
+        output = part.stock_items.order_by('-pk').first()
+        self.assertIsNone(output.serial)
+        self.assertEqual(output.quantity, 10)
+
 
 class BuildOutputScrapTest(BuildAPITest):
     """Unit tests for scrapping build outputs."""


### PR DESCRIPTION
- Improve documentation around serial numbers for build outputs
- Allow build outputs to be created manually without serial numbers
- Brings functionality into line with external build orders (where serials are not required)