### PR TITLE
Adjust demo-dataset for CI

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -33,6 +33,10 @@ env:
   INVENTREE_BACKUP_DIR: /home/runner/work/InvenTree/test_inventree_backup
   INVENTREE_SITE_URL: http://localhost:8000
 
+  # Use the same-named branch of the demo dataset as the target branch of this build,
+  # so that stable branches are not broken by changes to the demo dataset on main
+  DEMO_DATASET_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+
 permissions:
   contents: read
 
@@ -136,7 +140,7 @@ jobs:
           pip-dependency: psycopg2
       - name: Set up test data
         run: |
-          invoke dev.setup-test -iv
+          invoke dev.setup-test -iv --branch "$DEMO_DATASET_BRANCH"
           invoke int.rebuild-thumbnails
       - name: Install dependencies
         run: invoke int.frontend-compile --extract
@@ -218,7 +222,7 @@ jobs:
           pip-dependency: psycopg2
       - name: Set up test data
         run: |
-          invoke dev.setup-test -iv
+          invoke dev.setup-test -iv --branch "$DEMO_DATASET_BRANCH"
           invoke int.rebuild-thumbnails
       - name: Install dependencies
         run: invoke int.frontend-compile --extract

--- a/.github/workflows/import_export.yaml
+++ b/.github/workflows/import_export.yaml
@@ -40,6 +40,10 @@ env:
   INVENTREE_DB_HOST: "127.0.0.1"
   INVENTREE_DB_PORT: 5432
 
+  # Use the same-named branch of the demo dataset as the target branch of this build,
+  # so that stable branches are not broken by changes to the demo dataset on main
+  DEMO_DATASET_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+
 jobs:
 
   paths-filter:
@@ -90,7 +94,7 @@ jobs:
       - name: Setup Postgres Database
         run: |
           invoke migrate
-          invoke dev.setup-test -i
+          invoke dev.setup-test -i --branch "$DEMO_DATASET_BRANCH"
       - name: Create Plugin Data
         run: |
           pip install -U inventree-dummy-app-plugin==0.1.0

--- a/tasks.py
+++ b/tasks.py
@@ -1882,8 +1882,27 @@ def setup_test(
             # Use SSH protocol for cloning the demo dataset
             URL = 'git@github.com:inventree/demo-dataset.git'
 
+        # InvenTree's trunk branch is named "master", but the demo-dataset
+        # repository uses "main" as its trunk branch - map this automatically
+        # so CI can pass through the detected target branch unmodified.
+        if not branch or branch == 'master':
+            branch = 'main'
+
+        if branch != 'main':
+            # Stable release branches (e.g. "1.4.x") may not yet exist in the
+            # demo-dataset repository (e.g. it has not been backported yet).
+            # Fall back to "main" in that case, rather than failing the clone.
+            result = c.run(
+                f'git ls-remote --heads {URL} {branch}', hide=True, warn=True
+            )
+            if not result.ok or not result.stdout.strip():
+                warning(
+                    f"Demo dataset has no branch named '{branch}' - falling back to 'main'"
+                )
+                branch = 'main'
+
         # Get test data
-        info('Cloning demo dataset ...')
+        info(f"Cloning demo dataset (branch '{branch}') ...")
         run(c, f'git clone {URL} {template_dir} -b {branch} -v --depth=1')
 
     # Make sure migrations are done - might have just deleted sqlite database


### PR DESCRIPTION
Currently 1.4.x branch is failing CI because the demo dataset has "moved on" - and is no longer compatible.

So, we will make versioned branches for the demo dataset at time of release, and adjust CI here to account for this