### PR TITLE
Fix admin search for PurchaseOrderLineItem

### DIFF
--- a/src/backend/InvenTree/order/admin.py
+++ b/src/backend/InvenTree/order/admin.py
@@ -94,7 +94,14 @@ class PurchaseOrderLineItemAdmin(admin.ModelAdmin):
 
     list_display = ('order', 'part', 'quantity', 'reference')
 
-    search_fields = ('reference',)
+    search_fields = [
+        'part__part__name',
+        'part__part__description',
+        'part__SKU',
+        'order__reference',
+        'order__supplier__name',
+        'reference',
+    ]
 
     autocomplete_fields = ('order', 'part', 'destination')
 

--- a/src/backend/InvenTree/order/tests.py
+++ b/src/backend/InvenTree/order/tests.py
@@ -728,3 +728,13 @@ class OrderUpdatedAtTest(TestCase):
             before = self._refresh(instance).updated_at
             line.delete()
             self.assertGreaterEqual(self._refresh(instance).updated_at, before)
+
+    def test_po_lineitem_admin_search(self):
+        """Test search fields for PurchaseOrderLineItemAdmin."""
+        from order.admin import PurchaseOrderLineItemAdmin
+
+        admin_class = PurchaseOrderLineItemAdmin
+        self.assertIn('part__part__name', admin_class.search_fields)
+        self.assertIn('part__SKU', admin_class.search_fields)
+        self.assertIn('order__reference', admin_class.search_fields)
+        self.assertIn('order__supplier__name', admin_class.search_fields)


### PR DESCRIPTION
## Summary

Expands `search_fields` on `PurchaseOrderLineItemAdmin` to allow searching by part name, part description, supplier SKU, order reference, and supplier name.

## Motivation

Previously only the optional `reference` field was searchable, making it impossible to find line items by part or order details in the Django Admin panel.

Searching for a part name like `Widget` returned 0 results, while the same search on `SalesOrderLineItemAdmin` works correctly because it has `part__name` in its `search_fields`.

## Changes

- `src/backend/InvenTree/order/admin.py`: Expanded `search_fields` on `PurchaseOrderLineItemAdmin`
- `src/backend/InvenTree/order/tests.py`: Added unit test to verify search_fields configuration
