### PR TITLE
[sentry] Do not report MethodNotAllowed

### DIFF
--- a/src/backend/InvenTree/InvenTree/sentry.py
+++ b/src/backend/InvenTree/InvenTree/sentry.py
@@ -36,6 +36,7 @@ def sentry_ignore_errors():  # pragma: no cover
         rest_framework.exceptions.AuthenticationFailed,
         rest_framework.exceptions.NotAuthenticated,
         rest_framework.exceptions.PermissionDenied,
+        rest_framework.exceptions.MethodNotAllowed,
         rest_framework.exceptions.ValidationError,
     ]
 


### PR DESCRIPTION
These exceptions are already handled gracefully - we do not need to report them to sentry