### PR TITLE
fix: support UUID notification references

### DIFF
--- a/src/backend/InvenTree/InvenTree/test_tasks.py
+++ b/src/backend/InvenTree/InvenTree/test_tasks.py
@@ -211,7 +211,7 @@ class InvenTreeTaskTests(PluginRegistryMixin, TestCase):
             entry = NotificationEntry.objects.get()
 
             self.assertEqual(message.link, release_url)
-            self.assertEqual(entry.uid, 0)
+            self.assertEqual(entry.uid, '0')
 
             serialized = NotificationMessageSerializer(message).data
             self.assertEqual(serialized['target']['link'], release_url)

--- a/src/backend/InvenTree/common/migrations/0049_notificationentry_charfield_uid.py
+++ b/src/backend/InvenTree/common/migrations/0049_notificationentry_charfield_uid.py
@@ -1,0 +1,18 @@
+"""Allow notification entries to reference UUID primary keys."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('common', '0048_notificationmessage_link'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='notificationentry',
+            name='uid',
+            field=models.CharField(max_length=255),
+        ),
+    ]

--- a/src/backend/InvenTree/common/models.py
+++ b/src/backend/InvenTree/common/models.py
@@ -1656,10 +1656,12 @@ class NotificationEntry(MetaMixin):
 
     key = models.CharField(max_length=250, blank=False)
 
-    uid = models.IntegerField()
+    # Notification references may point to models with UUID primary keys.
+    # Store the value as text so both integer and non-integer identifiers work.
+    uid = models.CharField(max_length=255)
 
     @classmethod
-    def check_recent(cls, key: str, uid: int, delta: timedelta):
+    def check_recent(cls, key: str, uid: str | int | uuid.UUID, delta: timedelta):
         """Test if a particular notification has been sent in the specified time period."""
         since = InvenTree.helpers.current_date() - delta
 
@@ -1668,7 +1670,7 @@ class NotificationEntry(MetaMixin):
         return entries.exists()
 
     @classmethod
-    def notify(cls, key: str, uid: int):
+    def notify(cls, key: str, uid: str | int | uuid.UUID):
         """Notify the database that a particular notification has been sent out."""
         entry, _ = cls.objects.get_or_create(key=key, uid=uid)
 

--- a/src/backend/InvenTree/common/tests.py
+++ b/src/backend/InvenTree/common/tests.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import time
+import uuid
 from datetime import timedelta
 from http import HTTPStatus
 from unittest import mock
@@ -1332,6 +1333,18 @@ class NotificationTest(InvenTreeAPITestCase):
         self.assertFalse(NotificationEntry.check_recent('test.notification2', 1, delta))
 
         self.assertTrue(NotificationEntry.check_recent('test.notification', 1, delta))
+
+    def test_uuid_notification_entry(self):
+        """Notification entries support objects with UUID primary keys."""
+        notification_uid = uuid.uuid4()
+
+        NotificationEntry.notify('test.uuid_notification', notification_uid)
+
+        self.assertTrue(
+            NotificationEntry.check_recent(
+                'test.uuid_notification', notification_uid, timedelta(days=1)
+            )
+        )
 
     def test_api_list(self):
         """Test list URL."""


### PR DESCRIPTION
## What problem does this solve?

Fixes #12599. `NotificationEntry.uid` was an `IntegerField`, but notification deduplication can receive UUID primary keys from models such as `MachineConfig`. Saving those values caused database errors such as `integer out of range`.

## What changed?

- Store notification reference IDs in a `CharField(max_length=255)`.
- Add a migration that preserves existing notification entries while allowing non-integer IDs.
- Add a regression test covering UUID notification references.

## Validation

- `python manage.py migrate --noinput`
- `python -m pytest src/backend/InvenTree/common/tests.py -k 'uuid_notification_entry or check_notification_entries' -q --reuse-db` (2 passed)
- `python manage.py makemigrations --check --dry-run` (no changes detected)
