### PR TITLE
[bug] Handle duplicate email addresses for magic links

### DIFF
--- a/src/backend/InvenTree/InvenTree/magic_login.py
+++ b/src/backend/InvenTree/InvenTree/magic_login.py
@@ -69,6 +69,9 @@ class GetSimpleLoginView(GenericAPIView):
             return User.objects.get(email=email)
         except User.DoesNotExist:
             return None
+        except User.MultipleObjectsReturned:
+            logger.warning('Multiple users found with email: %s', email)
+            return None
 
     def create_link(self, user):
         """Create a login link for this user."""

--- a/src/backend/InvenTree/InvenTree/tests.py
+++ b/src/backend/InvenTree/InvenTree/tests.py
@@ -1708,6 +1708,18 @@ class MagicLoginTest(InvenTreeTestCase):
         # And we should be logged in again
         self.assertEqual(resp.wsgi_request.user, self.user)
 
+    def test_duplicate_email(self):
+        """Test that duplicate email addresses do not raise a server error."""
+        User = get_user_model()
+        User.objects.create_user(
+            username='duplicate', email=self.user.email, password='password'
+        )
+
+        resp = self.client.post(reverse('sesame-generate'), {'email': self.user.email})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, {'status': 'ok'})
+        self.assertEqual(len(mail.outbox), 0)
+
 
 class MaintenanceModeTest(InvenTreeTestCase):
     """Unit tests for maintenance mode."""


### PR DESCRIPTION
If multiple users exist with the same email, do not generate magic link emails