### PR TITLE
fix(frontend): adress flaky download assertation on firefox

### DIFF
--- a/src/frontend/tests/pages/pui_transfer.spec.ts
+++ b/src/frontend/tests/pages/pui_transfer.spec.ts
@@ -111,6 +111,8 @@ test('Transfer Order - Calendar', async ({ browser }) => {
   // Export calendar data - assert on download instead of notification
   await page.getByLabel('calendar-export-data').click();
 
+  await page.bringToFront();
+
   const [download] = await Promise.all([
     page.waitForEvent('download'),
     page.getByRole('button', { name: 'Export', exact: true }).click()


### PR DESCRIPTION
Closing in on 0 flaky tests on main 
<img width="2614" height="512" alt="grafik" src="https://github.com/user-attachments/assets/b9889582-e519-4f7e-a3bb-6edada2a6156" />
