### PR TITLE
Add previous/next navigation to detail pages

### DIFF
--- a/src/frontend/src/components/nav/PageDetail.tsx
+++ b/src/frontend/src/components/nav/PageDetail.tsx
@@ -1,13 +1,19 @@
-import { Group, Paper, Space, Stack, Text } from '@mantine/core';
+import { ActionIcon, Group, Paper, Space, Stack, Text } from '@mantine/core';
 
 import { StylishText } from '@lib/components/StylishText';
 import { useInvenTreeHotkeys } from '@lib/functions/Events';
+import { getDetailUrl, navigateToLink } from '@lib/functions/Navigation';
 import { shortenString } from '@lib/functions/String';
 import { t } from '@lingui/core/macro';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { Fragment, type ReactNode, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { usePluginUIFeature } from '../../hooks/UsePluginUIFeature';
 import { useUserSettingsState } from '../../states/SettingsStates';
+import {
+  setTableNavigationContext,
+  useTableNavigationState
+} from '../../states/TableNavigationState';
 import PrimaryActionButton from '../buttons/PrimaryActionButton';
 import { ApiImage } from '../images/ApiImage';
 import { ApiIcon } from '../items/ApiIcon';
@@ -53,6 +59,9 @@ export function PageDetail({
   const userSettings = useUserSettingsState();
   const navigate = useNavigate();
   const location = useLocation();
+
+  const navigationState = useTableNavigationState();
+  const navigationContext = navigationState.context;
 
   useInvenTreeHotkeys([
     [
@@ -130,6 +139,65 @@ export function PageDetail({
     return [...(extraActionArray ?? []), ...(actions ?? [])];
   }, [extraActions, actions]);
 
+  // previous / next navigation between the records in the list the user came from
+  const detailNavigation = useMemo(() => {
+    if (!navigationContext) return null;
+
+    const index = navigationContext.records.findIndex(
+      (record) => String(record) === String(navigationContext.current)
+    );
+
+    if (index < 0) return null;
+
+    const previous = index > 0 ? navigationContext.records[index - 1] : null;
+    const next =
+      index < navigationContext.records.length - 1
+        ? navigationContext.records[index + 1]
+        : null;
+
+    if (previous == null && next == null) return null;
+
+    const goTo = (pk: number | string, event: any) => {
+      const url = getDetailUrl(navigationContext.model, pk);
+
+      if (url) {
+        navigateToLink(url, navigate, event);
+        setTableNavigationContext({ ...navigationContext, current: pk });
+      }
+    };
+
+    return (
+      <Group gap={2} justify='right' wrap='nowrap' align='center'>
+        <ActionIcon
+          variant='subtle'
+          disabled={previous == null}
+          title={t`Previous`}
+          aria-label='previous-object'
+          onClick={(event) => {
+            if (previous != null) {
+              goTo(previous, event);
+            }
+          }}
+        >
+          <IconChevronLeft />
+        </ActionIcon>
+        <ActionIcon
+          variant='subtle'
+          disabled={next == null}
+          title={t`Next`}
+          aria-label='next-object'
+          onClick={(event) => {
+            if (next != null) {
+              goTo(next, event);
+            }
+          }}
+        >
+          <IconChevronRight />
+        </ActionIcon>
+      </Group>
+    );
+  }, [navigationContext, navigate]);
+
   return (
     <>
       <PageTitle title={pageTitleString} />
@@ -184,6 +252,7 @@ export function PageDetail({
                 </Group>
               )}
             </Group>
+            {detailNavigation}
             {computedActions && (
               <Group gap={5} justify='right' wrap='nowrap' align='flex-start'>
                 {computedActions.map((action, idx) => (

--- a/src/frontend/src/components/tables/InvenTreeTable.tsx
+++ b/src/frontend/src/components/tables/InvenTreeTable.tsx
@@ -39,6 +39,7 @@ import { showApiErrorMessage } from '../../functions/notifications';
 import { useLocalState } from '../../states/LocalState';
 import { usePreviewDrawerState } from '../../states/PreviewDrawerState';
 import { useUserSettingsState } from '../../states/SettingsStates';
+import { setTableNavigationContext } from '../../states/TableNavigationState';
 import { ColumnFilterPopover } from './FilterSelectDrawer';
 import InvenTreeTableHeader from './InvenTreeTableHeader';
 
@@ -746,6 +747,15 @@ export function InvenTreeTableInternal<T extends Record<string, any>>({
         const pk = resolveItem(record, accessor);
 
         if (pk) {
+          // Record list context so the detail header can offer prev/next
+          setTableNavigationContext({
+            model: tableProps.modelType,
+            records: (tableState.records ?? []).map((record) =>
+              resolveItem(record, accessor)
+            ),
+            current: pk
+          });
+
           cancelEvent(event);
           // If a model type is provided, navigate to the detail view for that model
           const url = getDetailUrl(tableProps.modelType, pk);

--- a/src/frontend/src/states/TableNavigationState.tsx
+++ b/src/frontend/src/states/TableNavigationState.tsx
@@ -1,0 +1,42 @@
+import type { ModelType } from '@lib/enums/ModelType';
+import { create } from 'zustand';
+
+type InstanceId = number | string;
+
+/**
+ * Context describing the "list" a detail view was opened from.
+ *
+ * When a user clicks a row in a table, we record the ordered list of
+ * primary keys currently displayed (the filtered result set) and the
+ * primary key that was clicked. The detail view header (PageDetail) then
+ * uses this context to render "previous / next" navigation buttons.
+ */
+export interface TableNavigationContext {
+  model: ModelType;
+  records: InstanceId[];
+  current: InstanceId;
+}
+
+interface TableNavigationStateProps {
+  context: TableNavigationContext | null;
+  setContext: (context: TableNavigationContext) => void;
+  clearContext: () => void;
+}
+
+export const useTableNavigationState = create<TableNavigationStateProps>()(
+  (set) => ({
+    context: null,
+
+    setContext: (context) => set({ context }),
+
+    clearContext: () => set({ context: null })
+  })
+);
+
+/**
+ * Helper for setting the navigation context from outside of React
+ * (e.g. inside a plain event handler in a table component).
+ */
+export function setTableNavigationContext(context: TableNavigationContext) {
+  useTableNavigationState.getState().setContext(context);
+}

--- a/src/frontend/tests/pui_detail_navigation.spec.ts
+++ b/src/frontend/tests/pui_detail_navigation.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from './baseFixtures.js';
+import { allaccessuser } from './defaults.js';
+import { navigate } from './helpers.js';
+import { doLogin } from './login.js';
+
+/**
+ * Tests for previous / next navigation on detail pages.
+ *
+ * NOTE: written against the source tree without a running stack; the exact
+ * list URL and row selectors below may need a small adjustment once verified
+ * against the test database in CI. See TODO markers.
+ */
+test('Detail - previous/next navigation from a list', async ({ page }) => {
+  await doLogin(page, { user: allaccessuser });
+
+  // Open the parts list (canonical overview URL for the "part" model)
+  await navigate(page, 'part/category/index/parts');
+  await page.waitForLoadState('networkidle');
+  await page.waitForURL(/\/web\/part/);
+
+  // Click the first data row's first cell to open its detail view
+  await page.locator('table tbody tr').first().locator('td').first().click();
+  await page.waitForURL(/\/web\/part\/\d+/);
+
+  // Navigation buttons should be rendered
+  const prevButton = page.getByLabel('previous-object');
+  const nextButton = page.getByLabel('next-object');
+  await expect(prevButton).toBeVisible();
+  await expect(nextButton).toBeVisible();
+
+  // The first row in the list has no "previous"
+  await expect(prevButton).toBeDisabled();
+
+  // Clicking "next" moves to a different object
+  const beforeUrl = page.url();
+  await nextButton.click();
+  await page.waitForURL(/\/web\/part\/\d+/);
+  await expect(page).not.toHaveURL(beforeUrl);
+
+  // After moving forward, "previous" becomes enabled
+  await expect(page.getByLabel('previous-object')).toBeEnabled();
+});
+
+test('Detail - no navigation when opened directly', async ({ page }) => {
+  await doLogin(page, { user: allaccessuser });
+
+  // Open a detail view directly (no list context)
+  await navigate(page, 'part/1/');
+  await page.waitForLoadState('networkidle');
+  await page.waitForURL(/\/web\/part\/1/);
+
+  // Without a list context, the navigation buttons should be absent
+  await expect(page.getByLabel('previous-object')).toHaveCount(0);
+  await expect(page.getByLabel('next-object')).toHaveCount(0);
+});


### PR DESCRIPTION
## What

Adds previous/next navigation to detail pages so a user can move between
the filtered records they came from, without having to return to the list.

Closes #12397

## How

- A small zustand store (`TableNavigationState`) records the ordered list of
  primary keys and the current record when a table row is clicked.
- `PageDetail` reads that context and renders previous/next buttons in the
  header, disabled at the first/last record, navigating via `getDetailUrl()`.
- When no list context exists (e.g. opening a detail URL directly), the
  buttons are not rendered.

## Screenshots / GIF

<!-- add a screenshot of the buttons here if you have one; optional -->

## Checklist

- [x] Frontend change only
- [x] i18n keys added (`Previous`, `Next`)
- [x] Playwright test added
