### PR TITLE
[1.5.x] [FR] stop shipping docs with packages (#12657)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,6 +215,12 @@ jobs:
           echo "calculate release channel"
           pip install --require-hashes -r contrib/dev_reqs/requirements.txt
           python3 .github/scripts/version_check.py
+      - name: cleanup
+        run: |
+          # remove .map files from static build - these are only needed for debug
+          find src/backend/InvenTree/web/static/web -name "*.map" -type f -delete
+          # remove the whole docs dir - we are not doing anything with them
+          rm -rf docs
       - name: Package - current release channel
         uses: pkgr/action/package@c5666febcd31750da6428042193fc5b2fb765435 # main
         id: package


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [[FR] stop shipping docs with packages (#12657)](https://github.com/inventree/InvenTree/pull/12657)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)