### PR TITLE
feat(frontend): add user setting to control navigation behaviour

### DIFF
--- a/docs/docs/settings/user.md
+++ b/docs/docs/settings/user.md
@@ -33,6 +33,7 @@ The *Display Settings* screen shows general display configuration options:
 {{ usersetting("SHOW_EXTRA_MODEL_INFO") }}
 {{ usersetting("SHOW_FULL_LOCATION_IN_TABLES") }}
 {{ usersetting("DISPLAY_ITEMS_FINAL_LEVEL") }}
+{{ usersetting("USE_TABLE_NAVIGATION") }}
 
 ### Search Settings
 

--- a/src/backend/InvenTree/common/setting/user.py
+++ b/src/backend/InvenTree/common/setting/user.py
@@ -296,4 +296,12 @@ USER_SETTINGS: dict[str, InvenTreeSettingsKeyType] = {
         'default': False,
         'validator': bool,
     },
+    'USE_TABLE_NAVIGATION': {
+        'name': _('Enable Filtered Detail Navigation'),
+        'description': _(
+            'Enable persisting of filtered detail navigation parameters to the view url'
+        ),
+        'default': True,
+        'validator': bool,
+    },
 }

--- a/src/frontend/src/components/tables/InvenTreeTable.tsx
+++ b/src/frontend/src/components/tables/InvenTreeTable.tsx
@@ -821,10 +821,11 @@ export function InvenTreeTableInternal<T extends Record<string, any>>({
 
         if (pk) {
           cancelEvent(event);
-          // If a model type is provided, navigate to the detail view for that model
-          const detailUrl =
-            getDetailNavigationUrl(record, index) ??
-            getDetailUrl(tableProps.modelType, pk);
+          // If a model type is provided and USE_TABLE_NAVIGATION is enabled, navigate to the detail view for that model
+          const detailUrl = userSettings.isSet('USE_TABLE_NAVIGATION')
+            ? (getDetailNavigationUrl(record, index) ??
+              getDetailUrl(tableProps.modelType, pk))
+            : getDetailUrl(tableProps.modelType, pk);
 
           if (!showPreviewPanel || eventModified(event as any)) {
             navigateToLink(detailUrl, navigate, event);
@@ -888,9 +889,10 @@ export function InvenTreeTableInternal<T extends Record<string, any>>({
         const recordIndex = tableState.records.findIndex(
           (item) => String(resolveItem(item, accessor)) === String(pk)
         );
-        const detailUrl =
-          getDetailNavigationUrl(record, recordIndex) ??
-          getDetailUrl(props.modelType, pk);
+        const detailUrl = userSettings.isSet('USE_TABLE_NAVIGATION')
+          ? (getDetailNavigationUrl(record, recordIndex) ??
+            getDetailUrl(props.modelType, pk))
+          : getDetailUrl(props.modelType, pk);
 
         const model: string | undefined =
           ModelInformationDict[props.modelType]?.label?.();

--- a/src/frontend/src/pages/Index/Settings/UserSettings.tsx
+++ b/src/frontend/src/pages/Index/Settings/UserSettings.tsx
@@ -66,7 +66,8 @@ export default function UserSettings() {
               'SHOW_FULL_LOCATION_IN_TABLES',
               'SHOW_FULL_CATEGORY_IN_TABLES',
               'SHOW_BOM_SUBASSEMBLY_LEVELS',
-              'DISPLAY_ITEMS_FINAL_LEVEL'
+              'DISPLAY_ITEMS_FINAL_LEVEL',
+              'USE_TABLE_NAVIGATION'
             ]}
           />
         )


### PR DESCRIPTION
follow up to https://github.com/inventree/InvenTree/pull/12585

This adds a user setting to control the new behavior (by default it remains enabled). All the mechanisms still work with it disabled, the parameters are just not added to links / navigation actions by the specific user.

This - together with https://github.com/inventree/InvenTree/pull/12668 and https://github.com/inventree/InvenTree/issues/12661 - completes the immediate work I see to round off https://github.com/inventree/InvenTree/issues/12397. After https://github.com/inventree/InvenTree/pull/10715 is rewritten / worked in I will probably add one more PR to teach users about the new capability.