### PR TITLE
Fix table migration

### DIFF
--- a/src/backend/InvenTree/users/migrations/0016_remove_legacy_user_sessions_table.py
+++ b/src/backend/InvenTree/users/migrations/0016_remove_legacy_user_sessions_table.py
@@ -23,5 +23,5 @@ class Migration(migrations.Migration):
     dependencies = [('users', '0015_alter_userprofile_type')]
 
     operations = [
-        migrations.RunPython(remove_legacy_table, reverse_code=migrations.RunPython.noop)
+        migrations.RunPython(remove_legacy_table, reverse_code=migrations.RunPython.noop, atomic=False)
     ]


### PR DESCRIPTION
- Prevent error on MYSQL migration
- Follow-up to https://github.com/inventree/InvenTree/pull/12675

Error message on mysql:

```
  File "/opt/inventree/src/backend/InvenTree/users/migrations/0016_remove_legacy_user_sessions_table.py", line 19, in remove_legacy_table
    schema_editor.execute(f'DROP TABLE {table_name}')
  File "/opt/inventree/.venv/lib/python3.12/site-packages/django/db/backends/base/schema.py", line 184, in execute
    raise TransactionManagementError(
django.db.transaction.TransactionManagementError: Executing DDL statements while in a transaction on databases that can't perform a rollback is prohibited.
```