### PR TITLE
Fix Issue 9426 

### DIFF
--- a/src/frontend/src/tables/build/BuildLineTable.tsx
+++ b/src/frontend/src/tables/build/BuildLineTable.tsx
@@ -889,8 +889,13 @@ export default function BuildLineTable({
       <ActionButton
         key='auto-allocate'
         icon={<IconWand />}
-        tooltip={t`Auto Allocate Stock`}
-        hidden={!visible || hasOutput}
+        tooltip={
+          production
+            ? t`Auto Allocate Stock`
+            : t`Build order must be issued before stock can be allocated`
+        }
+        hidden={!canEdit || !isActive || hasOutput}
+        disabled={!production}
         color='blue'
         onClick={() => {
           setAutoAllocateInitialData({
@@ -969,6 +974,7 @@ export default function BuildLineTable({
     build,
     buildStatus,
     hasOutput,
+    isActive,
     table.hasSelectedRecords,
     table.selectedRecords
   ]);


### PR DESCRIPTION
## What does this PR do?

This PR updates the Auto Allocate Stock button for build orders that have not yet been issued. Instead of hiding the button, it is now disabled, and hovering over it displays a tooltip explaining that the build order must be issued before stock can be allocated.

## Why was this PR needed?

Prior to this fix, the Auto Allocate Stock button was hidden when a build order had not been issued, giving users no indication of why the action was unavailable. Keeping the button visible with a tooltip makes the required next step clearer. 

## What are the relevant issue numbers?

Closes #9426 

## Screenshots

### Disabled Auto Allocate Stock button functionality
<img width="1917" height="967" alt="Disabled Button Build Order" src="https://github.com/user-attachments/assets/cd8fd12b-4d22-4584-bfe7-996ee95b1603" />
<img width="1915" height="963" alt="Disabled Button Build Order With Mouse Hovering" src="https://github.com/user-attachments/assets/5110c438-f7e1-4273-a74a-aa76e2cddd43" />

### Enabled Auto Allocate Stock button still works the same
<img width="1914" height="961" alt="Production Build Order Displaying Auto Allocate Button" src="https://github.com/user-attachments/assets/99752f04-1bf7-4173-89bd-73862689235b" />


## Does this PR meet the acceptance criteria?

- [ ] Tests added for new/changed behavior
- [X] All tests passing
- [X] Follows project style guide
- [X] No breaking changes introduced
- [ ] Documentation updated 