### PR TITLE
Fix PurchaseOrderExtraLine admin search and add search fields across admin classes

### DIFF
--- a/src/backend/InvenTree/company/admin.py
+++ b/src/backend/InvenTree/company/admin.py
@@ -61,6 +61,8 @@ class SupplierPriceBreakAdmin(admin.ModelAdmin):
 
     list_display = ('part', 'quantity', 'price')
 
+    search_fields = ['part__SKU', 'part__part__name', 'part__supplier__name']
+
     autocomplete_fields = ('part',)
 
 

--- a/src/backend/InvenTree/order/admin.py
+++ b/src/backend/InvenTree/order/admin.py
@@ -110,6 +110,8 @@ class PurchaseOrderLineItemAdmin(admin.ModelAdmin):
 class PurchaseOrderExtraLineAdmin(GeneralExtraLineAdmin, admin.ModelAdmin):
     """Admin class for the PurchaseOrderExtraLine model."""
 
+    search_fields = ['order__reference', 'order__supplier__name', 'reference']
+
 
 @admin.register(models.SalesOrderLineItem)
 class SalesOrderLineItemAdmin(admin.ModelAdmin):

--- a/src/backend/InvenTree/part/admin.py
+++ b/src/backend/InvenTree/part/admin.py
@@ -111,6 +111,10 @@ class PartSellPriceBreakAdmin(admin.ModelAdmin):
 
     list_display = ('part', 'quantity', 'price')
 
+    search_fields = ['part__name', 'part__IPN']
+
+    autocomplete_fields = ('part',)
+
 
 @admin.register(models.PartInternalPriceBreak)
 class PartInternalPriceBreakAdmin(admin.ModelAdmin):
@@ -122,5 +126,7 @@ class PartInternalPriceBreakAdmin(admin.ModelAdmin):
         model = models.PartInternalPriceBreak
 
     list_display = ('part', 'quantity', 'price')
+
+    search_fields = ['part__name', 'part__IPN']
 
     autocomplete_fields = ('part',)

--- a/src/backend/InvenTree/users/admin.py
+++ b/src/backend/InvenTree/users/admin.py
@@ -20,6 +20,14 @@ class ApiTokenAdmin(admin.ModelAdmin):
 
     list_display = ('token', 'user', 'name', 'expiry', 'active')
     list_filter = ('user', 'revoked')
+    search_fields = [
+        'name',
+        'user__username',
+        'user__first_name',
+        'user__last_name',
+        'user__email',
+    ]
+    autocomplete_fields = ('user',)
     fields = (
         'token',
         'user',


### PR DESCRIPTION
### Summary
This PR fixes a `FieldError` crash in the Django admin interface and adds missing `search_fields` and `autocomplete_fields` to improve administrative usability:

1. **Fix `PurchaseOrderExtraLineAdmin` search crash (`order/admin.py`):**
   - `PurchaseOrderExtraLineAdmin` inherited `GeneralExtraLineAdmin` with `search_fields` referencing `order__customer__name`. Because `PurchaseOrder` models use `supplier` instead of `customer`, performing a search caused a backend `FieldError` crash.
   - Overrode `search_fields` in `PurchaseOrderExtraLineAdmin` to search `order__supplier__name`.

2. **Add `search_fields` and `autocomplete_fields`:**
   - **`SupplierPriceBreakAdmin` (`company/admin.py`):** Added `search_fields` (`part__SKU`, `part__part__name`, `part__supplier__name`).
   - **`PartSellPriceBreakAdmin` (`part/admin.py`):** Added `search_fields` (`part__name`, `part__IPN`) and `autocomplete_fields = ('part',)`.
   - **`PartInternalPriceBreakAdmin` (`part/admin.py`):** Added `search_fields` (`part__name`, `part__IPN`).
   - **`ApiTokenAdmin` (`users/admin.py`):** Added `search_fields` (`name`, `user__username`, `user__first_name`, `user__last_name`, `user__email`) and `autocomplete_fields = ('user',)`.
