### PR TITLE
Add Chinese (zh_Hans) translations and fix media file access for single-machine deployment

### DIFF
--- a/src/backend/InvenTree/InvenTree/middleware.py
+++ b/src/backend/InvenTree/InvenTree/middleware.py
@@ -84,6 +84,9 @@ paths_own_security = [
     ensure_slashes(
         settings.FRONTEND_URL_BASE
     ),  # Frontend files - frontend paths have their own security model
+    ensure_slashes(
+        settings.MEDIA_URL
+    ),  # Media files - served with DRF token / session auth in single-machine mode
 ]
 """Paths that handle their own security model."""
 pages_mfa_bypass = [

--- a/src/backend/InvenTree/InvenTree/urls.py
+++ b/src/backend/InvenTree/InvenTree/urls.py
@@ -167,13 +167,27 @@ urlpatterns += platform_urls
 if settings.PLUGINS_ENABLED:
     urlpatterns.append(get_plugin_urls())
 
-# Server running in "DEBUG" mode?
+# Static file access (only in DEBUG mode; production uses collectstatic + web server)
 if settings.DEBUG:
-    # Static file access
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
-    # Media file access
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+# Media file access - always serve (single-machine deployment without reverse proxy)
+# Auth is handled by AuthRequiredMiddleware + DRF token/session auth
+from django.views.static import serve as media_serve
+
+media_url = settings.MEDIA_URL.lstrip('/')
+media_root = settings.MEDIA_ROOT
+if not media_url:
+    media_url = 'media/'
+
+urlpatterns += [
+    re_path(
+        r'^media/(?P<path>.*)$',
+        media_serve,
+        {'document_root': media_root},
+        name='media-serve',
+    ),
+]
 
 # Redirect for favicon.ico
 urlpatterns.append(

--- a/src/backend/InvenTree/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/src/backend/InvenTree/locale/zh_Hans/LC_MESSAGES/django.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: inventree\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-27 05:02+0000\n"
-"PO-Revision-Date: 2026-08-27 05:05\n"
+"POT-Creation-Date: 2026-08-10 13:25+0000\n"
+"PO-Revision-Date: 2026-08-10 13:27\n"
 "Last-Translator: \n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
@@ -51,9 +51,9 @@ msgstr "此字段的值必须是唯一的。"
 
 #: InvenTree/api.py:614
 msgid "Item no longer matches the provided criteria"
-msgstr ""
+msgstr "项目不再符合提供的条件"
 
-#: InvenTree/api.py:864 InvenTree/models.py:1459
+#: InvenTree/api.py:861 InvenTree/models.py:1459
 msgid "User does not have permission to view this model"
 msgstr "用户没有权限查阅当前模型。"
 
@@ -92,14 +92,14 @@ msgid "Could not convert {original} to {unit}"
 msgstr "不能将 {original} 转换到 {unit}"
 
 #: InvenTree/conversion.py:289 InvenTree/conversion.py:303
-#: InvenTree/helpers.py:627 order/models.py:822 order/models.py:1107
-#: part/models.py:3847 stock/models.py:2114
+#: InvenTree/helpers.py:627 order/models.py:814 order/models.py:1146
+#: part/models.py:3845 stock/models.py:2114
 msgid "Invalid quantity provided"
 msgstr "提供的数量无效"
 
 #: InvenTree/exceptions.py:128
 msgid "Server is temporarily reloading, please retry the request"
-msgstr ""
+msgstr "服务器正在临时重载，请重试请求"
 
 #: InvenTree/exceptions.py:161
 msgid "Error details can be found in the admin panel"
@@ -115,9 +115,9 @@ msgstr "无效的数值"
 
 #: InvenTree/fields.py:286 InvenTree/models.py:1365 build/serializers.py:530
 #: build/serializers.py:591 build/serializers.py:1775 company/models.py:828
-#: order/models.py:2154
+#: order/models.py:2225
 #: report/templates/report/inventree_build_order_report.html:172
-#: stock/models.py:3785 stock/models.py:3911 stock/serializers.py:753
+#: stock/models.py:3780 stock/models.py:3906 stock/serializers.py:753
 #: stock/serializers.py:935 stock/serializers.py:1114 stock/serializers.py:1280
 #: stock/serializers.py:1664 stock/serializers.py:1753
 #: stock/serializers.py:1962
@@ -281,18 +281,18 @@ msgstr "参考编号过大"
 msgid "Invalid choice"
 msgstr "无效选项"
 
-#: InvenTree/models.py:1099 common/models.py:1455 common/models.py:1891
-#: common/models.py:2327 common/models.py:2452 common/models.py:2762
+#: InvenTree/models.py:1099 common/models.py:1455 common/models.py:1889
+#: common/models.py:2325 common/models.py:2450 common/models.py:2760
 #: common/serializers.py:681 generic/states/serializers.py:20
 #: machine/models.py:28 part/models.py:1119 plugin/models.py:54
 #: report/models.py:222 stock/models.py:89
 msgid "Name"
 msgstr "名称"
 
-#: InvenTree/models.py:1105 build/models.py:274 common/models.py:180
-#: common/models.py:2459 common/models.py:2600 common/models.py:2777
-#: company/models.py:563 company/models.py:819 order/models.py:508
-#: order/models.py:2199 part/models.py:1142 report/models.py:228
+#: InvenTree/models.py:1105 build/models.py:266 common/models.py:180
+#: common/models.py:2457 common/models.py:2598 common/models.py:2775
+#: company/models.py:563 company/models.py:819 order/models.py:500
+#: order/models.py:2270 part/models.py:1142 report/models.py:228
 #: report/models.py:872 report/models.py:898
 #: report/templates/report/inventree_build_order_report.html:117
 #: stock/models.py:95
@@ -303,7 +303,7 @@ msgstr "描述"
 msgid "Description (optional)"
 msgstr "描述（选填）"
 
-#: InvenTree/models.py:1121 common/models.py:3135
+#: InvenTree/models.py:1121 common/models.py:3133
 msgid "Path"
 msgstr "路径"
 
@@ -343,82 +343,82 @@ msgstr "服务器错误"
 msgid "An error has been logged by the server."
 msgstr "服务器记录了一个错误。"
 
-#: InvenTree/models.py:1660 common/models.py:1802
+#: InvenTree/models.py:1660 common/models.py:1800
 #: report/templates/report/inventree_bill_of_materials_report.html:126
 #: report/templates/report/inventree_bill_of_materials_report.html:148
 #: report/templates/report/inventree_return_order_report.html:35
 msgid "Image"
 msgstr "图像"
 
-#: InvenTree/serializers.py:554
+#: InvenTree/serializers.py:545
 msgid "Must be a valid number"
 msgstr "必须是有效数字"
 
-#: InvenTree/serializers.py:596 company/models.py:217 part/models.py:3215
+#: InvenTree/serializers.py:587 company/models.py:217 part/models.py:3215
 msgid "Currency"
 msgstr "货币"
 
-#: InvenTree/serializers.py:599 part/serializers.py:1389
+#: InvenTree/serializers.py:590 part/serializers.py:1389
 msgid "Select currency from available options"
 msgstr "从可用选项中选择货币"
 
-#: InvenTree/serializers.py:945
+#: InvenTree/serializers.py:936
 msgid "This field may not be null."
 msgstr "此字段不能为空。"
 
-#: InvenTree/serializers.py:951
+#: InvenTree/serializers.py:942
 msgid "Invalid value"
 msgstr "无效值"
 
-#: InvenTree/serializers.py:1106
+#: InvenTree/serializers.py:1097
 msgid "Invalid content type format"
 msgstr "无效的内容类型格式"
 
-#: InvenTree/serializers.py:1109
+#: InvenTree/serializers.py:1100
 msgid "Content type not found"
 msgstr "未找到内容类型"
 
-#: InvenTree/serializers.py:1115
+#: InvenTree/serializers.py:1106
 msgid "Content type does not match required mixin class"
 msgstr "内容类型不匹配所需的 mixin 类"
 
-#: InvenTree/serializers.py:1132
+#: InvenTree/serializers.py:1123
 msgid "Copy Parameters"
 msgstr "复制参数"
 
-#: InvenTree/serializers.py:1133
+#: InvenTree/serializers.py:1124
 msgid "Copy parameters from the original item"
 msgstr "从原始条目复制参数"
 
-#: InvenTree/serializers.py:1138
+#: InvenTree/serializers.py:1129
 msgid "Copy Lines"
 msgstr "复制行"
 
-#: InvenTree/serializers.py:1139
+#: InvenTree/serializers.py:1130
 msgid "Copy line items from the original order"
 msgstr "从原始订单复制行项目"
 
-#: InvenTree/serializers.py:1144
+#: InvenTree/serializers.py:1135
 msgid "Copy Extra Lines"
 msgstr "复制额外行"
 
-#: InvenTree/serializers.py:1145
+#: InvenTree/serializers.py:1136
 msgid "Copy extra line items from the original order"
 msgstr "从原始订单复制额外的行项目"
 
-#: InvenTree/serializers.py:1169
+#: InvenTree/serializers.py:1160
 msgid "Duplication Options"
 msgstr "复制选项"
 
-#: InvenTree/serializers.py:1171
+#: InvenTree/serializers.py:1162
 msgid "Specify options for duplicating this item"
 msgstr "指定该条目的克隆选项"
 
-#: InvenTree/serializers.py:1209
+#: InvenTree/serializers.py:1200
 msgid "Original"
 msgstr "原始条目"
 
-#: InvenTree/serializers.py:1210
+#: InvenTree/serializers.py:1201
 msgid "Select instance to duplicate"
 msgstr "选择要克隆的实例"
 
@@ -582,40 +582,40 @@ msgstr "有可用更新"
 msgid "An update for InvenTree is available"
 msgstr "InvenTree有可用更新"
 
-#: InvenTree/validators.py:36 InvenTree/validators.py:41
+#: InvenTree/validators.py:28
 msgid "Invalid physical unit"
 msgstr "无效的物理单位"
 
-#: InvenTree/validators.py:47
+#: InvenTree/validators.py:34
 msgid "Not a valid currency code"
 msgstr "无效的货币代码"
 
-#: build/api.py:57 order/api.py:128 order/api.py:297 order/api.py:1537
+#: build/api.py:57 order/api.py:119 order/api.py:288 order/api.py:1467
 #: order/serializers.py:99
 msgid "Order Status"
 msgstr "订单状态"
 
-#: build/api.py:83 build/models.py:286
+#: build/api.py:83 build/models.py:278
 msgid "Parent Build"
 msgstr "父级生产订单"
 
-#: build/api.py:87 build/api.py:1070 order/api.py:612 order/api.py:852
-#: order/api.py:1329 order/api.py:1641 order/api.py:1958 order/api.py:2168
+#: build/api.py:87 build/api.py:1055 order/api.py:565 order/api.py:804
+#: order/api.py:1259 order/api.py:1571 order/api.py:1867 order/api.py:2057
 #: stock/api.py:632
 msgid "Include Variants"
 msgstr "包含变体"
 
-#: build/api.py:103 build/api.py:490 build/api.py:1084 build/models.py:292
+#: build/api.py:103 build/api.py:490 build/api.py:1069 build/models.py:284
 #: build/serializers.py:1200 build/serializers.py:1376
 #: build/serializers.py:1469 company/models.py:1038 company/serializers.py:473
-#: order/api.py:325 order/api.py:329 order/api.py:1009 order/api.py:1342
-#: order/api.py:1345 order/api.py:2181 order/api.py:2184 order/api.py:2338
-#: order/models.py:2331 order/models.py:2499 order/models.py:2500
-#: order/models.py:4021 order/models.py:4022 part/api.py:1179 part/api.py:1182
+#: order/api.py:316 order/api.py:320 order/api.py:961 order/api.py:1272
+#: order/api.py:1275 order/api.py:2070 order/api.py:2073 order/api.py:2227
+#: order/models.py:2402 order/models.py:2570 order/models.py:2571
+#: order/models.py:4195 order/models.py:4196 part/api.py:1179 part/api.py:1182
 #: part/api.py:1399 part/models.py:530 part/models.py:3226 part/models.py:3369
 #: part/models.py:3427 part/models.py:3449 part/models.py:3471
-#: part/models.py:3612 part/models.py:3941 part/models.py:4395
-#: part/serializers.py:1338 part/serializers.py:2015
+#: part/models.py:3612 part/models.py:3939 part/models.py:4377
+#: part/serializers.py:1338 part/serializers.py:2004
 #: report/templates/report/inventree_bill_of_materials_report.html:110
 #: report/templates/report/inventree_bill_of_materials_report.html:137
 #: report/templates/report/inventree_build_order_report.html:109
@@ -638,7 +638,7 @@ msgstr "零件"
 
 #: build/api.py:123 build/api.py:126 build/serializers.py:1483 part/api.py:1012
 #: part/api.py:1410 part/models.py:414 part/models.py:1160 part/models.py:3499
-#: part/serializers.py:1348 part/serializers.py:1786 stock/api.py:923
+#: part/serializers.py:1348 part/serializers.py:1775 stock/api.py:923
 msgid "Category"
 msgstr "类别"
 
@@ -646,7 +646,7 @@ msgstr "类别"
 msgid "Ancestor Build"
 msgstr "可测试部分"
 
-#: build/api.py:155 order/api.py:146
+#: build/api.py:155 order/api.py:137
 msgid "Assigned to me"
 msgstr "分配给我"
 
@@ -694,11 +694,11 @@ msgstr "完成日期早于"
 msgid "Completed after"
 msgstr "完成日期晚于"
 
-#: build/api.py:252 order/api.py:251
+#: build/api.py:252 order/api.py:242
 msgid "Min Date"
 msgstr "最小日期"
 
-#: build/api.py:275 order/api.py:270
+#: build/api.py:275 order/api.py:261
 msgid "Max Date"
 msgstr "最大日期"
 
@@ -711,16 +711,16 @@ msgid "Build must be cancelled before it can be deleted"
 msgstr "生产订单必须取消后才能删除"
 
 #: build/api.py:460 build/serializers.py:1410 part/models.py:1327
-#: part/models.py:3983
+#: part/models.py:3981
 msgid "Consumable"
 msgstr "耗材"
 
-#: build/api.py:476 build/serializers.py:1413 part/models.py:3977
+#: build/api.py:476 build/serializers.py:1413 part/models.py:3975
 msgid "Optional"
 msgstr "可选项"
 
 #: build/api.py:479 build/serializers.py:1455 common/setting/system.py:476
-#: part/models.py:1275 part/serializers.py:1731 part/serializers.py:1757
+#: part/models.py:1275 part/serializers.py:1720 part/serializers.py:1746
 #: stock/api.py:698
 msgid "Assembly"
 msgstr "装配件"
@@ -733,16 +733,16 @@ msgstr "可追溯"
 msgid "Testable"
 msgstr "需检测"
 
-#: build/api.py:495 order/api.py:1073 order/api.py:1527 order/api.py:2402
+#: build/api.py:495 order/api.py:1025 order/api.py:1457 order/api.py:2291
 msgid "Order Outstanding"
 msgstr "未结算订单"
 
-#: build/api.py:505 build/serializers.py:1512 order/api.py:1032
-#: order/api.py:2361
+#: build/api.py:505 build/serializers.py:1512 order/api.py:984
+#: order/api.py:2250
 msgid "Allocated"
 msgstr "已分配"
 
-#: build/api.py:530 build/models.py:2225 build/serializers.py:1429
+#: build/api.py:530 build/models.py:2268 build/serializers.py:1429
 msgid "Consumed"
 msgstr "已消耗"
 
@@ -755,7 +755,7 @@ msgstr "可用数量"
 
 #: build/api.py:580 build/serializers.py:1514 company/serializers.py:447
 #: order/serializers.py:1409 order/serializers.py:2727 part/serializers.py:844
-#: part/serializers.py:1199 part/serializers.py:1795
+#: part/serializers.py:1199 part/serializers.py:1784
 msgid "On Order"
 msgstr "已订购"
 
@@ -763,17 +763,17 @@ msgstr "已订购"
 msgid "Build not found"
 msgstr "未找到版本"
 
-#: build/api.py:1107 build/models.py:129 order/models.py:2364
+#: build/api.py:1092 build/models.py:121 order/models.py:2435
 #: report/templates/report/inventree_build_order_report.html:105
 #: stock/serializers.py:98 templates/email/build_order_completed.html:16
 #: templates/email/overdue_build_order.html:15
 msgid "Build Order"
 msgstr "生产订单"
 
-#: build/api.py:1121 build/api.py:1125 build/serializers.py:412
+#: build/api.py:1106 build/api.py:1110 build/serializers.py:412
 #: build/serializers.py:518 build/serializers.py:569 build/serializers.py:1250
-#: build/serializers.py:1256 order/api.py:1389 order/api.py:1394
-#: order/api.py:2220 order/api.py:2225 order/serializers.py:867
+#: build/serializers.py:1256 order/api.py:1319 order/api.py:1324
+#: order/api.py:2109 order/api.py:2114 order/serializers.py:867
 #: order/serializers.py:1007 order/serializers.py:2294 part/serializers.py:1358
 #: stock/api.py:1038 stock/serializers.py:116 stock/serializers.py:626
 #: stock/serializers.py:746 stock/serializers.py:930 stock/serializers.py:1039
@@ -784,53 +784,53 @@ msgstr "生产订单"
 msgid "Location"
 msgstr "库存位置"
 
-#: build/api.py:1133 part/serializers.py:1383
+#: build/api.py:1118 part/serializers.py:1383
 msgid "Output"
 msgstr "产出"
 
-#: build/api.py:1135
+#: build/api.py:1120
 msgid "Filter by output stock item ID. Use 'null' to find uninstalled build items."
 msgstr "按产出库存项ID筛选，使用“null”查找未安装的生产项。"
 
-#: build/models.py:130 users/ruleset.py:48
+#: build/models.py:122 users/ruleset.py:34
 msgid "Build Orders"
 msgstr "生产订单"
 
-#: build/models.py:190
+#: build/models.py:182
 msgid "Assembly BOM has not been validated"
 msgstr "装配物料清单尚未验证"
 
-#: build/models.py:197
+#: build/models.py:189
 msgid "Build order cannot be created for an inactive part"
 msgstr "无法为未激活的零件创建生产订单"
 
-#: build/models.py:204
+#: build/models.py:196
 msgid "Build order cannot be created for an unlocked part"
 msgstr "无法为已解锁的零件创建生产订单"
 
-#: build/models.py:222
+#: build/models.py:214
 msgid "Build orders can only be externally fulfilled for purchaseable parts"
 msgstr "生产订单仅能通过外部采购可购买零件来完成"
 
-#: build/models.py:229 order/models.py:422
+#: build/models.py:221 order/models.py:414
 msgid "Responsible user or group must be specified"
 msgstr "必须指定负责的用户或组"
 
-#: build/models.py:234
+#: build/models.py:226
 msgid "Build order part cannot be changed"
 msgstr "生产订单关联零件不可变更"
 
-#: build/models.py:239 order/models.py:440
+#: build/models.py:231 order/models.py:432
 msgid "Target date must be after start date"
 msgstr "目标日期必须在开始日期之后"
 
-#: build/models.py:267
+#: build/models.py:259
 msgid "Build Order Reference"
 msgstr "生产订单编号"
 
-#: build/models.py:268 build/serializers.py:1407 order/models.py:721
-#: order/models.py:1440 order/models.py:2147 order/models.py:3294
-#: order/models.py:3736 part/models.py:4033
+#: build/models.py:260 build/serializers.py:1407 order/models.py:713
+#: order/models.py:1479 order/models.py:2218 order/models.py:3365
+#: order/models.py:3844 part/models.py:4021
 #: report/templates/report/inventree_bill_of_materials_report.html:139
 #: report/templates/report/inventree_purchase_order_report.html:35
 #: report/templates/report/inventree_return_order_report.html:26
@@ -839,237 +839,237 @@ msgstr "生产订单编号"
 msgid "Reference"
 msgstr "编号"
 
-#: build/models.py:277
+#: build/models.py:269
 msgid "Brief description of the build (optional)"
 msgstr "生产订单的简要说明（可选）"
 
-#: build/models.py:287
+#: build/models.py:279
 msgid "Build Order to which this build is allocated"
 msgstr "该生产订单所属的上级生产订单"
 
-#: build/models.py:296
+#: build/models.py:288
 msgid "Select part to build"
 msgstr "选择要生产的零件"
 
-#: build/models.py:301
+#: build/models.py:293
 msgid "Sales Order Reference"
 msgstr "销售订单编号"
 
-#: build/models.py:306
+#: build/models.py:298
 msgid "Sales Order to which this build is allocated"
 msgstr "该生产订单关联的销售订单"
 
-#: build/models.py:311 build/serializers.py:1061 order/models.py:3756
+#: build/models.py:303 build/serializers.py:1061 order/models.py:3864
 #: order/serializers.py:2033
 msgid "Source Location"
 msgstr "源库位"
 
-#: build/models.py:317
+#: build/models.py:309
 msgid "Select location to take stock from for this build (leave blank to take from any stock location)"
 msgstr "指定本次生产领料的来源库位（留空可从任意库位调拨）"
 
-#: build/models.py:323
+#: build/models.py:315
 msgid "External Build"
 msgstr "外协生产"
 
-#: build/models.py:324
+#: build/models.py:316
 msgid "This build order is fulfilled externally"
 msgstr "该生产订单由外部供应商完成"
 
-#: build/models.py:329 order/models.py:3766
+#: build/models.py:321 order/models.py:3874
 msgid "Destination Location"
 msgstr "目标库位"
 
-#: build/models.py:334
+#: build/models.py:326
 msgid "Select location where the completed items will be stored"
 msgstr "选择生产完成品的存放库位"
 
-#: build/models.py:338
+#: build/models.py:330
 msgid "Build Quantity"
 msgstr "生产数量"
 
-#: build/models.py:341
+#: build/models.py:333
 msgid "Number of stock items to build"
 msgstr "需要生产的库存品数量"
 
-#: build/models.py:345
+#: build/models.py:337
 msgid "Completed items"
 msgstr "已完成项目"
 
-#: build/models.py:347
+#: build/models.py:339
 msgid "Number of stock items which have been completed"
 msgstr "已完成并入库的库存物品数量"
 
-#: build/models.py:351
+#: build/models.py:343
 msgid "Build Status"
 msgstr "生产状态"
 
-#: build/models.py:356
+#: build/models.py:348
 msgid "Build status code"
 msgstr "生产状态代码"
 
-#: build/models.py:365 build/serializers.py:399 order/serializers.py:883
+#: build/models.py:357 build/serializers.py:399 order/serializers.py:883
 #: stock/models.py:1239 stock/serializers.py:90 stock/serializers.py:1920
 msgid "Batch Code"
 msgstr "批号"
 
-#: build/models.py:369 build/serializers.py:400
+#: build/models.py:361 build/serializers.py:400
 msgid "Batch code for this build output"
 msgstr "本批产出的批次编号"
 
-#: build/models.py:373 order/models.py:545 order/serializers.py:164
+#: build/models.py:365 order/models.py:537 order/serializers.py:164
 #: part/models.py:1362 stock/models.py:1320
 msgid "Creation Date"
 msgstr "建立日期"
 
-#: build/models.py:379
+#: build/models.py:371
 msgid "Build start date"
 msgstr "生产开始日期"
 
-#: build/models.py:380
+#: build/models.py:372
 msgid "Scheduled start date for this build order"
 msgstr "此生产订单的计划开始日期"
 
-#: build/models.py:386
+#: build/models.py:378
 msgid "Target completion date"
 msgstr "计划完成日期"
 
-#: build/models.py:388
+#: build/models.py:380
 msgid "Target date for build completion. Build will be overdue after this date."
 msgstr "生产订单的计划完成时间，逾期后系统将标记为超期。"
 
-#: build/models.py:393 order/models.py:769 order/models.py:3333
-#: order/models.py:3785
+#: build/models.py:385 order/models.py:761 order/models.py:3404
+#: order/models.py:3893
 msgid "Completion Date"
 msgstr "完成日期"
 
-#: build/models.py:401
+#: build/models.py:393
 msgid "completed by"
 msgstr "完成人"
 
-#: build/models.py:410
+#: build/models.py:402
 msgid "Issued by"
 msgstr "发起人"
 
-#: build/models.py:411
+#: build/models.py:403
 msgid "User who issued this build order"
 msgstr "创建该生产订单的用户"
 
-#: build/models.py:428 common/models.py:195 order/api.py:196
-#: order/models.py:577 part/models.py:1379
+#: build/models.py:420 common/models.py:195 order/api.py:187
+#: order/models.py:569 part/models.py:1379
 #: report/templates/report/inventree_build_order_report.html:158
 msgid "Responsible"
 msgstr "责任方"
 
-#: build/models.py:429
+#: build/models.py:421
 msgid "User or group responsible for this build order"
 msgstr "该生产订单的责任人或责任团队"
 
-#: build/models.py:434 stock/models.py:1232
+#: build/models.py:426 stock/models.py:1232
 msgid "External Link"
 msgstr "外部链接"
 
-#: build/models.py:436 common/models.py:2148 part/models.py:1194
+#: build/models.py:428 common/models.py:2146 part/models.py:1194
 #: stock/models.py:1234
 msgid "Link to external URL"
 msgstr "指向外部资源的URL链接"
 
-#: build/models.py:441
+#: build/models.py:433
 msgid "Build Priority"
 msgstr "生产优先级"
 
-#: build/models.py:444
+#: build/models.py:436
 msgid "Priority of this build order"
 msgstr "此生产订单的优先级"
 
-#: build/models.py:452 common/models.py:159 common/models.py:173
-#: order/api.py:182 order/models.py:517 order/models.py:2179
+#: build/models.py:444 common/models.py:159 common/models.py:173
+#: order/api.py:173 order/models.py:509 order/models.py:2250
 msgid "Project Code"
 msgstr "项目编号"
 
-#: build/models.py:453
+#: build/models.py:445
 msgid "Project code for this build order"
 msgstr "该生产订单归属的项目编号"
 
-#: build/models.py:997
+#: build/models.py:1002
 msgid "Cannot complete build order with open child builds"
 msgstr "无法完成生产订单，存在未关闭的子生产订单"
 
-#: build/models.py:1002
+#: build/models.py:1007
 msgid "Cannot complete build order with incomplete outputs"
 msgstr "无法完成生产订单，存在未完成的产出项"
 
-#: build/models.py:1143
+#: build/models.py:1186
 msgid "Serial numbers must be provided for trackable parts"
 msgstr "可追溯零件必须填写序列号"
 
-#: build/models.py:1235 build/models.py:1321
+#: build/models.py:1278 build/models.py:1364
 msgid "No build output specified"
 msgstr "未指定产出"
 
-#: build/models.py:1238
+#: build/models.py:1281
 msgid "Build output is already completed"
 msgstr "产出已完成"
 
-#: build/models.py:1241 build/models.py:1330 build/models.py:1408
+#: build/models.py:1284 build/models.py:1373 build/models.py:1451
 msgid "Build output does not match Build Order"
 msgstr "产出与生产订单不匹配"
 
-#: build/models.py:1327 build/models.py:1405
+#: build/models.py:1370 build/models.py:1448
 msgid "Build output has already been completed"
-msgstr ""
+msgstr "构建输出已完成"
 
-#: build/models.py:1337 build/models.py:1438 build/serializers.py:321
+#: build/models.py:1380 build/models.py:1481 build/serializers.py:321
 #: build/serializers.py:375 build/serializers.py:918 build/serializers.py:1726
-#: order/models.py:819 order/serializers.py:643 order/serializers.py:878
-#: part/models.py:3831 stock/models.py:1079 stock/models.py:1504
+#: order/models.py:811 order/serializers.py:643 order/serializers.py:878
+#: part/models.py:3829 stock/models.py:1079 stock/models.py:1504
 #: stock/models.py:1588 stock/models.py:1906 stock/models.py:2117
 #: stock/models.py:2440 stock/serializers.py:724 stock/serializers.py:1030
 #: stock/serializers.py:1092 stock/serializers.py:1909
 msgid "Quantity must be greater than zero"
 msgstr "数量必须大于零"
 
-#: build/models.py:1341 build/models.py:1443 build/serializers.py:326
+#: build/models.py:1384 build/models.py:1486 build/serializers.py:326
 msgid "Quantity cannot be greater than the output quantity"
 msgstr "数量不能大于产出数量"
 
-#: build/models.py:1417
+#: build/models.py:1460
 msgid "Build output has not passed all required tests"
 msgstr "产出未通过所有必要测试"
 
-#: build/models.py:1425
+#: build/models.py:1468
 msgid "Allocated stock items are still in production"
 msgstr "已分配的库存物料仍在生产中"
 
-#: build/models.py:1432
+#: build/models.py:1475
 msgid "Cannot partially complete a build output with allocated items"
 msgstr "存在已分配物料时无法部分完成生产输出"
 
-#: build/models.py:1615 order/models.py:4208 order/serializers.py:1997
+#: build/models.py:1658 order/models.py:4382 order/serializers.py:1997
 #: order/serializers.py:2848 stock/models.py:1494 stock/models.py:1898
 #: stock/models.py:2121 stock/models.py:2444 stock/models.py:2738
 msgid "Stock item no longer exists"
-msgstr ""
+msgstr "库存项目已不存在"
 
-#: build/models.py:1633 build/serializers.py:966 order/serializers.py:1775
+#: build/models.py:1676 build/serializers.py:966 order/serializers.py:1775
 #: order/serializers.py:2804
 #, python-brace-format
 msgid "Available quantity ({q}) exceeded"
 msgstr "可用量 ({q}) 超出限制"
 
-#: build/models.py:2179
+#: build/models.py:2222
 msgid "Build Order Line Item"
 msgstr "生产订单行项目"
 
-#: build/models.py:2204
+#: build/models.py:2247
 msgid "Build object"
 msgstr "生产对象"
 
-#: build/models.py:2216 build/models.py:2496 build/serializers.py:307
+#: build/models.py:2259 build/models.py:2539 build/serializers.py:307
 #: build/serializers.py:360 build/serializers.py:1428 common/models.py:1379
-#: order/models.py:2110 order/models.py:3185 order/models.py:4175
+#: order/models.py:2181 order/models.py:3256 order/models.py:4349
 #: order/serializers.py:1884 order/serializers.py:2388
-#: order/serializers.py:2974 part/models.py:3383 part/models.py:3971
+#: order/serializers.py:2974 part/models.py:3383 part/models.py:3969
 #: report/templates/report/inventree_bill_of_materials_report.html:138
 #: report/templates/report/inventree_build_order_report.html:113
 #: report/templates/report/inventree_purchase_order_report.html:36
@@ -1089,40 +1089,40 @@ msgstr "生产对象"
 msgid "Quantity"
 msgstr "数量"
 
-#: build/models.py:2217
+#: build/models.py:2260
 msgid "Required quantity for build order"
 msgstr "生产订单所需数量"
 
-#: build/models.py:2226
+#: build/models.py:2269
 msgid "Quantity of consumed stock"
 msgstr "库存消耗量"
 
-#: build/models.py:2327
+#: build/models.py:2370
 msgid "Build item must specify a build output, as master part is marked as trackable"
 msgstr "生产项必须指定产出，因为主零件已经被标记为可追踪的"
 
-#: build/models.py:2390 build/serializers.py:949
+#: build/models.py:2433 build/serializers.py:949
 msgid "Selected stock item does not match BOM line"
 msgstr "所选库存项与物料清单行项不匹配"
 
-#: build/models.py:2409
+#: build/models.py:2452
 msgid "Allocated quantity must be greater than zero"
 msgstr "分配的数量必须大于零"
 
-#: build/models.py:2415
+#: build/models.py:2458
 msgid "Quantity must be 1 for serialized stock"
 msgstr "序列化物料的数量必须为1"
 
-#: build/models.py:2425
+#: build/models.py:2468
 #, python-brace-format
 msgid "Allocated quantity ({q}) must not exceed available stock quantity ({a})"
 msgstr "分配数量 ({q}) 不得超过可用库存数量 ({a})"
 
-#: build/models.py:2442 order/models.py:3134 order/models.py:4139
+#: build/models.py:2485 order/models.py:3205 order/models.py:4313
 msgid "Stock item is over-allocated"
 msgstr "库存品项超额分配"
 
-#: build/models.py:2486 build/serializers.py:901 build/serializers.py:1217
+#: build/models.py:2529 build/serializers.py:901 build/serializers.py:1217
 #: order/serializers.py:1712 order/serializers.py:1733
 #: order/serializers.py:2750 order/serializers.py:2771
 #: report/templates/report/inventree_sales_order_shipment_report.html:29
@@ -1131,19 +1131,19 @@ msgstr "库存品项超额分配"
 msgid "Stock Item"
 msgstr "库存项"
 
-#: build/models.py:2487
+#: build/models.py:2530
 msgid "Source stock item"
 msgstr "源库存项"
 
-#: build/models.py:2497
+#: build/models.py:2540
 msgid "Stock quantity to allocate to build"
 msgstr "分配给该生产任务的库存量"
 
-#: build/models.py:2506
+#: build/models.py:2549
 msgid "Install into"
 msgstr "安裝到"
 
-#: build/models.py:2507
+#: build/models.py:2550
 msgid "Destination stock item"
 msgstr "目标库存项"
 
@@ -1455,8 +1455,8 @@ msgstr "安裝到"
 msgid "Build"
 msgstr "生产"
 
-#: build/serializers.py:1288 company/models.py:641 order/api.py:338
-#: order/api.py:343 order/api.py:608 order/serializers.py:635
+#: build/serializers.py:1288 company/models.py:641 order/api.py:329
+#: order/api.py:334 order/api.py:561 order/serializers.py:635
 #: stock/models.py:1175 stock/serializers.py:593
 msgid "Supplier Part"
 msgstr "供应商零件"
@@ -1481,17 +1481,17 @@ msgstr "可追踪"
 msgid "Inherited"
 msgstr "已继承的"
 
-#: build/serializers.py:1425 part/models.py:4066
+#: build/serializers.py:1425 part/models.py:4054
 msgid "Allow Variants"
 msgstr "允许变体"
 
-#: build/serializers.py:1431 build/serializers.py:1437 part/models.py:3705
-#: part/models.py:4387 stock/api.py:936 stock/serializers.py:1014
+#: build/serializers.py:1431 build/serializers.py:1437 part/models.py:3703
+#: part/models.py:4369 stock/api.py:936 stock/serializers.py:1014
 msgid "BOM Item"
 msgstr "物料清单项"
 
 #: build/serializers.py:1515 order/serializers.py:1410
-#: order/serializers.py:2728 part/serializers.py:1203 part/serializers.py:1799
+#: order/serializers.py:2728 part/serializers.py:1203 part/serializers.py:1788
 msgid "In Production"
 msgstr "生产中"
 
@@ -1503,7 +1503,7 @@ msgstr "生产计划"
 msgid "External Stock"
 msgstr "外部库存"
 
-#: build/serializers.py:1521 part/serializers.py:1193 part/serializers.py:1862
+#: build/serializers.py:1521 part/serializers.py:1193 part/serializers.py:1851
 msgid "Available Stock"
 msgstr "可用库存"
 
@@ -1543,56 +1543,56 @@ msgstr "重复的订单行项目分配"
 msgid "At least one item or line must be provided"
 msgstr "必须提供至少一个物料项或行项目"
 
-#: build/status_codes.py:19 generic/states/tests.py:21
-#: generic/states/tests.py:131 order/status_codes.py:21
-#: order/status_codes.py:64 order/status_codes.py:100 order/status_codes.py:131
-#: order/status_codes.py:150
+#: build/status_codes.py:11 generic/states/tests.py:21
+#: generic/states/tests.py:131 order/status_codes.py:12
+#: order/status_codes.py:44 order/status_codes.py:77 order/status_codes.py:103
+#: order/status_codes.py:125
 msgid "Pending"
 msgstr "待生产"
 
-#: build/status_codes.py:20
+#: build/status_codes.py:12
 msgid "Production"
 msgstr "生产中"
 
-#: build/status_codes.py:21 order/status_codes.py:23 order/status_codes.py:67
-#: order/status_codes.py:102 order/status_codes.py:152
+#: build/status_codes.py:13 order/status_codes.py:14 order/status_codes.py:51
+#: order/status_codes.py:82 order/status_codes.py:127
 msgid "On Hold"
 msgstr "已暂停"
 
-#: build/status_codes.py:22 order/status_codes.py:25 order/status_codes.py:69
-#: order/status_codes.py:104 order/status_codes.py:154
+#: build/status_codes.py:14 order/status_codes.py:16 order/status_codes.py:53
+#: order/status_codes.py:85 order/status_codes.py:129
 msgid "Cancelled"
 msgstr "已取消"
 
-#: build/status_codes.py:23 generic/states/tests.py:23 importer/models.py:693
-#: importer/status_codes.py:23 order/status_codes.py:24
-#: order/status_codes.py:68 order/status_codes.py:103 order/status_codes.py:153
+#: build/status_codes.py:15 generic/states/tests.py:23 importer/models.py:693
+#: importer/status_codes.py:27 order/status_codes.py:15
+#: order/status_codes.py:52 order/status_codes.py:84 order/status_codes.py:128
 msgid "Complete"
 msgstr "完成"
 
-#: build/tasks.py:370
+#: build/tasks.py:350
 #, python-brace-format
 msgid "Build order {build} has been completed"
 msgstr "生产订单 {build} 已完成"
 
-#: build/tasks.py:376
+#: build/tasks.py:356
 msgid "A build order has been completed"
 msgstr "生产订单已完成"
 
-#: build/tasks.py:507
+#: build/tasks.py:487
 msgid "Stock required for build order"
 msgstr "生产订单所需库存"
 
-#: build/tasks.py:517
+#: build/tasks.py:497
 #, python-brace-format
 msgid "Build order {build} requires additional stock"
 msgstr "生产订单{build}需补充库存"
 
-#: build/tasks.py:541
+#: build/tasks.py:521
 msgid "Overdue Build Order"
 msgstr "逾期的生产订单"
 
-#: build/tasks.py:546
+#: build/tasks.py:526
 #, python-brace-format
 msgid "Build order {bo} is now overdue"
 msgstr "生产订单 {bo} 现已逾期"
@@ -1609,23 +1609,19 @@ msgstr "是否链接"
 msgid "Is File"
 msgstr "是否为文件"
 
-#: common/api.py:856
+#: common/api.py:828
 msgid "User does not have permission to delete these attachments"
 msgstr "用户没有权限删除此附件"
 
-#: common/api.py:869
-msgid "User does not have permission to view this attachment"
-msgstr ""
-
-#: common/api.py:880
+#: common/api.py:841
 msgid "User does not have permission to edit this attachment"
 msgstr "用户没有编辑此附件的权限"
 
-#: common/api.py:906
+#: common/api.py:867
 msgid "User does not have permission to delete this attachment"
 msgstr "用户没有权限删除此附件"
 
-#: common/api.py:1283 common/serializers.py:1017 common/serializers.py:1065
+#: common/api.py:1244 common/serializers.py:1017 common/serializers.py:1065
 msgid "Selection list is locked"
 msgstr "选择列表已锁定"
 
@@ -1645,7 +1641,8 @@ msgstr "未提供有效的货币代码"
 msgid "No plugin"
 msgstr "暂无插件"
 
-#: common/filters.py:110
+#: common/filters.py:110 company/api.py:155 company/api.py:311 stock/api.py:415
+#: stock/api.py:1070
 msgid "Tags"
 msgstr "标签"
 
@@ -1653,11 +1650,11 @@ msgstr "标签"
 msgid "Project Code Label"
 msgstr "项目编号标签"
 
-#: common/models.py:108 common/models.py:133 common/models.py:3475
+#: common/models.py:108 common/models.py:133 common/models.py:3473
 msgid "Updated"
 msgstr "已是最新"
 
-#: common/models.py:109 common/models.py:134 order/models.py:568
+#: common/models.py:109 common/models.py:134 order/models.py:560
 msgid "Timestamp of last update"
 msgstr "最后更新时间戳"
 
@@ -1677,8 +1674,8 @@ msgstr "唯一项目编码"
 msgid "Project description"
 msgstr "项目描述"
 
-#: common/models.py:186 common/models.py:1460 common/models.py:2472
-#: common/models.py:2607 company/models.py:194 company/models.py:787
+#: common/models.py:186 common/models.py:1460 common/models.py:2470
+#: common/models.py:2605 company/models.py:194 company/models.py:787
 #: machine/models.py:43 part/models.py:1310 plugin/models.py:69
 #: stock/api.py:701 users/models.py:191 users/models.py:550
 #: users/serializers.py:349 users/serializers.py:470
@@ -1726,8 +1723,8 @@ msgid "Key string must be unique"
 msgstr "键字符串必须是唯一的"
 
 #: common/models.py:1357 common/models.py:1358 common/models.py:1468
-#: common/models.py:1469 common/models.py:1716 common/models.py:1717
-#: common/models.py:2164 common/models.py:2165 common/models.py:3123
+#: common/models.py:1469 common/models.py:1714 common/models.py:1715
+#: common/models.py:2162 common/models.py:2163 common/models.py:3121
 #: importer/models.py:105 part/models.py:3478 part/models.py:3506
 #: plugin/models.py:392 plugin/models.py:393
 #: report/templates/report/inventree_test_report.html:105 users/models.py:122
@@ -1739,8 +1736,8 @@ msgstr "使用者"
 msgid "Price break quantity"
 msgstr "批发价数量"
 
-#: common/models.py:1387 company/serializers.py:348 order/models.py:2216
-#: order/models.py:3623
+#: common/models.py:1387 company/serializers.py:348 order/models.py:2287
+#: order/models.py:3731
 msgid "Price"
 msgstr "价格"
 
@@ -1780,11 +1777,11 @@ msgstr "密钥"
 msgid "Shared secret for HMAC"
 msgstr "HMAC共享密钥"
 
-#: common/models.py:1594 common/models.py:3360
+#: common/models.py:1594 common/models.py:3358
 msgid "Message ID"
 msgstr "消息ID"
 
-#: common/models.py:1595 common/models.py:3350
+#: common/models.py:1595 common/models.py:3348
 msgid "Unique identifier for this message"
 msgstr "此邮件的唯一标识符"
 
@@ -1824,512 +1821,512 @@ msgstr "工作于"
 msgid "Was the work on this message finished?"
 msgstr "这条消息的工作完成了吗？"
 
-#: common/models.py:1732
+#: common/models.py:1730
 msgid "Optional explicit URL associated with this notification"
-msgstr ""
+msgstr "与此通知关联的可选显式 URL"
 
-#: common/models.py:1772
+#: common/models.py:1770
 msgid "Id"
 msgstr "标识"
 
-#: common/models.py:1774
+#: common/models.py:1772
 msgid "Title"
 msgstr "标题"
 
-#: common/models.py:1776 common/models.py:2147 company/models.py:188
+#: common/models.py:1774 common/models.py:2145 company/models.py:188
 #: company/models.py:483 company/models.py:554 company/models.py:810
-#: order/models.py:523 order/models.py:2160 order/models.py:2736
+#: order/models.py:515 order/models.py:2231 order/models.py:2807
 #: part/models.py:1193
 #: report/templates/report/inventree_build_order_report.html:164
 msgid "Link"
 msgstr "链接"
 
-#: common/models.py:1778
+#: common/models.py:1776
 msgid "Published"
 msgstr "已发布"
 
-#: common/models.py:1780
+#: common/models.py:1778
 msgid "Author"
 msgstr "作者"
 
-#: common/models.py:1782
+#: common/models.py:1780
 msgid "Summary"
 msgstr "摘要"
 
-#: common/models.py:1785 common/models.py:3327
+#: common/models.py:1783 common/models.py:3325
 msgid "Read"
 msgstr "阅读"
 
-#: common/models.py:1785
+#: common/models.py:1783
 msgid "Was this news item read?"
 msgstr "这条新闻被阅读了吗？"
 
-#: common/models.py:1802
+#: common/models.py:1800
 msgid "Image file"
 msgstr "图像文件"
 
-#: common/models.py:1814
+#: common/models.py:1812
 msgid "Target model type for this image"
 msgstr "此图像的目标模型类型"
 
-#: common/models.py:1818
+#: common/models.py:1816
 msgid "Target model ID for this image"
 msgstr "此图像的目标型号ID"
 
-#: common/models.py:1840
+#: common/models.py:1838
 msgid "Custom Unit"
 msgstr "自定义单位"
 
-#: common/models.py:1858
+#: common/models.py:1856
 msgid "Unit symbol must be unique"
 msgstr "单位符号必须唯一"
 
-#: common/models.py:1873
+#: common/models.py:1871
 msgid "Unit name must be a valid identifier"
 msgstr "单位名称必须是有效的标识符"
 
-#: common/models.py:1892
+#: common/models.py:1890
 msgid "Unit name"
 msgstr "单位名称"
 
-#: common/models.py:1899
+#: common/models.py:1897
 msgid "Symbol"
 msgstr "符号"
 
-#: common/models.py:1900
+#: common/models.py:1898
 msgid "Optional unit symbol"
 msgstr "可选单位符号"
 
-#: common/models.py:1906
+#: common/models.py:1904
 msgid "Definition"
 msgstr "定义"
 
-#: common/models.py:1907
+#: common/models.py:1905
 msgid "Unit definition"
 msgstr "单位定义"
 
-#: common/models.py:1975 common/models.py:2130 stock/models.py:3906
+#: common/models.py:1973 common/models.py:2128 stock/models.py:3901
 #: stock/serializers.py:263
 msgid "Attachment"
 msgstr "附件"
 
-#: common/models.py:2021
+#: common/models.py:2019
 msgid "Missing file"
 msgstr "缺少文件"
 
-#: common/models.py:2022
+#: common/models.py:2020
 msgid "Missing external link"
 msgstr "缺少外部链接"
 
-#: common/models.py:2070
+#: common/models.py:2068
 msgid "No file attached to rename"
 msgstr "没有要重命名的文件"
 
-#: common/models.py:2073
+#: common/models.py:2071
 msgid "Filename cannot be empty"
 msgstr "文件名不能为空"
 
-#: common/models.py:2078 common/models.py:2098
+#: common/models.py:2076 common/models.py:2096
 msgid "Invalid filename"
 msgstr "无效的文件名"
 
-#: common/models.py:2084
+#: common/models.py:2082
 msgid "Cannot change file extension"
 msgstr "无法更改文件扩展名"
 
-#: common/models.py:2103
+#: common/models.py:2101
 msgid "A file with this name already exists"
 msgstr "已存在同名文件"
 
-#: common/models.py:2110
+#: common/models.py:2108
 msgid "Failed to save renamed file"
 msgstr "重命名文件保存失败"
 
-#: common/models.py:2122 common/models.py:2756
+#: common/models.py:2120 common/models.py:2754
 msgid "Model type"
 msgstr "模型类型"
 
-#: common/models.py:2123
+#: common/models.py:2121
 msgid "Target model type for image"
 msgstr "图片的目标模型类型"
 
-#: common/models.py:2132
+#: common/models.py:2130
 msgid "Select file to attach"
 msgstr "选择附件"
 
-#: common/models.py:2138
+#: common/models.py:2136
 msgid "Thumbnail"
 msgstr "缩略图"
 
-#: common/models.py:2139
+#: common/models.py:2137
 msgid "Thumbnail image for this attachment"
 msgstr "该附件对应的缩略预览图"
 
-#: common/models.py:2155
+#: common/models.py:2153
 msgid "Comment"
 msgstr "备注"
 
-#: common/models.py:2156
+#: common/models.py:2154
 msgid "Attachment comment"
 msgstr "附件备注"
 
-#: common/models.py:2172
+#: common/models.py:2170
 msgid "Upload date"
 msgstr "上传日期"
 
-#: common/models.py:2173
+#: common/models.py:2171
 msgid "Date the file was uploaded"
 msgstr "上传文件的日期"
 
-#: common/models.py:2178
+#: common/models.py:2176
 msgid "Is image"
 msgstr "是否为图片文件"
 
-#: common/models.py:2179
+#: common/models.py:2177
 msgid "True if this attachment is a valid image file"
 msgstr "若该附件是合法图片文件，则值为 True（是）"
 
-#: common/models.py:2183
+#: common/models.py:2181
 msgid "File size"
 msgstr "文件大小"
 
-#: common/models.py:2183
+#: common/models.py:2181
 msgid "File size in bytes"
 msgstr "文件大小，以字节为单位"
 
-#: common/models.py:2219 common/serializers.py:843
+#: common/models.py:2217 common/serializers.py:843
 msgid "Invalid model type specified for attachment"
 msgstr "为附件指定的模型类型无效"
 
-#: common/models.py:2303
+#: common/models.py:2301
 msgid "Custom State"
 msgstr "自定状态"
 
-#: common/models.py:2304
+#: common/models.py:2302
 msgid "Custom States"
 msgstr "定制状态"
 
-#: common/models.py:2309
+#: common/models.py:2307
 msgid "Reference Status Set"
 msgstr "参考状态设置"
 
-#: common/models.py:2310
+#: common/models.py:2308
 msgid "Status set that is extended with this custom state"
 msgstr "使用此自定义状态扩展状态的状态集"
 
-#: common/models.py:2314 generic/states/serializers.py:18
+#: common/models.py:2312 generic/states/serializers.py:18
 msgid "Logical Key"
 msgstr "逻辑密钥"
 
-#: common/models.py:2316
+#: common/models.py:2314
 msgid "State logical key that is equal to this custom state in business logic"
 msgstr "等同于商业逻辑中自定义状态的状态逻辑键"
 
-#: common/models.py:2321 common/models.py:2588 machine/serializers.py:27
-#: report/templates/report/inventree_test_report.html:104 stock/models.py:3898
+#: common/models.py:2319 common/models.py:2586 machine/serializers.py:27
+#: report/templates/report/inventree_test_report.html:104 stock/models.py:3893
 msgid "Value"
 msgstr "值"
 
-#: common/models.py:2322
+#: common/models.py:2320
 msgid "Numerical value that will be saved in the models database"
 msgstr "将保存至模型数据库的数值"
 
-#: common/models.py:2328
+#: common/models.py:2326
 msgid "Name of the state"
 msgstr "状态名"
 
-#: common/models.py:2337 common/models.py:2594 generic/states/serializers.py:22
+#: common/models.py:2335 common/models.py:2592 generic/states/serializers.py:22
 msgid "Label"
 msgstr "标签"
 
-#: common/models.py:2338
+#: common/models.py:2336
 msgid "Label that will be displayed in the frontend"
 msgstr "将在前端显示的标签"
 
-#: common/models.py:2345 generic/states/serializers.py:24
+#: common/models.py:2343 generic/states/serializers.py:24
 msgid "Color"
 msgstr "颜色"
 
-#: common/models.py:2346
+#: common/models.py:2344
 msgid "Color that will be displayed in the frontend"
 msgstr "将在前端显示颜色"
 
-#: common/models.py:2354
+#: common/models.py:2352
 msgid "Model"
 msgstr "型号"
 
-#: common/models.py:2355
+#: common/models.py:2353
 msgid "Model this state is associated with"
 msgstr "该状态关联的模型"
 
-#: common/models.py:2370
+#: common/models.py:2368
 msgid "Model must be selected"
 msgstr "必须选定模型"
 
-#: common/models.py:2373
+#: common/models.py:2371
 msgid "Key must be selected"
 msgstr "必须选取密钥"
 
-#: common/models.py:2376
+#: common/models.py:2374
 msgid "Logical key must be selected"
 msgstr "必须选中逻辑密钥"
 
-#: common/models.py:2380
+#: common/models.py:2378
 msgid "Key must be different from logical key"
 msgstr "密钥必须不同于逻辑密钥"
 
-#: common/models.py:2387
+#: common/models.py:2385
 msgid "Valid reference status class must be provided"
 msgstr "必须提供有效的参考状态类"
 
-#: common/models.py:2393
+#: common/models.py:2391
 msgid "Key must be different from the logical keys of the reference status"
 msgstr "密钥必须不同于参考状态的逻辑密钥"
 
-#: common/models.py:2400
+#: common/models.py:2398
 msgid "Logical key must be in the logical keys of the reference status"
 msgstr "逻辑密钥必须在参考状态的逻辑键中"
 
-#: common/models.py:2407
+#: common/models.py:2405
 msgid "Name must be different from the names of the reference status"
 msgstr "名称必须不同于参考状态的名称"
 
-#: common/models.py:2447 common/models.py:2582 common/models.py:2801
+#: common/models.py:2445 common/models.py:2580 common/models.py:2799
 msgid "Selection List"
 msgstr "选择列表"
 
-#: common/models.py:2448
+#: common/models.py:2446
 msgid "Selection Lists"
 msgstr "选择列表"
 
-#: common/models.py:2453
+#: common/models.py:2451
 msgid "Name of the selection list"
 msgstr "选择列表的名称"
 
-#: common/models.py:2460
+#: common/models.py:2458
 msgid "Description of the selection list"
 msgstr "选择列表的描述"
 
-#: common/models.py:2466 part/models.py:1315
+#: common/models.py:2464 part/models.py:1315
 msgid "Locked"
 msgstr "已锁定"
 
-#: common/models.py:2467
+#: common/models.py:2465
 msgid "Is this selection list locked?"
 msgstr "此选择列表是否已锁定？"
 
-#: common/models.py:2473
+#: common/models.py:2471
 msgid "Can this selection list be used?"
 msgstr "能否使用此选择列表？"
 
-#: common/models.py:2481
+#: common/models.py:2479
 msgid "Source Plugin"
 msgstr "源插件"
 
-#: common/models.py:2482
+#: common/models.py:2480
 msgid "Plugin which provides the selection list"
 msgstr "提供选择列表的插件"
 
-#: common/models.py:2487
+#: common/models.py:2485
 msgid "Source String"
 msgstr "源字符串"
 
-#: common/models.py:2488
+#: common/models.py:2486
 msgid "Optional string identifying the source used for this list"
 msgstr "可选字符串，用于标识本列表的数据来源"
 
-#: common/models.py:2497
+#: common/models.py:2495
 msgid "Default Entry"
 msgstr "缺省项"
 
-#: common/models.py:2498
+#: common/models.py:2496
 msgid "Default entry for this selection list"
 msgstr "本选择列表的默认选项"
 
-#: common/models.py:2503 common/models.py:3470
+#: common/models.py:2501 common/models.py:3468
 msgid "Created"
 msgstr "已创建"
 
-#: common/models.py:2504
+#: common/models.py:2502
 msgid "Date and time that the selection list was created"
 msgstr "选择列表的创建日期和时间"
 
-#: common/models.py:2509
+#: common/models.py:2507
 msgid "Last Updated"
 msgstr "最近更新"
 
-#: common/models.py:2510
+#: common/models.py:2508
 msgid "Date and time that the selection list was last updated"
 msgstr "选择列表的最后更新时间"
 
-#: common/models.py:2572
+#: common/models.py:2570
 msgid "Selection List Entry"
 msgstr "选择列表项"
 
-#: common/models.py:2573
+#: common/models.py:2571
 msgid "Selection List Entries"
 msgstr "选择列表项"
 
-#: common/models.py:2583
+#: common/models.py:2581
 msgid "Selection list to which this entry belongs"
 msgstr "此选项归属的选择列表"
 
-#: common/models.py:2589
+#: common/models.py:2587
 msgid "Value of the selection list entry"
 msgstr "选择列表项的值"
 
-#: common/models.py:2595
+#: common/models.py:2593
 msgid "Label for the selection list entry"
 msgstr "选择列表项的标签"
 
-#: common/models.py:2601
+#: common/models.py:2599
 msgid "Description of the selection list entry"
 msgstr "选择列表项的描述"
 
-#: common/models.py:2608
+#: common/models.py:2606
 msgid "Is this selection list entry active?"
 msgstr "该选择列表项是否处于激活状态？"
 
-#: common/models.py:2642
+#: common/models.py:2640
 msgid "Parameter Template"
 msgstr "参数模板"
 
-#: common/models.py:2643
+#: common/models.py:2641
 msgid "Parameter Templates"
 msgstr "参数模板"
 
-#: common/models.py:2664
+#: common/models.py:2662
 msgid "No uniqueness required"
-msgstr ""
+msgstr "不要求唯一"
 
-#: common/models.py:2665
+#: common/models.py:2663
 msgid "Unique for model type"
-msgstr ""
+msgstr "按模型类型唯一"
 
-#: common/models.py:2666
+#: common/models.py:2664
 msgid "Globally unique"
-msgstr ""
+msgstr "全局唯一"
 
-#: common/models.py:2693
+#: common/models.py:2691
 msgid "Checkbox parameters cannot have units"
 msgstr "勾选框参数不能有单位"
 
-#: common/models.py:2698
+#: common/models.py:2696
 msgid "Checkbox parameters cannot have choices"
 msgstr "复选框参数不能有选项"
 
-#: common/models.py:2718 part/models.py:3576
+#: common/models.py:2716 part/models.py:3576
 msgid "Choices must be unique"
 msgstr "选择必须是唯一的"
 
-#: common/models.py:2735
+#: common/models.py:2733
 msgid "Parameter template name must be unique"
 msgstr "参数模板名称必须是唯一的"
 
-#: common/models.py:2757
+#: common/models.py:2755
 msgid "Target model type for this parameter template"
 msgstr "此参数模板的目标模型类型"
 
-#: common/models.py:2763
+#: common/models.py:2761
 msgid "Parameter Name"
 msgstr "参数名称"
 
-#: common/models.py:2769 part/models.py:1268
+#: common/models.py:2767 part/models.py:1268
 msgid "Units"
 msgstr "单位"
 
-#: common/models.py:2770
+#: common/models.py:2768
 msgid "Physical units for this parameter"
 msgstr "此参数的物理单位"
 
-#: common/models.py:2778
+#: common/models.py:2776
 msgid "Parameter description"
 msgstr "参数说明"
 
-#: common/models.py:2784
+#: common/models.py:2782
 msgid "Checkbox"
 msgstr "勾选框"
 
-#: common/models.py:2785
+#: common/models.py:2783
 msgid "Is this parameter a checkbox?"
 msgstr "此参数是否为勾选框？"
 
-#: common/models.py:2790 part/models.py:3663
+#: common/models.py:2788 part/models.py:3663
 msgid "Choices"
 msgstr "选项"
 
-#: common/models.py:2791
+#: common/models.py:2789
 msgid "Valid choices for this parameter (comma-separated)"
 msgstr "此参数的有效选择 (逗号分隔)"
 
-#: common/models.py:2802
+#: common/models.py:2800
 msgid "Selection list for this parameter"
 msgstr "此参数的选择列表"
 
-#: common/models.py:2807 part/models.py:3638 report/models.py:297
+#: common/models.py:2805 part/models.py:3638 report/models.py:297
 msgid "Enabled"
 msgstr "已启用"
 
-#: common/models.py:2808
+#: common/models.py:2806
 msgid "Is this parameter template enabled?"
 msgstr "此参数模板是否启用？"
 
-#: common/models.py:2814
+#: common/models.py:2812
 msgid "Uniqueness"
-msgstr ""
+msgstr "唯一性"
 
-#: common/models.py:2816
+#: common/models.py:2814
 msgid "Enforce uniqueness of linked parameter values against this template"
-msgstr ""
+msgstr "强制此模板下关联参数值唯一"
 
-#: common/models.py:2858
+#: common/models.py:2856
 msgid "Parameter"
 msgstr "参数"
 
-#: common/models.py:2859
+#: common/models.py:2857
 msgid "Parameters"
 msgstr "参数"
 
-#: common/models.py:2905
+#: common/models.py:2903
 msgid "Invalid choice for parameter value"
 msgstr "无效的参数值选择"
 
-#: common/models.py:3009
+#: common/models.py:3007
 msgid "Parameter value must be unique"
-msgstr ""
+msgstr "参数值必须唯一"
 
-#: common/models.py:3018 common/serializers.py:940
+#: common/models.py:3016 common/serializers.py:940
 msgid "Invalid model type specified for parameter"
 msgstr "为附件指定的模型类型无效"
 
-#: common/models.py:3054
+#: common/models.py:3052
 msgid "Model ID"
 msgstr "型号ID"
 
-#: common/models.py:3055
+#: common/models.py:3053
 msgid "ID of the target model for this parameter"
 msgstr "此参数的目标模型的 ID"
 
-#: common/models.py:3064 common/setting/system.py:470 report/models.py:383
-#: report/models.py:717 report/serializers.py:115 report/serializers.py:166
+#: common/models.py:3062 common/setting/system.py:470 report/models.py:383
+#: report/models.py:717 report/serializers.py:115 report/serializers.py:156
 #: stock/serializers.py:250
 msgid "Template"
 msgstr "模板"
 
-#: common/models.py:3065
+#: common/models.py:3063
 msgid "Parameter template"
 msgstr "参数模板"
 
-#: common/models.py:3070 common/models.py:3112 importer/models.py:684
+#: common/models.py:3068 common/models.py:3110 importer/models.py:684
 msgid "Data"
 msgstr "数据"
 
-#: common/models.py:3071
+#: common/models.py:3069
 msgid "Parameter Value"
 msgstr "参数值"
 
-#: common/models.py:3080 company/models.py:827 order/serializers.py:917
-#: order/serializers.py:2299 part/models.py:4041 part/models.py:4427
+#: common/models.py:3078 company/models.py:827 order/serializers.py:917
+#: order/serializers.py:2299 part/models.py:4029 part/models.py:4409
 #: report/templates/report/inventree_bill_of_materials_report.html:140
 #: report/templates/report/inventree_purchase_order_report.html:39
 #: report/templates/report/inventree_return_order_report.html:27
@@ -2340,181 +2337,181 @@ msgstr "参数值"
 msgid "Note"
 msgstr "备注"
 
-#: common/models.py:3081 stock/serializers.py:754 stock/serializers.py:1115
+#: common/models.py:3079 stock/serializers.py:754 stock/serializers.py:1115
 msgid "Optional note field"
 msgstr "可选注释字段"
 
-#: common/models.py:3108
+#: common/models.py:3106
 msgid "Barcode Scan"
 msgstr "扫描条码"
 
-#: common/models.py:3113
+#: common/models.py:3111
 msgid "Barcode data"
 msgstr "条码数据"
 
-#: common/models.py:3124
+#: common/models.py:3122
 msgid "User who scanned the barcode"
 msgstr "扫描条码的用户"
 
-#: common/models.py:3129 importer/models.py:72
+#: common/models.py:3127 importer/models.py:72
 msgid "Timestamp"
 msgstr "时间戳"
 
-#: common/models.py:3130
+#: common/models.py:3128
 msgid "Date and time of the barcode scan"
 msgstr "扫描条形码的日期和时间"
 
-#: common/models.py:3136
+#: common/models.py:3134
 msgid "URL endpoint which processed the barcode"
 msgstr "处理条码的 URL 端点"
 
-#: common/models.py:3143 order/models.py:2206 plugin/serializers.py:93
+#: common/models.py:3141 order/models.py:2277 plugin/serializers.py:93
 msgid "Context"
 msgstr "上下文"
 
-#: common/models.py:3144
+#: common/models.py:3142
 msgid "Context data for the barcode scan"
 msgstr "扫描条形码的上下文数据"
 
-#: common/models.py:3151
+#: common/models.py:3149
 msgid "Response"
 msgstr "响应"
 
-#: common/models.py:3152
+#: common/models.py:3150
 msgid "Response data from the barcode scan"
 msgstr "扫描条形码的响应数据"
 
-#: common/models.py:3158 report/templates/report/inventree_test_report.html:103
-#: stock/models.py:3892
+#: common/models.py:3156 report/templates/report/inventree_test_report.html:103
+#: stock/models.py:3887
 msgid "Result"
 msgstr "结果"
 
-#: common/models.py:3159
+#: common/models.py:3157
 msgid "Was the barcode scan successful?"
 msgstr "条码扫描成功吗？"
 
-#: common/models.py:3241
+#: common/models.py:3239
 msgid "An error occurred"
 msgstr "发生错误"
 
-#: common/models.py:3262
+#: common/models.py:3260
 msgid "INVE-E8: Email log deletion is protected. Set INVENTREE_PROTECT_EMAIL_LOG to False to allow deletion."
 msgstr "INVE-E8：邮件日志删除受保护。需设置 INVENTREE_PROTECT_EMAIL_LOG 为 False 以允许删除。"
 
-#: common/models.py:3309
+#: common/models.py:3307
 msgid "Email Message"
 msgstr "电子邮件信息"
 
-#: common/models.py:3310
+#: common/models.py:3308
 msgid "Email Messages"
 msgstr "电子邮箱信息"
 
-#: common/models.py:3317
+#: common/models.py:3315
 msgid "Announced"
 msgstr "已发布"
 
-#: common/models.py:3319
+#: common/models.py:3317
 msgid "Sent"
 msgstr "已发送"
 
-#: common/models.py:3320
+#: common/models.py:3318
 msgid "Failed"
 msgstr "失败"
 
-#: common/models.py:3323
+#: common/models.py:3321
 msgid "Delivered"
 msgstr "已送达"
 
-#: common/models.py:3331
+#: common/models.py:3329
 msgid "Confirmed"
 msgstr "已确认"
 
-#: common/models.py:3337
+#: common/models.py:3335
 msgid "Inbound"
 msgstr "入站"
 
-#: common/models.py:3338
+#: common/models.py:3336
 msgid "Outbound"
 msgstr "出站"
 
-#: common/models.py:3343
+#: common/models.py:3341
 msgid "No Reply"
 msgstr "暂无回复消息"
 
-#: common/models.py:3344
+#: common/models.py:3342
 msgid "Track Delivery"
 msgstr "跟踪交付"
 
-#: common/models.py:3345
+#: common/models.py:3343
 msgid "Track Read"
 msgstr "已读追踪"
 
-#: common/models.py:3346
+#: common/models.py:3344
 msgid "Track Click"
 msgstr "点击追踪"
 
-#: common/models.py:3349 common/models.py:3457
+#: common/models.py:3347 common/models.py:3455
 msgid "Global ID"
 msgstr "全局ID"
 
-#: common/models.py:3362
+#: common/models.py:3360
 msgid "Identifier for this message (might be supplied by external system)"
 msgstr "此消息的标识符 (可能由外部系统提供)"
 
-#: common/models.py:3369
+#: common/models.py:3367
 msgid "Thread ID"
 msgstr "主题 ID"
 
-#: common/models.py:3371
+#: common/models.py:3369
 msgid "Identifier for this message thread (might be supplied by external system)"
 msgstr "此消息主题的标识符 (可能由外部系统提供)"
 
-#: common/models.py:3380
+#: common/models.py:3378
 msgid "Thread"
 msgstr "主题"
 
-#: common/models.py:3381
+#: common/models.py:3379
 msgid "Linked thread for this message"
 msgstr "链接到此消息的主题"
 
-#: common/models.py:3397
+#: common/models.py:3395
 msgid "Priority"
 msgstr "优先"
 
-#: common/models.py:3439
+#: common/models.py:3437
 msgid "Email Thread"
 msgstr "邮件主题"
 
-#: common/models.py:3440
+#: common/models.py:3438
 msgid "Email Threads"
 msgstr "邮件主题"
 
-#: common/models.py:3451 generic/states/serializers.py:16
+#: common/models.py:3449 generic/states/serializers.py:16
 #: machine/serializers.py:24 plugin/models.py:46 users/models.py:111
 msgid "Key"
 msgstr "键"
 
-#: common/models.py:3454
+#: common/models.py:3452
 msgid "Unique key for this thread (used to identify the thread)"
 msgstr "此主题的唯一密钥 (用于识别主题)"
 
-#: common/models.py:3458
+#: common/models.py:3456
 msgid "Unique identifier for this thread"
 msgstr "此主题的唯一标识符"
 
-#: common/models.py:3465
+#: common/models.py:3463
 msgid "Started Internal"
 msgstr "内部服务已启动"
 
-#: common/models.py:3466
+#: common/models.py:3464
 msgid "Was this thread started internally?"
 msgstr "该线程是否为内部启动的？"
 
-#: common/models.py:3471
+#: common/models.py:3469
 msgid "Date and time that the thread was created"
 msgstr "创建主题的日期和时间"
 
-#: common/models.py:3476
+#: common/models.py:3474
 msgid "Date and time that the thread was last updated"
 msgstr "主题最后更新的日期和时间"
 
@@ -2536,7 +2533,7 @@ msgstr "{verbose_name} 已取消"
 msgid "A order that is assigned to you was canceled"
 msgstr "分配给您的订单已取消"
 
-#: common/notifications.py:73 common/notifications.py:80 order/api.py:659
+#: common/notifications.py:73 common/notifications.py:80 order/api.py:612
 msgid "Items Received"
 msgstr "收到的物品"
 
@@ -3020,8 +3017,8 @@ msgstr "零件默认为模板"
 msgid "Parts can be assembled from other components by default"
 msgstr "默认情况下，元件可由其他零件组装而成"
 
-#: common/setting/system.py:482 part/models.py:1281 part/serializers.py:1766
-#: part/serializers.py:1774
+#: common/setting/system.py:482 part/models.py:1281 part/serializers.py:1755
+#: part/serializers.py:1763
 msgid "Component"
 msgstr "组件"
 
@@ -3544,11 +3541,11 @@ msgstr "生成调拨单编号字段所需的编码格式模板"
 
 #: common/setting/system.py:955
 msgid "Edit Completed Transfer Orders"
-msgstr ""
+msgstr "编辑已完成的调拨订单"
 
 #: common/setting/system.py:957
 msgid "Allow editing of transfer orders after they have been completed"
-msgstr ""
+msgstr "允许在调拨订单完成后对其进行编辑"
 
 #: common/setting/system.py:963
 msgid "Block Incomplete Item Tests"
@@ -3592,11 +3589,11 @@ msgstr "当收到所有行项目时，自动将采购订单标记为完成"
 
 #: common/setting/system.py:1007
 msgid "Merge Purchase Order Line Items"
-msgstr ""
+msgstr "合并采购订单行项目"
 
 #: common/setting/system.py:1009
 msgid "Merge new purchase order line items with existing lines that share the same part, destination, and target date"
-msgstr ""
+msgstr "将具有相同零件、目的地和目标日期的新采购订单行项目与现有行合并"
 
 #: common/setting/system.py:1016
 msgid "Enable password forgot"
@@ -4116,11 +4113,11 @@ msgstr "在搜索预览窗口的每个部分中显示的结果数"
 
 #: common/setting/user.py:163
 msgid "Search Results Preview Panel"
-msgstr ""
+msgstr "搜索结果预览面板"
 
 #: common/setting/user.py:165
 msgid "Open search results in the preview panel, rather than navigating directly to the result"
-msgstr ""
+msgstr "在预览面板中打开搜索结果，而不是直接跳转到结果"
 
 #: common/setting/user.py:171
 msgid "Regex Search"
@@ -4276,14 +4273,6 @@ msgstr "最终级别的展示项目"
 msgid "Automatically default to showing items/parts instead of sub-levels for locations or categories with no children"
 msgstr "对于没有子项的位置或类别，自动默认显示项目/零件，而不是子级别"
 
-#: common/setting/user.py:300
-msgid "Enable Filtered Detail Navigation"
-msgstr ""
-
-#: common/setting/user.py:302
-msgid "Enable persisting of filtered detail navigation parameters to the view url"
-msgstr ""
-
 #: common/validators.py:40
 msgid "All models"
 msgstr "全部型号"
@@ -4400,7 +4389,7 @@ msgstr "联系电话"
 msgid "Contact email address"
 msgstr "联系人电子邮箱地址"
 
-#: company/models.py:181 company/models.py:315 order/models.py:586
+#: company/models.py:181 company/models.py:315 order/models.py:578
 #: users/models.py:557
 msgid "Contact"
 msgstr "联系人"
@@ -4453,7 +4442,7 @@ msgstr "税号"
 msgid "Company Tax ID"
 msgstr "公司税号"
 
-#: company/models.py:354 order/models.py:596 order/models.py:2681
+#: company/models.py:354 order/models.py:588 order/models.py:2752
 msgid "Address"
 msgstr "地址"
 
@@ -4593,7 +4582,7 @@ msgid "Linked manufacturer part must reference the same base part"
 msgstr "链接的制造商零件必须引用相同的基础零件"
 
 #: company/models.py:775 company/serializers.py:486 company/serializers.py:521
-#: order/models.py:741 part/serializers.py:452
+#: order/models.py:733 part/serializers.py:452
 #: plugin/builtin/suppliers/digikey.py:26 plugin/builtin/suppliers/lcsc.py:27
 #: plugin/builtin/suppliers/mouser.py:25 plugin/builtin/suppliers/tme.py:27
 #: stock/api.py:626 templates/email/overdue_purchase_order.html:16
@@ -4709,27 +4698,27 @@ msgstr "数据导出过程中发生错误"
 msgid "Data export plugin returned incorrect data format"
 msgstr "数据导出插件返回的数据格式不正确"
 
-#: data_exporter/serializers.py:83
+#: data_exporter/serializers.py:73
 msgid "Export Format"
 msgstr "导出格式"
 
-#: data_exporter/serializers.py:84
+#: data_exporter/serializers.py:74
 msgid "Select export file format"
 msgstr "选择导出文件格式"
 
-#: data_exporter/serializers.py:91
+#: data_exporter/serializers.py:81
 msgid "Export Plugin"
 msgstr "导出插件"
 
-#: data_exporter/serializers.py:92
+#: data_exporter/serializers.py:82
 msgid "Select export plugin"
 msgstr "选择导出插件"
 
-#: generic/states/fields.py:174
+#: generic/states/fields.py:159
 msgid "Additional status information for this item"
 msgstr "此项目的附加状态信息"
 
-#: generic/states/fields.py:188
+#: generic/states/fields.py:173
 msgid "Custom status key"
 msgstr "自定义状态密钥"
 
@@ -4745,13 +4734,9 @@ msgstr "类别"
 msgid "Values"
 msgstr "值"
 
-#: generic/states/tests.py:22 order/status_codes.py:22
+#: generic/states/tests.py:22 order/status_codes.py:13
 msgid "Placed"
 msgstr "放置"
-
-#: generic/states/transition.py:194
-msgid "Failed to offload background task for this transition"
-msgstr ""
 
 #: generic/states/validators.py:21
 msgid "Invalid status code"
@@ -4912,7 +4897,7 @@ msgstr "打开数据文件失败"
 
 #: importer/operations.py:55
 msgid "Could not decode data file as text"
-msgstr ""
+msgstr "无法将数据文件解码为文本"
 
 #: importer/operations.py:62
 msgid "Invalid data file dimensions"
@@ -4930,35 +4915,35 @@ msgstr "无效的字段覆盖"
 msgid "Invalid field filters"
 msgstr "字段筛选器无效"
 
-#: importer/serializers.py:218
+#: importer/serializers.py:196
 msgid "Rows"
 msgstr "行"
 
-#: importer/serializers.py:219
+#: importer/serializers.py:197
 msgid "List of row IDs to accept"
 msgstr "要接受的行ID列表"
 
-#: importer/serializers.py:232
+#: importer/serializers.py:210
 msgid "No rows provided"
 msgstr "未提供行"
 
-#: importer/serializers.py:236
+#: importer/serializers.py:214
 msgid "Row does not belong to this session"
 msgstr "行不属于此会话"
 
-#: importer/serializers.py:239
+#: importer/serializers.py:217
 msgid "Row contains invalid data"
 msgstr "行包含无效数据"
 
-#: importer/serializers.py:242
+#: importer/serializers.py:220
 msgid "Row has already been completed"
 msgstr "行已完成"
 
-#: importer/status_codes.py:19
+#: importer/status_codes.py:13
 msgid "Initializing"
 msgstr "正在初始化"
 
-#: importer/status_codes.py:20
+#: importer/status_codes.py:18
 msgid "Mapping Columns"
 msgstr "映射列"
 
@@ -4966,7 +4951,7 @@ msgstr "映射列"
 msgid "Importing Data"
 msgstr "导入数据"
 
-#: importer/status_codes.py:22
+#: importer/status_codes.py:24
 msgid "Processing Data"
 msgstr "处理数据中"
 
@@ -5002,7 +4987,7 @@ msgstr "每个标签要打印的份数"
 msgid "Connected"
 msgstr "已连接"
 
-#: machine/machine_types/label_printer.py:236 order/api.py:2567
+#: machine/machine_types/label_printer.py:236 order/api.py:2456
 msgid "Unknown"
 msgstr "未知"
 
@@ -5130,134 +5115,118 @@ msgstr "最大进度"
 msgid "Maximum value for progress type, required if type=progress"
 msgstr "进度类型的最大值。当 type=progress 时为必填项"
 
-#: order/api.py:142
+#: order/api.py:133
 msgid "Order Reference"
 msgstr "订单参考"
 
-#: order/api.py:170 order/api.py:1362 order/api.py:2201
+#: order/api.py:161 order/api.py:1292 order/api.py:2090
 msgid "Outstanding"
 msgstr "未完成"
 
-#: order/api.py:186
+#: order/api.py:177
 msgid "Has Project Code"
 msgstr "有项目编码"
 
-#: order/api.py:200 order/models.py:554
+#: order/api.py:191 order/models.py:546
 msgid "Created By"
 msgstr "创建人"
 
-#: order/api.py:204
+#: order/api.py:195
 msgid "Created Before"
 msgstr "创建时间早于"
 
-#: order/api.py:208
+#: order/api.py:199
 msgid "Created After"
 msgstr "创建时间晚于"
 
-#: order/api.py:212
+#: order/api.py:203
 msgid "Has Start Date"
 msgstr "有开始日期"
 
-#: order/api.py:220
+#: order/api.py:211
 msgid "Start Date Before"
 msgstr "开始日期早于"
 
-#: order/api.py:224
+#: order/api.py:215
 msgid "Start Date After"
 msgstr "开始日期晚于"
 
-#: order/api.py:228
+#: order/api.py:219
 msgid "Has Target Date"
 msgstr "有目标日期"
 
-#: order/api.py:236
+#: order/api.py:227
 msgid "Target Date Before"
 msgstr "目标日期早于"
 
-#: order/api.py:240
+#: order/api.py:231
 msgid "Target Date After"
 msgstr "目标日期晚于"
 
-#: order/api.py:244
+#: order/api.py:235
 msgid "Updated Before"
 msgstr "更新时间早于"
 
-#: order/api.py:248
+#: order/api.py:239
 msgid "Updated After"
 msgstr "更新时间晚于"
 
-#: order/api.py:301
+#: order/api.py:292
 msgid "Has Pricing"
 msgstr "有定价"
 
-#: order/api.py:354 order/api.py:894 order/api.py:1682 order/api.py:1999
+#: order/api.py:345 order/api.py:846 order/api.py:1612 order/api.py:1908
 msgid "Completed Before"
 msgstr "完成时间早于"
 
-#: order/api.py:358 order/api.py:898 order/api.py:1686 order/api.py:2003
+#: order/api.py:349 order/api.py:850 order/api.py:1616 order/api.py:1912
 msgid "Completed After"
 msgstr "完成时间晚于"
 
-#: order/api.py:364 order/api.py:368
+#: order/api.py:355 order/api.py:359
 msgid "External Build Order"
 msgstr "外部生产订单"
 
-#: order/api.py:459
-msgid "Purchase order not found"
-msgstr ""
-
-#: order/api.py:591 order/api.py:994 order/api.py:1325 order/api.py:2164
-#: order/api.py:2323 order/models.py:2312 order/models.py:2438
-#: order/models.py:2490 order/models.py:2672 order/models.py:3061
-#: order/models.py:3579 order/models.py:3645 order/models.py:4012
+#: order/api.py:544 order/api.py:946 order/api.py:1255 order/api.py:2053
+#: order/api.py:2212 order/models.py:2383 order/models.py:2509
+#: order/models.py:2561 order/models.py:2743 order/models.py:3132
+#: order/models.py:3687 order/models.py:3753 order/models.py:4186
 msgid "Order"
 msgstr "订单"
 
-#: order/api.py:595 order/api.py:1062 order/api.py:2391
+#: order/api.py:548 order/api.py:1014 order/api.py:2280
 msgid "Order Complete"
 msgstr "订单完成"
 
-#: order/api.py:627 order/api.py:631 order/serializers.py:775
+#: order/api.py:580 order/api.py:584 order/serializers.py:775
 msgid "Internal Part"
 msgstr "内部零件"
 
-#: order/api.py:649
+#: order/api.py:602
 msgid "Order Pending"
 msgstr "订单待定"
 
-#: order/api.py:1047 order/api.py:2376
+#: order/api.py:999 order/api.py:2265
 msgid "Completed"
 msgstr "已完成"
 
-#: order/api.py:1196
-msgid "Sales order not found"
-msgstr ""
-
-#: order/api.py:1378
+#: order/api.py:1308
 msgid "Has Shipment"
 msgstr "有配送"
 
-#: order/api.py:1597
+#: order/api.py:1527
 msgid "Shipment not found"
 msgstr "未找到发货记录"
 
-#: order/api.py:1775
-msgid "Return order not found"
-msgstr ""
-
-#: order/api.py:2078
-msgid "Transfer order not found"
-msgstr ""
-
-#: order/api.py:2559 order/models.py:656 order/models.py:2313
-#: order/models.py:2439
+#: order/api.py:2448 order/models.py:648 order/models.py:2384
+#: order/models.py:2510
 #: report/templates/report/inventree_purchase_order_report.html:14
 #: stock/serializers.py:134 templates/email/overdue_purchase_order.html:15
 msgid "Purchase Order"
 msgstr "采购订单"
 
-#: order/api.py:2561 order/models.py:1377 order/models.py:2491
-#: order/models.py:2673 order/models.py:3062
+#: order/api.py:2450 order/models.py:1416 order/models.py:2562
+#: order/models.py:2744 order/models.py:3133
 #: report/templates/report/inventree_build_order_report.html:135
 #: report/templates/report/inventree_sales_order_report.html:14
 #: report/templates/report/inventree_sales_order_shipment_report.html:15
@@ -5265,616 +5234,616 @@ msgstr "采购订单"
 msgid "Sales Order"
 msgstr "销售订单"
 
-#: order/api.py:2563 order/models.py:3228 order/models.py:3580
-#: order/models.py:3646
+#: order/api.py:2452 order/models.py:3299 order/models.py:3688
+#: order/models.py:3754
 #: report/templates/report/inventree_return_order_report.html:13
 #: templates/email/overdue_return_order.html:15
 msgid "Return Order"
 msgstr "退货订单"
 
-#: order/api.py:2565 order/models.py:3668 order/models.py:4013
+#: order/api.py:2454 order/models.py:3776 order/models.py:4187
 #: report/templates/report/inventree_transfer_order_report.html:12
 msgid "Transfer Order"
 msgstr "调拨单"
 
-#: order/models.py:109
+#: order/models.py:101
 #: report/templates/report/inventree_purchase_order_report.html:38
 #: report/templates/report/inventree_sales_order_report.html:31
 msgid "Total Price"
 msgstr "总价格"
 
-#: order/models.py:110
+#: order/models.py:102
 msgid "Total price for this order"
 msgstr "此订单的总价"
 
-#: order/models.py:115 order/serializers.py:70
+#: order/models.py:107 order/serializers.py:70
 msgid "Order Currency"
 msgstr "订单货币"
 
-#: order/models.py:118 order/serializers.py:71
+#: order/models.py:110 order/serializers.py:71
 msgid "Currency for this order (leave blank to use company default)"
 msgstr "此订单的货币 (留空以使用公司默认值)"
 
-#: order/models.py:375
+#: order/models.py:367
 msgid "This order is locked and cannot be modified"
 msgstr "该订单已锁定，不可修改"
 
-#: order/models.py:434
+#: order/models.py:426
 msgid "Contact does not match selected company"
 msgstr "联系人与所选公司不匹配"
 
-#: order/models.py:441
+#: order/models.py:433
 msgid "Start date must be before target date"
 msgstr "开始日期必须早于目标日期"
 
-#: order/models.py:452
+#: order/models.py:444
 msgid "Address does not match selected company"
 msgstr "地址与所选公司不匹配"
 
-#: order/models.py:509
+#: order/models.py:501
 msgid "Order description (optional)"
 msgstr "订单描述 (可选)"
 
-#: order/models.py:518 order/models.py:2180
+#: order/models.py:510 order/models.py:2251
 msgid "Select project code for this order"
 msgstr "为此订单选择项目编码"
 
-#: order/models.py:524 order/models.py:2161 order/models.py:2737
+#: order/models.py:516 order/models.py:2232 order/models.py:2808
 msgid "Link to external page"
 msgstr "链接到外部页面"
 
-#: order/models.py:531
+#: order/models.py:523
 msgid "Start date"
 msgstr "开始日期"
 
-#: order/models.py:532
+#: order/models.py:524
 msgid "Scheduled start date for this order"
 msgstr "本订单的预定开始日期"
 
-#: order/models.py:538 order/models.py:2168 order/serializers.py:306
+#: order/models.py:530 order/models.py:2239 order/serializers.py:306
 #: report/templates/report/inventree_build_order_report.html:125
 msgid "Target Date"
 msgstr "预计日期"
 
-#: order/models.py:540
+#: order/models.py:532
 msgid "Expected date for order delivery. Order will be overdue after this date."
 msgstr "订单交付的预期日期。订单将在此日期后过期。"
 
-#: order/models.py:560
+#: order/models.py:552
 msgid "Issue Date"
 msgstr "签发日期"
 
-#: order/models.py:561
+#: order/models.py:553
 msgid "Date order was issued"
 msgstr "订单发出日期"
 
-#: order/models.py:567
+#: order/models.py:559
 msgid "Updated At"
 msgstr "更新时间"
 
-#: order/models.py:576
+#: order/models.py:568
 msgid "User or group responsible for this order"
 msgstr "负责此订单的用户或组"
 
-#: order/models.py:587
+#: order/models.py:579
 msgid "Point of contact for this order"
 msgstr "此订单的联系人"
 
-#: order/models.py:597
+#: order/models.py:589
 msgid "Company address for this order"
 msgstr "此订单的公司地址"
 
-#: order/models.py:722 order/models.py:1441
+#: order/models.py:714 order/models.py:1480
 msgid "Order reference"
 msgstr "订单参考"
 
-#: order/models.py:731 order/models.py:1465 order/models.py:3319
-#: order/models.py:3745 stock/serializers.py:976 users/models.py:538
+#: order/models.py:723 order/models.py:1504 order/models.py:3390
+#: order/models.py:3853 stock/serializers.py:976 users/models.py:538
 msgid "Status"
 msgstr "狀態"
 
-#: order/models.py:732
+#: order/models.py:724
 msgid "Purchase order status"
 msgstr "采购订单状态"
 
-#: order/models.py:742
+#: order/models.py:734
 msgid "Company from which the items are being ordered"
 msgstr "订购物品的公司"
 
-#: order/models.py:753
+#: order/models.py:745
 msgid "Supplier Reference"
 msgstr "供应商参考"
 
-#: order/models.py:754
+#: order/models.py:746
 msgid "Supplier order reference code"
 msgstr "供应商订单参考代码"
 
-#: order/models.py:763
+#: order/models.py:755
 msgid "received by"
 msgstr "接收人"
 
-#: order/models.py:770 order/models.py:3334 order/models.py:3786
+#: order/models.py:762 order/models.py:3405 order/models.py:3894
 msgid "Date order was completed"
 msgstr "订单完成日期"
 
-#: order/models.py:779 order/models.py:2371
+#: order/models.py:771 order/models.py:2442
 msgid "Destination"
 msgstr "目的地"
 
-#: order/models.py:780 order/models.py:2375
+#: order/models.py:772 order/models.py:2446
 msgid "Destination for received items"
 msgstr "接收物品的目标"
 
-#: order/models.py:826
+#: order/models.py:818
 msgid "Part supplier must match PO supplier"
 msgstr "零件供应商必须与采购订单供应商匹配"
 
-#: order/models.py:1086
+#: order/models.py:1125
 msgid "Line item does not match purchase order"
 msgstr "行项目与采购订单不匹配"
 
-#: order/models.py:1089
+#: order/models.py:1128
 msgid "Line item is missing a linked part"
 msgstr "行项目缺少关联零件"
 
-#: order/models.py:1103
+#: order/models.py:1142
 msgid "Quantity must be a positive number"
 msgstr "数量必须是正数"
 
-#: order/models.py:1144
+#: order/models.py:1183
 msgid "Serial numbers cannot be assigned to virtual parts"
 msgstr "序列号不能分配给虚拟件"
 
-#: order/models.py:1358
+#: order/models.py:1397
 msgid "Allow any stock (serialized or unserialized)"
 msgstr "允许选用所有库存（含序列号物料与无序列号物料）"
 
-#: order/models.py:1359
+#: order/models.py:1398
 msgid "Serialized stock only"
 msgstr "仅序列号库存"
 
-#: order/models.py:1360
+#: order/models.py:1399
 msgid "Unserialized stock only"
 msgstr "仅无序列号库存"
 
-#: order/models.py:1452 order/models.py:3306 stock/models.py:1217
+#: order/models.py:1491 order/models.py:3377 stock/models.py:1217
 #: stock/models.py:1218 stock/serializers.py:1650
 #: templates/email/overdue_return_order.html:16
 #: templates/email/overdue_sales_order.html:16
 msgid "Customer"
 msgstr "客户"
 
-#: order/models.py:1453
+#: order/models.py:1492
 msgid "Company to which the items are being sold"
 msgstr "出售物品的公司"
 
-#: order/models.py:1466
+#: order/models.py:1505
 msgid "Sales order status"
 msgstr "销售订单状态"
 
-#: order/models.py:1472 order/models.py:3326
+#: order/models.py:1511 order/models.py:3397
 msgid "Customer Reference "
 msgstr "客户参考 "
 
-#: order/models.py:1473 order/models.py:3327
+#: order/models.py:1512 order/models.py:3398
 msgid "Customer order reference code"
 msgstr "客户订单参考代码"
 
-#: order/models.py:1477 order/models.py:2689
+#: order/models.py:1516 order/models.py:2760
 msgid "Shipment Date"
 msgstr "发货日期"
 
-#: order/models.py:1486
+#: order/models.py:1525
 msgid "shipped by"
 msgstr "发货人"
 
-#: order/models.py:1660 order/serializers.py:1724 order/serializers.py:1879
+#: order/models.py:1699 order/serializers.py:1724 order/serializers.py:1879
 #: order/serializers.py:2762 order/serializers.py:2969
 msgid "Line item is not associated with this order"
 msgstr "行项目与此订单不关联"
 
-#: order/models.py:1717 order/serializers.py:3063
+#: order/models.py:1756 order/serializers.py:3063
 msgid "No match found for the following serial numbers"
 msgstr "未找到以下序列号的匹配项"
 
-#: order/models.py:1724 order/serializers.py:3070
+#: order/models.py:1763 order/serializers.py:3070
 msgid "The following serial numbers are unavailable"
 msgstr "以下序列号不可用"
 
-#: order/models.py:1764 order/models.py:3830
+#: order/models.py:1803 order/models.py:3937
 msgid "Order is already complete"
 msgstr "订单已完成"
 
-#: order/models.py:1767 order/models.py:3833
+#: order/models.py:1806 order/models.py:3940
 msgid "Order is already cancelled"
 msgstr "订单已取消"
 
-#: order/models.py:1771
+#: order/models.py:1810
 msgid "Only an open order can be marked as complete"
 msgstr "只有未结订单才能标记为已完成"
 
-#: order/models.py:1775
+#: order/models.py:1814
 msgid "Order cannot be completed as there are incomplete shipments"
 msgstr "由于发货不完整，订单无法完成"
 
-#: order/models.py:1780
+#: order/models.py:1819
 msgid "Order cannot be completed as there are incomplete allocations"
 msgstr "由于缺货，订单无法完成"
 
-#: order/models.py:1789
+#: order/models.py:1828
 msgid "Order cannot be completed as there are incomplete line items"
 msgstr "订单无法完成，因为行项目不完整"
 
-#: order/models.py:2078 order/models.py:2103
+#: order/models.py:2149 order/models.py:2174
 msgid "The order is locked and cannot be modified"
 msgstr "订单已锁定，不可修改"
 
-#: order/models.py:2111
+#: order/models.py:2182
 msgid "Item quantity"
 msgstr "项目数量"
 
-#: order/models.py:2119
+#: order/models.py:2190
 msgid "Discount"
-msgstr ""
+msgstr "折扣"
 
-#: order/models.py:2120
+#: order/models.py:2191
 msgid "Discount percentage applied to this line item (0-100)"
-msgstr ""
+msgstr "应用于此行项目的折扣百分比（0-100）"
 
-#: order/models.py:2138
+#: order/models.py:2209
 msgid "Line Number"
 msgstr "行号"
 
-#: order/models.py:2139
+#: order/models.py:2210
 msgid "Line number for this item (optional)"
 msgstr "此项目的行号(可选)"
 
-#: order/models.py:2148
+#: order/models.py:2219
 msgid "Line item reference"
 msgstr "行项目参考"
 
-#: order/models.py:2155
+#: order/models.py:2226
 msgid "Line item notes"
 msgstr "行项目注释"
 
-#: order/models.py:2170
+#: order/models.py:2241
 msgid "Target date for this line item (leave blank to use the target date from the order)"
 msgstr "此行项目的目标日期 (留空以使用订单中的目标日期)"
 
-#: order/models.py:2200
+#: order/models.py:2271
 msgid "Line item description (optional)"
 msgstr "行项目描述 (可选)"
 
-#: order/models.py:2207
+#: order/models.py:2278
 msgid "Additional context for this line"
 msgstr "此行的附加上下文"
 
-#: order/models.py:2217
+#: order/models.py:2288
 msgid "Unit price"
 msgstr "单位价格"
 
-#: order/models.py:2236
+#: order/models.py:2307
 msgid "Purchase Order Line Item"
 msgstr "采购订单行项目"
 
-#: order/models.py:2265
+#: order/models.py:2336
 msgid "Supplier part must match supplier"
 msgstr "供应商零件必须与供应商匹配"
 
-#: order/models.py:2273
+#: order/models.py:2344
 msgid "Build order must be marked as external"
 msgstr "生产订单必须标记为外部"
 
-#: order/models.py:2280
+#: order/models.py:2351
 msgid "Build orders can only be linked to assembly parts"
 msgstr "生产订单仅可关联至装配零件"
 
-#: order/models.py:2286
+#: order/models.py:2357
 msgid "Build order part must match line item part"
 msgstr "生产订单零件必须与行项目零件一致"
 
-#: order/models.py:2296
+#: order/models.py:2367
 msgid "An external build order is required for assembly parts"
 msgstr "装配零件需要外部生产订单"
 
-#: order/models.py:2332
+#: order/models.py:2403
 msgid "Supplier part"
 msgstr "供应商零件"
 
-#: order/models.py:2339
+#: order/models.py:2410
 msgid "Received"
 msgstr "已接收"
 
-#: order/models.py:2340
+#: order/models.py:2411
 msgid "Number of items received"
 msgstr "收到的物品数量"
 
-#: order/models.py:2348 stock/models.py:1347 stock/serializers.py:673
+#: order/models.py:2419 stock/models.py:1347 stock/serializers.py:673
 #: stock/serializers.py:1048
 msgid "Purchase Price"
 msgstr "采购价格"
 
-#: order/models.py:2349
+#: order/models.py:2420
 msgid "Unit purchase price"
 msgstr "每单位的采购价格"
 
-#: order/models.py:2365
+#: order/models.py:2436
 msgid "External Build Order to be fulfilled by this line item"
 msgstr "外部生产订单需由此行项目履行"
 
-#: order/models.py:2427
+#: order/models.py:2498
 msgid "Purchase Order Extra Line"
 msgstr "采购订单附加行"
 
-#: order/models.py:2456
+#: order/models.py:2527
 msgid "Sales Order Line Item"
 msgstr "销售订单行项目"
 
-#: order/models.py:2483
+#: order/models.py:2554
 msgid "Only salable parts can be assigned to a sales order"
 msgstr "只有可销售的零件才能分配给销售订单"
 
-#: order/models.py:2509
+#: order/models.py:2580
 msgid "Sale Price"
 msgstr "售出价格"
 
-#: order/models.py:2510
+#: order/models.py:2581
 msgid "Unit sale price"
 msgstr "单位售出价格"
 
-#: order/models.py:2519 order/status_codes.py:66
+#: order/models.py:2590 order/status_codes.py:50
 msgid "Shipped"
 msgstr "已配送"
 
-#: order/models.py:2520
+#: order/models.py:2591
 msgid "Shipped quantity"
 msgstr "发货数量"
 
-#: order/models.py:2633
+#: order/models.py:2704
 msgid "Sales Order Shipment"
 msgstr "销售订单发货"
 
-#: order/models.py:2646
+#: order/models.py:2717
 msgid "Shipment address must match the customer"
 msgstr "收货地址必须与该客户的资料一致"
 
-#: order/models.py:2682
+#: order/models.py:2753
 msgid "Shipping address for this shipment"
 msgstr "本次发货的收货地址"
 
-#: order/models.py:2690
+#: order/models.py:2761
 msgid "Date of shipment"
 msgstr "发货日期"
 
-#: order/models.py:2696
+#: order/models.py:2767
 msgid "Delivery Date"
 msgstr "送达日期"
 
-#: order/models.py:2697
+#: order/models.py:2768
 msgid "Date of delivery of shipment"
 msgstr "装运交货日期"
 
-#: order/models.py:2705
+#: order/models.py:2776
 msgid "Checked By"
 msgstr "审核人"
 
-#: order/models.py:2706
+#: order/models.py:2777
 msgid "User who checked this shipment"
 msgstr "检查此装运的用户"
 
-#: order/models.py:2713 order/models.py:3162 order/serializers.py:1899
+#: order/models.py:2784 order/models.py:3233 order/serializers.py:1899
 #: order/serializers.py:1952 order/serializers.py:2053
 #: report/templates/report/inventree_sales_order_shipment_report.html:14
 msgid "Shipment"
 msgstr "配送"
 
-#: order/models.py:2714
+#: order/models.py:2785
 msgid "Shipment number"
 msgstr "配送单号"
 
-#: order/models.py:2722
+#: order/models.py:2793
 msgid "Tracking Number"
 msgstr "跟踪单号"
 
-#: order/models.py:2723
+#: order/models.py:2794
 msgid "Shipment tracking information"
 msgstr "配送跟踪信息"
 
-#: order/models.py:2730
+#: order/models.py:2801
 msgid "Invoice Number"
 msgstr "发票编号"
 
-#: order/models.py:2731
+#: order/models.py:2802
 msgid "Reference number for associated invoice"
 msgstr "相关发票的参考号"
 
-#: order/models.py:2777
+#: order/models.py:2848
 msgid "Shipment has already been sent"
 msgstr "货物已发出"
 
-#: order/models.py:2780
+#: order/models.py:2851
 msgid "Shipment has no allocated stock items"
 msgstr "发货没有分配库存项目"
 
-#: order/models.py:2787
+#: order/models.py:2858
 msgid "Shipment must be checked before it can be completed"
 msgstr "货件必须先经核对，方可标记为完成"
 
-#: order/models.py:3050
+#: order/models.py:3121
 msgid "Sales Order Extra Line"
 msgstr "销售订单加行"
 
-#: order/models.py:3079
+#: order/models.py:3150
 msgid "Sales Order Allocation"
 msgstr "销售订单分配"
 
-#: order/models.py:3102 order/models.py:3104 order/models.py:4105
-#: order/models.py:4107
+#: order/models.py:3173 order/models.py:3175 order/models.py:4279
+#: order/models.py:4281
 msgid "Stock item has not been assigned"
 msgstr "库存项目尚未分配"
 
-#: order/models.py:3111 order/models.py:4114
+#: order/models.py:3182 order/models.py:4288
 msgid "Cannot allocate stock item to a line with a different part"
 msgstr "无法将库存项目分配给具有不同零件的行"
 
-#: order/models.py:3114 order/models.py:4117
+#: order/models.py:3185 order/models.py:4291
 msgid "Cannot allocate stock to a line without a part"
 msgstr "无法将库存分配给没有零件的生产线"
 
-#: order/models.py:3117 order/models.py:4120
+#: order/models.py:3188 order/models.py:4294
 msgid "Allocation quantity cannot exceed stock quantity"
 msgstr "分配数量不能超过库存数量"
 
-#: order/models.py:3137 order/models.py:4142
+#: order/models.py:3208 order/models.py:4316
 msgid "Allocation quantity must be greater than zero"
 msgstr "分配的数量必须大于零"
 
-#: order/models.py:3140 order/models.py:4145 order/serializers.py:1769
+#: order/models.py:3211 order/models.py:4319 order/serializers.py:1769
 #: order/serializers.py:2798
 msgid "Quantity must be 1 for serialized stock item"
 msgstr "序列化库存项目的数量必须为1"
 
-#: order/models.py:3143
+#: order/models.py:3214
 msgid "Sales order does not match shipment"
 msgstr "销售订单与发货不匹配"
 
-#: order/models.py:3144 plugin/base/barcodes/api.py:721
+#: order/models.py:3215 plugin/base/barcodes/api.py:721
 msgid "Shipment does not match sales order"
 msgstr "发货与销售订单不匹配"
 
-#: order/models.py:3152 order/models.py:4153
+#: order/models.py:3223 order/models.py:4327
 msgid "Line"
 msgstr "行"
 
-#: order/models.py:3163
+#: order/models.py:3234
 msgid "Sales order shipment reference"
 msgstr "销售订单发货参考"
 
-#: order/models.py:3176 order/models.py:3587 order/models.py:4166
+#: order/models.py:3247 order/models.py:3695 order/models.py:4340
 msgid "Item"
 msgstr "项目"
 
-#: order/models.py:3177 order/models.py:4167
+#: order/models.py:3248 order/models.py:4341
 msgid "Select stock item to allocate"
 msgstr "选择要分配的库存项目"
 
-#: order/models.py:3186 order/models.py:4176
+#: order/models.py:3257 order/models.py:4350
 msgid "Enter stock allocation quantity"
 msgstr "输入库存分配数量"
 
-#: order/models.py:3295
+#: order/models.py:3366
 msgid "Return Order reference"
 msgstr "退货订单参考"
 
-#: order/models.py:3307
+#: order/models.py:3378
 msgid "Company from which items are being returned"
 msgstr "退回物品的公司"
 
-#: order/models.py:3320
+#: order/models.py:3391
 msgid "Return order status"
 msgstr "退货订单状态"
 
-#: order/models.py:3545
+#: order/models.py:3653
 msgid "Return Order Line Item"
 msgstr "退货订单行项目"
 
-#: order/models.py:3558
+#: order/models.py:3666
 msgid "Stock item must be specified"
 msgstr "必须指定库存项"
 
-#: order/models.py:3562
+#: order/models.py:3670
 msgid "Return quantity exceeds stock quantity"
 msgstr "退回数量超过库存数量"
 
-#: order/models.py:3567
+#: order/models.py:3675
 msgid "Return quantity must be greater than zero"
 msgstr "退回数量必须大于零"
 
-#: order/models.py:3572
+#: order/models.py:3680
 msgid "Invalid quantity for serialized stock item"
 msgstr "序列化库存项的数量无效"
 
-#: order/models.py:3588
+#: order/models.py:3696
 msgid "Select item to return from customer"
 msgstr "选择要从客户处退回的商品"
 
-#: order/models.py:3603
+#: order/models.py:3711
 msgid "Received Date"
 msgstr "接收日期"
 
-#: order/models.py:3604
+#: order/models.py:3712
 msgid "The date this return item was received"
 msgstr "收到此退货的日期"
 
-#: order/models.py:3616
+#: order/models.py:3724
 msgid "Outcome"
 msgstr "结果"
 
-#: order/models.py:3617
+#: order/models.py:3725
 msgid "Outcome for this line item"
 msgstr "该行项目的结果"
 
-#: order/models.py:3624
+#: order/models.py:3732
 msgid "Cost associated with return or repair for this line item"
 msgstr "与此行项目的退货或维修相关的成本"
 
-#: order/models.py:3634
+#: order/models.py:3742
 msgid "Return Order Extra Line"
 msgstr "退货订单附加行"
 
-#: order/models.py:3735
+#: order/models.py:3843
 msgid "Transfer Order Reference"
 msgstr "调拨单号"
 
-#: order/models.py:3746
+#: order/models.py:3854
 msgid "Transfer order status"
 msgstr "调拨单状态"
 
-#: order/models.py:3761
+#: order/models.py:3869
 msgid "Source for transferred items"
 msgstr "转出物料来源仓库"
 
-#: order/models.py:3771
+#: order/models.py:3879
 msgid "Destination for transferred items"
 msgstr "物料转入目标仓库"
 
-#: order/models.py:3776
+#: order/models.py:3884
 msgid "Consume Stock"
 msgstr "消耗库存"
 
-#: order/models.py:3778
+#: order/models.py:3886
 msgid "Rather than transfer the stock to the destination, \"consume\" it, by removing transferred quantity from the allocated stock item"
 msgstr "不将库存调拨至目标仓库，而是直接消耗库存：从分配库存中扣减调拨数量"
 
-#: order/models.py:3837
+#: order/models.py:3944
 msgid "Order cannot be completed until a destination location is set"
 msgstr "需设置目标库位后方可完成该单据"
 
-#: order/models.py:3842
+#: order/models.py:3949
 msgid "Order cannot be completed until it is fully allocated"
 msgstr "单据需完成全部库存分配后方可办结"
 
-#: order/models.py:3994
+#: order/models.py:4168
 msgid "Transfer Order Line Item"
 msgstr "调拨单行项目"
 
-#: order/models.py:4027
+#: order/models.py:4201
 msgid "transferred"
 msgstr "已调拨"
 
-#: order/models.py:4028
+#: order/models.py:4202
 msgid "transferred quantity"
 msgstr "已调拨数量"
 
-#: order/models.py:4082
+#: order/models.py:4256
 msgid "Transfer Order Allocation"
 msgstr "调拨单分配"
 
-#: order/models.py:4235
+#: order/models.py:4409
 msgid "Failed to consume stock item against transfer order"
 msgstr "调拨单扣减库存物件失败"
 
-#: order/models.py:4247 order/models.py:4259
+#: order/models.py:4421 order/models.py:4433
 msgid "Failed to transfer stock item against transfer order"
 msgstr "无法依据调拨单转移库存物件"
 
@@ -6038,7 +6007,7 @@ msgstr "提供的条形码值必须是唯一的"
 
 #: order/serializers.py:1075
 msgid "Supplied serial numbers must be unique"
-msgstr ""
+msgstr "提供的序列号必须唯一"
 
 #: order/serializers.py:1217
 msgid "Shipments"
@@ -6150,39 +6119,39 @@ msgstr "允许单据在库存未完全分配完成时结案"
 msgid "Order has incomplete allocations"
 msgstr "单据存在未完成分配的物料"
 
-#: order/status_codes.py:26 order/status_codes.py:70 stock/status_codes.py:27
+#: order/status_codes.py:17 order/status_codes.py:54 stock/status_codes.py:16
 msgid "Lost"
 msgstr "丢失"
 
-#: order/status_codes.py:27 order/status_codes.py:71 stock/status_codes.py:29
+#: order/status_codes.py:18 order/status_codes.py:55 stock/status_codes.py:24
 msgid "Returned"
 msgstr "已退回"
 
-#: order/status_codes.py:65 order/status_codes.py:101
+#: order/status_codes.py:47 order/status_codes.py:80
 msgid "In Progress"
 msgstr "正在进行"
 
-#: order/status_codes.py:132
+#: order/status_codes.py:106
 msgid "Return"
 msgstr "退回"
 
-#: order/status_codes.py:133
+#: order/status_codes.py:109
 msgid "Repair"
 msgstr "维修"
 
-#: order/status_codes.py:134
+#: order/status_codes.py:112
 msgid "Replace"
 msgstr "替換"
 
-#: order/status_codes.py:135
+#: order/status_codes.py:115
 msgid "Refund"
 msgstr "退款"
 
-#: order/status_codes.py:136
+#: order/status_codes.py:118
 msgid "Reject"
 msgstr "拒绝"
 
-#: order/status_codes.py:151
+#: order/status_codes.py:126
 #: report/templates/report/inventree_build_order_report.html:121
 msgid "Issued"
 msgstr "已派发"
@@ -6347,7 +6316,7 @@ msgstr "使用"
 msgid "Part Category"
 msgstr "零件类别"
 
-#: part/models.py:95 users/ruleset.py:43
+#: part/models.py:95 users/ruleset.py:29
 msgid "Part Categories"
 msgstr "零件类别"
 
@@ -6400,7 +6369,7 @@ msgstr "默认值"
 msgid "Default Parameter Value"
 msgstr "默认参数值"
 
-#: part/models.py:531 part/serializers.py:135 users/ruleset.py:44
+#: part/models.py:531 part/serializers.py:135 users/ruleset.py:30
 msgid "Parts"
 msgstr "零件"
 
@@ -6801,7 +6770,7 @@ msgid "Total available stock at time of stocktake"
 msgstr "盘点时可用库存总额"
 
 #: part/models.py:3388 report/templates/report/inventree_test_report.html:106
-#: stock/models.py:3938
+#: stock/models.py:3933
 msgid "Date"
 msgstr "日期"
 
@@ -6905,167 +6874,159 @@ msgstr "添加测试结果时是否需要文件附件？"
 msgid "Valid choices for this test (comma-separated)"
 msgstr "此测试的有效选择 (逗号分隔)"
 
-#: part/models.py:3815
+#: part/models.py:3813
 msgid "Invalid quantity - no units specified for part"
 msgstr "数量无效 - 未指定零件的单位"
 
-#: part/models.py:3824
+#: part/models.py:3822
 msgid "Quantity must be greater than or equal to zero"
 msgstr "数量必须大于或等于零"
 
-#: part/models.py:3925
+#: part/models.py:3923
 msgid "BOM item cannot be modified - assembly is locked"
 msgstr "物料清单项目不能被修改 - 装配已锁定"
 
-#: part/models.py:3932
+#: part/models.py:3930
 msgid "BOM item cannot be modified - variant assembly is locked"
 msgstr "物料清单项目不能修改 - 变体装配已锁定"
 
-#: part/models.py:3942
+#: part/models.py:3940
 msgid "Select parent part"
 msgstr "选择父零件"
 
-#: part/models.py:3952
+#: part/models.py:3950
 msgid "Sub part"
 msgstr "子零件"
 
-#: part/models.py:3953
+#: part/models.py:3951
 msgid "Select part to be used in BOM"
 msgstr "选择要用于物料清单的零件"
 
-#: part/models.py:3959 part/serializers.py:1704
+#: part/models.py:3957 part/serializers.py:1703
 msgid "Amount"
 msgstr "数量"
 
-#: part/models.py:3960
+#: part/models.py:3958
 msgid "Amount of sub-part consumed to produce one part"
 msgstr "生产一个部件所消耗的子零件数量"
 
-#: part/models.py:3972
+#: part/models.py:3970
 msgid "BOM quantity for this BOM item"
 msgstr "此物料清单项目的数量"
 
-#: part/models.py:3978
+#: part/models.py:3976
 msgid "This BOM item is optional"
 msgstr "此物料清单项目是可选的"
 
-#: part/models.py:3984
+#: part/models.py:3982
 msgid "This BOM item is consumable (it is not tracked in build orders)"
 msgstr "这个物料清单项目是耗材 (它没有在生产订单中被追踪)"
 
-#: part/models.py:3992
+#: part/models.py:3990
 msgid "Setup Quantity"
 msgstr "设置数量"
 
-#: part/models.py:3993
+#: part/models.py:3991
 msgid "Extra required quantity for a build, to account for setup losses"
 msgstr "为补偿生产准备损耗所需的额外数量"
 
-#: part/models.py:4001
+#: part/models.py:3999
 msgid "Attrition"
 msgstr "损耗"
 
-#: part/models.py:4003
+#: part/models.py:4001
 msgid "Estimated attrition for a build, expressed as a percentage (0-100)"
 msgstr "生产预估损耗率（百分比，0-100）"
 
-#: part/models.py:4014
+#: part/models.py:4012
 msgid "Rounding Multiple"
 msgstr "舍入倍数"
 
-#: part/models.py:4016
+#: part/models.py:4014
 msgid "Round up required production quantity to nearest multiple of this value"
 msgstr "将所需生产数量向上舍入至该值的最接近倍数"
 
-#: part/models.py:4023 part/serializers.py:1722
-msgid "Piece Count"
-msgstr ""
-
-#: part/models.py:4025 part/serializers.py:1724
-msgid "Number of pieces required (for cut-to-length items). Total material = quantity x piece_count."
-msgstr ""
-
-#: part/models.py:4034
+#: part/models.py:4022
 msgid "BOM item reference"
 msgstr "物料清单项目引用"
 
-#: part/models.py:4042
+#: part/models.py:4030
 msgid "BOM item notes"
 msgstr "物料清单项目注释"
 
-#: part/models.py:4048
+#: part/models.py:4036
 msgid "Checksum"
 msgstr "校验和"
 
-#: part/models.py:4049
+#: part/models.py:4037
 msgid "BOM line checksum"
 msgstr "物料清单行校验和"
 
-#: part/models.py:4054
+#: part/models.py:4042
 msgid "Validated"
 msgstr "已验证"
 
-#: part/models.py:4055
+#: part/models.py:4043
 msgid "This BOM item has been validated"
 msgstr "此物料清单项目已验证"
 
-#: part/models.py:4060
+#: part/models.py:4048
 msgid "Gets inherited"
 msgstr "获取继承的"
 
-#: part/models.py:4061
+#: part/models.py:4049
 msgid "This BOM item is inherited by BOMs for variant parts"
 msgstr "此物料清单项目是由物料清单继承的变体零件"
 
-#: part/models.py:4067
+#: part/models.py:4055
 msgid "Stock items for variant parts can be used for this BOM item"
 msgstr "变体零件的库存项可以用于此物料清单项目"
 
-#: part/models.py:4204 stock/models.py:1064
+#: part/models.py:4191 stock/models.py:1064
 msgid "Quantity must be integer value for trackable parts"
 msgstr "可追踪零件的数量必须是整数"
 
-#: part/models.py:4214 part/models.py:4216
+#: part/models.py:4201 part/models.py:4203
 msgid "Sub part must be specified"
 msgstr "必须指定子零件"
 
-#: part/models.py:4354
+#: part/models.py:4336
 msgid "BOM Item Substitute"
 msgstr "物料清单项目替代品"
 
-#: part/models.py:4375
+#: part/models.py:4357
 msgid "Substitute part cannot be the same as the master part"
 msgstr "替代品零件不能与主零件相同"
 
-#: part/models.py:4388
+#: part/models.py:4370
 msgid "Parent BOM item"
 msgstr "上级物料清单项目"
 
-#: part/models.py:4396
+#: part/models.py:4378
 msgid "Substitute part"
 msgstr "替代品零件"
 
-#: part/models.py:4412
+#: part/models.py:4394
 msgid "Part 1"
 msgstr "零件 1"
 
-#: part/models.py:4420
+#: part/models.py:4402
 msgid "Part 2"
 msgstr "零件2"
 
-#: part/models.py:4421
+#: part/models.py:4403
 msgid "Select Related Part"
 msgstr "选择相关的零件"
 
-#: part/models.py:4428
+#: part/models.py:4410
 msgid "Note for this relationship"
 msgstr "此关系的注释"
 
-#: part/models.py:4447
+#: part/models.py:4429
 msgid "Part relationship cannot be created between a part and itself"
 msgstr "零件关系不能在零件和自身之间创建"
 
-#: part/models.py:4452
+#: part/models.py:4434
 msgid "Duplicate relationship already exists"
 msgstr "复制关系已经存在"
 
@@ -7174,7 +7135,7 @@ msgid "Outstanding quantity of this part scheduled to be built"
 msgstr "此零件计划待产数量"
 
 #: part/serializers.py:856 stock/serializers.py:1264 stock/serializers.py:1480
-#: users/ruleset.py:47
+#: users/ruleset.py:33
 msgid "Stock Items"
 msgstr "库存项"
 
@@ -7276,7 +7237,7 @@ msgstr "图片不存在"
 msgid "Validate entire Bill of Materials"
 msgstr "验证整个物料清单"
 
-#: part/serializers.py:1196 part/serializers.py:1805
+#: part/serializers.py:1196 part/serializers.py:1794
 msgid "Can Build"
 msgstr "可以创建"
 
@@ -7377,55 +7338,55 @@ msgstr "最低价格不能高于最高价格。"
 msgid "Maximum price must not be less than minimum price"
 msgstr "最高价格不能低于最低价格"
 
-#: part/serializers.py:1705
+#: part/serializers.py:1704
 msgid "Amount required for this item (can include units)"
 msgstr "此商品所需数量（可包含单位）"
 
-#: part/serializers.py:1732
+#: part/serializers.py:1721
 msgid "Select the parent assembly"
 msgstr "选择父装配"
 
-#: part/serializers.py:1767
+#: part/serializers.py:1756
 msgid "Select the component part"
 msgstr "选择零部件"
 
-#: part/serializers.py:1887
+#: part/serializers.py:1876
 msgid "Invalid quantity format"
 msgstr "无效的数量格式"
 
-#: part/serializers.py:2016
+#: part/serializers.py:2005
 msgid "Select part to copy BOM from"
 msgstr "选择要复制物料清单的零件"
 
-#: part/serializers.py:2024
+#: part/serializers.py:2013
 msgid "Remove Existing Data"
 msgstr "移除现有数据"
 
-#: part/serializers.py:2025
+#: part/serializers.py:2014
 msgid "Remove existing BOM items before copying"
 msgstr "复制前删除现有的物料清单项目"
 
-#: part/serializers.py:2030
+#: part/serializers.py:2019
 msgid "Include Inherited"
 msgstr "包含继承的"
 
-#: part/serializers.py:2031
+#: part/serializers.py:2020
 msgid "Include BOM items which are inherited from templated parts"
 msgstr "包含从模板零件继承的物料清单项目"
 
-#: part/serializers.py:2036
+#: part/serializers.py:2025
 msgid "Skip Invalid Rows"
 msgstr "跳过无效行"
 
-#: part/serializers.py:2037
+#: part/serializers.py:2026
 msgid "Enable this option to skip invalid rows"
 msgstr "启用此选项以跳过无效行"
 
-#: part/serializers.py:2042
+#: part/serializers.py:2031
 msgid "Copy Substitute Parts"
 msgstr "复制替代品零件"
 
-#: part/serializers.py:2043
+#: part/serializers.py:2032
 msgid "Copy substitute parts when duplicate BOM items"
 msgstr "复制物料清单项目时复制替代品零件"
 
@@ -7530,7 +7491,7 @@ msgstr "找到多个匹配的供应商零件"
 
 #: plugin/base/barcodes/api.py:448 plugin/base/barcodes/api.py:508
 msgid "You do not have the required permissions for purchase orders"
-msgstr ""
+msgstr "您没有采购订单所需的权限"
 
 #: plugin/base/barcodes/api.py:458 plugin/base/barcodes/api.py:761
 msgid "No matching plugin found for barcode data"
@@ -7566,7 +7527,7 @@ msgstr "未找到匹配的行项目"
 
 #: plugin/base/barcodes/api.py:749
 msgid "You do not have the required permissions for sales orders"
-msgstr ""
+msgstr "您没有销售订单所需的权限"
 
 #: plugin/base/barcodes/api.py:758
 msgid "No sales order provided"
@@ -8252,7 +8213,7 @@ msgstr "作为‘TME’的供应商"
 
 #: plugin/installer.py:44
 msgid "Pip is not installed in the current environment"
-msgstr ""
+msgstr "当前环境中未安装 pip"
 
 #: plugin/installer.py:243 plugin/installer.py:348 plugin/serializers.py:169
 #: plugin/serializers.py:275
@@ -8265,7 +8226,7 @@ msgstr "插件安装已禁用"
 
 #: plugin/installer.py:267
 msgid "Invalid URL and no package name provided"
-msgstr ""
+msgstr "URL 无效且未提供包名称"
 
 #: plugin/installer.py:276
 msgid "No package name or URL provided for installation"
@@ -8627,7 +8588,7 @@ msgstr "标识该配置项是否被外部配置覆盖"
 msgid "The user for which this setting applies"
 msgstr "该设置项适用的目标用户"
 
-#: report/api.py:45 report/serializers.py:123 report/serializers.py:183
+#: report/api.py:45 report/serializers.py:123 report/serializers.py:173
 msgid "Items"
 msgstr "项目"
 
@@ -8808,19 +8769,19 @@ msgstr "用户必须通过身份验证才能保存报告模板"
 msgid "Select report template"
 msgstr "选择报表模板"
 
-#: report/serializers.py:124 report/serializers.py:184
+#: report/serializers.py:124 report/serializers.py:174
 msgid "List of item primary keys to include in the report"
 msgstr "要包含在报告中的项目主键列表"
 
-#: report/serializers.py:167
+#: report/serializers.py:157
 msgid "Select label template"
 msgstr "选择标签模板"
 
-#: report/serializers.py:175
+#: report/serializers.py:165
 msgid "Printing Plugin"
 msgstr "打印插件"
 
-#: report/serializers.py:176
+#: report/serializers.py:166
 msgid "Select plugin to use for label printing"
 msgstr "选择用于标签打印的插件"
 
@@ -9161,7 +9122,7 @@ msgstr "为所有没有图标的位置设置默认图标(可选)"
 msgid "Stock Location"
 msgstr "库存地点"
 
-#: stock/models.py:152 users/ruleset.py:46
+#: stock/models.py:152 users/ruleset.py:32
 msgid "Stock Locations"
 msgstr "库存地点"
 
@@ -9408,7 +9369,7 @@ msgstr "必须以列表形式提供序列号"
 msgid "Quantity does not match serial numbers"
 msgstr "数量不匹配序列号"
 
-#: stock/models.py:2606 stock/models.py:3856
+#: stock/models.py:2606 stock/models.py:3851
 msgid "Test template does not exist"
 msgstr "测试模板不存在"
 
@@ -9456,67 +9417,67 @@ msgstr "库存状态码必须匹配"
 msgid "StockItem cannot be moved as it is not in stock"
 msgstr "库存项不能移动，因为它没有库存"
 
-#: stock/models.py:3736
+#: stock/models.py:3731
 msgid "Stock Item Tracking"
 msgstr "库存项跟踪"
 
-#: stock/models.py:3786
+#: stock/models.py:3781
 msgid "Entry notes"
 msgstr "条目注释"
 
-#: stock/models.py:3826
+#: stock/models.py:3821
 msgid "Stock Item Test Result"
 msgstr "库存项测试结果"
 
-#: stock/models.py:3859
+#: stock/models.py:3854
 msgid "Value must be provided for this test"
 msgstr "必须为此测试提供值"
 
-#: stock/models.py:3863
+#: stock/models.py:3858
 msgid "Attachment must be uploaded for this test"
 msgstr "测试附件必须上传"
 
-#: stock/models.py:3868
+#: stock/models.py:3863
 msgid "Invalid value for this test"
 msgstr "此测试的值无效"
 
-#: stock/models.py:3892
+#: stock/models.py:3887
 msgid "Test result"
 msgstr "测试结果"
 
-#: stock/models.py:3899
+#: stock/models.py:3894
 msgid "Test output value"
 msgstr "测试输出值"
 
-#: stock/models.py:3907 stock/serializers.py:264
+#: stock/models.py:3902 stock/serializers.py:264
 msgid "Test result attachment"
 msgstr "测验结果附件"
 
-#: stock/models.py:3911
+#: stock/models.py:3906
 msgid "Test notes"
 msgstr "测试备注"
 
-#: stock/models.py:3919
+#: stock/models.py:3914
 msgid "Test station"
 msgstr "测试站"
 
-#: stock/models.py:3920
+#: stock/models.py:3915
 msgid "The identifier of the test station where the test was performed"
 msgstr "进行测试的测试站的标识符"
 
-#: stock/models.py:3926
+#: stock/models.py:3921
 msgid "Started"
 msgstr "已开始"
 
-#: stock/models.py:3927
+#: stock/models.py:3922
 msgid "The timestamp of the test start"
 msgstr "测试开始的时间戳"
 
-#: stock/models.py:3933
+#: stock/models.py:3928
 msgid "Finished"
 msgstr "已完成"
 
-#: stock/models.py:3934
+#: stock/models.py:3929
 msgid "The timestamp of the test finish"
 msgstr "测试结束的时间戳"
 
@@ -9867,147 +9828,147 @@ msgstr "下一个序列号"
 msgid "Previous Serial Number"
 msgstr "上一个序列号"
 
-#: stock/status_codes.py:22
+#: stock/status_codes.py:11
 msgid "OK"
-msgstr "OK"
+msgstr "正常"
 
-#: stock/status_codes.py:23
+#: stock/status_codes.py:12
 msgid "Attention needed"
 msgstr "需要关注"
 
-#: stock/status_codes.py:24
+#: stock/status_codes.py:13
 msgid "Damaged"
 msgstr "破损"
 
-#: stock/status_codes.py:25
+#: stock/status_codes.py:14
 msgid "Destroyed"
 msgstr "销毁"
 
-#: stock/status_codes.py:26
+#: stock/status_codes.py:15
 msgid "Rejected"
 msgstr "拒绝"
 
-#: stock/status_codes.py:28
+#: stock/status_codes.py:19
 msgid "Quarantined"
 msgstr "隔离"
 
-#: stock/status_codes.py:95
+#: stock/status_codes.py:44
 msgid "Legacy stock tracking entry"
 msgstr "旧库存跟踪条目"
 
-#: stock/status_codes.py:97
+#: stock/status_codes.py:46
 msgid "Stock item created"
 msgstr "库存项已创建"
 
-#: stock/status_codes.py:100
+#: stock/status_codes.py:49
 msgid "Edited stock item"
 msgstr "已编辑库存项"
 
-#: stock/status_codes.py:101
+#: stock/status_codes.py:50
 msgid "Assigned serial number"
 msgstr "已分配序列号"
 
-#: stock/status_codes.py:104
+#: stock/status_codes.py:53
 msgid "Stock counted"
 msgstr "库存计数"
 
-#: stock/status_codes.py:105
+#: stock/status_codes.py:54
 msgid "Stock manually added"
 msgstr "已手动添加库存"
 
-#: stock/status_codes.py:106
+#: stock/status_codes.py:55
 msgid "Stock manually removed"
 msgstr "已手动删除库存"
 
-#: stock/status_codes.py:107
+#: stock/status_codes.py:56
 msgid "Serialized stock items"
 msgstr "已序列化的库存物品"
 
-#: stock/status_codes.py:109
+#: stock/status_codes.py:58
 msgid "Returned to stock"
 msgstr "退回库存"
 
-#: stock/status_codes.py:112
+#: stock/status_codes.py:61
 msgid "Location changed"
 msgstr "地点已更改"
 
-#: stock/status_codes.py:113
+#: stock/status_codes.py:62
 msgid "Stock updated"
 msgstr "库存已更新"
 
-#: stock/status_codes.py:116
+#: stock/status_codes.py:65
 msgid "Installed into assembly"
 msgstr "已安装到装配中"
 
-#: stock/status_codes.py:117
+#: stock/status_codes.py:66
 msgid "Removed from assembly"
 msgstr "已从装配中删除"
 
-#: stock/status_codes.py:119
+#: stock/status_codes.py:68
 msgid "Installed component item"
 msgstr "已安装组件项"
 
-#: stock/status_codes.py:120
+#: stock/status_codes.py:69
 msgid "Removed component item"
 msgstr "已删除组件项"
 
-#: stock/status_codes.py:123
+#: stock/status_codes.py:72
 msgid "Split from parent item"
 msgstr "从上级项拆分"
 
-#: stock/status_codes.py:124
+#: stock/status_codes.py:73
 msgid "Split child item"
 msgstr "拆分子项"
 
-#: stock/status_codes.py:127
+#: stock/status_codes.py:76
 msgid "Merged stock items"
 msgstr "合并的库存项"
 
-#: stock/status_codes.py:130
+#: stock/status_codes.py:79
 msgid "Disassembled into components"
 msgstr "已拆解为组件"
 
-#: stock/status_codes.py:131
+#: stock/status_codes.py:80
 msgid "Created from disassembly"
 msgstr "由拆解生成"
 
-#: stock/status_codes.py:134
+#: stock/status_codes.py:83
 msgid "Converted to variant"
 msgstr "转换为变体"
 
-#: stock/status_codes.py:137
+#: stock/status_codes.py:86
 msgid "Build order output created"
 msgstr "已创建生产订单产出"
 
-#: stock/status_codes.py:138
+#: stock/status_codes.py:87
 msgid "Build order output completed"
 msgstr "生产订单已出产"
 
-#: stock/status_codes.py:139
+#: stock/status_codes.py:88
 msgid "Build order output rejected"
 msgstr "生产订单产出被拒绝"
 
-#: stock/status_codes.py:140
+#: stock/status_codes.py:89
 msgid "Consumed by build order"
 msgstr "被生产订单消耗"
 
-#: stock/status_codes.py:143
+#: stock/status_codes.py:92
 msgid "Shipped against Sales Order"
 msgstr "根据销售订单发货"
 
-#: stock/status_codes.py:146
+#: stock/status_codes.py:95
 msgid "Received against Purchase Order"
 msgstr "根据采购订单接收"
 
-#: stock/status_codes.py:149
+#: stock/status_codes.py:98
 msgid "Returned against Return Order"
 msgstr "根据退货订单退货"
 
-#: stock/status_codes.py:152
+#: stock/status_codes.py:101
 msgid "Sent to customer"
 msgstr "发往客户"
 
-#: stock/status_codes.py:153
+#: stock/status_codes.py:102
 msgid "Returned from customer"
 msgstr "客户退回"
 
@@ -10337,27 +10298,27 @@ msgstr "主组"
 msgid "Primary group for the user"
 msgstr "用户主组"
 
-#: users/ruleset.py:42
+#: users/ruleset.py:28
 msgid "Admin"
 msgstr "管理员"
 
-#: users/ruleset.py:45
+#: users/ruleset.py:31
 msgid "Bills of Material"
 msgstr "物料清单"
 
-#: users/ruleset.py:49
+#: users/ruleset.py:35
 msgid "Purchase Orders"
 msgstr "采购订单"
 
-#: users/ruleset.py:50
+#: users/ruleset.py:36
 msgid "Sales Orders"
 msgstr "销售订单"
 
-#: users/ruleset.py:51
+#: users/ruleset.py:37
 msgid "Return Orders"
 msgstr "退货订单"
 
-#: users/ruleset.py:52
+#: users/ruleset.py:38
 msgid "Transfer Orders"
 msgstr "调拨单"
 

--- a/src/frontend/src/locales/zh_Hans/messages.po
+++ b/src/frontend/src/locales/zh_Hans/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Language: zh\n"
 "Project-Id-Version: inventree\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2026-08-25 04:38\n"
+"PO-Revision-Date: 2026-08-10 05:57\n"
 "Last-Translator: \n"
 "Language-Team: Chinese Simplified\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
@@ -28,7 +28,7 @@ msgstr "渲染组件出错"
 
 #: lib/components/Boundary.tsx:20
 msgid "An error occurred while rendering this component."
-msgstr ""
+msgstr "渲染此组件时发生错误。"
 
 #: lib/components/Boundary.tsx:23
 msgid "Try reloading the page, or contact your administrator if the problem persists."
@@ -56,17 +56,17 @@ msgstr "复制"
 
 #: lib/components/RowActions.tsx:56
 #: src/components/items/ActionDropdown.tsx:248
-#: src/components/nav/PageDetail.tsx:63
+#: src/components/nav/PageDetail.tsx:60
 msgid "Edit"
 msgstr "编辑"
 
 #: lib/components/RowActions.tsx:66
-#: src/components/forms/ApiForm.tsx:852
+#: src/components/forms/ApiForm.tsx:835
 #: src/components/items/ActionDropdown.tsx:260
 #: src/components/items/RoleTable.tsx:155
 #: src/hooks/UseForm.tsx:174
 #: src/pages/Notifications.tsx:109
-#: src/tables/plugin/PluginListTable.tsx:253
+#: src/tables/plugin/PluginListTable.tsx:254
 msgid "Delete"
 msgstr "删除"
 
@@ -88,7 +88,7 @@ msgstr "取消"
 
 #: lib/components/RowActions.tsx:146
 #: src/components/nav/NavigationDrawer.tsx:185
-#: src/forms/PurchaseOrderForms.tsx:939
+#: src/forms/PurchaseOrderForms.tsx:931
 #: src/forms/StockForms.tsx:911
 #: src/forms/StockForms.tsx:1478
 #: src/forms/StockForms.tsx:1526
@@ -105,7 +105,7 @@ msgstr "操作"
 #: src/components/nav/Header.tsx:191
 #: src/components/wizards/ImportPartWizard.tsx:200
 #: src/components/wizards/ImportPartWizard.tsx:233
-#: src/pages/Index/Settings/UserSettings.tsx:77
+#: src/pages/Index/Settings/UserSettings.tsx:75
 #: src/pages/part/PartDetail.tsx:758
 msgid "Search"
 msgstr "搜索"
@@ -153,7 +153,7 @@ msgstr "否"
 #: src/forms/BuildForms.tsx:702
 #: src/forms/BuildForms.tsx:866
 #: src/forms/BuildForms.tsx:970
-#: src/forms/PurchaseOrderForms.tsx:935
+#: src/forms/PurchaseOrderForms.tsx:927
 #: src/forms/ReturnOrderForms.tsx:241
 #: src/forms/SalesOrderForms.tsx:434
 #: src/forms/StockForms.tsx:393
@@ -341,7 +341,7 @@ msgstr "库存历史记录"
 #: src/pages/stock/StockDetailsPanel.tsx:280
 #: src/tables/build/BuildAllocatedStockTable.tsx:88
 #: src/tables/part/PartBuildAllocationsTable.tsx:46
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:165
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:155
 #: src/tables/stock/StockTrackingTable.tsx:142
 msgid "Build Order"
 msgstr "生产订单"
@@ -352,7 +352,7 @@ msgstr "生产订单"
 #: src/pages/Index/Settings/SystemSettings.tsx:316
 #: src/pages/build/BuildIndex.tsx:87
 #: src/pages/part/PartDetail.tsx:419
-#: src/pages/sales/SalesOrderDetail.tsx:215
+#: src/pages/sales/SalesOrderDetail.tsx:214
 msgid "Build Orders"
 msgstr "生产订单"
 
@@ -408,7 +408,7 @@ msgstr "项目编码"
 #: src/components/previews/models/PurchaseOrderPreview.tsx:15
 #: src/components/wizards/OrderPartsWizard.tsx:350
 #: src/pages/part/pricing/PurchaseHistoryPanel.tsx:34
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:368
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:367
 #: src/pages/stock/StockDetailsPanel.tsx:288
 #: src/tables/part/PartPurchaseOrdersTable.tsx:40
 #: src/tables/stock/StockItemTable.tsx:104
@@ -439,7 +439,7 @@ msgstr "采购订单行"
 #: src/components/previews/models/SalesOrderPreview.tsx:15
 #: src/pages/build/BuildOrderDetailsPanel.tsx:135
 #: src/pages/part/pricing/SaleHistoryPanel.tsx:25
-#: src/pages/sales/SalesOrderDetail.tsx:419
+#: src/pages/sales/SalesOrderDetail.tsx:418
 #: src/pages/sales/SalesOrderShipmentDetail.tsx:270
 #: src/pages/sales/SalesOrderShipmentDetailsPanel.tsx:58
 #: src/pages/stock/StockDetailsPanel.tsx:297
@@ -472,7 +472,7 @@ msgstr "销售订单配送"
 
 #: lib/enums/ModelInformation.tsx:238
 #: src/components/previews/models/ReturnOrderPreview.tsx:15
-#: src/pages/sales/ReturnOrderDetail.tsx:349
+#: src/pages/sales/ReturnOrderDetail.tsx:348
 #: src/tables/stock/StockTrackingTable.tsx:175
 msgid "Return Order"
 msgstr "退货订单"
@@ -622,7 +622,7 @@ msgid "Report Templates"
 msgstr "报告模板"
 
 #: lib/enums/ModelInformation.tsx:331
-#: src/components/plugins/PluginDrawer.tsx:168
+#: src/components/plugins/PluginDrawer.tsx:153
 msgid "Plugin Configuration"
 msgstr "插件配置"
 
@@ -676,7 +676,7 @@ msgstr "入选"
 #: src/components/tables/InvenTreeTableHeader.tsx:164
 #: src/components/wizards/ImportPartWizard.tsx:574
 #: src/components/wizards/ImportPartWizard.tsx:719
-#: src/forms/BomForms.tsx:87
+#: src/forms/BomForms.tsx:83
 #: src/functions/auth.tsx:711
 #: src/pages/ErrorPage.tsx:11
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:317
@@ -687,7 +687,7 @@ msgstr "入选"
 #: src/pages/part/PartPricingPanel.tsx:71
 #: src/states/IconState.tsx:46
 #: src/states/IconState.tsx:76
-#: src/tables/bom/BomTable.tsx:605
+#: src/tables/bom/BomTable.tsx:592
 #: src/tables/settings/EmailTable.tsx:109
 #: src/tables/stock/StockItemTestResultTable.tsx:336
 msgid "Error"
@@ -819,8 +819,8 @@ msgstr "输入条形码数据"
 #: src/components/barcodes/BarcodeScanDialog.tsx:56
 #: src/components/buttons/ScanButton.tsx:56
 #: src/components/nav/NavigationDrawer.tsx:122
-#: src/forms/PurchaseOrderForms.tsx:533
-#: src/forms/PurchaseOrderForms.tsx:673
+#: src/forms/PurchaseOrderForms.tsx:534
+#: src/forms/PurchaseOrderForms.tsx:674
 msgid "Scan Barcode"
 msgstr "扫描条形码"
 
@@ -835,11 +835,11 @@ msgstr "条形码与预期型号不匹配"
 #: src/components/barcodes/BarcodeScanDialog.tsx:161
 #: src/components/editors/NotesEditor.tsx:91
 #: src/components/editors/NotesEditor.tsx:125
-#: src/components/forms/ApiForm.tsx:550
+#: src/components/forms/ApiForm.tsx:533
 #: src/components/wizards/ImportPartWizard.tsx:566
 #: src/components/wizards/ImportPartWizard.tsx:691
 #: src/pages/Index/Settings/AdminCenter/CurrencyManagementPanel.tsx:45
-#: src/tables/bom/BomTable.tsx:596
+#: src/tables/bom/BomTable.tsx:583
 #: src/tables/settings/PendingTasksTable.tsx:68
 msgid "Success"
 msgstr "操作成功"
@@ -906,7 +906,7 @@ msgstr "这将删除关联条形码的链接"
 
 #: src/components/barcodes/QRCode.tsx:205
 #: src/components/items/ActionDropdown.tsx:194
-#: src/forms/PurchaseOrderForms.tsx:663
+#: src/forms/PurchaseOrderForms.tsx:664
 msgid "Unlink Barcode"
 msgstr "解绑条形码"
 
@@ -1108,8 +1108,8 @@ msgstr "开始日期"
 #: src/pages/stock/TransferOrderDetailsPanel.tsx:141
 #: src/tables/part/PartPurchaseOrdersTable.tsx:110
 #: src/tables/part/PartSalesOrdersTable.tsx:72
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:206
-#: src/tables/sales/SalesOrderLineItemTable.tsx:172
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:159
+#: src/tables/sales/SalesOrderLineItemTable.tsx:142
 #: src/tables/stock/TransferOrderLineItemTable.tsx:117
 msgid "Target Date"
 msgstr "预计日期"
@@ -1560,7 +1560,7 @@ msgid "Clear"
 msgstr "清除"
 
 #: src/components/details/DetailsImage.tsx:305
-#: src/components/forms/ApiForm.tsx:794
+#: src/components/forms/ApiForm.tsx:777
 #: src/contexts/ThemeContext.tsx:56
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:151
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:570
@@ -1829,8 +1829,8 @@ msgstr "服务器错误"
 msgid "A server error occurred"
 msgstr "服务器出错。"
 
-#: src/components/forms/ApiForm.tsx:112
-#: src/components/forms/ApiForm.tsx:713
+#: src/components/forms/ApiForm.tsx:109
+#: src/components/forms/ApiForm.tsx:696
 msgid "Form Error"
 msgstr "表单错误"
 
@@ -1838,17 +1838,17 @@ msgstr "表单错误"
 #~ msgid "Form Errors Exist"
 #~ msgstr "Form Errors Exist"
 
-#: src/components/forms/ApiForm.tsx:674
+#: src/components/forms/ApiForm.tsx:657
 msgid "Submit form"
 msgstr "提交表单"
 
-#: src/components/forms/ApiForm.tsx:723
+#: src/components/forms/ApiForm.tsx:706
 msgid "Errors exist for one or more form fields"
 msgstr "一个或多个表单字段存在错误"
 
-#: src/components/forms/ApiForm.tsx:832
+#: src/components/forms/ApiForm.tsx:815
 #: src/hooks/UseForm.tsx:143
-#: src/tables/plugin/PluginListTable.tsx:216
+#: src/tables/plugin/PluginListTable.tsx:217
 msgid "Update"
 msgstr "更新"
 
@@ -2034,7 +2034,7 @@ msgstr "主机"
 #: src/components/forms/HostOptionsForm.tsx:42
 #: src/components/forms/HostOptionsForm.tsx:70
 #: src/components/forms/InstanceOptions.tsx:125
-#: src/components/plugins/PluginDrawer.tsx:85
+#: src/components/plugins/PluginDrawer.tsx:68
 #: src/pages/Index/Settings/AdminCenter/UnitManagementPanel.tsx:19
 #: src/pages/part/PartCategoryDetailsPanel.tsx:22
 #: src/pages/part/PartDetailsPanel.tsx:79
@@ -2104,7 +2104,7 @@ msgid "Server"
 msgstr "服务器"
 
 #: src/components/forms/InstanceOptions.tsx:131
-#: src/components/plugins/PluginDrawer.tsx:103
+#: src/components/plugins/PluginDrawer.tsx:88
 #: src/tables/plugin/PluginListTable.tsx:134
 msgid "Version"
 msgstr "版本"
@@ -2233,7 +2233,7 @@ msgstr "添加新行"
 #: src/components/forms/fields/TreeField.tsx:328
 #: src/components/render/Instance.tsx:145
 #: src/components/render/ModelHoverCard.tsx:73
-#: src/components/tables/InvenTreeTable.tsx:900
+#: src/components/tables/InvenTreeTable.tsx:810
 msgid "View details"
 msgstr "查看详情"
 
@@ -2421,7 +2421,7 @@ msgstr "数据已成功导入"
 #: src/components/modals/AboutInvenTreeModal.tsx:206
 #: src/components/modals/ServerInfoModal.tsx:134
 #: src/components/wizards/ImportPartWizard.tsx:773
-#: src/forms/BomForms.tsx:150
+#: src/forms/BomForms.tsx:146
 #: src/pages/Index/Settings/AccountSettings/MFASettings.tsx:687
 msgid "Close"
 msgstr "关闭"
@@ -2574,7 +2574,7 @@ msgid "Create a new part"
 msgstr "创建一个新零件"
 
 #: src/components/items/PartCreationMenu.tsx:92
-#: src/tables/bom/BomTable.tsx:683
+#: src/tables/bom/BomTable.tsx:670
 #: src/tables/general/ParameterTable.tsx:203
 msgid "Import from File"
 msgstr "从文件导入"
@@ -2656,7 +2656,7 @@ msgid "No items"
 msgstr "没有项目"
 
 #: src/components/items/TransferList.tsx:161
-#: src/components/render/Stock.tsx:98
+#: src/components/render/Stock.tsx:97
 #: src/components/tables/ColumnRenderers.tsx:265
 #: src/components/tables/PartStockCell.tsx:85
 #: src/pages/part/PartDetail.tsx:575
@@ -2915,24 +2915,6 @@ msgstr "存在待处理的数据库迁移。"
 msgid "Learn more about {code}"
 msgstr "了解更多关于{code}的信息"
 
-#: src/components/nav/DetailNavigation.tsx:34
-msgid "Next item"
-msgstr ""
-
-#: src/components/nav/DetailNavigation.tsx:35
-msgid "Previous item"
-msgstr ""
-
-#: src/components/nav/DetailNavigation.tsx:36
-msgid "Remove navigation filters from current view"
-msgstr ""
-
-#. placeholder {0}: navigation.position.current
-#. placeholder {1}: navigation.position.total
-#: src/components/nav/DetailNavigation.tsx:54
-msgid "{0} of {1}"
-msgstr ""
-
 #: src/components/nav/Header.tsx:63
 #: src/components/nav/Header.tsx:70
 msgid "Open search"
@@ -2942,7 +2924,7 @@ msgstr "打开搜索框"
 #: src/components/nav/NavigationDrawer.tsx:134
 #: src/components/nav/NotificationDrawer.tsx:181
 #: src/pages/Index/Settings/SystemSettings.tsx:146
-#: src/pages/Index/Settings/UserSettings.tsx:110
+#: src/pages/Index/Settings/UserSettings.tsx:108
 #: src/pages/Notifications.tsx:45
 #: src/pages/Notifications.tsx:130
 msgid "Notifications"
@@ -2989,8 +2971,8 @@ msgstr "设置"
 #: src/components/nav/NavigationDrawer.tsx:140
 #: src/components/nav/SettingsHeader.tsx:40
 #: src/defaults/actions.tsx:106
-#: src/pages/Index/Settings/UserSettings.tsx:147
-#: src/pages/Index/Settings/UserSettings.tsx:151
+#: src/pages/Index/Settings/UserSettings.tsx:145
+#: src/pages/Index/Settings/UserSettings.tsx:149
 msgid "User Settings"
 msgstr "用户设置"
 
@@ -3083,7 +3065,7 @@ msgstr "生产"
 #: src/pages/company/ManufacturerPartDetail.tsx:185
 #: src/pages/company/SupplierDetail.tsx:9
 #: src/pages/company/SupplierPartDetail.tsx:203
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:371
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:370
 #: src/pages/purchasing/PurchasingIndex.tsx:237
 msgid "Purchasing"
 msgstr "采购"
@@ -3092,9 +3074,9 @@ msgstr "采购"
 #: src/defaults/links.tsx:69
 #: src/pages/Index/Settings/SystemSettings.tsx:356
 #: src/pages/company/CustomerDetail.tsx:9
-#: src/pages/sales/ReturnOrderDetail.tsx:354
+#: src/pages/sales/ReturnOrderDetail.tsx:353
 #: src/pages/sales/SalesIndex.tsx:211
-#: src/pages/sales/SalesOrderDetail.tsx:424
+#: src/pages/sales/SalesOrderDetail.tsx:423
 #: src/pages/sales/SalesOrderShipmentDetail.tsx:272
 msgid "Sales"
 msgstr "销售"
@@ -3136,7 +3118,7 @@ msgstr "通知加载错误。"
 #~ msgid "Edit {title}"
 #~ msgstr "Edit {title}"
 
-#: src/components/nav/PageDetail.tsx:265
+#: src/components/nav/PageDetail.tsx:263
 msgid "Primary Action"
 msgstr "主操作"
 
@@ -3232,24 +3214,24 @@ msgstr "附件"
 msgid "Notes"
 msgstr "备注"
 
-#: src/components/panels/PanelGroup.tsx:281
+#: src/components/panels/PanelGroup.tsx:278
 msgid "Plugin Provided"
 msgstr "插件已提供"
 
-#: src/components/panels/PanelGroup.tsx:302
+#: src/components/panels/PanelGroup.tsx:299
 msgid "You have unsaved changes, are you sure you want to navigate away from this panel?"
 msgstr "您有未保存的更改，确定要离开此面板吗？"
 
 #. placeholder {0}: panel.name
-#: src/components/panels/PanelGroup.tsx:352
+#: src/components/panels/PanelGroup.tsx:349
 msgid "Navigate to panel {0}"
 msgstr "导航至面板 {0}"
 
-#: src/components/panels/PanelGroup.tsx:412
+#: src/components/panels/PanelGroup.tsx:409
 msgid "Collapse panels"
 msgstr "收起面板"
 
-#: src/components/panels/PanelGroup.tsx:412
+#: src/components/panels/PanelGroup.tsx:409
 msgid "Expand panels"
 msgstr "展开面板"
 
@@ -3262,19 +3244,19 @@ msgstr "定位项目"
 msgid "Item location requested"
 msgstr "已请求项目位置"
 
-#: src/components/plugins/PluginDrawer.tsx:66
+#: src/components/plugins/PluginDrawer.tsx:47
 msgid "Plugin Inactive"
 msgstr "插件未激活"
 
-#: src/components/plugins/PluginDrawer.tsx:69
+#: src/components/plugins/PluginDrawer.tsx:50
 msgid "Plugin is not active"
 msgstr "插件未激活"
 
-#: src/components/plugins/PluginDrawer.tsx:78
+#: src/components/plugins/PluginDrawer.tsx:59
 msgid "Plugin Information"
 msgstr "插件信息"
 
-#: src/components/plugins/PluginDrawer.tsx:88
+#: src/components/plugins/PluginDrawer.tsx:73
 #: src/components/tables/ColumnRenderers.tsx:495
 #: src/pages/build/BuildOrderDetailsPanel.tsx:96
 #: src/pages/company/CompanyDetailsPanel.tsx:29
@@ -3295,11 +3277,11 @@ msgstr "插件信息"
 msgid "Description"
 msgstr "描述"
 
-#: src/components/plugins/PluginDrawer.tsx:93
+#: src/components/plugins/PluginDrawer.tsx:78
 msgid "Author"
 msgstr "作者"
 
-#: src/components/plugins/PluginDrawer.tsx:98
+#: src/components/plugins/PluginDrawer.tsx:83
 #: src/components/tables/ColumnRenderers.tsx:717
 #: src/pages/part/pricing/PurchaseHistoryPanel.tsx:42
 #: src/pages/part/pricing/SaleHistoryPanel.tsx:39
@@ -3307,7 +3289,7 @@ msgstr "作者"
 msgid "Date"
 msgstr "日期"
 
-#: src/components/plugins/PluginDrawer.tsx:108
+#: src/components/plugins/PluginDrawer.tsx:93
 #: src/pages/Index/Settings/AccountSettings/AccountDetailPanel.tsx:68
 #: src/pages/core/UserDetail.tsx:78
 #: src/pages/core/UserDetail.tsx:208
@@ -3321,7 +3303,7 @@ msgstr "日期"
 #: src/tables/part/PartTableFilters.tsx:13
 #: src/tables/part/PartVariantTable.tsx:15
 #: src/tables/plugin/PluginListTable.tsx:101
-#: src/tables/plugin/PluginListTable.tsx:431
+#: src/tables/plugin/PluginListTable.tsx:427
 #: src/tables/purchasing/SupplierPartTable.tsx:139
 #: src/tables/purchasing/SupplierPartTable.tsx:254
 #: src/tables/settings/ApiTokenTable.tsx:66
@@ -3331,36 +3313,36 @@ msgstr "日期"
 msgid "Active"
 msgstr "激活"
 
-#: src/components/plugins/PluginDrawer.tsx:114
+#: src/components/plugins/PluginDrawer.tsx:99
 #: src/pages/company/CompanyDetailsPanel.tsx:35
 #: src/tables/plugin/PluginListTable.tsx:147
 msgid "Website"
 msgstr "网站"
 
-#: src/components/plugins/PluginDrawer.tsx:128
+#: src/components/plugins/PluginDrawer.tsx:113
 msgid "Package Name"
 msgstr "软件包名"
 
-#: src/components/plugins/PluginDrawer.tsx:134
+#: src/components/plugins/PluginDrawer.tsx:119
 msgid "Installation Path"
 msgstr "安装路径"
 
-#: src/components/plugins/PluginDrawer.tsx:139
+#: src/components/plugins/PluginDrawer.tsx:124
 #: src/tables/machine/MachineTypeTable.tsx:185
 #: src/tables/machine/MachineTypeTable.tsx:294
 #: src/tables/plugin/PluginListTable.tsx:107
-#: src/tables/plugin/PluginListTable.tsx:436
+#: src/tables/plugin/PluginListTable.tsx:432
 msgid "Builtin"
 msgstr "内置"
 
-#: src/components/plugins/PluginDrawer.tsx:144
+#: src/components/plugins/PluginDrawer.tsx:129
 msgid "Package"
 msgstr "软件包"
 
-#: src/components/plugins/PluginDrawer.tsx:156
+#: src/components/plugins/PluginDrawer.tsx:141
 #: src/pages/Index/Settings/AdminCenter/PluginManagementPanel.tsx:67
 #: src/pages/Index/Settings/PluginSettingsGroup.tsx:119
-#: src/pages/Index/Settings/UserSettings.tsx:132
+#: src/pages/Index/Settings/UserSettings.tsx:130
 msgid "Plugin Settings"
 msgstr "插件设置"
 
@@ -3488,7 +3470,7 @@ msgstr "虚拟"
 
 #: src/components/render/Part.tsx:34
 #: src/components/tables/PartStockCell.tsx:113
-#: src/tables/bom/BomTable.tsx:348
+#: src/tables/bom/BomTable.tsx:335
 msgid "No stock"
 msgstr "无库存"
 
@@ -3499,7 +3481,7 @@ msgstr "无库存"
 #: src/pages/company/SupplierPartDetailsPanel.tsx:151
 #: src/pages/part/PartDetail.tsx:602
 #: src/pages/part/PartDetailsPanel.tsx:174
-#: src/tables/bom/BomTable.tsx:491
+#: src/tables/bom/BomTable.tsx:478
 #: src/tables/build/BuildLineTable.tsx:241
 #: src/tables/part/PartTable.tsx:83
 #: src/tables/part/PartTableFilters.tsx:149
@@ -3531,14 +3513,14 @@ msgstr "详情"
 msgid "Category"
 msgstr "类别"
 
-#: src/components/render/Stock.tsx:37
-#: src/components/render/Stock.tsx:112
-#: src/components/render/Stock.tsx:137
+#: src/components/render/Stock.tsx:36
+#: src/components/render/Stock.tsx:109
+#: src/components/render/Stock.tsx:127
 #: src/components/tables/ColumnRenderers.tsx:385
 #: src/components/tables/ColumnRenderers.tsx:394
 #: src/components/tables/Filter.tsx:507
 #: src/forms/BuildForms.tsx:868
-#: src/forms/PurchaseOrderForms.tsx:706
+#: src/forms/PurchaseOrderForms.tsx:707
 #: src/forms/StockForms.tsx:635
 #: src/forms/StockForms.tsx:673
 #: src/forms/StockForms.tsx:1474
@@ -3557,7 +3539,7 @@ msgstr "类别"
 msgid "Location"
 msgstr "位置"
 
-#: src/components/render/Stock.tsx:95
+#: src/components/render/Stock.tsx:94
 #: src/forms/StockForms.tsx:680
 #: src/pages/stock/StockDetail.tsx:657
 #: src/pages/stock/StockDetailsPanel.tsx:135
@@ -3567,13 +3549,13 @@ msgstr "位置"
 msgid "Serial Number"
 msgstr "序列号"
 
-#: src/components/render/Stock.tsx:100
+#: src/components/render/Stock.tsx:99
 #: src/components/wizards/OrderPartsWizard.tsx:389
 #: src/forms/BomForms.tsx:42
 #: src/forms/BuildForms.tsx:283
 #: src/forms/BuildForms.tsx:706
 #: src/forms/BuildForms.tsx:870
-#: src/forms/PurchaseOrderForms.tsx:938
+#: src/forms/PurchaseOrderForms.tsx:930
 #: src/forms/ReturnOrderForms.tsx:242
 #: src/forms/SalesOrderForms.tsx:437
 #: src/forms/StockForms.tsx:685
@@ -3594,14 +3576,14 @@ msgstr "序列号"
 #: src/tables/build/BuildLineTable.tsx:99
 #: src/tables/part/PartPurchaseOrdersTable.tsx:103
 #: src/tables/part/PartTestResultTable.tsx:282
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:183
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:214
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:173
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:204
 #: src/tables/purchasing/SupplierPriceBreakTable.tsx:69
 #: src/tables/stock/StockTrackingTable.tsx:105
 msgid "Quantity"
 msgstr "数量"
 
-#: src/components/render/Stock.tsx:115
+#: src/components/render/Stock.tsx:112
 #: src/forms/BuildForms.tsx:384
 #: src/forms/BuildForms.tsx:467
 #: src/forms/BuildForms.tsx:542
@@ -3756,7 +3738,7 @@ msgstr "零件未激活"
 
 #: src/components/tables/ColumnRenderers.tsx:75
 #: src/pages/part/PartDetail.tsx:494
-#: src/tables/bom/BomTable.tsx:726
+#: src/tables/bom/BomTable.tsx:713
 #: src/tables/part/PartTestTemplateTable.tsx:262
 msgid "Part is Locked"
 msgstr "零件已锁定"
@@ -3834,7 +3816,7 @@ msgstr "此库存项已被部分分配"
 
 #: src/components/tables/ColumnRenderers.tsx:274
 #: src/tables/build/BuildLineTable.tsx:322
-#: src/tables/sales/SalesOrderLineItemTable.tsx:198
+#: src/tables/sales/SalesOrderLineItemTable.tsx:168
 #: src/tables/stock/TransferOrderLineItemTable.tsx:143
 msgid "No stock available"
 msgstr "无可用库存"
@@ -3845,8 +3827,8 @@ msgstr "库存项已耗尽"
 
 #: src/components/tables/ColumnRenderers.tsx:301
 #: src/components/tables/PartStockCell.tsx:134
-#: src/tables/bom/BomTable.tsx:399
-#: src/tables/sales/SalesOrderLineItemTable.tsx:227
+#: src/tables/bom/BomTable.tsx:386
+#: src/tables/sales/SalesOrderLineItemTable.tsx:197
 #: src/tables/stock/TransferOrderLineItemTable.tsx:172
 msgid "Stock Information"
 msgstr "库存信息"
@@ -3878,7 +3860,7 @@ msgid "Reference"
 msgstr "参考"
 
 #: src/components/tables/ColumnRenderers.tsx:553
-#: src/forms/PurchaseOrderForms.tsx:850
+#: src/forms/PurchaseOrderForms.tsx:848
 #: src/pages/company/SupplierPartDetailsPanel.tsx:74
 msgid "Note"
 msgstr "备注"
@@ -3933,12 +3915,12 @@ msgstr "货币"
 #: src/components/tables/ColumnRenderers.tsx:813
 #: src/pages/part/pricing/BomPricingPanel.tsx:61
 #: src/pages/part/pricing/BomPricingPanel.tsx:142
-#: src/tables/bom/BomTable.tsx:323
-#: src/tables/general/ExtraLineItemTable.tsx:86
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:275
+#: src/tables/bom/BomTable.tsx:310
+#: src/tables/general/ExtraLineItemTable.tsx:80
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:265
 #: src/tables/purchasing/PurchaseOrderTable.tsx:101
 #: src/tables/sales/ReturnOrderTable.tsx:99
-#: src/tables/sales/SalesOrderLineItemTable.tsx:162
+#: src/tables/sales/SalesOrderLineItemTable.tsx:132
 #: src/tables/sales/SalesOrderTable.tsx:136
 msgid "Total Price"
 msgstr "总价"
@@ -3956,7 +3938,7 @@ msgid "Show items which have a batch code"
 msgstr "显示有批号的项目"
 
 #: src/components/tables/Filter.tsx:125
-#: src/forms/PurchaseOrderForms.tsx:776
+#: src/forms/PurchaseOrderForms.tsx:777
 #: src/forms/StockForms.tsx:692
 #: src/pages/build/BuildOrderDetailsPanel.tsx:186
 #: src/pages/stock/StockDetail.tsx:679
@@ -4185,7 +4167,7 @@ msgstr "包含零件变体结果"
 #: src/forms/BuildForms.tsx:385
 #: src/forms/BuildForms.tsx:468
 #: src/forms/BuildForms.tsx:543
-#: src/forms/PurchaseOrderForms.tsx:840
+#: src/forms/PurchaseOrderForms.tsx:838
 #: src/forms/ReturnOrderForms.tsx:195
 #: src/forms/ReturnOrderForms.tsx:243
 #: src/forms/StockForms.tsx:650
@@ -4203,8 +4185,8 @@ msgstr "包含零件变体结果"
 #: src/tables/part/PartPurchaseOrdersTable.tsx:46
 #: src/tables/part/PartSalesOrdersTable.tsx:45
 #: src/tables/part/PartTestResultTable.tsx:328
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:185
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:228
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:138
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:181
 #: src/tables/settings/CustomStateTable.tsx:79
 #: src/tables/settings/EmailTable.tsx:95
 #: src/tables/settings/ImportSessionTable.tsx:135
@@ -4392,38 +4374,38 @@ msgstr "保存筛选条件"
 #~ msgid "Select from the available filters"
 #~ msgstr "Select from the available filters"
 
-#: src/components/tables/InvenTreeTable.tsx:59
-#: src/components/tables/InvenTreeTable.tsx:652
+#: src/components/tables/InvenTreeTable.tsx:53
+#: src/components/tables/InvenTreeTable.tsx:585
 msgid "No records found"
 msgstr "没有找到记录"
 
-#: src/components/tables/InvenTreeTable.tsx:187
+#: src/components/tables/InvenTreeTable.tsx:167
 msgid "Error loading table options"
 msgstr "表格选项加载错误"
 
-#: src/components/tables/InvenTreeTable.tsx:697
+#: src/components/tables/InvenTreeTable.tsx:630
 msgid "Server returned incorrect data type"
 msgstr "服务器返回了错误的数据类型"
 
-#: src/components/tables/InvenTreeTable.tsx:730
+#: src/components/tables/InvenTreeTable.tsx:663
 msgid "Error loading table data"
 msgstr "表格数据加载错误"
 
-#: src/components/tables/InvenTreeTable.tsx:903
+#: src/components/tables/InvenTreeTable.tsx:813
 msgid "View {model}"
 msgstr "{model} 视图"
 
 #: src/components/tables/InvenTreeTableHeader.tsx:130
 msgid "No items selected"
-msgstr ""
+msgstr "未选择任何项目"
 
 #: src/components/tables/InvenTreeTableHeader.tsx:132
 msgid "1 selected item will be deleted"
-msgstr ""
+msgstr "将删除 1 个选中项目"
 
 #: src/components/tables/InvenTreeTableHeader.tsx:134
 msgid "{N} selected items will be deleted"
-msgstr ""
+msgstr "将删除 {N} 个选中项目"
 
 #: src/components/tables/InvenTreeTableHeader.tsx:140
 msgid "Delete Selected Items"
@@ -4464,10 +4446,10 @@ msgid "Active Filters"
 msgstr "当前生效的筛选条件"
 
 #: src/components/tables/PartStockCell.tsx:11
-#: src/tables/bom/BomTable.tsx:343
-#: src/tables/sales/SalesOrderLineItemTable.tsx:179
-#: src/tables/sales/SalesOrderLineItemTable.tsx:237
-#: src/tables/sales/SalesOrderLineItemTable.tsx:254
+#: src/tables/bom/BomTable.tsx:330
+#: src/tables/sales/SalesOrderLineItemTable.tsx:149
+#: src/tables/sales/SalesOrderLineItemTable.tsx:207
+#: src/tables/sales/SalesOrderLineItemTable.tsx:224
 #: src/tables/stock/TransferOrderLineItemTable.tsx:124
 #: src/tables/stock/TransferOrderLineItemTable.tsx:183
 #: src/tables/stock/TransferOrderLineItemTable.tsx:201
@@ -4483,7 +4465,7 @@ msgid "Maximum stock"
 msgstr "最大库存"
 
 #: src/components/tables/PartStockCell.tsx:62
-#: src/tables/bom/BomTable.tsx:390
+#: src/tables/bom/BomTable.tsx:377
 msgid "Building"
 msgstr "正在生产"
 
@@ -4500,22 +4482,22 @@ msgid "Sales Order Allocations"
 msgstr "分配销售订单"
 
 #: src/components/tables/PartStockCell.tsx:93
-#: src/tables/bom/BomTable.tsx:356
+#: src/tables/bom/BomTable.tsx:343
 #: src/tables/build/BuildLineTable.tsx:295
 msgid "External stock"
 msgstr "外部库存"
 
 #: src/components/tables/PartStockCell.tsx:101
-#: src/tables/bom/BomTable.tsx:373
+#: src/tables/bom/BomTable.tsx:360
 #: src/tables/build/BuildLineTable.tsx:268
-#: src/tables/sales/SalesOrderLineItemTable.tsx:204
+#: src/tables/sales/SalesOrderLineItemTable.tsx:174
 #: src/tables/stock/TransferOrderLineItemTable.tsx:149
 msgid "Includes variant stock"
 msgstr "包括变体库存"
 
 #: src/components/tables/PartStockCell.tsx:106
 msgid "Direct stock"
-msgstr ""
+msgstr "直接库存"
 
 #: src/components/tables/bom/BomTable.tsx:200
 #~ msgid "Validate"
@@ -5101,7 +5083,7 @@ msgstr "请修正所选零件中的错误"
 #: src/components/wizards/OrderPartsWizard.tsx:629
 #: src/tables/build/BuildLineTable.tsx:908
 #: src/tables/part/PartTable.tsx:267
-#: src/tables/sales/SalesOrderLineItemTable.tsx:459
+#: src/tables/sales/SalesOrderLineItemTable.tsx:426
 #: src/tables/stock/TransferOrderLineItemTable.tsx:333
 msgid "Order Parts"
 msgstr "订购零件"
@@ -5486,7 +5468,7 @@ msgstr "InvenTree 开发者手册"
 
 #: src/defaults/links.tsx:121
 msgid "FAQ"
-msgstr "FAQ"
+msgstr "常见问题"
 
 #: src/defaults/links.tsx:124
 msgid "Frequently asked questions"
@@ -5641,27 +5623,19 @@ msgstr "关于InvenTree项目"
 msgid "Required component quantity"
 msgstr "所需元件数量"
 
-#: src/forms/BomForms.tsx:46
-msgid "Piece Count"
-msgstr ""
-
-#: src/forms/BomForms.tsx:47
-msgid "Number of pieces required (for cut-to-length items). Total material = quantity × piece_count."
-msgstr ""
-
-#: src/forms/BomForms.tsx:127
+#: src/forms/BomForms.tsx:123
 msgid "Substitute Part"
 msgstr "替代零件"
 
-#: src/forms/BomForms.tsx:144
+#: src/forms/BomForms.tsx:140
 msgid "Edit BOM Substitutes"
 msgstr "编辑物料清单替代项"
 
-#: src/forms/BomForms.tsx:151
+#: src/forms/BomForms.tsx:147
 msgid "Add Substitute"
 msgstr "添加替代项"
 
-#: src/forms/BomForms.tsx:152
+#: src/forms/BomForms.tsx:148
 msgid "Substitute added"
 msgstr "替代项已添加"
 
@@ -5738,7 +5712,7 @@ msgstr "已分配的库存物料将退回可用库存"
 #: src/pages/part/PartDetail.tsx:590
 #: src/tables/build/BuildAllocatedStockTable.tsx:132
 #: src/tables/build/BuildLineTable.tsx:201
-#: src/tables/sales/SalesOrderLineItemTable.tsx:428
+#: src/tables/sales/SalesOrderLineItemTable.tsx:398
 #: src/tables/stock/StockItemTable.tsx:213
 #: src/tables/stock/TransferOrderLineItemTable.tsx:493
 msgid "Allocated"
@@ -5768,8 +5742,8 @@ msgstr "选择分配库存的源位置"
 #: src/tables/build/BuildLineTable.tsx:822
 #: src/tables/build/BuildLineTable.tsx:923
 #: src/tables/build/BuildOutputTable.tsx:239
-#: src/tables/sales/SalesOrderLineItemTable.tsx:469
-#: src/tables/sales/SalesOrderLineItemTable.tsx:515
+#: src/tables/sales/SalesOrderLineItemTable.tsx:436
+#: src/tables/sales/SalesOrderLineItemTable.tsx:481
 #: src/tables/stock/TransferOrderLineItemTable.tsx:343
 #: src/tables/stock/TransferOrderLineItemTable.tsx:369
 msgid "Allocate Stock"
@@ -5876,34 +5850,34 @@ msgstr "订阅此类别的通知"
 #~ msgid "Remove item from list"
 #~ msgstr "Remove item from list"
 
-#: src/forms/PurchaseOrderForms.tsx:480
+#: src/forms/PurchaseOrderForms.tsx:481
 msgid "Choose Location"
 msgstr "选择位置"
 
-#: src/forms/PurchaseOrderForms.tsx:488
+#: src/forms/PurchaseOrderForms.tsx:489
 msgid "Item Destination selected"
 msgstr "已选择项目目的地"
 
-#: src/forms/PurchaseOrderForms.tsx:498
+#: src/forms/PurchaseOrderForms.tsx:499
 msgid "Part category default location selected"
 msgstr "已选择零件类别默认位置"
 
-#: src/forms/PurchaseOrderForms.tsx:508
+#: src/forms/PurchaseOrderForms.tsx:509
 msgid "Received stock location selected"
 msgstr "已选择接收库存位置"
 
-#: src/forms/PurchaseOrderForms.tsx:516
+#: src/forms/PurchaseOrderForms.tsx:517
 msgid "Default location selected"
 msgstr "已选择默认位置"
 
-#: src/forms/PurchaseOrderForms.tsx:563
+#: src/forms/PurchaseOrderForms.tsx:564
 #: src/pages/part/PartDetailsPanel.tsx:268
-#: src/tables/bom/BomTable.tsx:289
-#: src/tables/bom/BomTable.tsx:481
+#: src/tables/bom/BomTable.tsx:276
+#: src/tables/bom/BomTable.tsx:468
 msgid "Virtual Part"
 msgstr "虚拟零件"
 
-#: src/forms/PurchaseOrderForms.tsx:564
+#: src/forms/PurchaseOrderForms.tsx:565
 msgid "This part is virtual, no physical stock will be received."
 msgstr "该零件为虚拟件，不会接收实物库存。"
 
@@ -5915,36 +5889,36 @@ msgstr "该零件为虚拟件，不会接收实物库存。"
 #~ msgid "Store at line item destination"
 #~ msgstr "Store at line item destination"
 
-#: src/forms/PurchaseOrderForms.tsx:598
+#: src/forms/PurchaseOrderForms.tsx:599
 #: src/forms/StockForms.tsx:577
 msgid "Set Location"
 msgstr "设置位置"
 
-#: src/forms/PurchaseOrderForms.tsx:607
+#: src/forms/PurchaseOrderForms.tsx:608
 msgid "Assign Batch Code"
 msgstr "分配批号"
 
-#: src/forms/PurchaseOrderForms.tsx:617
+#: src/forms/PurchaseOrderForms.tsx:618
 msgid "Assign Serial Numbers"
 msgstr "分配序列号"
 
-#: src/forms/PurchaseOrderForms.tsx:629
+#: src/forms/PurchaseOrderForms.tsx:630
 msgid "Set Expiry Date"
 msgstr "设置到期日期"
 
-#: src/forms/PurchaseOrderForms.tsx:638
+#: src/forms/PurchaseOrderForms.tsx:639
 #: src/forms/StockForms.tsx:1358
 msgid "Adjust Packaging"
 msgstr "调整封包"
 
-#: src/forms/PurchaseOrderForms.tsx:647
+#: src/forms/PurchaseOrderForms.tsx:648
 #: src/forms/StockForms.tsx:585
 #: src/forms/StockForms.tsx:1349
 #: src/hooks/UseStockAdjustActions.tsx:152
 msgid "Change Status"
 msgstr "更改状态"
 
-#: src/forms/PurchaseOrderForms.tsx:654
+#: src/forms/PurchaseOrderForms.tsx:655
 msgid "Add Note"
 msgstr "添加备注"
 
@@ -5952,69 +5926,69 @@ msgstr "添加备注"
 #~ msgid "Receive line items"
 #~ msgstr "Receive line items"
 
-#: src/forms/PurchaseOrderForms.tsx:721
+#: src/forms/PurchaseOrderForms.tsx:722
 msgid "Store at default location"
 msgstr "存储在默认位置"
 
-#: src/forms/PurchaseOrderForms.tsx:736
+#: src/forms/PurchaseOrderForms.tsx:737
 msgid "Store at line item destination "
 msgstr "存储至行项目指定位置 "
 
-#: src/forms/PurchaseOrderForms.tsx:752
+#: src/forms/PurchaseOrderForms.tsx:753
 msgid "Store with already received stock"
 msgstr "存储已收到的库存"
 
-#: src/forms/PurchaseOrderForms.tsx:777
+#: src/forms/PurchaseOrderForms.tsx:778
 msgid "Enter batch code for received items"
 msgstr "输入接收项目的批号"
 
-#: src/forms/PurchaseOrderForms.tsx:793
+#: src/forms/PurchaseOrderForms.tsx:791
 #: src/forms/StockForms.tsx:247
 msgid "Serial Numbers"
 msgstr "序列号"
 
-#: src/forms/PurchaseOrderForms.tsx:794
+#: src/forms/PurchaseOrderForms.tsx:792
 msgid "Enter serial numbers for received items"
 msgstr "输入接收项目的序列号"
 
-#: src/forms/PurchaseOrderForms.tsx:811
+#: src/forms/PurchaseOrderForms.tsx:809
 #: src/pages/stock/StockDetailsPanel.tsx:316
 #: src/tables/stock/StockItemTable.tsx:171
 msgid "Expiry Date"
 msgstr "有效期至"
 
-#: src/forms/PurchaseOrderForms.tsx:812
+#: src/forms/PurchaseOrderForms.tsx:810
 msgid "Enter an expiry date for received items"
 msgstr "输入接收项目的到期日期"
 
-#: src/forms/PurchaseOrderForms.tsx:826
+#: src/forms/PurchaseOrderForms.tsx:824
 #: src/forms/StockForms.tsx:1404
 #: src/pages/company/SupplierPartDetailsPanel.tsx:126
 #: src/pages/company/SupplierPartDetailsPanel.tsx:184
 #: src/pages/stock/StockDetailsPanel.tsx:350
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:234
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:224
 msgid "Packaging"
 msgstr "包装"
 
-#: src/forms/PurchaseOrderForms.tsx:936
+#: src/forms/PurchaseOrderForms.tsx:928
 #: src/pages/company/SupplierPartDetailsPanel.tsx:92
 #: src/tables/purchasing/SupplierPriceBreakTable.tsx:49
 msgid "SKU"
 msgstr "库存单位  (SKU)"
 
-#: src/forms/PurchaseOrderForms.tsx:937
+#: src/forms/PurchaseOrderForms.tsx:929
 #: src/tables/part/PartPurchaseOrdersTable.tsx:136
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:221
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:296
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:223
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:211
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:286
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:176
 msgid "Received"
 msgstr "已接收"
 
-#: src/forms/PurchaseOrderForms.tsx:954
+#: src/forms/PurchaseOrderForms.tsx:946
 msgid "Receive Line Items"
 msgstr "接收行项目"
 
-#: src/forms/PurchaseOrderForms.tsx:960
+#: src/forms/PurchaseOrderForms.tsx:952
 msgid "Items received"
 msgstr "物料已收货"
 
@@ -6168,9 +6142,9 @@ msgstr "单位数量"
 #: src/pages/part/pricing/PurchaseHistoryPanel.tsx:129
 #: src/pages/part/pricing/SupplierPricingPanel.tsx:67
 #: src/pages/stock/StockDetailsPanel.tsx:323
-#: src/tables/bom/BomTable.tsx:313
-#: src/tables/general/ExtraLineItemTable.tsx:73
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:266
+#: src/tables/bom/BomTable.tsx:300
+#: src/tables/general/ExtraLineItemTable.tsx:67
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:256
 #: src/tables/purchasing/SupplierPriceBreakTable.tsx:84
 #: src/tables/stock/StockItemTable.tsx:126
 msgid "Unit Price"
@@ -7924,7 +7898,7 @@ msgstr "数据管理"
 
 #: src/pages/Index/Settings/AdminCenter/Index.tsx:296
 #: src/pages/Index/Settings/SystemSettings.tsx:194
-#: src/pages/Index/Settings/UserSettings.tsx:122
+#: src/pages/Index/Settings/UserSettings.tsx:120
 msgid "Reporting"
 msgstr "报告"
 
@@ -8166,7 +8140,7 @@ msgstr "显示"
 #~ msgstr "Exchange Rates"
 
 #: src/pages/Index/Settings/SystemSettings.tsx:152
-#: src/pages/Index/Settings/UserSettings.tsx:116
+#: src/pages/Index/Settings/UserSettings.tsx:114
 msgid "The settings below are specific to each available notification method"
 msgstr "以下设置专属于每种可用的通知方式"
 
@@ -8317,7 +8291,7 @@ msgid "Required Parts"
 msgstr "所需零件"
 
 #: src/pages/build/BuildDetail.tsx:262
-#: src/pages/sales/SalesOrderDetail.tsx:201
+#: src/pages/sales/SalesOrderDetail.tsx:200
 #: src/pages/sales/SalesOrderShipmentDetail.tsx:86
 #: src/pages/stock/TransferOrderDetail.tsx:157
 #: src/tables/part/PartSalesAllocationsTable.tsx:74
@@ -8381,17 +8355,17 @@ msgid "Cancel Build Order"
 msgstr "取消生产订单"
 
 #: src/pages/build/BuildDetail.tsx:429
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:234
-#: src/pages/sales/ReturnOrderDetail.tsx:227
-#: src/pages/sales/SalesOrderDetail.tsx:259
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:233
+#: src/pages/sales/ReturnOrderDetail.tsx:226
+#: src/pages/sales/SalesOrderDetail.tsx:258
 #: src/pages/stock/TransferOrderDetail.tsx:250
 msgid "Order cancelled"
 msgstr "订单已取消"
 
 #: src/pages/build/BuildDetail.tsx:430
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:233
-#: src/pages/sales/ReturnOrderDetail.tsx:226
-#: src/pages/sales/SalesOrderDetail.tsx:258
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:232
+#: src/pages/sales/ReturnOrderDetail.tsx:225
+#: src/pages/sales/SalesOrderDetail.tsx:257
 #: src/pages/stock/TransferOrderDetail.tsx:249
 msgid "Cancel this order"
 msgstr "取消此订单"
@@ -8401,17 +8375,17 @@ msgid "Hold Build Order"
 msgstr "挂起生产订单"
 
 #: src/pages/build/BuildDetail.tsx:441
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:241
-#: src/pages/sales/ReturnOrderDetail.tsx:234
-#: src/pages/sales/SalesOrderDetail.tsx:266
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:240
+#: src/pages/sales/ReturnOrderDetail.tsx:233
+#: src/pages/sales/SalesOrderDetail.tsx:265
 #: src/pages/stock/TransferOrderDetail.tsx:257
 msgid "Place this order on hold"
 msgstr "将此订单挂起"
 
 #: src/pages/build/BuildDetail.tsx:442
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:242
-#: src/pages/sales/ReturnOrderDetail.tsx:235
-#: src/pages/sales/SalesOrderDetail.tsx:267
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:241
+#: src/pages/sales/ReturnOrderDetail.tsx:234
+#: src/pages/sales/SalesOrderDetail.tsx:266
 #: src/pages/stock/TransferOrderDetail.tsx:258
 msgid "Order placed on hold"
 msgstr "挂起订单"
@@ -8421,17 +8395,17 @@ msgid "Issue Build Order"
 msgstr "发出生产订单"
 
 #: src/pages/build/BuildDetail.tsx:449
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:225
-#: src/pages/sales/ReturnOrderDetail.tsx:218
-#: src/pages/sales/SalesOrderDetail.tsx:250
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:224
+#: src/pages/sales/ReturnOrderDetail.tsx:217
+#: src/pages/sales/SalesOrderDetail.tsx:249
 #: src/pages/stock/TransferOrderDetail.tsx:241
 msgid "Issue this order"
 msgstr "发出这个订单"
 
 #: src/pages/build/BuildDetail.tsx:450
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:226
-#: src/pages/sales/ReturnOrderDetail.tsx:219
-#: src/pages/sales/SalesOrderDetail.tsx:251
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:225
+#: src/pages/sales/ReturnOrderDetail.tsx:218
+#: src/pages/sales/SalesOrderDetail.tsx:250
 #: src/pages/stock/TransferOrderDetail.tsx:242
 msgid "Order issued"
 msgstr "订单发起"
@@ -8441,33 +8415,33 @@ msgid "Complete Build Order"
 msgstr "完成生产订单"
 
 #: src/pages/build/BuildDetail.tsx:475
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:254
-#: src/pages/sales/ReturnOrderDetail.tsx:242
-#: src/pages/sales/SalesOrderDetail.tsx:285
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:253
+#: src/pages/sales/ReturnOrderDetail.tsx:241
+#: src/pages/sales/SalesOrderDetail.tsx:284
 #: src/pages/stock/TransferOrderDetail.tsx:265
 msgid "Mark this order as complete"
 msgstr "标记该订单为已完成"
 
 #: src/pages/build/BuildDetail.tsx:478
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:248
-#: src/pages/sales/ReturnOrderDetail.tsx:243
-#: src/pages/sales/SalesOrderDetail.tsx:286
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:247
+#: src/pages/sales/ReturnOrderDetail.tsx:242
+#: src/pages/sales/SalesOrderDetail.tsx:285
 #: src/pages/stock/TransferOrderDetail.tsx:266
 msgid "Order completed"
 msgstr "订单已完成"
 
 #: src/pages/build/BuildDetail.tsx:505
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:277
-#: src/pages/sales/ReturnOrderDetail.tsx:270
-#: src/pages/sales/SalesOrderDetail.tsx:321
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:276
+#: src/pages/sales/ReturnOrderDetail.tsx:269
+#: src/pages/sales/SalesOrderDetail.tsx:320
 #: src/pages/stock/TransferOrderDetail.tsx:291
 msgid "Issue Order"
 msgstr "发布订单"
 
 #: src/pages/build/BuildDetail.tsx:512
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:284
-#: src/pages/sales/ReturnOrderDetail.tsx:277
-#: src/pages/sales/SalesOrderDetail.tsx:335
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:283
+#: src/pages/sales/ReturnOrderDetail.tsx:276
+#: src/pages/sales/SalesOrderDetail.tsx:334
 #: src/pages/stock/TransferOrderDetail.tsx:298
 msgid "Complete Order"
 msgstr "完成订单"
@@ -8477,33 +8451,33 @@ msgid "Build Order Actions"
 msgstr "生产订单操作"
 
 #: src/pages/build/BuildDetail.tsx:536
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:307
-#: src/pages/sales/ReturnOrderDetail.tsx:300
-#: src/pages/sales/SalesOrderDetail.tsx:359
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:306
+#: src/pages/sales/ReturnOrderDetail.tsx:299
+#: src/pages/sales/SalesOrderDetail.tsx:358
 #: src/pages/stock/TransferOrderDetail.tsx:321
 msgid "Edit order"
 msgstr "编辑订单"
 
 #: src/pages/build/BuildDetail.tsx:540
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:315
-#: src/pages/sales/ReturnOrderDetail.tsx:306
-#: src/pages/sales/SalesOrderDetail.tsx:364
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:314
+#: src/pages/sales/ReturnOrderDetail.tsx:305
+#: src/pages/sales/SalesOrderDetail.tsx:363
 #: src/pages/stock/TransferOrderDetail.tsx:327
 msgid "Duplicate order"
 msgstr "复制订单"
 
 #: src/pages/build/BuildDetail.tsx:544
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:318
-#: src/pages/sales/ReturnOrderDetail.tsx:311
-#: src/pages/sales/SalesOrderDetail.tsx:367
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:317
+#: src/pages/sales/ReturnOrderDetail.tsx:310
+#: src/pages/sales/SalesOrderDetail.tsx:366
 #: src/pages/stock/TransferOrderDetail.tsx:332
 msgid "Hold order"
 msgstr "挂起订单"
 
 #: src/pages/build/BuildDetail.tsx:549
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:323
-#: src/pages/sales/ReturnOrderDetail.tsx:316
-#: src/pages/sales/SalesOrderDetail.tsx:372
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:322
+#: src/pages/sales/ReturnOrderDetail.tsx:315
+#: src/pages/sales/SalesOrderDetail.tsx:371
 #: src/pages/stock/TransferOrderDetail.tsx:337
 msgid "Cancel order"
 msgstr "取消订单"
@@ -8582,8 +8556,8 @@ msgstr "生产数量"
 
 #: src/pages/build/BuildOrderDetailsPanel.tsx:121
 #: src/pages/part/PartDetailsPanel.tsx:224
-#: src/tables/bom/BomTable.tsx:406
-#: src/tables/bom/BomTable.tsx:449
+#: src/tables/bom/BomTable.tsx:393
+#: src/tables/bom/BomTable.tsx:436
 msgid "Can Build"
 msgstr "可以创建"
 
@@ -8608,7 +8582,7 @@ msgstr "已创建"
 #: src/pages/build/BuildOrderDetailsPanel.tsx:220
 #: src/tables/build/BuildOrderTable.tsx:76
 #: src/tables/part/PartSalesOrdersTable.tsx:98
-#: src/tables/sales/SalesOrderLineItemTable.tsx:433
+#: src/tables/sales/SalesOrderLineItemTable.tsx:403
 #: src/tables/stock/TransferOrderLineItemTable.tsx:498
 msgid "Completed"
 msgstr "已完成"
@@ -8694,7 +8668,7 @@ msgstr "制造商零件详情"
 
 #: src/pages/company/ManufacturerPartDetail.tsx:77
 #: src/pages/company/SupplierPartDetail.tsx:85
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:188
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:187
 msgid "Received Stock"
 msgstr "接收库存"
 
@@ -8789,8 +8763,8 @@ msgstr "零件描述"
 
 #: src/pages/company/SupplierPartDetailsPanel.tsx:133
 #: src/tables/part/PartPurchaseOrdersTable.tsx:82
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:199
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:240
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:189
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:230
 #: src/tables/purchasing/SupplierPartTable.tsx:173
 msgid "Pack Quantity"
 msgstr "包装数量"
@@ -9003,7 +8977,7 @@ msgstr "不足"
 
 #: src/pages/part/PartDetail.tsx:632
 #: src/pages/part/bom/BomCompare.tsx:38
-#: src/tables/bom/BomTable.tsx:516
+#: src/tables/bom/BomTable.tsx:503
 #: src/tables/build/BuildLineTable.tsx:216
 #: src/tables/part/PartTableFilters.tsx:109
 msgid "Consumable"
@@ -9079,10 +9053,10 @@ msgid "Keywords"
 msgstr "关键词"
 
 #: src/pages/part/PartDetailsPanel.tsx:168
-#: src/tables/bom/BomTable.tsx:486
+#: src/tables/bom/BomTable.tsx:473
 #: src/tables/build/BuildLineTable.tsx:325
 #: src/tables/part/PartTableFilters.tsx:143
-#: src/tables/sales/SalesOrderLineItemTable.tsx:176
+#: src/tables/sales/SalesOrderLineItemTable.tsx:146
 #: src/tables/stock/TransferOrderLineItemTable.tsx:121
 msgid "Available Stock"
 msgstr "可用库存"
@@ -9119,7 +9093,7 @@ msgid "Template Part"
 msgstr "模板零件"
 
 #: src/pages/part/PartDetailsPanel.tsx:252
-#: src/tables/bom/BomTable.tsx:476
+#: src/tables/bom/BomTable.tsx:463
 msgid "Assembled Part"
 msgstr "组装零件"
 
@@ -9128,12 +9102,12 @@ msgid "Component Part"
 msgstr "组件零件"
 
 #: src/pages/part/PartDetailsPanel.tsx:257
-#: src/tables/bom/BomTable.tsx:461
+#: src/tables/bom/BomTable.tsx:448
 msgid "Testable Part"
 msgstr "可测试零件"
 
 #: src/pages/part/PartDetailsPanel.tsx:260
-#: src/tables/bom/BomTable.tsx:466
+#: src/tables/bom/BomTable.tsx:453
 msgid "Trackable Part"
 msgstr "可追溯零件"
 
@@ -9338,18 +9312,18 @@ msgid "Validated By"
 msgstr "验证人"
 
 #: src/pages/part/bom/BomCompare.tsx:35
-#: src/tables/bom/BomTable.tsx:506
+#: src/tables/bom/BomTable.tsx:493
 msgid "Allow Variants"
 msgstr "允许变体"
 
 #: src/pages/part/bom/BomCompare.tsx:36
-#: src/tables/bom/BomTable.tsx:501
+#: src/tables/bom/BomTable.tsx:488
 #: src/tables/bom/UsedInTable.tsx:92
 msgid "Inherited"
 msgstr "继承项"
 
 #: src/pages/part/bom/BomCompare.tsx:37
-#: src/tables/bom/BomTable.tsx:511
+#: src/tables/bom/BomTable.tsx:498
 #: src/tables/bom/UsedInTable.tsx:102
 #: src/tables/build/BuildLineTable.tsx:221
 msgid "Optional"
@@ -9651,25 +9625,25 @@ msgstr "额外行项目"
 #~ msgid "Created On"
 #~ msgstr "Created On"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:223
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:222
 msgid "Issue Purchase Order"
 msgstr "发布采购订单"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:231
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:230
 msgid "Cancel Purchase Order"
 msgstr "取消采购订单"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:239
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:238
 msgid "Hold Purchase Order"
 msgstr "挂起采购订单"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:247
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:246
 msgid "Complete Purchase Order"
 msgstr "完成采购订单"
 
-#: src/pages/purchasing/PurchaseOrderDetail.tsx:303
-#: src/pages/sales/ReturnOrderDetail.tsx:296
-#: src/pages/sales/SalesOrderDetail.tsx:354
+#: src/pages/purchasing/PurchaseOrderDetail.tsx:302
+#: src/pages/sales/ReturnOrderDetail.tsx:295
+#: src/pages/sales/SalesOrderDetail.tsx:353
 #: src/pages/stock/TransferOrderDetail.tsx:317
 msgid "Order Actions"
 msgstr "订单操作"
@@ -9686,7 +9660,7 @@ msgid "Completed Line Items"
 msgstr "已完成行项目"
 
 #: src/pages/purchasing/PurchaseOrderDetailsPanel.tsx:100
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:285
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:275
 msgid "Destination"
 msgstr "目的地"
 
@@ -9721,29 +9695,29 @@ msgstr "联系电话"
 msgid "Issue Date"
 msgstr "签发日期"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:188
+#: src/pages/sales/ReturnOrderDetail.tsx:187
 msgid "Edit Return Order"
 msgstr "编辑退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:207
+#: src/pages/sales/ReturnOrderDetail.tsx:206
 #: src/tables/sales/ReturnOrderTable.tsx:115
 #: src/tables/sales/ReturnOrderTable.tsx:129
 msgid "Add Return Order"
 msgstr "添加退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:216
+#: src/pages/sales/ReturnOrderDetail.tsx:215
 msgid "Issue Return Order"
 msgstr "发布退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:224
+#: src/pages/sales/ReturnOrderDetail.tsx:223
 msgid "Cancel Return Order"
 msgstr "取消退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:232
+#: src/pages/sales/ReturnOrderDetail.tsx:231
 msgid "Hold Return Order"
 msgstr "挂起退货订单"
 
-#: src/pages/sales/ReturnOrderDetail.tsx:240
+#: src/pages/sales/ReturnOrderDetail.tsx:239
 msgid "Complete Return Order"
 msgstr "完成退货订单"
 
@@ -9778,40 +9752,40 @@ msgstr "编辑销售订单"
 msgid "Add Sales Order"
 msgstr "添加销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:190
+#: src/pages/sales/SalesOrderDetail.tsx:189
 #: src/tables/sales/SalesOrderTable.tsx:105
 msgid "Shipments"
 msgstr "配送"
 
-#: src/pages/sales/SalesOrderDetail.tsx:248
+#: src/pages/sales/SalesOrderDetail.tsx:247
 msgid "Issue Sales Order"
 msgstr "发布销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:256
+#: src/pages/sales/SalesOrderDetail.tsx:255
 msgid "Cancel Sales Order"
 msgstr "取消销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:264
+#: src/pages/sales/SalesOrderDetail.tsx:263
 msgid "Hold Sales Order"
 msgstr "挂起销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:272
+#: src/pages/sales/SalesOrderDetail.tsx:271
 msgid "Ship Sales Order"
 msgstr "销售订单发货"
 
-#: src/pages/sales/SalesOrderDetail.tsx:274
+#: src/pages/sales/SalesOrderDetail.tsx:273
 msgid "Ship this order?"
 msgstr "确认发货此订单？"
 
-#: src/pages/sales/SalesOrderDetail.tsx:275
+#: src/pages/sales/SalesOrderDetail.tsx:274
 msgid "Order shipped"
 msgstr "订单已发货"
 
-#: src/pages/sales/SalesOrderDetail.tsx:283
+#: src/pages/sales/SalesOrderDetail.tsx:282
 msgid "Complete Sales Order"
 msgstr "完成销售订单"
 
-#: src/pages/sales/SalesOrderDetail.tsx:328
+#: src/pages/sales/SalesOrderDetail.tsx:327
 msgid "Ship Order"
 msgstr "装货单"
 
@@ -10390,7 +10364,7 @@ msgstr "该物料清单物料未经验证"
 msgid "Part Information"
 msgstr "零件信息"
 
-#: src/tables/bom/BomTable.tsx:275
+#: src/tables/bom/BomTable.tsx:262
 msgid "Substitutes"
 msgstr "替代料"
 
@@ -10419,6 +10393,11 @@ msgstr "替代料"
 #~ msgstr "Bom item deleted"
 
 #: src/tables/bom/BomTable.tsx:351
+#: src/tables/build/BuildLineTable.tsx:258
+msgid "Includes substitute stock"
+msgstr "包括替代库存"
+
+#: src/tables/bom/BomTable.tsx:351
 #~ msgid "Are you sure you want to remove this BOM item?"
 #~ msgstr "Are you sure you want to remove this BOM item?"
 
@@ -10426,173 +10405,168 @@ msgstr "替代料"
 #~ msgid "Validate BOM line"
 #~ msgstr "Validate BOM line"
 
-#: src/tables/bom/BomTable.tsx:364
-#: src/tables/build/BuildLineTable.tsx:258
-msgid "Includes substitute stock"
-msgstr "包括替代库存"
-
-#: src/tables/bom/BomTable.tsx:382
+#: src/tables/bom/BomTable.tsx:369
 #: src/tables/build/BuildLineTable.tsx:286
-#: src/tables/sales/SalesOrderLineItemTable.tsx:218
+#: src/tables/sales/SalesOrderLineItemTable.tsx:188
 #: src/tables/stock/TransferOrderLineItemTable.tsx:163
 msgid "On order"
 msgstr "订购中"
 
-#: src/tables/bom/BomTable.tsx:441
+#: src/tables/bom/BomTable.tsx:428
 #: src/tables/build/BuildLineTable.tsx:527
 #: src/tables/build/BuildLineTable.tsx:572
 msgid "Consumable item"
 msgstr "可耗物品"
 
-#: src/tables/bom/BomTable.tsx:444
+#: src/tables/bom/BomTable.tsx:431
 msgid "No available stock"
 msgstr "无可用库存"
 
-#: src/tables/bom/BomTable.tsx:462
+#: src/tables/bom/BomTable.tsx:449
 #: src/tables/build/BuildLineTable.tsx:232
 msgid "Show testable items"
 msgstr "显示可跟踪项目"
 
-#: src/tables/bom/BomTable.tsx:467
+#: src/tables/bom/BomTable.tsx:454
 msgid "Show trackable items"
 msgstr "显示可跟踪项目"
 
-#: src/tables/bom/BomTable.tsx:471
+#: src/tables/bom/BomTable.tsx:458
 #: src/tables/purchasing/ManufacturerPartParametricTable.tsx:46
 #: src/tables/purchasing/ManufacturerPartTable.tsx:161
 #: src/tables/purchasing/SupplierPartTable.tsx:264
 msgid "Active Part"
 msgstr "激活的零件"
 
-#: src/tables/bom/BomTable.tsx:472
+#: src/tables/bom/BomTable.tsx:459
 #: src/tables/settings/ProjectCodeTable.tsx:105
 msgid "Show active items"
 msgstr "显示有效项"
 
-#: src/tables/bom/BomTable.tsx:477
+#: src/tables/bom/BomTable.tsx:464
 #: src/tables/build/BuildLineTable.tsx:227
 msgid "Show assembled items"
 msgstr "显示已装配的项目"
 
-#: src/tables/bom/BomTable.tsx:482
+#: src/tables/bom/BomTable.tsx:469
 msgid "Show virtual items"
 msgstr "显示虚拟项"
 
-#: src/tables/bom/BomTable.tsx:487
+#: src/tables/bom/BomTable.tsx:474
 msgid "Show items with available stock"
 msgstr "显示有可用库存的项目"
 
-#: src/tables/bom/BomTable.tsx:492
+#: src/tables/bom/BomTable.tsx:479
 msgid "Show items on order"
 msgstr "按顺序显示项目"
 
-#: src/tables/bom/BomTable.tsx:496
+#: src/tables/bom/BomTable.tsx:483
 msgid "Validated"
 msgstr "已验证"
 
-#: src/tables/bom/BomTable.tsx:497
+#: src/tables/bom/BomTable.tsx:484
 msgid "Show validated items"
 msgstr "显示已验证的项目"
 
-#: src/tables/bom/BomTable.tsx:502
+#: src/tables/bom/BomTable.tsx:489
 #: src/tables/bom/UsedInTable.tsx:93
 msgid "Show inherited items"
 msgstr "显示继承的项目"
 
-#: src/tables/bom/BomTable.tsx:507
+#: src/tables/bom/BomTable.tsx:494
 msgid "Show items which allow variant substitution"
 msgstr "显示允许变体替换的项目"
 
-#: src/tables/bom/BomTable.tsx:512
+#: src/tables/bom/BomTable.tsx:499
 #: src/tables/bom/UsedInTable.tsx:103
 msgid "Show optional items"
 msgstr "显示可选项目"
 
-#: src/tables/bom/BomTable.tsx:517
+#: src/tables/bom/BomTable.tsx:504
 msgid "Show consumable items"
 msgstr "显示可消耗项目"
 
-#: src/tables/bom/BomTable.tsx:521
+#: src/tables/bom/BomTable.tsx:508
 #: src/tables/part/PartTableFilters.tsx:137
 msgid "Has Pricing"
 msgstr "是否有价格"
 
-#: src/tables/bom/BomTable.tsx:522
+#: src/tables/bom/BomTable.tsx:509
 msgid "Show items with pricing"
 msgstr "显示带定价的项目"
 
-#: src/tables/bom/BomTable.tsx:544
+#: src/tables/bom/BomTable.tsx:531
 msgid "Import BOM Data"
 msgstr "导入物料清单数据"
 
-#: src/tables/bom/BomTable.tsx:555
-#: src/tables/bom/BomTable.tsx:677
+#: src/tables/bom/BomTable.tsx:542
+#: src/tables/bom/BomTable.tsx:664
 msgid "Add BOM Item"
 msgstr "添加物料清单项"
 
-#: src/tables/bom/BomTable.tsx:560
+#: src/tables/bom/BomTable.tsx:547
 msgid "BOM item created"
 msgstr "BOM 项目已创建"
 
-#: src/tables/bom/BomTable.tsx:567
+#: src/tables/bom/BomTable.tsx:554
 #: src/tables/bom/UsedInTable.tsx:123
 msgid "Edit BOM Item"
 msgstr "编辑物料清单项目"
 
-#: src/tables/bom/BomTable.tsx:569
+#: src/tables/bom/BomTable.tsx:556
 #: src/tables/bom/UsedInTable.tsx:127
 msgid "BOM item updated"
 msgstr "物料清单 项目已更新"
 
-#: src/tables/bom/BomTable.tsx:576
+#: src/tables/bom/BomTable.tsx:563
 msgid "Delete BOM Item"
 msgstr "删除物料清单项目"
 
-#: src/tables/bom/BomTable.tsx:577
+#: src/tables/bom/BomTable.tsx:564
 msgid "BOM item deleted"
 msgstr "物料清单项目已删除"
 
-#: src/tables/bom/BomTable.tsx:597
+#: src/tables/bom/BomTable.tsx:584
 msgid "BOM item validated"
 msgstr "物料清单项目已验证"
 
-#: src/tables/bom/BomTable.tsx:606
+#: src/tables/bom/BomTable.tsx:593
 msgid "Failed to validate BOM item"
 msgstr "验证物料清单项目失败"
 
-#: src/tables/bom/BomTable.tsx:618
+#: src/tables/bom/BomTable.tsx:605
 msgid "View BOM"
 msgstr "查看 物料清单"
 
-#: src/tables/bom/BomTable.tsx:629
+#: src/tables/bom/BomTable.tsx:616
 msgid "Validate BOM Line"
 msgstr "验证物料清单行"
 
-#: src/tables/bom/BomTable.tsx:646
+#: src/tables/bom/BomTable.tsx:633
 msgid "Edit Substitutes"
 msgstr "编辑替代零件"
 
-#: src/tables/bom/BomTable.tsx:671
+#: src/tables/bom/BomTable.tsx:658
 msgid "Add BOM Items"
 msgstr "添加物料清单项目"
 
-#: src/tables/bom/BomTable.tsx:679
+#: src/tables/bom/BomTable.tsx:666
 msgid "Add a single BOM item"
 msgstr "添加单个物料清单项目"
 
-#: src/tables/bom/BomTable.tsx:685
+#: src/tables/bom/BomTable.tsx:672
 msgid "Import BOM items from a file"
 msgstr "从文件导入物料清单项目"
 
-#: src/tables/bom/BomTable.tsx:693
+#: src/tables/bom/BomTable.tsx:680
 msgid "Edit BOM"
 msgstr "编辑物料清单"
 
-#: src/tables/bom/BomTable.tsx:703
+#: src/tables/bom/BomTable.tsx:690
 msgid "Finish Editing BOM"
 msgstr "完成物料清单编辑"
 
-#: src/tables/bom/BomTable.tsx:731
+#: src/tables/bom/BomTable.tsx:718
 msgid "Bill of materials cannot be edited, as the part is locked"
 msgstr "无法编辑材料清单，因为零件已锁定"
 
@@ -10780,7 +10754,7 @@ msgid "Show items with stock on order"
 msgstr "显示已订购在途库存的物料"
 
 #: src/tables/build/BuildLineTable.tsx:277
-#: src/tables/sales/SalesOrderLineItemTable.tsx:210
+#: src/tables/sales/SalesOrderLineItemTable.tsx:180
 #: src/tables/stock/TransferOrderLineItemTable.tsx:155
 msgid "In production"
 msgstr "生产中"
@@ -10807,7 +10781,7 @@ msgstr "完全分配"
 #~ msgstr "Auto allocation in progress"
 
 #: src/tables/build/BuildLineTable.tsx:598
-#: src/tables/sales/SalesOrderLineItemTable.tsx:351
+#: src/tables/sales/SalesOrderLineItemTable.tsx:321
 #: src/tables/stock/TransferOrderLineItemTable.tsx:251
 msgid "Create Build Order"
 msgstr "创建生产订单"
@@ -10823,7 +10797,7 @@ msgstr "正在为生产订单分配库存"
 
 #: src/tables/build/BuildLineTable.tsx:614
 #: src/tables/build/BuildOutputTable.tsx:230
-#: src/tables/sales/SalesOrderLineItemTable.tsx:377
+#: src/tables/sales/SalesOrderLineItemTable.tsx:347
 msgid "Stock allocation complete"
 msgstr "库存分配完成"
 
@@ -10832,8 +10806,8 @@ msgstr "库存分配完成"
 #: src/tables/build/BuildLineTable.tsx:892
 #: src/tables/build/BuildOutputTable.tsx:253
 #: src/tables/build/BuildOutputTable.tsx:537
-#: src/tables/sales/SalesOrderLineItemTable.tsx:408
-#: src/tables/sales/SalesOrderLineItemTable.tsx:482
+#: src/tables/sales/SalesOrderLineItemTable.tsx:378
+#: src/tables/sales/SalesOrderLineItemTable.tsx:449
 msgid "Auto Allocate Stock"
 msgstr "自动分配库存量"
 
@@ -10879,7 +10853,7 @@ msgid "Build Stock"
 msgstr "生产库存"
 
 #: src/tables/build/BuildLineTable.tsx:874
-#: src/tables/sales/SalesOrderLineItemTable.tsx:596
+#: src/tables/sales/SalesOrderLineItemTable.tsx:562
 #: src/tables/stock/TransferOrderLineItemTable.tsx:450
 msgid "View Part"
 msgstr "查看零件"
@@ -11207,57 +11181,42 @@ msgstr "型号"
 msgid "View Item"
 msgstr "查看项目"
 
-#: src/tables/general/ExtraLineItemTable.tsx:81
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:270
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:201
-#: src/tables/sales/SalesOrderLineItemTable.tsx:157
+#: src/tables/general/ExtraLineItemTable.tsx:75
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:260
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:154
+#: src/tables/sales/SalesOrderLineItemTable.tsx:127
 msgid "Discount"
-msgstr ""
+msgstr "折扣"
 
-#: src/tables/general/ExtraLineItemTable.tsx:108
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:313
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:412
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:413
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:91
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:239
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:240
-#: src/tables/sales/SalesOrderLineItemTable.tsx:290
-#: src/tables/sales/SalesOrderLineItemTable.tsx:443
-#: src/tables/sales/SalesOrderLineItemTable.tsx:444
+#: src/tables/general/ExtraLineItemTable.tsx:102
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:303
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:409
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:86
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:192
+#: src/tables/sales/SalesOrderLineItemTable.tsx:260
+#: src/tables/sales/SalesOrderLineItemTable.tsx:413
 #: src/tables/stock/TransferOrderLineItemTable.tsx:266
 #: src/tables/stock/TransferOrderLineItemTable.tsx:320
 msgid "Add Line Item"
 msgstr "添加行项目"
 
-#: src/tables/general/ExtraLineItemTable.tsx:121
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:336
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:104
-#: src/tables/sales/SalesOrderLineItemTable.tsx:309
+#: src/tables/general/ExtraLineItemTable.tsx:115
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:326
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:99
+#: src/tables/sales/SalesOrderLineItemTable.tsx:279
 #: src/tables/stock/TransferOrderLineItemTable.tsx:283
 msgid "Edit Line Item"
 msgstr "编辑行项目"
 
-#: src/tables/general/ExtraLineItemTable.tsx:130
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:345
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:113
-#: src/tables/sales/SalesOrderLineItemTable.tsx:318
+#: src/tables/general/ExtraLineItemTable.tsx:124
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:335
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:108
+#: src/tables/sales/SalesOrderLineItemTable.tsx:288
 #: src/tables/stock/TransferOrderLineItemTable.tsx:292
 msgid "Delete Line Item"
 msgstr "删除行项目"
 
-#: src/tables/general/ExtraLineItemTable.tsx:151
-#: src/tables/general/ExtraLineItemTable.tsx:195
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:111
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:414
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:136
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:241
-#: src/tables/sales/SalesOrderLineItemTable.tsx:106
-#: src/tables/sales/SalesOrderLineItemTable.tsx:445
-msgid "Import Line Items"
-msgstr "导入行项目"
-
-#: src/tables/general/ExtraLineItemTable.tsx:193
-#: src/tables/general/ExtraLineItemTable.tsx:194
+#: src/tables/general/ExtraLineItemTable.tsx:162
 msgid "Add Extra Line Item"
 msgstr "添加额外行项目"
 
@@ -11655,7 +11614,7 @@ msgid "Required Stock"
 msgstr "所需库存"
 
 #: src/tables/part/PartBuildAllocationsTable.tsx:125
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:397
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:387
 msgid "View Build Order"
 msgstr "查看生产订单"
 
@@ -11744,7 +11703,7 @@ msgstr "在此分类下新建的零件，将自动继承此处设置的默认参
 #~ msgstr "Add parameter template"
 
 #: src/tables/part/PartPurchaseOrdersTable.tsx:88
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:205
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:195
 msgid "Total Quantity"
 msgstr "总数量"
 
@@ -11763,11 +11722,11 @@ msgstr "查看销售订单"
 
 #: src/tables/part/PartSalesOrdersTable.tsx:94
 msgid "Show outstanding orders"
-msgstr ""
+msgstr "显示未完成订单"
 
 #: src/tables/part/PartSalesOrdersTable.tsx:99
 msgid "Show completed line items"
-msgstr ""
+msgstr "显示已完成行项目"
 
 #: src/tables/part/PartTable.tsx:214
 #: src/tables/part/PartTable.tsx:257
@@ -11924,7 +11883,7 @@ msgstr "按有可用库存的零件筛选"
 
 #: src/tables/part/PartTableFilters.tsx:150
 msgid "Filter by parts which are on order"
-msgstr ""
+msgstr "按已订购零件筛选"
 
 #: src/tables/part/PartTableFilters.tsx:156
 msgid "Filter by parts to which the user is subscribed"
@@ -12126,7 +12085,7 @@ msgstr "插件"
 #~ msgstr "An error occurred while fetching plugin details"
 
 #: src/tables/plugin/PluginListTable.tsx:113
-#: src/tables/plugin/PluginListTable.tsx:441
+#: src/tables/plugin/PluginListTable.tsx:437
 msgid "Mandatory"
 msgstr "必填"
 
@@ -12160,23 +12119,23 @@ msgstr "描述不可用."
 #~ msgid "Package information"
 #~ msgstr "Package information"
 
-#: src/tables/plugin/PluginListTable.tsx:165
+#: src/tables/plugin/PluginListTable.tsx:166
 msgid "Confirm plugin activation"
 msgstr "确认插件激活"
 
-#: src/tables/plugin/PluginListTable.tsx:166
+#: src/tables/plugin/PluginListTable.tsx:167
 msgid "Confirm plugin deactivation"
 msgstr "确认插件停用"
 
-#: src/tables/plugin/PluginListTable.tsx:171
+#: src/tables/plugin/PluginListTable.tsx:172
 msgid "The selected plugin will be activated"
 msgstr "所选插件将被激活"
 
-#: src/tables/plugin/PluginListTable.tsx:172
+#: src/tables/plugin/PluginListTable.tsx:173
 msgid "The selected plugin will be deactivated"
 msgstr "所选插件将被停用"
 
-#: src/tables/plugin/PluginListTable.tsx:190
+#: src/tables/plugin/PluginListTable.tsx:191
 msgid "Deactivate"
 msgstr "停用"
 
@@ -12184,28 +12143,28 @@ msgstr "停用"
 #~ msgid "Plugin settings"
 #~ msgstr "Plugin settings"
 
-#: src/tables/plugin/PluginListTable.tsx:204
+#: src/tables/plugin/PluginListTable.tsx:205
 msgid "Activate"
 msgstr "激活"
 
-#: src/tables/plugin/PluginListTable.tsx:205
+#: src/tables/plugin/PluginListTable.tsx:206
 msgid "Activate selected plugin"
 msgstr "激活所选插件"
 
-#: src/tables/plugin/PluginListTable.tsx:217
+#: src/tables/plugin/PluginListTable.tsx:218
 msgid "Update selected plugin"
 msgstr "更新所选插件"
 
-#: src/tables/plugin/PluginListTable.tsx:235
+#: src/tables/plugin/PluginListTable.tsx:236
 #: src/tables/stock/InstalledItemsTable.tsx:104
 msgid "Uninstall"
 msgstr "卸载"
 
-#: src/tables/plugin/PluginListTable.tsx:236
+#: src/tables/plugin/PluginListTable.tsx:237
 msgid "Uninstall selected plugin"
 msgstr "卸载所选插件"
 
-#: src/tables/plugin/PluginListTable.tsx:254
+#: src/tables/plugin/PluginListTable.tsx:255
 msgid "Delete selected plugin configuration"
 msgstr "删除选中的插件配置"
 
@@ -12230,7 +12189,7 @@ msgstr "插件已停用"
 #~ msgstr "Install plugin"
 
 #: src/tables/plugin/PluginListTable.tsx:292
-#: src/tables/plugin/PluginListTable.tsx:388
+#: src/tables/plugin/PluginListTable.tsx:384
 msgid "Install Plugin"
 msgstr "安装插件"
 
@@ -12294,7 +12253,7 @@ msgstr "插件重载成功"
 #~ msgid "Deactivating plugin"
 #~ msgstr "Deactivating plugin"
 
-#: src/tables/plugin/PluginListTable.tsx:381
+#: src/tables/plugin/PluginListTable.tsx:377
 msgid "Reload Plugins"
 msgstr "重载插件"
 
@@ -12302,19 +12261,19 @@ msgstr "重载插件"
 #~ msgid "Plugin updated"
 #~ msgstr "Plugin updated"
 
+#: src/tables/plugin/PluginListTable.tsx:400
+msgid "Plugin Detail"
+msgstr "插件详情"
+
 #: src/tables/plugin/PluginListTable.tsx:403
 #~ msgid "Error updating plugin"
 #~ msgstr "Error updating plugin"
 
-#: src/tables/plugin/PluginListTable.tsx:404
-msgid "Plugin Detail"
-msgstr "插件详情"
-
-#: src/tables/plugin/PluginListTable.tsx:446
+#: src/tables/plugin/PluginListTable.tsx:442
 msgid "Sample"
 msgstr "样本"
 
-#: src/tables/plugin/PluginListTable.tsx:451
+#: src/tables/plugin/PluginListTable.tsx:447
 #: src/tables/stock/StockItemTable.tsx:247
 msgid "Installed"
 msgstr "已安装"
@@ -12372,19 +12331,24 @@ msgstr "显示活动制造商部件。"
 #~ msgid "Are you sure you want to remove this manufacturer part?"
 #~ msgstr "Are you sure you want to remove this manufacturer part?"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:244
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:111
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:403
+msgid "Import Line Items"
+msgstr "导入行项目"
+
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:234
 msgid "Supplier Code"
 msgstr "供应商代码"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:252
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:242
 msgid "Supplier Link"
 msgstr "供应商链接"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:259
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:249
 msgid "Manufacturer Code"
 msgstr "制造商编号"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:297
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:287
 msgid "Show line items which have been received"
 msgstr "显示已收到的行项目"
 
@@ -12394,11 +12358,11 @@ msgstr "显示已收到的行项目"
 #~ msgid "Add line item"
 #~ msgstr "Add line item"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:366
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:356
 msgid "Receive line item"
 msgstr "接收这行项目"
 
-#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:426
+#: src/tables/purchasing/PurchaseOrderLineItemTable.tsx:420
 msgid "Receive items"
 msgstr "收到项目"
 
@@ -12450,35 +12414,23 @@ msgstr "显示活跃供应商"
 msgid "Show supplier parts with stock"
 msgstr "显示供应商零件库存"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:148
-msgid "Set Outcome"
-msgstr ""
-
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:151
-msgid "Adjust the outcome for the selected line items."
-msgstr ""
-
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:210
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:163
 msgid "Received Date"
 msgstr "接收日期"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:224
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:177
 msgid "Show items which have been received"
 msgstr "显示已收到的项目"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:229
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:182
 msgid "Filter by line item status"
 msgstr "按行项目状态筛选"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:250
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:200
 msgid "Receive selected items"
 msgstr "接收选中项目"
 
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:267
-msgid "Set outcome for selected items"
-msgstr ""
-
-#: src/tables/sales/ReturnOrderLineItemTable.tsx:304
+#: src/tables/sales/ReturnOrderLineItemTable.tsx:237
 msgid "Receive Item"
 msgstr "接收物品"
 
@@ -12547,48 +12499,48 @@ msgstr "安排发货"
 #~ msgid "Allocate Serials"
 #~ msgstr "Allocate Serials"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:331
+#: src/tables/sales/SalesOrderLineItemTable.tsx:301
 #: src/tables/stock/TransferOrderLineItemTable.tsx:305
 msgid "Allocate Serial Numbers"
 msgstr "分配序列号"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:339
+#: src/tables/sales/SalesOrderLineItemTable.tsx:309
 msgid "Stock allocated successfully"
 msgstr "库存分配成功"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:376
+#: src/tables/sales/SalesOrderLineItemTable.tsx:346
 msgid "Allocating stock to sales order"
 msgstr "为销售订单分配库存"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:393
+#: src/tables/sales/SalesOrderLineItemTable.tsx:363
 msgid "{count} line item(s) selected — only these lines will be allocated"
 msgstr "已选中 {count} 条明细条目，仅对选中行执行库存分配操作"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:400
+#: src/tables/sales/SalesOrderLineItemTable.tsx:370
 msgid "All unallocated line items will be allocated"
 msgstr "将对所有未分配库存的明细条目执行库存分配"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:429
+#: src/tables/sales/SalesOrderLineItemTable.tsx:399
 #: src/tables/stock/TransferOrderLineItemTable.tsx:494
 msgid "Show lines which are fully allocated"
 msgstr "显示已完全分配的行"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:434
+#: src/tables/sales/SalesOrderLineItemTable.tsx:404
 #: src/tables/stock/TransferOrderLineItemTable.tsx:499
 msgid "Show lines which are completed"
 msgstr "显示已完成的行"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:530
+#: src/tables/sales/SalesOrderLineItemTable.tsx:496
 #: src/tables/stock/TransferOrderLineItemTable.tsx:384
 msgid "Allocate serials"
 msgstr "分配序列号"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:548
+#: src/tables/sales/SalesOrderLineItemTable.tsx:514
 #: src/tables/stock/TransferOrderLineItemTable.tsx:402
 msgid "Build stock"
 msgstr "生产库存"
 
-#: src/tables/sales/SalesOrderLineItemTable.tsx:566
+#: src/tables/sales/SalesOrderLineItemTable.tsx:532
 #: src/tables/stock/TransferOrderLineItemTable.tsx:420
 msgid "Order stock"
 msgstr "订单库存"
@@ -12861,7 +12813,7 @@ msgstr "出库"
 
 #: src/tables/settings/ErrorTable.tsx:67
 msgid "Traceback"
-msgstr "Traceback"
+msgstr "跟踪堆栈"
 
 #: src/tables/settings/ErrorTable.tsx:103
 msgid "When"


### PR DESCRIPTION
## Summary

This PR adds 37 missing Chinese (zh_Hans) translations and fixes media file access for single-machine deployments without a reverse proxy.

## Changes

### Backend translations (26 entries in django.po)
- Stock status: `OK` ? `??`
- Sales/Purchase order: Discount, discount percentage hint, line item quantity
- System settings: Edit completed transfer orders, merge purchase order line items, search results preview panel
- Error messages: Stock item no longer exists, server reloading, missing purchase/sales order permissions
- Parameter templates: Uniqueness options (none, per model type, global), uniqueness enforcement

### Frontend translations (11 entries in messages.po)
- Discount, Show completed line items, Show outstanding orders, No items selected, delete confirmation text
- Direct stock, FAQ, Traceback, Filter by parts on order, render error message

### Code fixes for single-machine deployment
- **`middleware.py`**: Add `MEDIA_URL` to `paths_own_security` - media files use DRF token/session auth in single-machine mode
- **`urls.py`**: Serve media files via `django.views.static.serve` outside `DEBUG` mode - fixes export 404 when no reverse proxy is configured

## Testing
- Verified on Windows single-machine deployment (SQLite, port 17456, no reverse proxy)
- `/api/generic/status/` returns all Chinese status labels
- Sales order line item fields display in Chinese
- Media file export (reports, labels) works without 404 errors

## Notes
- Targeted at commit `e4b23b4` (master branch)
- `django.mo` is gitignored and must be compiled separately (`polib` or `django compilemessages`)
- Frontend requires `npm run compile` + `npm run build` after applying