### PR TITLE
chore: add types to templates; add AI agent catch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,7 @@
 name: "Bug"
 description: "Create a bug report to help us improve InvenTree!"
 labels: ["bug", "question", "triage:not-checked"]
+type: "bug"
 body:
   - type: checkboxes
     id: no-duplicate-issues
@@ -52,7 +53,7 @@ body:
       required: true
     attributes:
       label: "Version Information"
-      description: "The version info block."
+      description: "The version info block. An incomplete version block or just a version number can lead to unread closure of the issue."
       placeholder: "You can get this by going to the `About InvenTree` section in the upper right corner and clicking on the `copy version information` button"
   - type: dropdown
     id: tried-reproduce
@@ -81,3 +82,11 @@ body:
       render: shell
     validations:
       required: false
+  - type: checkboxes
+    id: report-check
+    attributes:
+      label: "I have reviewed this report for correctness and filled out all sections."
+      description: "Due to a rise in automatically filled AI reports that are now fully reviewed/true this needs to be answered."
+      options:
+        - label: "I have checked this report. I acknowledge that filing of bugs via AI agent without review might lead to being blocked."
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -88,5 +88,5 @@ body:
       label: "I have reviewed this report for correctness and filled out all sections."
       description: "Due to a rise in automatically filled AI reports that are now fully reviewed/true this needs to be answered."
       options:
-        - label: "I have checked this report. I acknowledge that filing of bugs via AI agent without review might lead to being blocked."
+        - label: "I have checked this report. I acknowledge that filing bugs via AI agents without review might lead to being blocked."
           required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -13,3 +13,11 @@ body:
       description: Please provide one distinct thing to fix or a clearly defined enhancement
     validations:
       required: true
+  - type: checkboxes
+    id: report-check
+    attributes:
+      label: "I have reviewed this report for correctness and filled out all sections."
+      description: "Due to a rise in automatically filled AI reports that are now fully reviewed/true this needs to be answered."
+      options:
+        - label: "I have checked this report. I acknowledge that filing bugs via AI agents without review might lead to being blocked."
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -2,6 +2,7 @@ name: Feature Request
 description: Suggest an idea for this project
 title: "[FR] title"
 labels: ["enhancement", "triage:not-checked"]
+type: enhancement
 body:
   - type: checkboxes
     id: no-duplicate-issues


### PR DESCRIPTION
This adds:
- types (better for API filtering than labels) by default to the FR/bug templates
- clarification to the template that lead at least Codex and Claude to stop automatically filing length bug reports that do not follow the template

Next step would be an AI text detection bot that labels fully AI reports automatically but lets see first if this helps ppl fill out the full template.