### PR TITLE
Prevent delete operation on /api/user/me/

### DIFF
--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,13 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 539
+INVENTREE_API_VERSION = 540
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v540 -> 2026-09-03 : https://github.com/inventree/InvenTree/pull/12770
+    - Prevent DELETE operation against the /api/user/me/ endpoint
 
 v539 -> 2026-09-02 : https://github.com/inventree/InvenTree/pull/12723
     - Adds search fields to AddressList, ContactList, UserList, GroupList, RuleSetList, and TokenListView API endpoints

--- a/src/backend/InvenTree/users/api.py
+++ b/src/backend/InvenTree/users/api.py
@@ -237,6 +237,9 @@ class MeUserDetail(RetrieveUpdateAPI, UserDetail):
 
     rolemap = {'POST': 'view', 'PUT': 'view', 'PATCH': 'view'}
 
+    # Prevent 'delete' operations on this endpoint
+    http_method_names = ['get', 'put', 'patch', 'head', 'options', 'trace']
+
     def get_object(self):
         """Always return the current user object."""
         return self.request.user

--- a/src/backend/InvenTree/users/test_api.py
+++ b/src/backend/InvenTree/users/test_api.py
@@ -335,6 +335,15 @@ class UserAPITests(InvenTreeAPITestCase):
         # User cannot fetch their own details if they are not active
         response = self.get(url, expected_code=401)
 
+    def test_me_endpoint_delete_is_blocked(self):
+        """A user must not be able to delete their own account via '/api/user/me/'."""
+        url = reverse('api-user-me')
+        pk = self.user.pk
+
+        self.delete(url, expected_code=405)
+
+        self.assertTrue(User.objects.filter(pk=pk).exists())
+
 
 class SuperuserAPITests(InvenTreeAPITestCase):
     """Tests for user API endpoints that require superuser rights."""


### PR DESCRIPTION
`UserMe` endpoint inherits from the `UserDetail` endpoint - this fix explicitly removes support for the 'delete' operation