### PR TITLE
feat: warn about unsafe CORS

### DIFF
--- a/docs/docs/settings/error_codes.md
+++ b/docs/docs/settings/error_codes.md
@@ -231,6 +231,10 @@ A process was interrupted by the user, likely by a keyboard interrupt. This migh
 
 The CORS settings are set to allow all origins. This might lead to security issues, as it allows any website to make requests to the InvenTree server. It is recommended to restrict the CORS settings to only allow trusted origins.
 
+CORS settings only affect user browsers that respect them. Setting them correctly is not a replacement for proper network segmentation (via firewalls, VPNs, proxies, etc.) and should be used in addition to them.
+
+Use the INVENTREE_CORS_ORIGIN_ALLOW_ALL and INVENTREE_CORS_ORIGIN_WHITELIST settings - see the [Server Access settings](../start/config.md#server-access).
+
 
 ### INVE-I (InvenTree Information)
 Information — These are not errors but information messages. They might point out potential issues or just provide information.

--- a/docs/docs/settings/error_codes.md
+++ b/docs/docs/settings/error_codes.md
@@ -226,6 +226,11 @@ Use separate accounts for administrative tasks and regular usage to reduce risk.
 
 A process was interrupted by the user, likely by a keyboard interrupt. This might lead to issues with the process that was interrupted, as it might not have completed its task. This is especially relevant for processes that are not idempotent or that do not have a good rollback mechanism.
 
+#### INVE-W16
+**CORS is set to allow all origins - Backend**
+
+The CORS settings are set to allow all origins. This might lead to security issues, as it allows any website to make requests to the InvenTree server. It is recommended to restrict the CORS settings to only allow trusted origins.
+
 
 ### INVE-I (InvenTree Information)
 Information — These are not errors but information messages. They might point out potential issues or just provide information.

--- a/src/backend/InvenTree/InvenTree/api.py
+++ b/src/backend/InvenTree/InvenTree/api.py
@@ -267,6 +267,8 @@ class InfoApiSerializer(serializers.Serializer):
     target = serializers.CharField(read_only=True, allow_null=True)
     django_admin = serializers.CharField(read_only=True)
     settings = SettingsSerializer(read_only=True, many=False)
+    """System state details that are mainly for warning purposes and do not require a hard API contract."""
+    system_state = serializers.JSONField(read_only=True)
 
 
 class InfoView(APIView):
@@ -337,6 +339,7 @@ class InfoView(APIView):
                     'LOGIN_ENABLE_PWD_FORGOT'
                 ),
             },
+            'system_state': {'cors_allow_all': settings.CORS_ALLOW_ALL_ORIGINS},
         }
 
         return JsonResponse(data)

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,10 +1,13 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 539
+INVENTREE_API_VERSION = 540
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 INVENTREE_API_TEXT = """
+
+v540 -> 2026-09-04 : https://github.com/inventree/InvenTree/pull/12773
+    - Adds a "system_state" field to the info endpoint for non-critical general system state information
 
 v539 -> 2026-09-02 : https://github.com/inventree/InvenTree/pull/12723
     - Adds search fields to AddressList, ContactList, UserList, GroupList, RuleSetList, and TokenListView API endpoints

--- a/src/frontend/src/components/nav/Alerts.tsx
+++ b/src/frontend/src/components/nav/Alerts.tsx
@@ -149,6 +149,13 @@ export function getAlerts(
       code: 'INVE-W8',
       message: t`There are pending database migrations.`,
       condition: n_migrations > 0
+    },
+    {
+      key: 'cors',
+      title: t`CORS Settings`,
+      code: 'INVE-W16',
+      message: t`CORS is set to allow all origins.`,
+      condition: server?.system_state?.cors_allow_all || false
     }
   ];
 

--- a/src/frontend/src/defaults/defaults.tsx
+++ b/src/frontend/src/defaults/defaults.tsx
@@ -21,7 +21,8 @@ export const emptyServerAPI = {
   default_locale: null,
   django_admin: null,
   settings: null,
-  customize: null
+  customize: null,
+  system_state: null
 };
 
 export interface SiteMarkProps {

--- a/src/frontend/src/states/states.tsx
+++ b/src/frontend/src/states/states.tsx
@@ -40,6 +40,9 @@ export interface ServerAPIProps {
     navbar_message: string;
     disable_theme_storage: boolean;
   };
+  system_state: {
+    cors_allow_all: null | boolean;
+  } | null;
 }
 
 let pendingGlobalStatesFetch: Promise<void> | null = null;


### PR DESCRIPTION
CORS allow all is a low-severity security issues that can be helpful for attackers that operate in the user browser domain. Not important enough to stop operations but we should warn about it.