### PR TITLE
Ignore 'piece_count' if default value

### DIFF
--- a/src/backend/InvenTree/part/models.py
+++ b/src/backend/InvenTree/part/models.py
@@ -4102,6 +4102,11 @@ class BomItem(InvenTree.models.MetadataMixin, InvenTree.models.InvenTreeModel):
             if value is None:
                 value = ''
 
+            if field == 'piece_count' and value == 1:
+                # Ignore the piece_count field if it is 1 (default value)
+                # This is to ensure backwards compatibility with BOM checksums calculated before this field was added
+                continue
+
             # Normalize decimal values to ensure consistent representation
             # These values are only included if they are non-zero
             # This is to provide some backwards compatibility from before these fields were added

--- a/src/backend/InvenTree/part/test_bom_item.py
+++ b/src/backend/InvenTree/part/test_bom_item.py
@@ -704,3 +704,53 @@ class BomItemTest(TestCase):
         # piece_count = 100 is a valid value
         item.piece_count = 100
         item.full_clean()  # Should not raise
+
+    def test_item_hash_piece_count_default(self):
+        """Regression test: a default 'piece_count' must not affect the checksum.
+
+        The 'piece_count' field is ignored by get_item_hash() when it holds its
+        default value (1), so that checksums calculated before this field was
+        added remain valid. Simulate a "legacy" checksum (calculated without
+        'piece_count' in the hashed fields) and confirm it still matches the
+        checksum calculated by the current code for a default piece_count.
+        """
+        item = BomItem.objects.get(part=100, sub_part=50)
+        item.piece_count = 1
+        item.save()
+
+        current_hash = item.get_item_hash()
+
+        legacy_fields = [f for f in item.hash_fields() if f != 'piece_count']
+
+        with mock.patch.object(BomItem, 'hash_fields', return_value=legacy_fields):
+            legacy_hash = item.get_item_hash()
+
+        self.assertEqual(current_hash, legacy_hash)
+
+        # A checksum validated under the "legacy" hashing scheme must still
+        # validate correctly against the current (piece_count aware) scheme
+        item.checksum = legacy_hash
+        item.save()
+        self.assertTrue(item.is_line_valid)
+
+    def test_item_hash_piece_count_non_default(self):
+        """A non-default 'piece_count' value must change the checksum hash."""
+        item = BomItem.objects.get(part=100, sub_part=50)
+        item.piece_count = 1
+        item.save()
+
+        # Validate the BOM item hash with the default piece_count
+        item.validate_hash()
+        self.assertTrue(item.is_line_valid)
+
+        # Changing piece_count away from the default must invalidate the checksum
+        item.piece_count = 5
+        item.save()
+        self.assertFalse(item.is_line_valid)
+
+        h_non_default = item.get_item_hash()
+
+        item.piece_count = 1
+        h_default = item.get_item_hash()
+
+        self.assertNotEqual(h_default, h_non_default)


### PR DESCRIPTION
Ref: https://github.com/inventree/InvenTree/pull/12422

When calculating BOM checksum, ignore the `piece_count` field if it is the default value (1) - this is to ensure backwards compatibility with checksum calculations performed before the field was introduced.

As https://github.com/inventree/InvenTree/pull/12422 has not made it into "stable" release code yet, it is good to catch this now.