### PR TITLE
Add owner field to stock location create/edit form

### DIFF
--- a/src/frontend/src/forms/StockForms.tsx
+++ b/src/frontend/src/forms/StockForms.tsx
@@ -2188,6 +2188,9 @@ export function stockLocationFields(): ApiFormFieldSet {
     },
     name: {},
     description: {},
+    owner: {
+      icon: <IconUsersGroup />
+    },
     structural: {},
     external: {},
     custom_icon: {

--- a/src/frontend/src/forms/StockForms.tsx
+++ b/src/frontend/src/forms/StockForms.tsx
@@ -2180,7 +2180,9 @@ export function useDeleteStockItem(props: StockOperationProps) {
   });
 }
 
-export function stockLocationFields(): ApiFormFieldSet {
+export function useStockLocationFields(): ApiFormFieldSet {
+  const globalSettings = useGlobalSettingsState();
+
   const fields: ApiFormFieldSet = {
     parent: {
       description: t`Parent stock location`,
@@ -2198,6 +2200,12 @@ export function stockLocationFields(): ApiFormFieldSet {
     },
     location_type: {}
   };
+
+  // Ownership of a stock location is only relevant if
+  // stock ownership control is enabled
+  if (!globalSettings.isSet('STOCK_OWNERSHIP_CONTROL')) {
+    delete fields.owner;
+  }
 
   return fields;
 }

--- a/src/frontend/src/pages/stock/LocationDetail.tsx
+++ b/src/frontend/src/pages/stock/LocationDetail.tsx
@@ -38,7 +38,7 @@ import { PanelGroup } from '../../components/panels/PanelGroup';
 import ParametersPanel from '../../components/panels/ParametersPanel';
 import SegmentedControlPanel from '../../components/panels/SegmentedControlPanel';
 import LocateItemButton from '../../components/plugins/LocateItemButton';
-import { stockLocationFields } from '../../forms/StockForms';
+import { useStockLocationFields } from '../../forms/StockForms';
 import { InvenTreeIcon } from '../../functions/icons';
 import {
   useDeleteApiFormModal,
@@ -224,7 +224,7 @@ export default function Stock() {
     url: ApiEndpoints.stock_location_list,
     pk: id,
     title: t`Edit Stock Location`,
-    fields: stockLocationFields(),
+    fields: useStockLocationFields(),
     onFormSuccess: refreshInstance
   });
 

--- a/src/frontend/src/tables/stock/StockLocationTable.tsx
+++ b/src/frontend/src/tables/stock/StockLocationTable.tsx
@@ -18,7 +18,7 @@ import {
   DescriptionColumn
 } from '../../components/tables/ColumnRenderers';
 import { InvenTreeTable } from '../../components/tables/InvenTreeTable';
-import { stockLocationFields } from '../../forms/StockForms';
+import { useStockLocationFields } from '../../forms/StockForms';
 import { InvenTreeIcon } from '../../functions/icons';
 import {
   useBulkEditApiFormModal,
@@ -109,7 +109,7 @@ export function StockLocationTable({ parentId }: Readonly<{ parentId?: any }>) {
   const newLocation = useCreateApiFormModal({
     url: ApiEndpoints.stock_location_list,
     title: t`Add Stock Location`,
-    fields: stockLocationFields(),
+    fields: useStockLocationFields(),
     focus: 'name',
     initialData: {
       parent: parentId
@@ -126,7 +126,7 @@ export function StockLocationTable({ parentId }: Readonly<{ parentId?: any }>) {
     url: ApiEndpoints.stock_location_list,
     pk: selectedLocation,
     title: t`Edit Stock Location`,
-    fields: stockLocationFields(),
+    fields: useStockLocationFields(),
     onFormSuccess: (record: any) => table.updateRecord(record)
   });
 


### PR DESCRIPTION
## Problem

The stock location create/edit form in the platform UI does not show the **Owner** field, even though stock ownership is enabled and the field is documented ([stock owner docs](https://docs.inventree.org/en/stable/stock/owner/)) with a screenshot of it in the location edit dialog. Reported in #12537.

### Root cause

The platform UI form is rendered from the explicit field list returned by `stockLocationFields()` in `src/frontend/src/forms/StockForms.tsx` - `ApiForm` constructs the rendered fields from exactly the keys present in that object, merging per-key definitions from the endpoint's OPTIONS metadata. The `owner` key was simply missing from that list, while:

- the `StockLocation` model has an `owner` FK (migration `0057_stock_location_item_owner`),
- `LocationSerializer` exposes `owner` (`src/backend/InvenTree/stock/serializers.py`),
- the API accepts it (also confirmed by a commenter in #12537: previously set default ownership is still applied), and
- the docs document setting a location owner from the UI.

## Solution

Add the `owner` field to `stockLocationFields()`, following the exact same pattern as the stock item form (`useStockFields` uses `owner: { icon: <IconUsersGroup /> }`). This restores UI parity between stock items and stock locations and matches the documented behavior.

## Testing

- `yarn run build` (`tsc` full typecheck + vite build) passes locally.
- Biome check reports no new findings on the changed lines.
- Manual verification path: enable *Stock Ownership Control* in system settings → edit a stock location → the Owner field is now rendered alongside the documented fields.

Closes #12537
