### PR TITLE
[1.5.x] chore(deps): bump python in /contrib/container (#12816)

### DIFF
--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -10,7 +10,7 @@
 # - Monitors source files for any changes, and live-reloads server
 
 # Base image last bumped 2026-06-16
-FROM python:3.14.7-slim-trixie@sha256:ce40764625a4ff50df3548277632e7f96c4e77fe75fa848aae9885476e7df5a4 AS inventree_base
+FROM python:3.14.7-slim-trixie@sha256:cad9a2c871761c413caa6fdd6441c783451e740a48aaeba60ae62a8b53525ef6 AS inventree_base
 
 # Build arguments for this image
 ARG commit_tag=""


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [chore(deps): bump python in /contrib/container (#12816)](https://github.com/inventree/InvenTree/pull/12816)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)