### PR TITLE
Fix global search "view all results" omitting notes matches

### DIFF
--- a/src/frontend/src/components/nav/SearchDrawer.tsx
+++ b/src/frontend/src/components/nav/SearchDrawer.tsx
@@ -78,7 +78,8 @@ function QueryResultGroup({
   navigate,
   onClose,
   onRemove,
-  onResultClick
+  onResultClick,
+  searchNotes
 }: Readonly<{
   searchText: string;
   query: SearchQuery;
@@ -86,6 +87,7 @@ function QueryResultGroup({
   onClose: () => void;
   onRemove: (query: ModelType) => void;
   onResultClick: (query: ModelType, pk: number, event: any) => void;
+  searchNotes: boolean;
 }>) {
   const modelInfo = useMemo(() => getModelInfo(query.model), [query.model]);
 
@@ -104,7 +106,11 @@ function QueryResultGroup({
       cancelEvent(event);
 
       if (overviewUrl) {
-        const url = `${overviewUrl}?search=${searchText}`;
+        // Keep the notes-search context so results found via their notes
+        // are also present in the full results table view
+        const url = `${overviewUrl}?search=${searchText}${
+          searchNotes ? '&search_notes=true' : ''
+        }`;
 
         // Close drawer if opening in the same tab
         if (!eventModified(event)) {
@@ -121,7 +127,7 @@ function QueryResultGroup({
         });
       }
     },
-    [overviewUrl, searchText]
+    [overviewUrl, searchText, searchNotes]
   );
 
   if (query.results.count == 0) {
@@ -592,6 +598,7 @@ export function SearchDrawer({
                   query={query}
                   navigate={navigate}
                   onClose={closeDrawer}
+                  searchNotes={searchNotes}
                   onRemove={(query) => removeResults(query)}
                   onResultClick={(query, pk, event) =>
                     onResultClick(query, pk, event)


### PR DESCRIPTION
## Problem

When global search has the "notes search" setting enabled, results whose notes match the search term appear correctly in the search drawer - but clicking "view all results" for that model opens the results table **without** those matches (reported in #12482, with reproduction steps).

## Root cause

The search drawer calls the API search endpoint with `search_notes: true`, but the "view all results" link only carries the plain `search` term to the overview table:

```tsx
const url = `${overviewUrl}?search=${searchText}`;
```

The overview table's list endpoint only searches notes when it receives the `search_notes` query parameter (supported by `InvenTreeSearchFilter`), so note-only matches were dropped from the table view.

## Solution

Pass the drawer's active notes-search state through to the overview URL:

- `QueryResultGroup` receives a `searchNotes` prop from the drawer
- `viewResults()` appends `&search_notes=true` when notes search is active
- The table already forwards URL query parameters to the API, where the existing `search_notes` support does the rest

## Testing

- [x] `yarn run build` (full `tsc` typecheck + vite build) passes
- [x] Reproduction path: add a unique string to the notes field of some parts, enable notes search in the global search settings, search for it, click "view all results" for parts - the table now includes the note matches (previously empty/omitted)
- [x] With notes search disabled, the URL is unchanged from before

Closes #12482
