### PR TITLE
Extend timeout for background label printing tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- [#12830](https://github.com/inventree/InvenTree/pull/12830) squashes all database migrations prior to the 1.0.0 release. This means that any users who are updating from a version older than 1.0.0 must first update to the 1.0.0 release before updating to the current release.
 - [#11971](https://github.com/inventree/InvenTree/pull/11971) is a major refactor of how notes are handled. Notes are now stored in a separate database table (in line with how attachments are handled), and each model instance can have multiple notes associated with it. The `notes` field has been removed from the individual models (and their associated API endpoints), and notes are now accessed via the new `/api/note/` endpoint. Existing notes data (and any embedded images) are automatically migrated to the new notes table, with the markdown content converted to HTML. Any external client applications which read or write the `notes` field via the API will need to be updated to use the new endpoint.
 - [#12507](https://github.com/inventree/InvenTree/pull/12507) calling an invalid or repeated state transition now raises a ValidationError. Plugins implementing state transitions should evaluate the PR and adapt their usage of transitions to gain the new safeguards.
 - [#12672](https://github.com/inventree/InvenTree/pull/12672) renames the newly added `tags` filter from 1.4.0 (https://github.com/inventree/InvenTree/pull/12077) to `tag_name` to remove a nameclash.
@@ -20,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#12731](https://github.com/inventree/InvenTree/pull/12731) adds OIDC provider settings to the Admin Center - making all Identity Federation settings now available in one place without the need to use the database admin interface.
 
 ### Changed
+
+- [#12840](https://github.com/inventree/InvenTree/pull/12840) increases the default timeout for background label printing tasks. Slow print jobs (e.g. when printing to remote networked printers) are no longer killed and re-delivered by the background worker, which could result in labels being printed multiple times.
 
 ### Removed
 

--- a/src/backend/InvenTree/InvenTree/tasks.py
+++ b/src/backend/InvenTree/InvenTree/tasks.py
@@ -290,6 +290,7 @@ def offload_task(
     force_async: bool = False,
     force_sync: bool = False,
     check_duplicates: bool = True,
+    timeout: int | None = None,
     **kwargs,
 ) -> str | bool:
     """Create an AsyncTask if workers are running. This is different to a 'scheduled' task, in that it only runs once!
@@ -302,6 +303,7 @@ def offload_task(
         force_async: If True, force the task to be offloaded (even if workers are not running)
         force_sync: If True, force the task to be run synchronously (even if workers are running)
         check_duplicates: If True, check for existing identical tasks before offloading
+        timeout: Optional timeout (in seconds) for the offloaded task, overriding the default worker timeout. Ignored when the task is run synchronously
         **kwargs: Keyword arguments to be passed to the task function
 
     Returns:
@@ -354,6 +356,11 @@ def offload_task(
 
         # Running as asynchronous task
         try:
+            if timeout is not None:
+                # Task-specific timeout (for tasks which may legitimately run
+                # longer than the default worker timeout) - consumed by django-q
+                kwargs['timeout'] = timeout
+
             task = AsyncTask(taskname, *args, group=group, **kwargs)
             with tracer.start_as_current_span(f'async worker: {taskname}'):
                 task.run()
@@ -993,6 +1000,63 @@ def get_migration_count():
     """Returns the number of all detected migrations."""
     executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
     return executor.loader.applied_migrations
+
+
+# The first and last individual migrations of each pre-1.0.0 squash range,
+# for every app squashed as part of the pre-1.0.0 migration-history cleanup.
+PRE_1_0_0_MIGRATION_BOUNDARIES = [
+    ('common', '0001_initial', '0007_colortheme'),
+    (
+        'common',
+        '0008_remove_inventreesetting_description',
+        '0039_emailthread_emailmessage',
+    ),
+    ('build', '0006_auto_20190913_1407', '0015_auto_20200425_1350'),
+    ('build', '0017_auto_20200426_0612', '0058_buildline_consumed'),
+    ('company', '0003_remove_supplierpart_minimum', '0047_supplierpart_pack_size'),
+    ('company', '0048_auto_20220913_0312', '0075_company_tax_id'),
+    ('order', '0001_initial', '0023_auto_20200420_2309'),
+    ('order', '0031_auto_20200426_0612', '0112_alter_salesorderlineitem_part'),
+    ('stock', '0002_auto_20190525_2226', '0030_auto_20200422_0015'),
+    ('stock', '0059_auto_20210404_2016', '0116_alter_stockitem_link'),
+    ('part', '0003_auto_20190525_2226', '0060_merge_20201112_1722'),
+    (
+        'part',
+        '0061_auto_20210103_2313',
+        '0142_remove_part_last_stocktake_remove_partstocktake_note_and_more',
+    ),
+    ('users', '0001_initial', '0015_alter_userprofile_type'),
+]
+
+
+def get_stuck_pre_1_0_0_apps() -> list:
+    """Detect apps stuck mid-way through the pre-1.0.0 migration squash.
+
+    A database which has applied the *first* migration of one of
+    PRE_1_0_0_MIGRATION_BOUNDARIES's ranges but not the *last* is stuck
+    between the old, granular history and the squashed one.
+
+    Returns a list of app labels which are in this "stuck" state. An empty
+    list means it is safe to proceed with migrations.
+    """
+    from django.db.migrations.recorder import MigrationRecorder
+
+    connection = connections[DEFAULT_DB_ALIAS]
+    recorder = MigrationRecorder(connection)
+
+    if not recorder.has_table():
+        # No migrations have ever been recorded - a genuinely fresh database
+        return []
+
+    applied = recorder.applied_migrations()
+
+    stuck_apps = set()
+
+    for app_label, first, last in PRE_1_0_0_MIGRATION_BOUNDARIES:
+        if (app_label, first) in applied and (app_label, last) not in applied:
+            stuck_apps.add(app_label)
+
+    return sorted(stuck_apps)
 
 
 @tracer.start_as_current_span('check_for_migrations')

--- a/src/backend/InvenTree/InvenTree/test_tasks.py
+++ b/src/backend/InvenTree/InvenTree/test_tasks.py
@@ -137,6 +137,55 @@ class InvenTreeTaskTests(PluginRegistryMixin, TestCase):
         ):
             InvenTree.tasks.offload_task('InvenTree.test_tasks.eval', force_sync=True)
 
+    def test_offload_task_timeout(self):
+        """Test that a custom timeout can be applied to an offloaded task.
+
+        The timeout must reach the background worker (overriding the default
+        worker timeout for that task), without being passed through to the
+        task function itself.
+        See https://github.com/inventree/InvenTree/issues/11650
+        """
+        # force_async ensures the task is queued (rather than run synchronously),
+        # even though no background worker is running in the test environment
+        InvenTree.tasks.offload_task(
+            'InvenTree.test_tasks.get_result', force_async=True, timeout=600
+        )
+
+        queued = [
+            t
+            for t in OrmQ.objects.all()
+            if t.task.get('func') == 'InvenTree.test_tasks.get_result'
+        ]
+
+        self.assertEqual(len(queued), 1)
+
+        # The timeout is attached to the queued task itself...
+        self.assertEqual(queued[0].task.get('timeout'), 600)
+
+        # ...and not passed through to the task function
+        self.assertNotIn('timeout', queued[0].task.get('kwargs', {}))
+
+        # Without a custom timeout, no task-level timeout is set
+        InvenTree.tasks.offload_task(
+            'InvenTree.test_tasks.get_result', force_async=True, sample='abc'
+        )
+
+        queued = [
+            t
+            for t in OrmQ.objects.all()
+            if t.task.get('kwargs', {}).get('sample') == 'abc'
+        ]
+
+        self.assertEqual(len(queued), 1)
+        self.assertIsNone(queued[0].task.get('timeout'))
+
+        # A custom timeout is ignored when the task is run synchronously
+        self.assertTrue(
+            InvenTree.tasks.offload_task(
+                'InvenTree.test_tasks.get_result', force_sync=True, timeout=600
+            )
+        )
+
     def test_task_heartbeat(self):
         """Test the task heartbeat."""
         InvenTree.tasks.offload_task(InvenTree.tasks.heartbeat)

--- a/src/backend/InvenTree/machine/tests.py
+++ b/src/backend/InvenTree/machine/tests.py
@@ -1,6 +1,7 @@
 """Machine app tests."""
 
 from typing import cast
+from unittest import mock
 
 from django.apps import apps
 from django.test import TestCase
@@ -10,6 +11,7 @@ from InvenTree.unit_test import AdminTestCase, InvenTreeAPITestCase
 from machine.models import MachineConfig
 from machine.registry import registry
 from part.models import Part
+from plugin.base.label.mixins import LABEL_PRINT_TIMEOUT
 from plugin.models import PluginConfig
 from plugin.registry import registry as plg_registry
 from report.models import LabelTemplate
@@ -296,6 +298,59 @@ class TestLabelPrinterMachineType(InvenTreeAPITestCase):
         )
 
         self.assertIn('is not a valid choice', str(response.data['machine']))
+
+    def test_print_label_timeout(self):
+        """Test that machine printing tasks are offloaded with an extended timeout.
+
+        A background print task may legitimately run longer than the default
+        worker timeout; if it is killed by the worker timeout it may be
+        re-delivered, resulting in duplicate prints.
+        See https://github.com/inventree/InvenTree/issues/11650
+        """
+        plugin_ref = 'inventreelabelmachine'
+
+        machine = self.create_machine('test-label-printer-api')
+
+        # setup the label app
+        apps.get_app_config('report').create_default_labels()
+        plg_registry.reload_plugins()
+
+        config = cast(PluginConfig, plg_registry.get_plugin(plugin_ref).plugin_config())
+        config.active = True
+        config.save()
+
+        parts = Part.objects.all()[:1]
+        template = LabelTemplate.objects.filter(enabled=True, model_type='part').first()
+        assert template
+
+        url = reverse('api-label-print')
+
+        # Patch offload_task in the module the plugin class was loaded from -
+        # plugin classes are not imported from the regular package namespace
+        plugin_module = type(
+            plg_registry.get_plugin(plugin_ref, active=None)
+        ).print_labels.__globals__['__name__']
+
+        with mock.patch(
+            f'{plugin_module}.offload_task', return_value=None
+        ) as mock_offload:
+            self.post(
+                url,
+                {
+                    'plugin': config.key,
+                    'items': [a.pk for a in parts],
+                    'template': template.pk,
+                    'machine': str(machine.pk),
+                    'driver_options': {'copies': '3'},
+                },
+                expected_code=201,
+            )
+
+            # The print task must be offloaded with the extended timeout
+            mock_offload.assert_called_once()
+            self.assertEqual(
+                mock_offload.call_args.kwargs.get('timeout'), LABEL_PRINT_TIMEOUT
+            )
 
     def test_printing_options_serializer(self):
         """Test the printing options serializer."""

--- a/src/backend/InvenTree/plugin/base/label/mixins.py
+++ b/src/backend/InvenTree/plugin/base/label/mixins.py
@@ -15,6 +15,13 @@ from plugin.base.label import label as plugin_label
 from plugin.helpers import MixinNotImplementedError
 from report.models import LabelTemplate
 
+# Timeout (in seconds) for label printing tasks which are run in the background.
+# Printing (especially to remote networked printers) can take longer than the
+# default background worker timeout. If a print task is killed by the worker
+# timeout it may be re-delivered, resulting in duplicate prints.
+# See https://github.com/inventree/InvenTree/issues/11650
+LABEL_PRINT_TIMEOUT = 600
+
 
 class LabelPrintingMixin:
     """Mixin which enables direct printing of stock labels.
@@ -191,6 +198,7 @@ class LabelPrintingMixin:
                     plugin_label.print_label,
                     self.plugin_slug(),
                     group='plugin',
+                    timeout=LABEL_PRINT_TIMEOUT,
                     **print_args,
                 )
 

--- a/src/backend/InvenTree/plugin/base/label/test_label_mixin.py
+++ b/src/backend/InvenTree/plugin/base/label/test_label_mixin.py
@@ -14,7 +14,7 @@ from InvenTree.config import get_testfolder_dir
 from InvenTree.unit_test import InvenTreeAPITestCase
 from part.models import Part
 from plugin import InvenTreePlugin, PluginMixinEnum, registry
-from plugin.base.label.mixins import LabelPrintingMixin
+from plugin.base.label.mixins import LABEL_PRINT_TIMEOUT, LabelPrintingMixin
 from plugin.helpers import MixinNotImplementedError
 from report.models import LabelTemplate
 from report.tests import PrintTestMixins
@@ -219,6 +219,48 @@ class LabelMixinTests(PrintTestMixins, InvenTreeAPITestCase):
 
         # And that it is a valid image file
         Image.open(f'{test_path}.png')
+
+    def test_async_printing_timeout(self):
+        """Test that non-blocking printing offloads tasks with an extended timeout.
+
+        A background print task may legitimately run longer than the default
+        worker timeout (e.g. when printing to a slow remote printer). If such a
+        task is killed by the worker timeout, it may be re-delivered, resulting
+        in duplicate prints.
+        See https://github.com/inventree/InvenTree/issues/11650
+        """
+        # Ensure the labels were created
+        apps.get_app_config('report').create_default_labels()
+
+        template = LabelTemplate.objects.filter(enabled=True, model_type='part').first()
+        assert template
+
+        part = Part.objects.all().first()
+
+        self.do_activate_plugin()
+        plugin = registry.get_plugin(self.plugin_ref)
+
+        # Force the non-blocking (background worker) code path; rendering is
+        # not under test here (covered by test_printing_process), so it is mocked
+        with (
+            mock.patch.object(plugin, 'BLOCKING_PRINT', False),
+            mock.patch.object(plugin, 'render_to_pdf', return_value=b'pdf-data'),
+            mock.patch.object(plugin, 'render_to_png', return_value=b'png-data'),
+            mock.patch(
+                'plugin.base.label.mixins.offload_task', return_value=True
+            ) as mock_offload,
+        ):
+            self.post(
+                self.printing_url,
+                {'template': template.pk, 'plugin': plugin.slug, 'items': [part.pk]},
+                expected_code=201,
+            )
+
+            # The print task must be offloaded with the extended timeout
+            mock_offload.assert_called_once()
+            self.assertEqual(
+                mock_offload.call_args.kwargs.get('timeout'), LABEL_PRINT_TIMEOUT
+            )
 
     def test_printing_options(self):
         """Test printing options."""

--- a/src/backend/InvenTree/plugin/builtin/labels/inventree_machine.py
+++ b/src/backend/InvenTree/plugin/builtin/labels/inventree_machine.py
@@ -12,6 +12,7 @@ from InvenTree.serializers import DependentField
 from InvenTree.tasks import offload_task
 from machine.machine_types import LabelPrinterBaseDriver, LabelPrinterMachine
 from plugin import InvenTreePlugin
+from plugin.base.label.mixins import LABEL_PRINT_TIMEOUT
 from plugin.machine import call_machine_function, registry
 from plugin.mixins import LabelPrintingMixin
 from report.models import LabelTemplate
@@ -108,6 +109,7 @@ class InvenTreeLabelPlugin(LabelPrintingMixin, InvenTreePlugin):
             output=output,
             force_sync=settings.TESTING or driver.USE_BACKGROUND_WORKER,
             group='plugin',
+            timeout=LABEL_PRINT_TIMEOUT,
             **print_kwargs,
         )
 


### PR DESCRIPTION
## Problem

When printing multiple labels at once (e.g. with the Brother label plugin on a remote networked printer), the print job can legitimately take longer than the default background worker timeout (90s). When the worker kills such a task, the queued task can be re-delivered and executed again - resulting in some labels being printed multiple times (and others never, as the output is marked complete). See #11650.

Per-task retries cannot be disabled (django-q2 only supports a global `max_attempts`, see django-q2#114), but a custom timeout per task is supported by django-q and honoured by the worker (`task.pop("timeout", ...)`).

## Solution

- `offload_task()` gains an optional `timeout` parameter: when provided (and the task is offloaded asynchronously), it is attached to the queued task as a task-level timeout which overrides the default worker timeout. It is not passed through to the task function itself, and it is ignored for synchronously executed tasks.
- Label printing tasks (both the plugin path and the label machine path) are now offloaded with an extended default timeout (`LABEL_PRINT_TIMEOUT = 600`), so slow printer communication no longer trips the worker timeout / re-delivery behaviour.

## Note on the `tasks.py` / `CHANGELOG.md` diff

This branch is based on a fork of InvenTree which cannot be synced with upstream (the sync is refused without the `workflow` OAuth scope, as upstream's recent commits touch workflow files). Consequently the `tasks.py` and `CHANGELOG.md` diffs also contain upstream changes made after the fork point (the `PRE_1_0_0_MIGRATION_BOUNDARIES` addition and recent changelog entries). **The changes introduced by this PR** are limited to:
- `offload_task()`: the new `timeout` parameter (signature, docstring, and passing it to the queued task)
- `plugin/base/label/mixins.py`: the `LABEL_PRINT_TIMEOUT` constant and its use
- `plugin/builtin/labels/inventree_machine.py`: using the constant
- the two new tests and the changelog entry

## How to test

- `InvenTree.test_tasks.InvenTreeTaskTests.test_offload_task_timeout`: verifies that a custom timeout lands on the queued task (not in the task kwargs), that no timeout key is set without one, and that it is ignored on the synchronous path.
- `plugin.base.label.test_label_mixin.LabelMixinTests.test_async_printing_timeout`: verifies non-blocking plugin printing offloads with `LABEL_PRINT_TIMEOUT`.
- `machine.tests.TestLabelPrinterMachineType.test_print_label_timeout`: same assertion for the label machine path.

Fixes #11650