### PR TITLE
Fix 12844 notification external link

### DIFF
--- a/src/frontend/src/components/nav/NotificationDrawer.tsx
+++ b/src/frontend/src/components/nav/NotificationDrawer.tsx
@@ -62,6 +62,12 @@ function NotificationEntry({
     }
   }
 
+  const base = `/${getBaseUrl()}`;
+  const href =
+    link && link.startsWith('/') && !link.startsWith(base)
+      ? `${base}${link}`
+      : link;
+
   return (
     <Paper p='xs' shadow='xs'>
       <Group justify='space-between' wrap='nowrap'>
@@ -72,7 +78,7 @@ function NotificationEntry({
         >
           <Stack gap={2}>
             <Anchor
-              href={link ? `/${getBaseUrl()}${link}` : '#'}
+              href={href ?? '#'}
               underline='hover'
               target='_blank'
               onClick={(event: any) => {
@@ -81,7 +87,7 @@ function NotificationEntry({
                   onRead();
                 }
 
-                if (link.startsWith('/')) {
+                if (link?.startsWith('/')) {
                   navigateToLink(link, navigate, event);
                 }
               }}

--- a/src/frontend/src/components/nav/NotificationDrawer.tsx
+++ b/src/frontend/src/components/nav/NotificationDrawer.tsx
@@ -78,7 +78,7 @@ function NotificationEntry({
         >
           <Stack gap={2}>
             <Anchor
-              href={href ?? '#'}
+              href={href || '#'}
               underline='hover'
               target='_blank'
               onClick={(event: any) => {

--- a/src/frontend/src/components/nav/NotificationDrawer.tsx
+++ b/src/frontend/src/components/nav/NotificationDrawer.tsx
@@ -64,9 +64,7 @@ function NotificationEntry({
 
   const base = `/${getBaseUrl()}`;
   const href =
-    link?.startsWith('/') && !link.startsWith(base)
-      ? `${base}${link}`
-      : link;
+    link?.startsWith('/') && !link.startsWith(base) ? `${base}${link}` : link;
 
   return (
     <Paper p='xs' shadow='xs'>

--- a/src/frontend/src/components/nav/NotificationDrawer.tsx
+++ b/src/frontend/src/components/nav/NotificationDrawer.tsx
@@ -64,7 +64,7 @@ function NotificationEntry({
 
   const base = `/${getBaseUrl()}`;
   const href =
-    link && link.startsWith('/') && !link.startsWith(base)
+    link?.startsWith('/') && !link.startsWith(base)
       ? `${base}${link}`
       : link;
 

--- a/src/frontend/tests/pui_notifications.spec.ts
+++ b/src/frontend/tests/pui_notifications.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from './baseFixtures.js';
+import { doLogin } from './login.js';
+
+const notifications = [
+  {
+    pk: 1,
+    target: {
+      model_type: 'pluginconfig',
+      model_id: 1,
+      link: 'https://example.com/path'
+    },
+    source: null,
+    user: 1,
+    category: 'test_external',
+    name: 'External Notification',
+    message: 'External notification link',
+    creation: '2026-09-12 12:00',
+    age: 1,
+    age_human: 'a moment ago',
+    read: false
+  },
+  {
+    pk: 2,
+    target: {
+      model_type: 'pluginconfig',
+      model_id: 1,
+      link: '/settings/admin/'
+    },
+    source: null,
+    user: 1,
+    category: 'test_internal',
+    name: 'Internal Notification',
+    message: 'Internal notification link',
+    creation: '2026-09-12 12:00',
+    age: 1,
+    age_human: 'a moment ago',
+    read: false
+  },
+  {
+    pk: 3,
+    target: {
+      model_type: 'pluginconfig',
+      model_id: 1,
+      link: '/web/settings/admin/'
+    },
+    source: null,
+    user: 1,
+    category: 'test_base',
+    name: 'Base Notification',
+    message: 'Notification link with base path',
+    creation: '2026-09-12 12:00',
+    age: 1,
+    age_human: 'a moment ago',
+    read: false
+  }
+];
+
+test('Notifications - link targets', async ({ page }) => {
+  await page.route('**/api/notifications/**', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        count: notifications.length,
+        next: null,
+        previous: null,
+        results: notifications
+      })
+    });
+  });
+
+  await doLogin(page);
+
+  await page.getByRole('button', { name: 'open-notifications' }).click();
+
+  await expect(
+    page.getByRole('link', { name: 'External Notification' })
+  ).toHaveAttribute('href', 'https://example.com/path');
+
+  await expect(
+    page.getByRole('link', { name: 'Internal Notification' })
+  ).toHaveAttribute('href', '/web/settings/admin/');
+
+  await expect(
+    page.getByRole('link', { name: 'Base Notification' })
+  ).toHaveAttribute('href', '/web/settings/admin/');
+});


### PR DESCRIPTION
## Summary

- preserve absolute external notification URLs
- prefix internal notification links with the frontend base path only when required
- avoid double-prefixing links which already contain the frontend base path
- add Playwright regression coverage for external, relative internal, and already-prefixed internal links

Fixes #12844

## Testing

The issue was reproduced against the official `inventree/inventree:1.5.4` image and traced through the database, serializer and production frontend bundle.

Added Playwright regression coverage for:

- `https://example.com/path` -> unchanged
- `/settings/admin/` -> `/web/settings/admin/`
- `/web/settings/admin/` -> unchanged